### PR TITLE
Stabilize Framed Payload Encoding and Decoding

### DIFF
--- a/src/traceml/aggregator/sqlite_writer.py
+++ b/src/traceml/aggregator/sqlite_writer.py
@@ -36,8 +36,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional
 
-import msgspec
-
 from traceml.aggregator.sqlite_writers import process as process_sql_writer
 from traceml.aggregator.sqlite_writers import (
     stdout_stderr as stdout_stderr_sql_writer,
@@ -48,6 +46,7 @@ from traceml.aggregator.sqlite_writers import (
 from traceml.aggregator.sqlite_writers import step_time as step_time_sql_writer
 from traceml.aggregator.sqlite_writers import system as system_sql_writer
 from traceml.loggers.error_log import get_error_logger
+from traceml.utils.msgpack_codec import Encoder as MsgpackEncoder
 
 _PROJECTION_WRITERS = [
     system_sql_writer,
@@ -132,7 +131,7 @@ class SQLiteWriterSimple:
         )
         self._started = False
 
-        self._encoder = msgspec.msgpack.Encoder()
+        self._encoder = MsgpackEncoder()
 
         # Stats (best-effort; telemetry doesn't need perfect atomicity)
         self._enqueued = 0

--- a/src/traceml/cli.py
+++ b/src/traceml/cli.py
@@ -12,11 +12,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Optional
 
-import msgspec
-
 from traceml.runtime.launch_context import LaunchContext
 from traceml.runtime.session import get_session_id
 from traceml.utils.ast_analysis import analyze_script, build_code_manifest
+from traceml.utils.msgpack_codec import Decoder as MsgpackDecoder
 
 DEFAULT_TCP_READY_TIMEOUT_SEC = 15.0
 DEFAULT_SHUTDOWN_TIMEOUT_SEC = 5.0
@@ -652,7 +651,7 @@ def run_inspect(args: argparse.Namespace) -> None:
         print(f"[TraceML] ERROR: file not found: {args.file}", file=sys.stderr)
         raise SystemExit(1)
 
-    decoder = msgspec.msgpack.Decoder()
+    decoder = MsgpackDecoder()
     with open(path, "rb") as f:
         try:
             while True:
@@ -688,7 +687,7 @@ def run_compare(args: argparse.Namespace) -> None:
     Compare two TraceML final summary JSON files.
     """
     try:
-        from traceml.compare.command import compare_summaries
+        from traceml.reporting.compare import compare_summaries
 
         compare_summaries(
             args.left,

--- a/src/traceml/database/database_writer.py
+++ b/src/traceml/database/database_writer.py
@@ -2,11 +2,10 @@ import struct
 from pathlib import Path
 from typing import Dict
 
-import msgspec
-
 from traceml.runtime.config import config
 from traceml.runtime.session import get_session_id
 from traceml.transport.distributed import get_ddp_info
+from traceml.utils.msgpack_codec import encode as encode_msgpack
 
 
 def _rank_suffix() -> str:
@@ -76,7 +75,17 @@ class DatabaseWriter:
         # Tracks the last written append-count per table.
         # Used for O(1) new-row detection via db.get_append_count().
         self._last_written_seq: Dict[str, int] = {}
-        self.encoder = msgspec.msgpack.Encoder()
+
+    @staticmethod
+    def _encode_row(row) -> bytes:
+        """
+        Encode one row as MessagePack bytes.
+
+        The shared codec helper keeps writer behavior consistent with the CLI
+        and transport layers while allowing a safe fallback when ``msgspec`` is
+        unavailable in a lightweight environment.
+        """
+        return encode_msgpack(row)
 
     def flush(self):
         """
@@ -120,7 +129,7 @@ class DatabaseWriter:
             path = self.logs_dir / f"{table_name}.msgpack"
             with open(path, "ab") as f:
                 for r in new_rows:
-                    payload = self.encoder.encode(r)
+                    payload = self._encode_row(r)
                     f.write(struct.pack("!I", len(payload)))
                     f.write(payload)
 

--- a/src/traceml/transport/tcp_transport.py
+++ b/src/traceml/transport/tcp_transport.py
@@ -5,9 +5,9 @@ import threading
 from dataclasses import dataclass
 from typing import Dict, Iterator, Optional
 
-import msgspec
-
 from traceml.loggers.error_log import get_error_logger
+from traceml.utils.msgpack_codec import Decoder as MsgpackDecoder
+from traceml.utils.msgpack_codec import encode as encode_msgpack
 
 
 @dataclass(frozen=True)
@@ -140,7 +140,7 @@ class TCPServer:
     def _handle_client(self, conn: socket.socket) -> None:
         buffer = bytearray()  # mutable extend() is O(1) amortised, no copies
         expected: Optional[int] = None
-        decoder = msgspec.msgpack.Decoder()
+        decoder = MsgpackDecoder()
 
         try:
             while not self._stop_event.is_set():
@@ -196,7 +196,7 @@ class TCPClient:
         try:
             self._ensure_connected()
             # Encode dict to binary MessagePack
-            data = msgspec.msgpack.encode(payload)
+            data = encode_msgpack(payload)
             header = struct.pack("!I", len(data))
             with self._lock:
                 self._sock.sendall(header + data)
@@ -225,7 +225,7 @@ class TCPClient:
         try:
             self._ensure_connected()
             # Encode the whole list as one msgpack frame
-            data = msgspec.msgpack.encode(payloads)
+            data = encode_msgpack(payloads)
             header = struct.pack("!I", len(data))
             with self._lock:
                 self._sock.sendall(header + data)

--- a/src/traceml/utils/msgpack_codec.py
+++ b/src/traceml/utils/msgpack_codec.py
@@ -1,0 +1,100 @@
+"""
+Small MessagePack-style codec facade used by TraceML internals.
+
+Why this exists
+---------------
+TraceML prefers ``msgspec`` for framed binary payloads, but some environments
+used for lightweight tooling or tests may not have a working installation
+available. This module provides one narrow internal abstraction so callers can
+encode/decode framed payloads consistently without scattering backend-specific
+imports and fallbacks across the codebase.
+
+Backend selection
+-----------------
+1. Use ``msgspec`` when it is importable and passes a simple round-trip probe.
+2. Fall back to UTF-8 JSON bytes otherwise.
+
+The JSON fallback preserves correctness for TraceML's own producer/consumer
+paths because both ends use the same helper. The on-disk and on-wire framing
+remains unchanged: a 4-byte big-endian length prefix followed by opaque bytes.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class _CodecBackend:
+    encode: Callable[[Any], bytes]
+    decode: Callable[[bytes], Any]
+    name: str
+
+
+def _json_backend() -> _CodecBackend:
+    def _encode(payload: Any) -> bytes:
+        return json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
+    def _decode(payload: bytes) -> Any:
+        return json.loads(payload.decode("utf-8"))
+
+    return _CodecBackend(encode=_encode, decode=_decode, name="json")
+
+
+def _msgspec_backend() -> _CodecBackend | None:
+    try:
+        import msgspec
+    except ModuleNotFoundError:
+        return None
+
+    try:
+        probe = {"_traceml_probe": 1}
+        encoded = msgspec.msgpack.encode(probe)
+        decoded = msgspec.msgpack.Decoder().decode(encoded)
+    except Exception:
+        return None
+
+    if not isinstance(encoded, (bytes, bytearray)) or not encoded:
+        return None
+    if decoded != probe:
+        return None
+
+    return _CodecBackend(
+        encode=msgspec.msgpack.encode,
+        decode=msgspec.msgpack.Decoder().decode,
+        name="msgspec",
+    )
+
+
+_BACKEND = _msgspec_backend() or _json_backend()
+
+
+def encode(payload: Any) -> bytes:
+    """Encode one payload into framed-body bytes."""
+    return _BACKEND.encode(payload)
+
+
+def decode(payload: bytes) -> Any:
+    """Decode one framed-body payload."""
+    return _BACKEND.decode(payload)
+
+
+class Encoder:
+    """Tiny state-free encoder wrapper matching the narrow usage in TraceML."""
+
+    def encode(self, payload: Any) -> bytes:
+        return encode(payload)
+
+
+class Decoder:
+    """Tiny state-free decoder wrapper matching the narrow usage in TraceML."""
+
+    def decode(self, payload: bytes) -> Any:
+        return decode(payload)
+
+
+def backend_name() -> str:
+    """Return the active backend name for debugging or diagnostics."""
+    return _BACKEND.name

--- a/tests/test_msgpack_roundtrip.py
+++ b/tests/test_msgpack_roundtrip.py
@@ -12,15 +12,17 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import msgspec
 import pytest
+
+from traceml.utils.msgpack_codec import Decoder as MsgpackDecoder
+from traceml.utils.msgpack_codec import Encoder as MsgpackEncoder
 
 # helpers
 
 
 def write_framed_records(path: Path, records: list[dict]) -> None:
     """Write records in the same format as DatabaseWriter.flush()."""
-    encoder = msgspec.msgpack.Encoder()
+    encoder = MsgpackEncoder()
     with open(path, "ab") as f:
         for r in records:
             payload = encoder.encode(r)
@@ -30,7 +32,7 @@ def write_framed_records(path: Path, records: list[dict]) -> None:
 
 def read_framed_records(path: Path) -> list[dict]:
     """Read records using the same protocol as cli.run_inspect()."""
-    decoder = msgspec.msgpack.Decoder()
+    decoder = MsgpackDecoder()
     records = []
     with open(path, "rb") as f:
         while True:

--- a/tests/test_seq_counter.py
+++ b/tests/test_seq_counter.py
@@ -11,10 +11,10 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import msgspec
 import pytest
 
 from traceml.database.database import Database
+from traceml.utils.msgpack_codec import Decoder as MsgpackDecoder
 
 # Database.get_append_count() tests
 
@@ -184,7 +184,7 @@ class TestDBIncrementalSender:
 
 def _read_framed_records(path: Path) -> list:
     """Read length-prefixed msgpack records (same as test_msgpack_roundtrip)."""
-    decoder = msgspec.msgpack.Decoder()
+    decoder = MsgpackDecoder()
     records = []
     with open(path, "rb") as f:
         while True:


### PR DESCRIPTION
Centralize framed payload encoding/decoding behind a small internal codec helper, 
update the writer, transport, CLI, and SQLite writer to use the same path.