### PR TITLE
rendererd ordered

### DIFF
--- a/src/traceml/aggregator/display_drivers/cli.py
+++ b/src/traceml/aggregator/display_drivers/cli.py
@@ -26,7 +26,7 @@ from traceml.aggregator.display_drivers.layout import (
     SYSTEM_LAYOUT,
 )
 from traceml.database.remote_database_store import RemoteDBStore
-from traceml.renderers.base_renderer import BaseRenderer
+from traceml.renderers.base_renderer import CLIRenderer
 from traceml.renderers.layer_combined_memory.renderer import (
     LayerCombinedMemoryRenderer,
 )
@@ -97,7 +97,7 @@ class CLIDisplayDriver(BaseDisplayDriver):
 
         # CLI chooses its renderer set (can differ from dashboard)
         # Watch profile
-        self._renderers: List[BaseRenderer] = [
+        self._renderers: List[CLIRenderer] = [
             SystemRenderer(db_path=self._settings.db_path),
             ProcessRenderer(db_path=self._settings.db_path),
             StdoutStderrRenderer(db_path=self._settings.db_path),

--- a/src/traceml/aggregator/display_drivers/nicegui.py
+++ b/src/traceml/aggregator/display_drivers/nicegui.py
@@ -54,7 +54,7 @@ from traceml.aggregator.display_drivers.nicegui_sections.pages import (
     define_pages,
 )
 from traceml.database.remote_database_store import RemoteDBStore
-from traceml.renderers.base_renderer import BaseRenderer
+from traceml.renderers.base_renderer import DashboardRenderer
 from traceml.renderers.layer_combined_memory.renderer import (
     LayerCombinedMemoryRenderer,
 )
@@ -127,7 +127,7 @@ class NiceGUIDisplayDriver(BaseDisplayDriver):
         self._registered: bool = False
 
         # ---- Renderers ----
-        self._renderers: List[BaseRenderer] = [
+        self._renderers: List[DashboardRenderer] = [
             SystemRenderer(db_path=self._settings.db_path),
             ProcessRenderer(db_path=self._settings.db_path),
             StepCombinedRenderer(db_path=self._settings.db_path),
@@ -370,7 +370,7 @@ class NiceGUIDisplayDriver(BaseDisplayDriver):
 
         for r in self._renderers:
 
-            def register(rr: BaseRenderer = r) -> None:
+            def register(rr: DashboardRenderer = r) -> None:
                 fn = getattr(rr, "get_dashboard_renderable", None)
                 if fn is None:
                     raise AttributeError(

--- a/src/traceml/core/__init__.py
+++ b/src/traceml/core/__init__.py
@@ -7,6 +7,7 @@ SQLite helpers, or TraceML runtime modules.
 """
 
 from .lifecycle import Startable, Stoppable, Tickable
+from .registry import Registry
 from .rendering import Formatter, RenderContext, Renderer
 from .summaries import ReportGenerator, SummaryResult, SummarySection
 from .telemetry import MetricComputer, ProjectionWriter, TelemetryPayload
@@ -18,6 +19,7 @@ __all__ = [
     "Formatter",
     "RenderContext",
     "Renderer",
+    "Registry",
     "ReportGenerator",
     "SummaryResult",
     "SummarySection",

--- a/src/traceml/core/registry.py
+++ b/src/traceml/core/registry.py
@@ -1,0 +1,97 @@
+"""
+Small typed registry helper.
+
+Registries are useful for extension points where TraceML wants stable names for
+components such as samplers, diagnostic rules, display drivers, or summary
+sections without hardcoding lookups throughout core orchestration code.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Iterable, Iterator, Mapping
+from typing import Generic, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+class Registry(Generic[T]):
+    """
+    Insertion-ordered mapping from stable string keys to typed objects.
+
+    The registry intentionally keeps a small surface area:
+    - duplicate registration fails immediately
+    - missing lookup fails with a clear error
+    - iteration and ``all()`` preserve registration order
+    """
+
+    def __init__(
+        self,
+        items: Optional[Iterable[tuple[str, T]]] = None,
+    ) -> None:
+        self._items: "OrderedDict[str, T]" = OrderedDict()
+        if items is not None:
+            for key, item in items:
+                self.register(key, item)
+
+    def register(self, key: str, item: T) -> T:
+        """
+        Register an item under a stable key and return the item.
+
+        Returning the item makes decorator-style registration possible later
+        without adding another API shape.
+        """
+        normalized = self._normalize_key(key)
+        if normalized in self._items:
+            raise KeyError(f"Registry key already registered: {normalized!r}")
+        self._items[normalized] = item
+        return item
+
+    def get(self, key: str) -> T:
+        """Return the registered item for ``key``."""
+        normalized = self._normalize_key(key)
+        try:
+            return self._items[normalized]
+        except KeyError as exc:
+            raise KeyError(
+                f"Registry key is not registered: {normalized!r}"
+            ) from exc
+
+    def keys(self) -> tuple[str, ...]:
+        """Return registered keys in registration order."""
+        return tuple(self._items.keys())
+
+    def all(self) -> tuple[T, ...]:
+        """Return all registered items in registration order."""
+        return tuple(self._items.values())
+
+    def items(self) -> tuple[tuple[str, T], ...]:
+        """Return registered key/item pairs in registration order."""
+        return tuple((key, item) for key, item in self._items.items())
+
+    def as_mapping(self) -> Mapping[str, T]:
+        """Return a shallow read-only mapping view of registered items."""
+        return self._items.copy()
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
+        return self._normalize_key(key) in self._items
+
+    def __iter__(self) -> Iterator[T]:
+        return iter(self._items.values())
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    @staticmethod
+    def _normalize_key(key: str) -> str:
+        normalized = str(key).strip()
+        if not normalized:
+            raise ValueError("Registry key cannot be empty.")
+        return normalized
+
+
+__all__ = [
+    "Registry",
+]

--- a/src/traceml/renderers/base_renderer.py
+++ b/src/traceml/renderers/base_renderer.py
@@ -1,34 +1,51 @@
-from typing import Any, Dict
+from __future__ import annotations
+
+from abc import ABC
+from typing import Any, Dict, Protocol, runtime_checkable
 
 
-class BaseRenderer:
+class BaseRenderer(ABC):
     """
-    Base class for specific stdout loggers. Each logger is responsible for
-    providing data for a specific part of the shared display.
+    Shared metadata/state base for live renderers.
+
+    Display-specific contracts are intentionally separate:
+    - CLIRenderer: implements get_panel_renderable()
+    - DashboardRenderer: implements get_dashboard_renderable()
     """
 
-    def __init__(self, name: str, layout_section_name: str):
+    def __init__(self, name: str, layout_section_name: str) -> None:
         self.name = name
         self.layout_section_name = layout_section_name
         self._latest_data: Dict[str, Any] = {}
 
-    def get_panel_renderable(
-        self,
-    ) -> Any:  # This will be implemented by subclasses
-        """
-        Abstract method: Subclasses must implement this to return a Rich Renderable
-        (e.g., Panel, Table, Text) based on their `_latest_data`.
-        """
-        raise NotImplementedError(
-            "Subclasses must implement _get_panel_renderable to provide content for the shared display."
-        )
 
-    def get_notebook_renderable(self) -> Any:
-        """
-        Subclasses implement this to return an HTML representation
-        (IPython.display.HTML) based on `get_data()`.
-        Used in Jupyter/Notebook display.
-        """
-        raise NotImplementedError(
-            "Subclasses must implement get_notebook_renderable()"
-        )
+@runtime_checkable
+class RendererMetadata(Protocol):
+    """Shared renderer metadata required by display drivers."""
+
+    name: str
+    layout_section_name: str
+
+
+@runtime_checkable
+class CLIRenderer(RendererMetadata, Protocol):
+    """Renderer contract used by the Rich CLI display driver."""
+
+    def get_panel_renderable(self) -> Any:
+        """Return a Rich-compatible renderable for the CLI layout."""
+
+
+@runtime_checkable
+class DashboardRenderer(RendererMetadata, Protocol):
+    """Renderer contract used by the NiceGUI dashboard display driver."""
+
+    def get_dashboard_renderable(self) -> Any:
+        """Return a dashboard payload for the subscribed layout section."""
+
+
+__all__ = [
+    "BaseRenderer",
+    "RendererMetadata",
+    "CLIRenderer",
+    "DashboardRenderer",
+]

--- a/src/traceml/renderers/layer_combined_memory/renderer.py
+++ b/src/traceml/renderers/layer_combined_memory/renderer.py
@@ -1,7 +1,6 @@
 import shutil
 from typing import Any, Optional
 
-from IPython.display import HTML
 from rich.console import Group
 from rich.panel import Panel
 from rich.table import Table
@@ -124,9 +123,6 @@ class LayerCombinedMemoryRenderer(BaseRenderer):
         Return the typed compute result directly to dashboard consumers.
         """
         return self._compute_service.compute_display_data()
-
-    def get_notebook_renderable(self) -> HTML:
-        pass
 
     def log_summary(self, path) -> None:
         pass

--- a/src/traceml/renderers/layer_combined_time/renderer.py
+++ b/src/traceml/renderers/layer_combined_time/renderer.py
@@ -1,7 +1,6 @@
 import shutil
 from typing import Optional
 
-from IPython.display import HTML
 from rich.console import Group
 from rich.panel import Panel
 from rich.table import Table
@@ -104,9 +103,6 @@ class LayerCombinedTimeRenderer(BaseRenderer):
         Dashboard consumes the typed dataclass directly.
         """
         return self._service.compute_display_data()
-
-    def get_notebook_renderable(self) -> HTML:
-        pass
 
     def log_summary(self, path) -> None:
         pass

--- a/src/traceml/renderers/stdout_stderr_renderer.py
+++ b/src/traceml/renderers/stdout_stderr_renderer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import List
 
-from IPython.display import HTML
 from rich.panel import Panel
 from rich.text import Text
 
@@ -86,14 +85,6 @@ class StdoutStderrRenderer(BaseRenderer):
             content,
             title=f"[bold cyan]STDOUT / STDERR (RANK {self._rank})[/bold cyan]",
             border_style="cyan",
-        )
-
-    def get_notebook_renderable(self) -> HTML:
-        """
-        Notebook mode is not currently supported for this renderer.
-        """
-        return HTML(
-            "<pre>Stdout/Stderr renderer disabled in notebook mode.</pre>"
         )
 
     def log_summary(self, path: str) -> None:

--- a/src/traceml/renderers/step_memory/formatter.py
+++ b/src/traceml/renderers/step_memory/formatter.py
@@ -1,0 +1,221 @@
+"""
+Rich formatter for the step-memory CLI renderer.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+from rich.console import Group
+from rich.panel import Panel
+from rich.table import Table
+
+from traceml.core import Formatter
+from traceml.utils.formatting import fmt_mem_new
+
+from .diagnostics import build_step_memory_diagnosis, format_cli_diagnosis
+from .schema import StepMemoryCombinedMetric, StepMemoryCombinedResult
+
+
+class StepMemoryRichFormatter(Formatter[StepMemoryCombinedResult, Panel]):
+    """Format step-memory combined metrics as a Rich panel."""
+
+    name = "step_memory_rich"
+
+    def format(self, payload: StepMemoryCombinedResult) -> Panel:
+        """
+        Convert a step-memory payload into the CLI Rich panel.
+        """
+        if not payload.metrics:
+            return Panel(
+                (
+                    payload.status_message
+                    if payload.status_message
+                    else "Waiting for first fully completed step across all ranks…"
+                ),
+                title="Model Step Memory",
+            )
+
+        metrics = self._sort_metrics(payload.metrics)
+
+        diag = build_step_memory_diagnosis(metrics)
+        diag_text = format_cli_diagnosis(diag)
+
+        # All metrics share the same window size by construction.
+        steps_used = metrics[0].summary.steps_used
+        single_rank = bool(
+            metrics[0].coverage.world_size <= 1
+            or metrics[0].coverage.ranks_present <= 1
+        )
+
+        table = self._build_table(metrics, single_rank=single_rank)
+        subtitle = (
+            f"Peaks over last {steps_used} fully completed steps"
+            if steps_used > 0
+            else "Waiting for first fully completed step"
+        )
+        footer = (
+            "\n\n[dim]Peaks = max over last K aligned steps for the only rank.[/dim]"
+            if single_rank
+            else "\n\n[dim]Peaks = per-rank max over last K; median/worst = across ranks.[/dim]"
+        )
+
+        cols, _ = shutil.get_terminal_size()
+        width = min(max(100, int(cols * 0.75)), 120)
+
+        return Panel(
+            Group(
+                diag_text,
+                "",
+                table,
+                footer,
+            ),
+            title=f"Model Step Memory ({subtitle})",
+            border_style="cyan",
+            width=width,
+        )
+
+    @staticmethod
+    def _sort_metrics(
+        metrics: list[StepMemoryCombinedMetric],
+    ) -> list[StepMemoryCombinedMetric]:
+        """
+        Return metrics in stable CLI display order.
+        """
+
+        def _sort_key(metric: StepMemoryCombinedMetric) -> int:
+            if metric.metric == "peak_allocated":
+                return 0
+            if metric.metric == "peak_reserved":
+                return 1
+            return 99
+
+        return sorted(metrics, key=_sort_key)
+
+    def _build_table(
+        self,
+        metrics: list[StepMemoryCombinedMetric],
+        *,
+        single_rank: bool,
+    ) -> Table:
+        """
+        Build the window-peak summary table.
+        """
+        steps_used = metrics[0].summary.steps_used
+
+        table = Table(
+            show_header=True,
+            header_style="bold blue",
+            box=None,
+            expand=False,
+        )
+
+        table.add_column("Metric", style="magenta")
+        for metric in metrics:
+            table.add_column(
+                self._metric_title(metric.metric), justify="right"
+            )
+
+        if single_rank:
+            table.add_row(
+                f"Peak (max/{steps_used})",
+                *[
+                    fmt_mem_new(metric.summary.worst_peak)
+                    for metric in metrics
+                ],
+            )
+        else:
+            table.add_row(
+                f"Median Peak (max/{steps_used})",
+                *[
+                    fmt_mem_new(metric.summary.median_peak)
+                    for metric in metrics
+                ],
+            )
+            table.add_row(
+                f"Worst Peak (max/{steps_used})",
+                *[
+                    fmt_mem_new(metric.summary.worst_peak)
+                    for metric in metrics
+                ],
+            )
+            table.add_row(
+                "Worst Rank",
+                *[
+                    (
+                        f"r{metric.summary.worst_rank}"
+                        if metric.summary.worst_rank is not None
+                        else "—"
+                    )
+                    for metric in metrics
+                ],
+            )
+            table.add_row(
+                "Skew (%)",
+                *[
+                    f"+{metric.summary.skew_pct * 100:.1f}%"
+                    for metric in metrics
+                ],
+            )
+
+        table.add_row("")
+        table.add_row(
+            "Head/Tail Delta" if single_rank else "Head/Tail Delta (worst)",
+            *[
+                self._format_worst_trend_delta(
+                    metric,
+                    single_rank=single_rank,
+                )
+                for metric in metrics
+            ],
+        )
+
+        return table
+
+    @staticmethod
+    def _metric_title(metric: str) -> str:
+        if metric == "peak_allocated":
+            return "Peak Allocated"
+        if metric == "peak_reserved":
+            return "Peak Reserved"
+        return metric.replace("_", " ").title()
+
+    @staticmethod
+    def _format_worst_trend_delta(
+        metric: StepMemoryCombinedMetric,
+        *,
+        single_rank: bool = False,
+    ) -> str:
+        """
+        Format a stable head-vs-tail delta for the displayed series.
+
+        Multi-rank mode uses the worst series; single-rank mode uses the only
+        rank series, which is stored identically in both median and worst.
+        """
+        series = metric.series
+        values_source = series.median if single_rank else series.worst
+        if not series.steps or not values_source:
+            return "—"
+
+        values = [float(value) for value in values_source]
+        n_values = len(values)
+        if n_values < 2:
+            return "—"
+
+        segment = max(4, int(round(n_values * 0.20)))
+        segment = min(segment, max(1, n_values // 2))
+
+        head_avg = sum(values[:segment]) / segment
+        tail_avg = sum(values[-segment:]) / segment
+        delta = tail_avg - head_avg
+
+        if delta == 0.0:
+            return fmt_mem_new(0.0)
+
+        sign = "+" if delta > 0.0 else "-"
+        return f"{sign}{fmt_mem_new(abs(delta))}"
+
+
+__all__ = [
+    "StepMemoryRichFormatter",
+]

--- a/src/traceml/renderers/step_memory/renderer.py
+++ b/src/traceml/renderers/step_memory/renderer.py
@@ -28,19 +28,15 @@ This table is intentionally stable and low-noise.
 Per-step volatility belongs in plots, not summaries.
 """
 
-import shutil
 from typing import Optional
 
-from rich.console import Group
 from rich.panel import Panel
-from rich.table import Table
 
 from traceml.aggregator.display_drivers.layout import MODEL_MEMORY_LAYOUT
 from traceml.renderers.base_renderer import BaseRenderer
-from traceml.utils.formatting import fmt_mem_new
 
 from .computer import StepMemoryMetricsComputer
-from .diagnostics import build_step_memory_diagnosis, format_cli_diagnosis
+from .formatter import StepMemoryRichFormatter
 from .schema import StepMemoryCombinedResult
 
 
@@ -62,6 +58,7 @@ class StepMemoryRenderer(BaseRenderer):
             layout_section_name=MODEL_MEMORY_LAYOUT,
         )
         self._computer = StepMemoryMetricsComputer(db_path=db_path)
+        self._formatter = StepMemoryRichFormatter()
         self._cached: Optional[StepMemoryCombinedResult] = None
 
     def _payload(self) -> Optional[StepMemoryCombinedResult]:
@@ -92,159 +89,16 @@ class StepMemoryRenderer(BaseRenderer):
         """
         payload = self._payload()
 
-        if payload is None or not payload.metrics:
-            return Panel(
-                (
-                    payload.status_message
-                    if payload is not None and payload.status_message
-                    else "Waiting for first fully completed step across all ranks…"
+        return self._formatter.format(
+            payload
+            if payload is not None
+            else StepMemoryCombinedResult(
+                metrics=[],
+                status_message=(
+                    "Waiting for first fully completed step across all ranks…"
                 ),
-                title="Model Step Memory",
             )
-
-        metrics = payload.metrics
-
-        diag = build_step_memory_diagnosis(metrics)
-        diag_text = format_cli_diagnosis(diag)
-
-        # Stable order: allocated then reserved (if present)
-        def _sort_key(m) -> int:
-            if m.metric == "peak_allocated":
-                return 0
-            if m.metric == "peak_reserved":
-                return 1
-            return 99
-
-        metrics = sorted(metrics, key=_sort_key)
-
-        # All metrics share the same window size by construction
-        K = metrics[0].summary.steps_used
-        single_rank = bool(
-            metrics[0].coverage.world_size <= 1
-            or metrics[0].coverage.ranks_present <= 1
         )
-
-        table = Table(
-            show_header=True,
-            header_style="bold blue",
-            box=None,
-            expand=False,
-        )
-
-        table.add_column("Metric", style="magenta")
-
-        for m in metrics:
-            if m.metric == "peak_allocated":
-                title = "Peak Allocated"
-            elif m.metric == "peak_reserved":
-                title = "Peak Reserved"
-            else:
-                title = m.metric.replace("_", " ").title()
-
-            table.add_column(title, justify="right")
-
-        # Window-peak rows (bytes formatted via fmt_mem_new)
-        if single_rank:
-            table.add_row(
-                f"Peak (max/{K})",
-                *[fmt_mem_new(m.summary.worst_peak) for m in metrics],
-            )
-        else:
-            table.add_row(
-                f"Median Peak (max/{K})",
-                *[fmt_mem_new(m.summary.median_peak) for m in metrics],
-            )
-
-            table.add_row(
-                f"Worst Peak (max/{K})",
-                *[fmt_mem_new(m.summary.worst_peak) for m in metrics],
-            )
-
-            table.add_row(
-                "Worst Rank",
-                *[
-                    (
-                        f"r{m.summary.worst_rank}"
-                        if m.summary.worst_rank is not None
-                        else "—"
-                    )
-                    for m in metrics
-                ],
-            )
-
-            table.add_row(
-                "Skew (%)",
-                *[f"+{m.summary.skew_pct * 100:.1f}%" for m in metrics],
-            )
-
-        # Optional: low-noise trend (use worst series delta)
-        # This is helpful for spotting monotonic growth / fragmentation.
-        table.add_row("")
-        table.add_row(
-            "Head/Tail Delta" if single_rank else "Head/Tail Delta (worst)",
-            *[
-                self._format_worst_trend_delta(m, single_rank=single_rank)
-                for m in metrics
-            ],
-        )
-
-        subtitle = (
-            f"Peaks over last {K} fully completed steps"
-            if K > 0
-            else "Waiting for first fully completed step"
-        )
-
-        cols, _ = shutil.get_terminal_size()
-        width = min(max(100, int(cols * 0.75)), 120)
-
-        footer = (
-            "\n\n[dim]Peaks = max over last K aligned steps for the only rank.[/dim]"
-            if single_rank
-            else "\n\n[dim]Peaks = per-rank max over last K; median/worst = across ranks.[/dim]"
-        )
-
-        return Panel(
-            Group(
-                diag_text,
-                "",
-                table,
-                footer,
-            ),
-            title=f"Model Step Memory ({subtitle})",
-            border_style="cyan",
-            width=width,
-        )
-
-    @staticmethod
-    def _format_worst_trend_delta(m, *, single_rank: bool = False) -> str:
-        """
-        Format a stable head-vs-tail delta for the displayed series.
-
-        Multi-rank mode uses the worst series; single-rank mode uses the only
-        rank series, which is stored identically in both median and worst.
-        """
-        series = m.series
-        values_source = series.median if single_rank else series.worst
-        if not series.steps or not values_source:
-            return "—"
-
-        values = [float(v) for v in values_source]
-        n = len(values)
-        if n < 2:
-            return "—"
-
-        segment = max(4, int(round(n * 0.20)))
-        segment = min(segment, max(1, n // 2))
-
-        head_avg = sum(values[:segment]) / segment
-        tail_avg = sum(values[-segment:]) / segment
-        delta = tail_avg - head_avg
-
-        if delta == 0.0:
-            return fmt_mem_new(0.0)
-
-        sign = "+" if delta > 0.0 else "-"
-        return f"{sign}{fmt_mem_new(abs(delta))}"
 
     def get_dashboard_renderable(self) -> StepMemoryCombinedResult:
         """

--- a/tests/test_base_renderer_contracts.py
+++ b/tests/test_base_renderer_contracts.py
@@ -1,0 +1,72 @@
+from traceml.renderers.base_renderer import (
+    BaseRenderer,
+    CLIRenderer,
+    DashboardRenderer,
+    RendererMetadata,
+)
+
+
+class MetadataOnlyRenderer(BaseRenderer):
+    pass
+
+
+class ExampleCLIRenderer(BaseRenderer):
+    def __init__(self) -> None:
+        super().__init__(name="cli", layout_section_name="cli_section")
+
+    def get_panel_renderable(self) -> str:
+        return "panel"
+
+
+class ExampleDashboardRenderer(BaseRenderer):
+    def __init__(self) -> None:
+        super().__init__(
+            name="dashboard",
+            layout_section_name="dashboard_section",
+        )
+
+    def get_dashboard_renderable(self) -> dict[str, str]:
+        return {"payload": "dashboard"}
+
+
+class ExampleDualRenderer(ExampleCLIRenderer):
+    def get_dashboard_renderable(self) -> dict[str, str]:
+        return {"payload": "dual"}
+
+
+def test_base_renderer_only_owns_shared_metadata() -> None:
+    renderer = MetadataOnlyRenderer(
+        name="metadata",
+        layout_section_name="section",
+    )
+
+    assert renderer.name == "metadata"
+    assert renderer.layout_section_name == "section"
+    assert renderer._latest_data == {}
+    assert isinstance(renderer, RendererMetadata)
+    assert not hasattr(renderer, "get_notebook_renderable")
+
+
+def test_cli_renderer_contract_is_separate_from_dashboard() -> None:
+    renderer = ExampleCLIRenderer()
+
+    assert isinstance(renderer, CLIRenderer)
+    assert not isinstance(renderer, DashboardRenderer)
+    assert renderer.get_panel_renderable() == "panel"
+
+
+def test_dashboard_renderer_contract_is_separate_from_cli() -> None:
+    renderer = ExampleDashboardRenderer()
+
+    assert isinstance(renderer, DashboardRenderer)
+    assert not isinstance(renderer, CLIRenderer)
+    assert renderer.get_dashboard_renderable() == {"payload": "dashboard"}
+
+
+def test_renderer_can_support_both_cli_and_dashboard_contracts() -> None:
+    renderer = ExampleDualRenderer()
+
+    assert isinstance(renderer, CLIRenderer)
+    assert isinstance(renderer, DashboardRenderer)
+    assert renderer.get_panel_renderable() == "panel"
+    assert renderer.get_dashboard_renderable() == {"payload": "dual"}

--- a/tests/test_core_registry.py
+++ b/tests/test_core_registry.py
@@ -1,0 +1,71 @@
+import pytest
+
+from traceml.core import Registry
+
+
+def test_registry_registers_and_fetches_items() -> None:
+    registry: Registry[int] = Registry()
+
+    returned = registry.register("system", 1)
+
+    assert returned == 1
+    assert registry.get("system") == 1
+    assert "system" in registry
+    assert len(registry) == 1
+
+
+def test_registry_preserves_registration_order() -> None:
+    registry = Registry[str](
+        [
+            ("system", "SystemSampler"),
+            ("process", "ProcessSampler"),
+        ]
+    )
+    registry.register("step_time", "StepTimeSampler")
+
+    assert registry.keys() == ("system", "process", "step_time")
+    assert registry.all() == (
+        "SystemSampler",
+        "ProcessSampler",
+        "StepTimeSampler",
+    )
+    assert registry.items() == (
+        ("system", "SystemSampler"),
+        ("process", "ProcessSampler"),
+        ("step_time", "StepTimeSampler"),
+    )
+    assert tuple(registry) == (
+        "SystemSampler",
+        "ProcessSampler",
+        "StepTimeSampler",
+    )
+
+
+def test_registry_rejects_duplicate_keys() -> None:
+    registry = Registry[int]()
+    registry.register("system", 1)
+
+    with pytest.raises(KeyError, match="already registered"):
+        registry.register("system", 2)
+
+
+def test_registry_rejects_missing_keys() -> None:
+    registry = Registry[int]()
+
+    with pytest.raises(KeyError, match="not registered"):
+        registry.get("missing")
+
+
+def test_registry_rejects_empty_keys() -> None:
+    registry = Registry[int]()
+
+    with pytest.raises(ValueError, match="cannot be empty"):
+        registry.register("  ", 1)
+
+
+def test_registry_returns_mapping_copy() -> None:
+    registry = Registry[int]([("system", 1)])
+    mapping = registry.as_mapping()
+
+    assert mapping == {"system": 1}
+    assert mapping is not registry.as_mapping()

--- a/tests/test_step_memory_formatter.py
+++ b/tests/test_step_memory_formatter.py
@@ -1,0 +1,141 @@
+from rich.console import Console
+from rich.panel import Panel
+
+from traceml.renderers.step_memory.formatter import StepMemoryRichFormatter
+from traceml.renderers.step_memory.schema import (
+    StepMemoryCombinedCoverage,
+    StepMemoryCombinedMetric,
+    StepMemoryCombinedResult,
+    StepMemoryCombinedSeries,
+    StepMemoryCombinedSummary,
+)
+
+
+def _metric(
+    name: str,
+    *,
+    world_size: int,
+    ranks_present: int,
+    median_peak: float = 1024.0,
+    worst_peak: float = 2048.0,
+    worst_rank: int | None = 1,
+    skew_pct: float = 1.0,
+) -> StepMemoryCombinedMetric:
+    return StepMemoryCombinedMetric(
+        metric=name,
+        device="cuda:0",
+        series=StepMemoryCombinedSeries(
+            steps=[1, 2, 3, 4, 5, 6],
+            median=[512.0, 512.0, 512.0, 1024.0, 1024.0, 1024.0],
+            worst=[1024.0, 1024.0, 1024.0, 2048.0, 2048.0, 2048.0],
+        ),
+        summary=StepMemoryCombinedSummary(
+            window_size=6,
+            steps_used=6,
+            median_peak=median_peak,
+            worst_peak=worst_peak,
+            worst_rank=worst_rank,
+            skew_ratio=skew_pct,
+            skew_pct=skew_pct,
+        ),
+        coverage=StepMemoryCombinedCoverage(
+            expected_steps=6,
+            steps_used=6,
+            completed_step=6,
+            world_size=world_size,
+            ranks_present=ranks_present,
+            incomplete=False,
+        ),
+    )
+
+
+def _render_text(panel: Panel) -> str:
+    console = Console(
+        force_terminal=True,
+        color_system=None,
+        width=140,
+        record=True,
+    )
+    console.print(panel)
+    return console.export_text()
+
+
+def test_step_memory_formatter_renders_empty_state() -> None:
+    formatter = StepMemoryRichFormatter()
+
+    panel = formatter.format(
+        StepMemoryCombinedResult(
+            metrics=[],
+            status_message="Waiting for memory samples",
+        )
+    )
+
+    assert isinstance(panel, Panel)
+    assert "Model Step Memory" in _render_text(panel)
+    assert "Waiting for memory samples" in _render_text(panel)
+
+
+def test_step_memory_formatter_renders_single_rank_shape() -> None:
+    formatter = StepMemoryRichFormatter()
+
+    text = _render_text(
+        formatter.format(
+            StepMemoryCombinedResult(
+                metrics=[
+                    _metric(
+                        "peak_reserved",
+                        world_size=1,
+                        ranks_present=1,
+                    ),
+                    _metric(
+                        "peak_allocated",
+                        world_size=1,
+                        ranks_present=1,
+                    ),
+                ],
+                status_message="",
+            )
+        )
+    )
+
+    assert "Peak Allocated" in text
+    assert "Peak Reserved" in text
+    assert "Peak (max/6)" in text
+    assert "Head/Tail Delta" in text
+    assert "Median Peak" not in text
+    assert "Peaks = max over last K aligned steps for the only rank." in text
+
+
+def test_step_memory_formatter_renders_multi_rank_shape() -> None:
+    formatter = StepMemoryRichFormatter()
+
+    text = _render_text(
+        formatter.format(
+            StepMemoryCombinedResult(
+                metrics=[
+                    _metric(
+                        "peak_allocated",
+                        world_size=4,
+                        ranks_present=4,
+                    ),
+                    _metric(
+                        "peak_reserved",
+                        world_size=4,
+                        ranks_present=4,
+                    ),
+                ],
+                status_message="",
+            )
+        )
+    )
+
+    assert "Median Peak (max/6)" in text
+    assert "Worst Peak (max/6)" in text
+    assert "Worst Rank" in text
+    assert "r1" in text
+    assert "Skew (%)" in text
+    assert "Head/Tail Delta (worst)" in text
+    assert (
+        "Peaks = per-rank max over last K; median/worst = across ranks."
+        in text
+    )


### PR DESCRIPTION
added a typed core registry, 
improved CLI vs dashboard renderers while removing unused notebook rendering, 
and extracts step-memory Rich formatting into a dedicated formatter.

Also adds focused tests for the registry, renderer contracts, and step-memory formatter.