### PR TITLE
perf: Eliminate O(N²) TCP buffer parsing overhead with offset tracking

### DIFF
--- a/src/traceml/transport/tcp_transport.py
+++ b/src/traceml/transport/tcp_transport.py
@@ -91,20 +91,25 @@ class TCPServer:
         expected: Optional[int],
     ) -> tuple[list[bytes], bytearray, Optional[int]]:
         frames: list[bytes] = []
+        offset = 0
+        buf_len = len(buffer)
 
         while True:
             if expected is None:
-                if len(buffer) < 4:
+                if buf_len - offset < 4:
                     break
-                expected = struct.unpack("!I", buffer[:4])[0]
-                buffer = buffer[4:]
+                expected = struct.unpack("!I", buffer[offset : offset + 4])[0]
+                offset += 4
 
-            if len(buffer) < expected:
+            if buf_len - offset < expected:
                 break
 
-            frames.append(buffer[:expected])
-            buffer = buffer[expected:]
+            frames.append(buffer[offset : offset + expected])
+            offset += expected
             expected = None
+
+        if offset > 0:
+            del buffer[:offset]
 
         return frames, buffer, expected
 

--- a/tests/bench_tcp_drain.py
+++ b/tests/bench_tcp_drain.py
@@ -22,6 +22,31 @@ def drain_frames_current(buffer: bytearray, expected: Optional[int]):
     return frames, buffer, expected
 
 
+def drain_frames_optimized(buffer: bytearray, expected: Optional[int]):
+    frames = []
+    offset = 0
+    buf_len = len(buffer)
+
+    while True:
+        if expected is None:
+            if buf_len - offset < 4:
+                break
+            expected = struct.unpack("!I", buffer[offset : offset + 4])[0]
+            offset += 4
+
+        if buf_len - offset < expected:
+            break
+
+        frames.append(buffer[offset : offset + expected])
+        offset += expected
+        expected = None
+
+    if offset > 0:
+        del buffer[:offset]
+
+    return frames, buffer, expected
+
+
 def benchmark_drain():
     # Simulate a massive payload of telemetry frames from worker ranks to the aggregator.
     # We use 100,000 messages of 128 bytes each, which mimics a fast burst of
@@ -42,16 +67,35 @@ def benchmark_drain():
         f"Total simulated TCP buffer size: {len(huge_payload) / 1024 / 1024:.2f} MB"
     )
 
-    buffer = bytearray(huge_payload)
-
+    buffer_copy1 = bytearray(huge_payload)
     print("Benchmarking current O(N^2) implementation...")
-    start = time.perf_counter()
-    frames, remaining_buffer, expected = drain_frames_current(buffer, None)
-    end = time.perf_counter()
+    start1 = time.perf_counter()
+    frames1, remaining_buffer1, expected1 = drain_frames_current(
+        buffer_copy1, None
+    )
+    end1 = time.perf_counter()
 
-    duration = end - start
-    print(f"Extraction completed in {duration:.4f} seconds.")
-    print(f"Total frames extracted: {len(frames)}")
+    duration1 = end1 - start1
+    print(f"Extraction completed in {duration1:.4f} seconds.")
+    print(f"Total frames extracted: {len(frames1)}\n")
+
+    buffer_copy2 = bytearray(huge_payload)
+    print("Benchmarking OPTIMIZED O(N) implementation...")
+    start2 = time.perf_counter()
+    frames2, remaining_buffer2, expected2 = drain_frames_optimized(
+        buffer_copy2, None
+    )
+    end2 = time.perf_counter()
+
+    duration2 = end2 - start2
+    print(f"Extraction completed in {duration2:.4f} seconds.")
+    print(f"Total frames extracted: {len(frames2)}")
+    if duration2 > 0:
+        print(f"Speedup: {duration1 / duration2:.2f}x\n")
+
+    assert len(frames1) == len(frames2)
+    for f1, f2 in zip(frames1, frames2):
+        assert f1 == f2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


## Summary

This PR addresses a performance bottleneck in TCP server's message parsing logic that was causing the main aggregator thread to freeze during large bursts of telemetry data. By refactoring how we process the incoming byte buffer, we achieved a **~2,644x speedup** on large payloads.

## The Problem (Before)

When worker nodes sent telemetry events to the aggregator, the data arrived as a raw stream of `msgpack` bytes with length-prepended headers.

Our original `_drain_frames` loop identified individual message frames and extracted them like this:

```
frames.append(buffer[:expected])
buffer = buffer[expected:]
```

While this looks clean, it’s actually quite expensive. In Python, slicing a `bytearray` like `buffer[expected:]` doesn’t just move a pointer  it creates a new array and copies all the remaining bytes into it.

If we received a sudden 12MB burst of telemetry containing 100,000 tiny frames, the server would:

1. Copy 11.99MB into a new array.
2. Next loop iteration, copy 11.98MB into a new array.
3. Next iteration, copy 11.97MB into a new array... and so on 100,000 times.

This resulted in **quadratic O(N²)** time complexity and massive memory fragmentation, freezing the event loop for ~87 seconds just to extract frames from a single 12MB chunk.

## The Solution 

Instead of slicing and mutating the buffer continuously, this PR introduces a simple `offset` integer tracker.

We now scan through the existing byte buffer using `offset` boundaries:

```
frames.append(buffer[offset : offset + expected])
offset += expected
```

Once the `while` loop extracts all complete frames from the current chunk, we make a **single** call to trim the buffer:

```
del buffer[:offset]
```

Rather than creating new byte arrays, Python's `del` shifts the memory of a `bytearray` leftwards in place. Because we only do this once at the very end of the loop, the time complexity drops from **O(N²)** down to **O(N)**.

## Benchmarks

I added a new script that simulates the aggregator receiving a 12.59MB burst of 100,000 telemetry frames at once.

**Results:**

* **Previous Implementation:** 87.4879 seconds
* **Optimized Implementation:** 0.0331 seconds
* **Speedup:** ~2,644x

By completely bypassing the redundant memory allocations, the aggregator thread can effortlessly handle massive telemetry dumps without UI hanging or dropping connections.
