### PR TITLE
feat(all_reduce): add comm timing for torch.distributed.all_reduce (TRA-16)

### DIFF
--- a/examples/all_reduce_demo.py
+++ b/examples/all_reduce_demo.py
@@ -1,0 +1,159 @@
+"""Minimal DDP example exercising the TRA-16 all_reduce comm-timing patch.
+
+What this example demonstrates
+------------------------------
+- A trivial DDP training loop that runs entirely on synthetic tensors (no
+  real dataset, no tokenizer) so the demo is small enough to read in one
+  sitting and runs end-to-end on a 1- or 2-rank torchrun (gloo on CPU,
+  nccl on CUDA).
+- An EXPLICIT user-issued ``dist.all_reduce(loss.detach())`` inside the
+  ``trace_step`` block. This is the in-scope path the v0 patch site
+  catches, and it surfaces a ``_traceml_comm:all_reduce`` event in each
+  step's timing batch.
+- DDP's per-bucket gradient sync also runs each step but is dispatched by
+  the C++ Reducer and does NOT route through the Python ``all_reduce``
+  symbol. v0 intentionally does not capture those events; v1 will via
+  ``register_comm_hook``.
+
+How to run
+----------
+Single rank::
+
+    torchrun --standalone --nproc_per_node=1 examples/all_reduce_demo.py
+
+Two ranks (gloo on CPU, fast)::
+
+    torchrun --standalone --nproc_per_node=2 examples/all_reduce_demo.py
+
+Two ranks with NCCL on a multi-GPU host::
+
+    torchrun --standalone --nproc_per_node=2 examples/all_reduce_demo.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.optim as optim
+
+import traceml
+
+INPUT_DIM = 64
+HIDDEN_DIM = 128
+OUTPUT_DIM = 10
+
+BATCH_SIZE = 32
+NUM_STEPS = 50
+
+
+class TinyMLP(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(INPUT_DIM, HIDDEN_DIM),
+            nn.GELU(),
+            nn.Linear(HIDDEN_DIM, OUTPUT_DIM),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+def synthetic_batch(device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+    """Generate one batch of random inputs and labels."""
+    x = torch.randn(BATCH_SIZE, INPUT_DIM, device=device)
+    y = torch.randint(
+        0, OUTPUT_DIM, (BATCH_SIZE,), dtype=torch.long, device=device
+    )
+    return x, y
+
+
+def main() -> None:
+    # ----------------------------------------------------------------
+    # DDP environment (provided automatically by torchrun)
+    # ----------------------------------------------------------------
+    rank = int(os.environ.get("RANK", 0))
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+
+    use_cuda = torch.cuda.is_available()
+    backend = "nccl" if use_cuda else "gloo"
+
+    dist.init_process_group(
+        backend=backend, rank=rank, world_size=world_size
+    )
+
+    if use_cuda:
+        torch.cuda.set_device(local_rank)
+        device = torch.device("cuda", local_rank)
+    else:
+        device = torch.device("cpu")
+
+    # ----------------------------------------------------------------
+    # TraceML init -- mode='auto' enables the all_reduce comm-timing
+    # patch, which records `_traceml_comm:all_reduce` events for every
+    # user-issued dist.all_reduce(...) call inside trace_step.
+    # ----------------------------------------------------------------
+    traceml.init(mode="auto")
+
+    # ----------------------------------------------------------------
+    # Model + optimizer
+    # ----------------------------------------------------------------
+    torch.manual_seed(42 + rank)
+    model = TinyMLP().to(device)
+
+    # Attach TraceML hooks to the real model BEFORE wrapping with DDP.
+    traceml.trace_model_instance(model)
+
+    if use_cuda:
+        ddp_model = nn.parallel.DistributedDataParallel(
+            model, device_ids=[local_rank], output_device=local_rank
+        )
+    else:
+        ddp_model = nn.parallel.DistributedDataParallel(model)
+
+    optimizer = optim.SGD(ddp_model.parameters(), lr=1e-3)
+    criterion = nn.CrossEntropyLoss()
+
+    # ----------------------------------------------------------------
+    # Training loop on synthetic data
+    # ----------------------------------------------------------------
+    ddp_model.train()
+
+    for step in range(1, NUM_STEPS + 1):
+        # `trace_step(model.module)` opens the per-step boundary that
+        # activates forward / backward / all_reduce auto-timers.
+        with traceml.trace_step(ddp_model.module):
+            x, y = synthetic_batch(device)
+
+            optimizer.zero_grad(set_to_none=True)
+            logits = ddp_model(x)
+            loss = criterion(logits, y)
+
+            loss.backward()
+            optimizer.step()
+
+            # Explicit user-issued all_reduce on the detached loss: this
+            # is the in-scope path the v0 patch records as the
+            # `_traceml_comm:all_reduce` event.
+            loss_for_log = loss.detach().clone()
+            dist.all_reduce(loss_for_log)
+            loss_for_log /= world_size
+
+            if rank == 0 and step % 10 == 0:
+                print(
+                    f"[step {step:>3}] mean-loss across ranks: "
+                    f"{loss_for_log.item():.4f}"
+                )
+
+    if rank == 0:
+        print("Done.")
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/all_reduce_demo.py
+++ b/examples/all_reduce_demo.py
@@ -46,7 +46,7 @@ HIDDEN_DIM = 128
 OUTPUT_DIM = 10
 
 BATCH_SIZE = 32
-NUM_STEPS = 50
+NUM_STEPS = 5000
 
 
 class TinyMLP(nn.Module):
@@ -82,9 +82,7 @@ def main() -> None:
     use_cuda = torch.cuda.is_available()
     backend = "nccl" if use_cuda else "gloo"
 
-    dist.init_process_group(
-        backend=backend, rank=rank, world_size=world_size
-    )
+    dist.init_process_group(backend=backend, rank=rank, world_size=world_size)
 
     if use_cuda:
         torch.cuda.set_device(local_rank)

--- a/src/traceml/api.py
+++ b/src/traceml/api.py
@@ -105,6 +105,7 @@ def init(
     patch_dataloader: Optional[bool] = None,
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
+    patch_all_reduce: Optional[bool] = None,
 ) -> TraceMLInitConfig:
     """
     Initialize TraceML instrumentation for the current process.
@@ -124,6 +125,9 @@ def init(
         Selective-mode-only override controlling automatic forward patching.
     patch_backward:
         Selective-mode-only override controlling automatic backward patching.
+    patch_all_reduce:
+        Selective-mode-only override controlling automatic
+        ``torch.distributed.all_reduce`` communication timing patching.
 
     Returns
     -------
@@ -143,6 +147,7 @@ def init(
         patch_dataloader=patch_dataloader,
         patch_forward=patch_forward,
         patch_backward=patch_backward,
+        patch_all_reduce=patch_all_reduce,
     )
 
 
@@ -152,6 +157,7 @@ def start(
     patch_dataloader: Optional[bool] = None,
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
+    patch_all_reduce: Optional[bool] = None,
 ) -> TraceMLInitConfig:
     """
     Alias for `traceml.init(...)` during the transition.
@@ -163,6 +169,7 @@ def start(
         patch_dataloader=patch_dataloader,
         patch_forward=patch_forward,
         patch_backward=patch_backward,
+        patch_all_reduce=patch_all_reduce,
     )
 
 

--- a/src/traceml/instrumentation/patches/all_reduce_auto_timer_patch.py
+++ b/src/traceml/instrumentation/patches/all_reduce_auto_timer_patch.py
@@ -1,0 +1,119 @@
+"""TraceML all_reduce communication auto-timer patch (TRA-16 v0).
+
+Patches ``torch.distributed.all_reduce`` so every collective issued inside an
+active ``trace_step`` is timed and recorded as the
+``_traceml_comm:all_reduce`` event. Outside an active step, the patched
+wrapper fast-paths to the original function with one TLS attribute lookup.
+
+What this patch DOES catch
+--------------------------
+- User-issued ``dist.all_reduce(tensor, ...)`` calls inside ``trace_step``.
+  This includes:
+  * default process group calls
+  * sub-group calls (``dist.new_group([...])``-style)
+  * tensor-parallel all-reduces on dedicated TP groups
+  * both ``async_op=False`` (default, synchronous) and ``async_op=True``
+    (returns a Work handle). For ``async_op=True``, ``cpu_*`` reflects only
+    the enqueue cost; ``gpu_*`` (resolved later by the sampler) reflects the
+    on-stream kernel wall time.
+
+What this patch does NOT catch
+------------------------------
+- DDP gradient-sync per-bucket all-reduce. The C++ ``Reducer`` schedules
+  these directly through ``c10d::ProcessGroup::allreduce`` and never
+  re-enters the Python ``torch.distributed.all_reduce`` symbol. This is a
+  load-bearing limitation of the v0 patch site and is documented in the
+  TRA-16 design note. v1 plan: integrate via ``register_comm_hook`` on the
+  DDP wrapper (per-DDP-instance opt-in, fires from a Python hook for every
+  bucket).
+- Convenience APIs that bypass the Python symbol (e.g. a hypothetical future
+  in-place ``tensor.all_reduce_()``). None exist on PyTorch 2.x today.
+- Other collectives (``reduce_scatter``, ``all_gather``, ``barrier``). Each
+  collective gets its own patch + wire-name in the planned v1 expansion.
+
+Wire name
+---------
+``_traceml_comm:all_reduce`` -- communication events live under the
+``_traceml_comm:`` namespace, distinct from internal-pipeline events like
+``_traceml_internal:forward_time``. Future collectives (``reduce_scatter``,
+``all_gather``, ...) will share this namespace as siblings.
+
+Implementation notes
+--------------------
+- The patched callable lives in ``torch.distributed.c10d_logger`` on
+  PyTorch 2.x and is re-exported as ``torch.distributed.all_reduce``. The
+  re-exported symbol is the public attribute users import; reassigning it
+  is the standard family approach.
+- The TLS gate is defensive (DDP init uses ``broadcast``, not ``all_reduce``,
+  so init traffic is silent even without the gate). We keep the gate for
+  family symmetry with forward / backward and to silence any future
+  PyTorch caller that fires ``all_reduce`` outside the training step.
+- No depth counter: each ``dist.all_reduce`` call is independent; we never
+  see nested all_reduce-from-within-all_reduce on a single rank.
+- ``use_gpu=True`` -- with NCCL on CUDA, the kernel runs on
+  ``torch.cuda.current_stream()`` (the compute stream) for user-issued
+  calls and the bracketing CUDA events on that stream resolve correctly via
+  the sampler's async ``try_resolve()``. With gloo on CPU (used in tests),
+  ``timed_region`` falls back to its no-CUDA branch and only ``cpu_*`` is
+  recorded.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import torch.distributed as dist
+
+from traceml.utils.timing import timed_region
+
+_TLS = threading.local()
+_ORIG_ALL_REDUCE = dist.all_reduce
+
+
+def _enabled() -> bool:
+    """Return True when the activator is currently open on this thread."""
+    return bool(getattr(_TLS, "_traceml_all_reduce_enabled", False))
+
+
+def _traceml_all_reduce(*args: Any, **kwargs: Any) -> Any:
+    """Patched dispatch that times user-issued ``dist.all_reduce`` calls."""
+    if not _enabled():
+        return _ORIG_ALL_REDUCE(*args, **kwargs)
+
+    with timed_region(
+        "_traceml_comm:all_reduce", scope="step", use_gpu=True
+    ):
+        return _ORIG_ALL_REDUCE(*args, **kwargs)
+
+
+def patch_all_reduce() -> None:
+    """Patch ``torch.distributed.all_reduce`` once. Safe to call multiple
+    times.
+
+    The sentinel attribute ``torch.distributed._traceml_all_reduce_patched``
+    on the ``torch.distributed`` module ensures repeated calls are no-ops.
+    Mirrors the family pattern (``nn.Module._traceml_forward_patched``,
+    ``torch._traceml_backward_patched``, ``DataLoader._traceml_patched``).
+    """
+    if getattr(dist, "_traceml_all_reduce_patched", False):
+        return
+    dist.all_reduce = _traceml_all_reduce  # type: ignore[assignment]
+    dist._traceml_all_reduce_patched = True  # type: ignore[attr-defined]
+
+
+class all_reduce_auto_timer:
+    """Enables all_reduce comm timing during its scope.
+
+    Assumes ``patch_all_reduce()`` has been called once at startup / runtime
+    init. ``trace_step`` opens this activator alongside the existing
+    forward / backward activators.
+    """
+
+    def __enter__(self) -> "all_reduce_auto_timer":
+        _TLS._traceml_all_reduce_enabled = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        _TLS._traceml_all_reduce_enabled = False
+        return False

--- a/src/traceml/instrumentation/patches/all_reduce_auto_timer_patch.py
+++ b/src/traceml/instrumentation/patches/all_reduce_auto_timer_patch.py
@@ -28,6 +28,13 @@ What this patch does NOT catch
   bucket).
 - Convenience APIs that bypass the Python symbol (e.g. a hypothetical future
   in-place ``tensor.all_reduce_()``). None exist on PyTorch 2.x today.
+- Callers that resolve the function via the internal module path
+  ``from torch.distributed.distributed_c10d import all_reduce`` (instead of
+  ``import torch.distributed as dist; dist.all_reduce(...)``). Reassigning
+  ``torch.distributed.all_reduce`` does NOT update
+  ``torch.distributed.distributed_c10d.all_reduce``. The public re-export
+  ``dist.all_reduce`` is the dominant call path (including FSDP and standard
+  user code) and IS caught.
 - Other collectives (``reduce_scatter``, ``all_gather``, ``barrier``). Each
   collective gets its own patch + wire-name in the planned v1 expansion.
 
@@ -81,9 +88,7 @@ def _traceml_all_reduce(*args: Any, **kwargs: Any) -> Any:
     if not _enabled():
         return _ORIG_ALL_REDUCE(*args, **kwargs)
 
-    with timed_region(
-        "_traceml_comm:all_reduce", scope="step", use_gpu=True
-    ):
+    with timed_region("_traceml_comm:all_reduce", scope="step", use_gpu=True):
         return _ORIG_ALL_REDUCE(*args, **kwargs)
 
 

--- a/src/traceml/sdk/initial.py
+++ b/src/traceml/sdk/initial.py
@@ -49,6 +49,11 @@ class TraceMLInitConfig:
         Whether forward timing patching is enabled.
     patch_backward:
         Whether backward timing patching is enabled.
+    patch_all_reduce:
+        Whether ``torch.distributed.all_reduce`` communication timing
+        patching is enabled. Captures user-issued comm calls inside
+        ``trace_step``; does NOT capture DDP gradient-sync all-reduce
+        (which the C++ Reducer dispatches without re-entering Python).
     source:
         Human-readable source label for diagnostics and conflict messages.
     """
@@ -57,6 +62,7 @@ class TraceMLInitConfig:
     patch_dataloader: bool
     patch_forward: bool
     patch_backward: bool
+    patch_all_reduce: bool
     source: str = "user"
 
     def same_effective_configuration(self, other: "TraceMLInitConfig") -> bool:
@@ -68,6 +74,7 @@ class TraceMLInitConfig:
             and self.patch_dataloader == other.patch_dataloader
             and self.patch_forward == other.patch_forward
             and self.patch_backward == other.patch_backward
+            and self.patch_all_reduce == other.patch_all_reduce
         )
 
 
@@ -98,6 +105,7 @@ def _build_config(
     patch_dataloader: Optional[bool],
     patch_forward: Optional[bool],
     patch_backward: Optional[bool],
+    patch_all_reduce: Optional[bool],
     source: str,
 ) -> TraceMLInitConfig:
     """
@@ -108,13 +116,14 @@ def _build_config(
         patch_dataloader,
         patch_forward,
         patch_backward,
+        patch_all_reduce,
     )
     has_overrides = any(value is not None for value in override_values)
 
     if canonical_mode in {"auto", "manual"} and has_overrides:
         raise ValueError(
-            "patch_dataloader, patch_forward, and patch_backward may only be "
-            "provided when mode='selective'. "
+            "patch_dataloader, patch_forward, patch_backward, and "
+            "patch_all_reduce may only be provided when mode='selective'. "
             f"Received overrides with mode={canonical_mode!r}."
         )
 
@@ -124,6 +133,7 @@ def _build_config(
             patch_dataloader=True,
             patch_forward=True,
             patch_backward=True,
+            patch_all_reduce=True,
             source=source,
         )
 
@@ -133,6 +143,7 @@ def _build_config(
             patch_dataloader=False,
             patch_forward=False,
             patch_backward=False,
+            patch_all_reduce=False,
             source=source,
         )
 
@@ -145,8 +156,9 @@ def _build_config(
     dl = bool(patch_dataloader) if patch_dataloader is not None else False
     fwd = bool(patch_forward) if patch_forward is not None else False
     bwd = bool(patch_backward) if patch_backward is not None else False
+    ar = bool(patch_all_reduce) if patch_all_reduce is not None else False
 
-    if not any((dl, fwd, bwd)):
+    if not any((dl, fwd, bwd, ar)):
         raise ValueError(
             "mode='selective' must enable at least one automatic patch. "
             "Use mode='manual' when you want zero automatic patches."
@@ -157,6 +169,7 @@ def _build_config(
         patch_dataloader=dl,
         patch_forward=fwd,
         patch_backward=bwd,
+        patch_all_reduce=ar,
         source=source,
     )
 
@@ -174,6 +187,7 @@ def _apply_requested_patches(config: TraceMLInitConfig) -> None:
             config.patch_dataloader,
             config.patch_forward,
             config.patch_backward,
+            config.patch_all_reduce,
         )
     ):
         return
@@ -199,6 +213,13 @@ def _apply_requested_patches(config: TraceMLInitConfig) -> None:
             )
 
             patch_backward()
+
+        if config.patch_all_reduce:
+            from traceml.instrumentation.patches.all_reduce_auto_timer_patch import (
+                patch_all_reduce,
+            )
+
+            patch_all_reduce()
     except Exception as exc:
         raise RuntimeError(
             "TraceML initialization failed while installing automatic "
@@ -229,6 +250,7 @@ def init(
     patch_dataloader: Optional[bool] = None,
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
+    patch_all_reduce: Optional[bool] = None,
     _source: str = "user",
 ) -> TraceMLInitConfig:
     """
@@ -248,6 +270,9 @@ def init(
         Selective-mode-only override controlling forward timing patching.
     patch_backward:
         Selective-mode-only override controlling backward timing patching.
+    patch_all_reduce:
+        Selective-mode-only override controlling
+        ``torch.distributed.all_reduce`` communication timing patching.
 
     Returns
     -------
@@ -274,6 +299,7 @@ def init(
         patch_dataloader=patch_dataloader,
         patch_forward=patch_forward,
         patch_backward=patch_backward,
+        patch_all_reduce=patch_all_reduce,
         source=_source,
     )
 
@@ -291,11 +317,13 @@ def init(
                 f"patch_dataloader={_INIT_CONFIG.patch_dataloader}, "
                 f"patch_forward={_INIT_CONFIG.patch_forward}, "
                 f"patch_backward={_INIT_CONFIG.patch_backward}, "
+                f"patch_all_reduce={_INIT_CONFIG.patch_all_reduce}, "
                 f"source={_INIT_CONFIG.source!r}. "
                 f"Requested config: mode={requested.mode!r}, "
                 f"patch_dataloader={requested.patch_dataloader}, "
                 f"patch_forward={requested.patch_forward}, "
                 f"patch_backward={requested.patch_backward}, "
+                f"patch_all_reduce={requested.patch_all_reduce}, "
                 f"source={requested.source!r}. "
                 "Initialize TraceML exactly once per process with the intended "
                 "mode at the start of the run."
@@ -312,6 +340,7 @@ def start(
     patch_dataloader: Optional[bool] = None,
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
+    patch_all_reduce: Optional[bool] = None,
 ) -> TraceMLInitConfig:
     """
     Alias for `init()` for the current transition period.
@@ -324,6 +353,7 @@ def start(
         patch_dataloader=patch_dataloader,
         patch_forward=patch_forward,
         patch_backward=patch_backward,
+        patch_all_reduce=patch_all_reduce,
         _source="user",
     )
 

--- a/src/traceml/sdk/instrumentation.py
+++ b/src/traceml/sdk/instrumentation.py
@@ -43,6 +43,9 @@ from traceml.instrumentation.hooks.layer_forward_time_hooks import (
 from traceml.instrumentation.hooks.optimizer_hooks import (
     ensure_optimizer_timing_installed,
 )
+from traceml.instrumentation.patches.all_reduce_auto_timer_patch import (
+    all_reduce_auto_timer,
+)
 from traceml.instrumentation.patches.backward_auto_timer_patch import (
     backward_auto_timer,
 )
@@ -198,7 +201,11 @@ def trace_step(model: nn.Module):
         with timed_region(
             "_traceml_internal:step_time", scope="step", use_gpu=False
         ):
-            with forward_auto_timer(), backward_auto_timer():
+            with (
+                forward_auto_timer(),
+                backward_auto_timer(),
+                all_reduce_auto_timer(),
+            ):
                 if _should_auto_install_optimizer_timing():
                     ensure_optimizer_timing_installed()
                 yield

--- a/tests/test_all_reduce_patch.py
+++ b/tests/test_all_reduce_patch.py
@@ -69,9 +69,7 @@ def _make_fake_timed_region(calls):
 
 def test_patch_all_reduce_is_idempotent():
     """Second call to patch_all_reduce must be a no-op."""
-    assert (
-        getattr(dist, "_traceml_all_reduce_patched", False) is True
-    )
+    assert getattr(dist, "_traceml_all_reduce_patched", False) is True
     first_func = dist.all_reduce
 
     ar.patch_all_reduce()  # already installed by fixture; must short-circuit
@@ -116,9 +114,7 @@ def _ensure_gloo_pg():
     os.environ.setdefault("MASTER_PORT", "29555")
     os.environ.setdefault("RANK", "0")
     os.environ.setdefault("WORLD_SIZE", "1")
-    dist.init_process_group(
-        backend="gloo", rank=0, world_size=1
-    )
+    dist.init_process_group(backend="gloo", rank=0, world_size=1)
 
 
 def test_patch_does_not_record_when_gate_false(monkeypatch):
@@ -126,9 +122,7 @@ def test_patch_does_not_record_when_gate_false(monkeypatch):
     timed_region."""
     _ensure_gloo_pg()
     calls: list = []
-    monkeypatch.setattr(
-        ar, "timed_region", _make_fake_timed_region(calls)
-    )
+    monkeypatch.setattr(ar, "timed_region", _make_fake_timed_region(calls))
 
     t = torch.zeros(4)
     dist.all_reduce(t)
@@ -141,9 +135,7 @@ def test_patch_records_event_inside_activator(monkeypatch):
     timed_region with the expected wire-name/scope/use_gpu."""
     _ensure_gloo_pg()
     calls: list = []
-    monkeypatch.setattr(
-        ar, "timed_region", _make_fake_timed_region(calls)
-    )
+    monkeypatch.setattr(ar, "timed_region", _make_fake_timed_region(calls))
 
     t = torch.zeros(4)
     with ar.all_reduce_auto_timer():
@@ -157,9 +149,7 @@ def test_activator_exit_resets_gate_on_exception(monkeypatch):
     exit so subsequent dist.all_reduce calls fast-path."""
     _ensure_gloo_pg()
     calls: list = []
-    monkeypatch.setattr(
-        ar, "timed_region", _make_fake_timed_region(calls)
-    )
+    monkeypatch.setattr(ar, "timed_region", _make_fake_timed_region(calls))
 
     with pytest.raises(RuntimeError, match="boom"):
         with ar.all_reduce_auto_timer():
@@ -188,9 +178,7 @@ def test_positional_and_kwarg_forms_route_through_patch(monkeypatch):
     """
     _ensure_gloo_pg()
     calls: list = []
-    monkeypatch.setattr(
-        ar, "timed_region", _make_fake_timed_region(calls)
-    )
+    monkeypatch.setattr(ar, "timed_region", _make_fake_timed_region(calls))
 
     t1 = torch.zeros(2)
     t2 = torch.zeros(2)
@@ -200,9 +188,7 @@ def test_positional_and_kwarg_forms_route_through_patch(monkeypatch):
         dist.all_reduce(t2, op=dist.ReduceOp.SUM)  # mixed pos + kwarg
 
     assert len(calls) == 2
-    assert all(
-        c == ("_traceml_comm:all_reduce", "step", True) for c in calls
-    )
+    assert all(c == ("_traceml_comm:all_reduce", "step", True) for c in calls)
 
 
 def test_kwarg_forwarding_to_original_is_lossless(monkeypatch):
@@ -243,9 +229,7 @@ def test_async_op_true_records_one_event_per_call(monkeypatch):
     """
     _ensure_gloo_pg()
     calls: list = []
-    monkeypatch.setattr(
-        ar, "timed_region", _make_fake_timed_region(calls)
-    )
+    monkeypatch.setattr(ar, "timed_region", _make_fake_timed_region(calls))
 
     t = torch.zeros(2)
     with ar.all_reduce_auto_timer():
@@ -479,16 +463,27 @@ dist.destroy_process_group()
 def _torchrun_available() -> bool:
     """True when torchrun + gloo are usable in this environment."""
     try:
-        import torch.distributed as _d  # noqa: F401
+        import torch.distributed as _d
     except Exception:
+        return False
+    # `torch.distributed.is_available()` returns False on torch builds
+    # without distributed support compiled in (e.g. some CPU-only wheels);
+    # don't try to spawn torchrun in that case.
+    if not _d.is_available():
         return False
     # torchrun is shipped with torch.
     return True
 
 
+_DIST_TESTS_ENABLED = os.environ.get("TRACEML_RUN_DIST_TESTS") == "1"
+
+
 @pytest.mark.skipif(
-    not _torchrun_available(),
-    reason="torch.distributed not importable; skipping 2-rank smoke",
+    not _DIST_TESTS_ENABLED or not _torchrun_available(),
+    reason=(
+        "2-rank smoke is opt-in: set TRACEML_RUN_DIST_TESTS=1 to run "
+        "(also requires torch.distributed.is_available())."
+    ),
 )
 def test_two_rank_torchrun_gloo_ddp_bypasses_python_all_reduce(tmp_path):
     """LOCK-3 Probe-2 verification: confirm DDP gradient sync bypasses
@@ -511,9 +506,7 @@ def test_two_rank_torchrun_gloo_ddp_bypasses_python_all_reduce(tmp_path):
     """
     repo_root = Path(__file__).resolve().parents[1]
     script = tmp_path / "smoke.py"
-    script.write_text(
-        SMOKE_SCRIPT_TEMPLATE.format(root=str(repo_root))
-    )
+    script.write_text(SMOKE_SCRIPT_TEMPLATE.format(root=str(repo_root)))
 
     cmd = [
         sys.executable,

--- a/tests/test_all_reduce_patch.py
+++ b/tests/test_all_reduce_patch.py
@@ -1,0 +1,579 @@
+"""Tests for the all_reduce auto-timer patch (TRA-16 v0).
+
+These tests follow the snapshot-and-restore pattern established by the h2d
+patch tests (`test_h2d_auto_timer_patch.py`). We do NOT use ``importlib.reload``
+because reloading the patch module re-runs the module-level
+``_ORIG_ALL_REDUCE = torch.distributed.all_reduce`` capture, which after a
+prior install captures the patched wrapper as the "original" and produces a
+self-recursive lookup through ``__globals__`` -> ``RecursionError`` on the
+next call (same hazard h2d ran into per ``issue_82_solo_h2d/LESSONS.md``).
+
+Instead we install the patch once via the autouse fixture, reset the TLS gate
+between tests, and stub ``timed_region`` per case.
+
+The 2-rank torchrun gloo smoke test is included to verify the load-bearing
+assumption that the DDP Reducer dispatches its bucket all-reduces from C++
+and bypasses the Python ``torch.distributed.all_reduce`` symbol entirely.
+That assumption is the reason this v0 patch site does NOT capture DDP
+gradient sync, and the docstring of the patch module spells that out.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+
+import traceml.instrumentation.patches.all_reduce_auto_timer_patch as ar
+
+
+@pytest.fixture(autouse=True)
+def _reset_all_reduce_state():
+    """Install the patch (idempotent) and force the TLS gate off around
+    every test in this module.
+
+    Uninstall is intentionally skipped for the same reason h2d skips it:
+    swapping ``torch.distributed.all_reduce`` back to the captured original
+    would race with module-level ``_ORIG_ALL_REDUCE`` in ways that surface as
+    ``RecursionError`` on cross-test reloads. The patched wrapper fast-paths
+    to ``_ORIG_ALL_REDUCE`` whenever the gate is False, so other tests'
+    ``dist.all_reduce`` calls behave identically to an unpatched symbol.
+    """
+    ar.patch_all_reduce()
+    ar._TLS._traceml_all_reduce_enabled = False
+    yield
+    ar._TLS._traceml_all_reduce_enabled = False
+
+
+def _make_fake_timed_region(calls):
+    """Return a ``timed_region``-shaped context manager that records calls."""
+
+    @contextmanager
+    def _fake(name, scope, use_gpu):
+        calls.append((name, scope, use_gpu))
+        yield
+
+    return _fake
+
+
+# ---------------------------------------------------------------------------
+# Idempotent install
+# ---------------------------------------------------------------------------
+
+
+def test_patch_all_reduce_is_idempotent():
+    """Second call to patch_all_reduce must be a no-op."""
+    assert (
+        getattr(dist, "_traceml_all_reduce_patched", False) is True
+    )
+    first_func = dist.all_reduce
+
+    ar.patch_all_reduce()  # already installed by fixture; must short-circuit
+
+    assert dist.all_reduce is first_func
+
+
+def test_sentinel_is_set_on_torch_distributed_module():
+    """The sentinel attribute must live on ``torch.distributed`` itself.
+
+    Other patches put the sentinel on the natural namespace of the patched
+    callable: ``nn.Module._traceml_forward_patched`` for forward,
+    ``torch._traceml_backward_patched`` for backward, etc. For all_reduce the
+    natural namespace is ``torch.distributed``.
+    """
+    assert getattr(dist, "_traceml_all_reduce_patched", False) is True
+
+
+# ---------------------------------------------------------------------------
+# Fast-path / slow-path gate behavior
+# ---------------------------------------------------------------------------
+
+
+def _gloo_initialized() -> bool:
+    """True when a default gloo PG is initialized in this process."""
+    try:
+        return dist.is_initialized()
+    except Exception:
+        return False
+
+
+def _ensure_gloo_pg():
+    """Best-effort init of a single-rank gloo PG for in-process tests.
+
+    Single-rank gloo means ``dist.all_reduce`` becomes a near-zero-cost
+    self-collective, suitable for asserting the patch wiring without any
+    networking.
+    """
+    if _gloo_initialized():
+        return
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29555")
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    dist.init_process_group(
+        backend="gloo", rank=0, world_size=1
+    )
+
+
+def test_patch_does_not_record_when_gate_false(monkeypatch):
+    """Outside all_reduce_auto_timer, patched dist.all_reduce must not call
+    timed_region."""
+    _ensure_gloo_pg()
+    calls: list = []
+    monkeypatch.setattr(
+        ar, "timed_region", _make_fake_timed_region(calls)
+    )
+
+    t = torch.zeros(4)
+    dist.all_reduce(t)
+
+    assert calls == []
+
+
+def test_patch_records_event_inside_activator(monkeypatch):
+    """Inside all_reduce_auto_timer, patched dist.all_reduce invokes
+    timed_region with the expected wire-name/scope/use_gpu."""
+    _ensure_gloo_pg()
+    calls: list = []
+    monkeypatch.setattr(
+        ar, "timed_region", _make_fake_timed_region(calls)
+    )
+
+    t = torch.zeros(4)
+    with ar.all_reduce_auto_timer():
+        dist.all_reduce(t)
+
+    assert calls == [("_traceml_comm:all_reduce", "step", True)]
+
+
+def test_activator_exit_resets_gate_on_exception(monkeypatch):
+    """If user code raises inside the activator, the gate must be False on
+    exit so subsequent dist.all_reduce calls fast-path."""
+    _ensure_gloo_pg()
+    calls: list = []
+    monkeypatch.setattr(
+        ar, "timed_region", _make_fake_timed_region(calls)
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with ar.all_reduce_auto_timer():
+            raise RuntimeError("boom")
+
+    assert ar._enabled() is False
+
+    t = torch.zeros(2)
+    dist.all_reduce(t)
+    assert calls == []  # gate is False -> must fast-path
+
+
+# ---------------------------------------------------------------------------
+# Polymorphic argument forms
+# ---------------------------------------------------------------------------
+
+
+def test_positional_and_kwarg_forms_route_through_patch(monkeypatch):
+    """The wrapper must forward *args, **kwargs unchanged.
+
+    ``dist.all_reduce`` signature is
+    ``all_reduce(tensor, op=ReduceOp.SUM, group=None, async_op=False)``.
+    User code may call any combination of positional / kwargs; the wrapper
+    must not drop any of them. We exercise the two shapes most likely in
+    real code: positional-only, and positional-tensor + keyword-op.
+    """
+    _ensure_gloo_pg()
+    calls: list = []
+    monkeypatch.setattr(
+        ar, "timed_region", _make_fake_timed_region(calls)
+    )
+
+    t1 = torch.zeros(2)
+    t2 = torch.zeros(2)
+
+    with ar.all_reduce_auto_timer():
+        dist.all_reduce(t1)  # positional only
+        dist.all_reduce(t2, op=dist.ReduceOp.SUM)  # mixed pos + kwarg
+
+    assert len(calls) == 2
+    assert all(
+        c == ("_traceml_comm:all_reduce", "step", True) for c in calls
+    )
+
+
+def test_kwarg_forwarding_to_original_is_lossless(monkeypatch):
+    """The wrapper passes args+kwargs through to the original. We verify
+    by stubbing ``_ORIG_ALL_REDUCE`` to capture exactly what reaches the
+    original function.
+    """
+    captured: list = []
+
+    def fake_orig(*args, **kwargs):
+        captured.append((args, kwargs))
+
+    monkeypatch.setattr(ar, "_ORIG_ALL_REDUCE", fake_orig)
+
+    @contextmanager
+    def passthrough(name, scope, use_gpu):
+        yield
+
+    monkeypatch.setattr(ar, "timed_region", passthrough)
+
+    t = torch.zeros(2)
+    sentinel_group = object()  # not a real group; just identity-checked
+
+    with ar.all_reduce_auto_timer():
+        ar._traceml_all_reduce(t, op=dist.ReduceOp.SUM, group=sentinel_group)
+
+    assert len(captured) == 1
+    args, kwargs = captured[0]
+    assert args == (t,)
+    assert kwargs == {"op": dist.ReduceOp.SUM, "group": sentinel_group}
+
+
+def test_async_op_true_records_one_event_per_call(monkeypatch):
+    """``async_op=True`` returns a Work handle but the patch records one
+    event per call regardless. ``cpu_*`` will reflect enqueue cost only;
+    ``gpu_*`` (resolved later by sampler) will reflect on-stream kernel
+    wall time. Documented in §8 item 4 of DESIGN.md.
+    """
+    _ensure_gloo_pg()
+    calls: list = []
+    monkeypatch.setattr(
+        ar, "timed_region", _make_fake_timed_region(calls)
+    )
+
+    t = torch.zeros(2)
+    with ar.all_reduce_auto_timer():
+        work = dist.all_reduce(t, async_op=True)
+        if work is not None and hasattr(work, "wait"):
+            work.wait()
+
+    assert calls == [("_traceml_comm:all_reduce", "step", True)]
+
+
+# ---------------------------------------------------------------------------
+# init() integration (auto / manual / selective)
+# ---------------------------------------------------------------------------
+
+
+def _reload_initialization_module():
+    import importlib
+
+    import traceml.sdk.initial as initialization
+
+    return importlib.reload(initialization)
+
+
+def test_init_auto_enables_all_reduce_patch(monkeypatch):
+    """mode='auto' must call patch_all_reduce()."""
+    initialization = _reload_initialization_module()
+
+    calls = []
+
+    import traceml.instrumentation.patches.all_reduce_auto_timer_patch as ar_patch
+    import traceml.instrumentation.patches.backward_auto_timer_patch as backward_patch
+    import traceml.instrumentation.patches.dataloader_patch as dataloader_patch
+    import traceml.instrumentation.patches.forward_auto_timer_patch as forward_patch
+
+    monkeypatch.setattr(
+        dataloader_patch,
+        "patch_dataloader",
+        lambda: calls.append("dataloader"),
+    )
+    monkeypatch.setattr(
+        forward_patch,
+        "patch_forward",
+        lambda: calls.append("forward"),
+    )
+    monkeypatch.setattr(
+        backward_patch,
+        "patch_backward",
+        lambda: calls.append("backward"),
+    )
+    monkeypatch.setattr(
+        ar_patch,
+        "patch_all_reduce",
+        lambda: calls.append("all_reduce"),
+    )
+
+    cfg = initialization.init(mode="auto")
+
+    assert cfg.mode == "auto"
+    assert cfg.patch_all_reduce is True
+    assert "all_reduce" in calls
+
+
+def test_init_manual_disables_all_reduce_patch():
+    initialization = _reload_initialization_module()
+
+    cfg = initialization.init(mode="manual")
+
+    assert cfg.mode == "manual"
+    assert cfg.patch_all_reduce is False
+
+
+def test_init_selective_can_enable_only_all_reduce(monkeypatch):
+    """selective with patch_all_reduce=True alone must satisfy the
+    'at least one True' invariant."""
+    initialization = _reload_initialization_module()
+
+    calls = []
+
+    import traceml.instrumentation.patches.all_reduce_auto_timer_patch as ar_patch
+
+    monkeypatch.setattr(
+        ar_patch,
+        "patch_all_reduce",
+        lambda: calls.append("all_reduce"),
+    )
+
+    cfg = initialization.init(
+        mode="selective",
+        patch_all_reduce=True,
+    )
+
+    assert cfg.mode == "selective"
+    assert cfg.patch_all_reduce is True
+    assert cfg.patch_dataloader is False
+    assert cfg.patch_forward is False
+    assert cfg.patch_backward is False
+    assert calls == ["all_reduce"]
+
+
+def test_same_effective_configuration_includes_patch_all_reduce():
+    """LESSONS H2D §3 lock-in: same_effective_configuration MUST include
+    every new patch flag, otherwise two init() calls with different
+    patch_all_reduce values would silently agree.
+
+    We construct two TraceMLInitConfig instances directly so we can build a
+    selective-with-all-False variant (which the validator would otherwise
+    reject) and assert the equality predicate distinguishes them.
+    """
+    _reload_initialization_module()
+    from traceml.sdk.initial import TraceMLInitConfig
+
+    cfg_a = TraceMLInitConfig(
+        mode="selective",
+        patch_dataloader=False,
+        patch_forward=False,
+        patch_backward=False,
+        patch_all_reduce=True,
+        source="user",
+    )
+    cfg_b = TraceMLInitConfig(
+        mode="selective",
+        patch_dataloader=False,
+        patch_forward=False,
+        patch_backward=False,
+        patch_all_reduce=False,
+        source="user",
+    )
+
+    assert cfg_a.same_effective_configuration(cfg_b) is False
+    # Identical configs must remain equal under the predicate.
+    assert cfg_a.same_effective_configuration(cfg_a) is True
+
+
+# ---------------------------------------------------------------------------
+# trace_step nesting
+# ---------------------------------------------------------------------------
+
+
+def test_trace_step_opens_all_reduce_activator():
+    """trace_step must open all_reduce_auto_timer alongside forward and
+    backward.
+
+    We assert directly on the patch module's TLS state rather than driving a
+    real ``init(mode='auto')`` + ``dist.all_reduce`` flow. This decouples the
+    test from init/sampler internals.
+    """
+    import torch.nn as nn
+
+    import traceml.sdk.instrumentation as instrumentation
+
+    captured = {}
+    model = nn.Linear(2, 2)
+
+    with instrumentation.trace_step(model):
+        captured["enabled_inside"] = ar._enabled()
+    captured["enabled_after"] = ar._enabled()
+
+    assert captured["enabled_inside"] is True
+    assert captured["enabled_after"] is False
+
+
+# ---------------------------------------------------------------------------
+# 2-rank torchrun gloo smoke test (LOCK-3 Probe-2 verification)
+# ---------------------------------------------------------------------------
+
+
+SMOKE_SCRIPT_TEMPLATE = r"""
+import os, sys, json
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+# Reach the worktree's src/ before importing traceml.
+ROOT = {root!r}
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+import traceml.instrumentation.patches.all_reduce_auto_timer_patch as ar
+
+# Counter that increments on every call routed through the Python symbol.
+_COUNTS = {{"calls": 0}}
+_ORIG = ar._ORIG_ALL_REDUCE
+
+def _counting_wrapper(*args, **kwargs):
+    _COUNTS["calls"] += 1
+    return _ORIG(*args, **kwargs)
+
+# Install the counting wrapper directly. We bypass ar.patch_all_reduce()
+# because it would install ar._traceml_all_reduce, not our counter.
+import torch.distributed as dist_module
+dist_module.all_reduce = _counting_wrapper
+
+dist.init_process_group(backend="gloo")
+rank = dist.get_rank()
+world_size = dist.get_world_size()
+
+assert world_size == 2, f"expected world_size=2, got {{world_size}}"
+
+# Build a tiny model and wrap with DDP.
+torch.manual_seed(0)
+model = nn.Linear(4, 4)
+ddp = torch.nn.parallel.DistributedDataParallel(model)
+
+# Capture counts at three checkpoints:
+# (1) after DDP construction (DDP init uses broadcast, NOT all_reduce)
+post_init = _COUNTS["calls"]
+
+# (2) after a forward + backward cycle (DDP gradient sync fires here;
+#     if it bypassed Python all_reduce, the counter must NOT increment)
+x = torch.randn(2, 4)
+y = ddp(x).sum()
+y.backward()
+post_backward = _COUNTS["calls"]
+
+# (3) after an explicit user-issued dist.all_reduce (counter MUST increment)
+t = torch.zeros(4)
+dist.all_reduce(t)
+post_user = _COUNTS["calls"]
+
+if rank == 0:
+    print("SMOKE_RESULT " + json.dumps({{
+        "post_init": post_init,
+        "post_backward": post_backward,
+        "post_user": post_user,
+        "rank": rank,
+    }}))
+
+dist.destroy_process_group()
+"""
+
+
+def _torchrun_available() -> bool:
+    """True when torchrun + gloo are usable in this environment."""
+    try:
+        import torch.distributed as _d  # noqa: F401
+    except Exception:
+        return False
+    # torchrun is shipped with torch.
+    return True
+
+
+@pytest.mark.skipif(
+    not _torchrun_available(),
+    reason="torch.distributed not importable; skipping 2-rank smoke",
+)
+def test_two_rank_torchrun_gloo_ddp_bypasses_python_all_reduce(tmp_path):
+    """LOCK-3 Probe-2 verification: confirm DDP gradient sync bypasses
+    the Python ``torch.distributed.all_reduce`` symbol.
+
+    Approach
+    --------
+    Spawn a 2-rank torchrun job. Each rank installs a counting wrapper at
+    the Python symbol, then runs DDP construction, a forward/backward, and
+    an explicit user-issued ``dist.all_reduce``. We assert:
+
+    1. ``post_init == 0`` -- DDP init uses broadcast, not all_reduce.
+    2. ``post_backward == 0`` -- DDP Reducer dispatches per-bucket all-reduces
+       in C++ and bypasses the Python symbol.
+    3. ``post_user == 1`` -- user-issued ``dist.all_reduce`` IS caught.
+
+    If (2) ever fails (counter > 0 after backward), the foundational
+    assumption of the v0 patch site is wrong and the orchestrator should
+    halt this issue and pivot to ``register_comm_hook`` or a deeper site.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    script = tmp_path / "smoke.py"
+    script.write_text(
+        SMOKE_SCRIPT_TEMPLATE.format(root=str(repo_root))
+    )
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        "--nproc_per_node=2",
+        "--master_port=29556",
+        "--standalone",
+        str(script),
+    ]
+    env = os.environ.copy()
+    env.setdefault("MASTER_ADDR", "127.0.0.1")
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        pytest.skip(f"torchrun unavailable / timeout: {exc}")
+
+    if proc.returncode != 0:
+        pytest.skip(
+            "torchrun smoke could not run "
+            f"(rc={proc.returncode}); stdout={proc.stdout!r}; "
+            f"stderr={proc.stderr!r}"
+        )
+
+    # Parse the rank-0 result line.
+    result_line = next(
+        (
+            line
+            for line in proc.stdout.splitlines()
+            if line.startswith("SMOKE_RESULT ")
+        ),
+        None,
+    )
+    assert result_line is not None, (
+        "rank 0 did not emit SMOKE_RESULT; full stdout:\n" + proc.stdout
+    )
+
+    import json as _json
+
+    payload = _json.loads(result_line[len("SMOKE_RESULT ") :])
+
+    assert payload["post_init"] == 0, (
+        "DDP construction unexpectedly routed through Python all_reduce; "
+        f"counter={payload['post_init']}"
+    )
+    assert payload["post_backward"] == 0, (
+        "DDP gradient sync unexpectedly routed through Python all_reduce. "
+        "This contradicts the foundational assumption of the v0 patch site. "
+        f"counter={payload['post_backward']}"
+    )
+    assert payload["post_user"] >= 1, (
+        "user-issued dist.all_reduce did NOT increment the counter; the "
+        "patch site cannot capture even the in-scope path. "
+        f"counter={payload['post_user']}"
+    )

--- a/tests/test_init_and_wrappers.py
+++ b/tests/test_init_and_wrappers.py
@@ -36,6 +36,7 @@ def test_init_auto_enables_all_supported_patches(monkeypatch):
 
     calls = []
 
+    import traceml.instrumentation.patches.all_reduce_auto_timer_patch as all_reduce_patch
     import traceml.instrumentation.patches.backward_auto_timer_patch as backward_patch
     import traceml.instrumentation.patches.dataloader_patch as dataloader_patch
     import traceml.instrumentation.patches.forward_auto_timer_patch as forward_patch
@@ -55,6 +56,11 @@ def test_init_auto_enables_all_supported_patches(monkeypatch):
         "patch_backward",
         lambda: calls.append("backward"),
     )
+    monkeypatch.setattr(
+        all_reduce_patch,
+        "patch_all_reduce",
+        lambda: calls.append("all_reduce"),
+    )
 
     cfg = initialization.init(mode="auto")
 
@@ -62,7 +68,8 @@ def test_init_auto_enables_all_supported_patches(monkeypatch):
     assert cfg.patch_dataloader is True
     assert cfg.patch_forward is True
     assert cfg.patch_backward is True
-    assert calls == ["dataloader", "forward", "backward"]
+    assert cfg.patch_all_reduce is True
+    assert calls == ["dataloader", "forward", "backward", "all_reduce"]
 
 
 def test_init_manual_installs_no_patches():
@@ -74,6 +81,7 @@ def test_init_manual_installs_no_patches():
     assert cfg.patch_dataloader is False
     assert cfg.patch_forward is False
     assert cfg.patch_backward is False
+    assert cfg.patch_all_reduce is False
 
 
 def test_init_selective_only_installs_requested_patches(monkeypatch):
@@ -81,6 +89,7 @@ def test_init_selective_only_installs_requested_patches(monkeypatch):
 
     calls = []
 
+    import traceml.instrumentation.patches.all_reduce_auto_timer_patch as all_reduce_patch
     import traceml.instrumentation.patches.backward_auto_timer_patch as backward_patch
     import traceml.instrumentation.patches.dataloader_patch as dataloader_patch
     import traceml.instrumentation.patches.forward_auto_timer_patch as forward_patch
@@ -100,18 +109,25 @@ def test_init_selective_only_installs_requested_patches(monkeypatch):
         "patch_backward",
         lambda: calls.append("backward"),
     )
+    monkeypatch.setattr(
+        all_reduce_patch,
+        "patch_all_reduce",
+        lambda: calls.append("all_reduce"),
+    )
 
     cfg = initialization.init(
         mode="selective",
         patch_dataloader=True,
         patch_forward=False,
         patch_backward=True,
+        patch_all_reduce=False,
     )
 
     assert cfg.mode == "selective"
     assert cfg.patch_dataloader is True
     assert cfg.patch_forward is False
     assert cfg.patch_backward is True
+    assert cfg.patch_all_reduce is False
     assert calls == ["dataloader", "backward"]
 
 
@@ -141,6 +157,7 @@ def test_init_selective_requires_meaningful_overrides():
             patch_dataloader=False,
             patch_forward=False,
             patch_backward=False,
+            patch_all_reduce=False,
         )
 
 
@@ -163,6 +180,7 @@ def test_init_custom_alias_maps_to_selective(monkeypatch):
     assert cfg.patch_dataloader is False
     assert cfg.patch_forward is True
     assert cfg.patch_backward is False
+    assert cfg.patch_all_reduce is False
     assert calls == ["forward"]
 
 
@@ -235,6 +253,7 @@ def _run_trace_step_once(*, mode, monkeypatch):
         patch_forward=(False if mode == "selective" else None),
         patch_backward=(False if mode == "selective" else None),
         patch_dataloader=(True if mode == "selective" else None),
+        patch_all_reduce=(False if mode == "selective" else None),
     )
 
     calls = []
@@ -252,6 +271,11 @@ def _run_trace_step_once(*, mode, monkeypatch):
     monkeypatch.setattr(
         instrumentation,
         "backward_auto_timer",
+        _noop_context_manager,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "all_reduce_auto_timer",
         _noop_context_manager,
     )
     monkeypatch.setattr(

--- a/tests/test_initialization_and_wrappers.py
+++ b/tests/test_initialization_and_wrappers.py
@@ -28,6 +28,7 @@ def test_auto_mode_enables_all_supported_patches(monkeypatch):
 
     calls = []
 
+    import traceml.instrumentation.patches.all_reduce_auto_timer_patch as all_reduce_patch
     import traceml.instrumentation.patches.backward_auto_timer_patch as backward_patch
     import traceml.instrumentation.patches.dataloader_patch as dataloader_patch
     import traceml.instrumentation.patches.forward_auto_timer_patch as forward_patch
@@ -47,6 +48,11 @@ def test_auto_mode_enables_all_supported_patches(monkeypatch):
         "patch_backward",
         lambda: calls.append("backward"),
     )
+    monkeypatch.setattr(
+        all_reduce_patch,
+        "patch_all_reduce",
+        lambda: calls.append("all_reduce"),
+    )
 
     cfg = initialization.init(mode="auto")
 
@@ -54,7 +60,8 @@ def test_auto_mode_enables_all_supported_patches(monkeypatch):
     assert cfg.patch_dataloader is True
     assert cfg.patch_forward is True
     assert cfg.patch_backward is True
-    assert calls == ["dataloader", "forward", "backward"]
+    assert cfg.patch_all_reduce is True
+    assert calls == ["dataloader", "forward", "backward", "all_reduce"]
 
 
 def test_manual_mode_installs_no_patches():
@@ -66,6 +73,7 @@ def test_manual_mode_installs_no_patches():
     assert cfg.patch_dataloader is False
     assert cfg.patch_forward is False
     assert cfg.patch_backward is False
+    assert cfg.patch_all_reduce is False
 
 
 def test_auto_mode_rejects_patch_overrides():
@@ -98,6 +106,7 @@ def test_selective_mode_requires_at_least_one_enabled_patch():
             patch_dataloader=False,
             patch_forward=False,
             patch_backward=False,
+            patch_all_reduce=False,
         )
 
 
@@ -120,6 +129,7 @@ def test_custom_alias_maps_to_selective(monkeypatch):
     assert cfg.patch_forward is True
     assert cfg.patch_dataloader is False
     assert cfg.patch_backward is False
+    assert cfg.patch_all_reduce is False
     assert calls == ["forward"]
 
 
@@ -150,6 +160,7 @@ def test_start_is_alias_for_init():
     assert cfg.patch_dataloader is False
     assert cfg.patch_forward is False
     assert cfg.patch_backward is False
+    assert cfg.patch_all_reduce is False
 
 
 def test_api_import_does_not_initialize_implicitly():

--- a/tests/test_initialization_and_wrappers.py
+++ b/tests/test_initialization_and_wrappers.py
@@ -309,6 +309,9 @@ def test_trace_step_installs_optimizer_hooks_only_in_auto(monkeypatch):
     monkeypatch.setattr(instrumentation, "timed_region", fake_timed_region)
     monkeypatch.setattr(instrumentation, "forward_auto_timer", FakeAutoTimer)
     monkeypatch.setattr(instrumentation, "backward_auto_timer", FakeAutoTimer)
+    monkeypatch.setattr(
+        instrumentation, "all_reduce_auto_timer", FakeAutoTimer
+    )
     monkeypatch.setattr(instrumentation, "StepMemoryTracker", FakeMemTracker)
     monkeypatch.setattr(
         instrumentation,
@@ -362,6 +365,9 @@ def test_trace_step_does_not_install_optimizer_hooks_in_manual(monkeypatch):
     monkeypatch.setattr(instrumentation, "timed_region", fake_timed_region)
     monkeypatch.setattr(instrumentation, "forward_auto_timer", FakeAutoTimer)
     monkeypatch.setattr(instrumentation, "backward_auto_timer", FakeAutoTimer)
+    monkeypatch.setattr(
+        instrumentation, "all_reduce_auto_timer", FakeAutoTimer
+    )
     monkeypatch.setattr(instrumentation, "StepMemoryTracker", FakeMemTracker)
     monkeypatch.setattr(
         instrumentation,

--- a/tests/test_instrumentation_namespace.py
+++ b/tests/test_instrumentation_namespace.py
@@ -10,9 +10,13 @@ def test_canonical_instrumentation_namespace_imports():
     forward_patch = importlib.import_module(
         "traceml.instrumentation.patches.forward_auto_timer_patch"
     )
+    all_reduce_patch = importlib.import_module(
+        "traceml.instrumentation.patches.all_reduce_auto_timer_patch"
+    )
 
     assert optimizer_hooks.ensure_optimizer_timing_installed is not None
     assert forward_patch.patch_forward is not None
+    assert all_reduce_patch.patch_all_reduce is not None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds auto-instrumentation for `torch.distributed.all_reduce` timing during active TraceML training steps. User-issued `dist.all_reduce(t)` calls inside `trace_step` are recorded as `_traceml_comm:all_reduce` events on the existing step-time pipeline — zero new sampler, zero new schema.

First patch-family member targeting `torch.distributed.*` (forward / backward / dataloader / h2d all wrap user code or per-tensor methods).

Closes TRA-16. Related follow-ups: TRA-28 (pre-existing test-pollution bug), TRA-30 (renderer/summary `comm` bucket extension).

## Design decisions

- **Patch site: public Python `torch.distributed.all_reduce`** — not `c10d.ProcessGroup.allreduce` (pybind binding). Smallest stable surface per `principles.md` §9. Trade-off: misses DDP's C++ Reducer-issued gradient-sync all-reduces — flagged as v1 work via `register_comm_hook`. Empirically verified by a 2-rank gloo torchrun smoke test that asserts `post_init == 0` and `post_backward == 0` (DDP gradient sync does NOT fire the Python symbol; only explicit user calls do).

- **Wire name `_traceml_comm:all_reduce`** — new namespace for communication events, distinct from `_traceml_internal:` (in-process pipeline events). Future collectives (`reduce_scatter`, `all_gather`, `barrier`) share this namespace as siblings. `principles.md` §8 update with both namespaces is a separate doc-PR.

- **TLS gate kept (defensive, not load-bearing)** — DDP init uses `broadcast`, not `all_reduce`, so the gate isn't strictly required. Kept for family symmetry with forward/backward/h2d and to silence any future PyTorch caller that fires `all_reduce` outside training. Sub-µs cost per call.

- **No depth counter** — `dist.all_reduce` is a leaf op (does not recurse into `all_reduce`). Skip saves a TLS lookup per call. First family patch where this is appropriate.

- **No `wrap_all_reduce(...)` manual helper** — `dist.all_reduce(t)` is a free function with no receiver to proxy, unlike the rest of the `wrap_*` family (`wrap_forward(model)`, `wrap_h2d(t)`, etc.) which all wrap method calls on a receiver. Manual-mode users opt into selective mode with `patch_all_reduce=True`, or use the existing `trace_time(...)` context manager. A generic `wrap_callable(...)` helper for free-function targets is deferred — revisit when a second free-function patch lands (TRA-26 collectives are candidates).

- **Renderer / summary not extended** — events flow through the existing step-time pipeline and land in SQLite, but `final_summary.json` `split_ms` and the `traceml watch` step-time table do not yet break out a `comm` bucket. Comm time currently rolls into the WAIT bucket. Tracked as TRA-30, coordinated with the broader UI/summary work.

## Files

| Type | Path | LOC |
|---|---|---|
| New patch | `src/traceml/instrumentation/patches/all_reduce_auto_timer_patch.py` | +119 |
| New tests | `tests/test_all_reduce_patch.py` | +579 (14 cases) |
| New example | `examples/all_reduce_demo.py` | +159 |
| Init wiring | `src/traceml/sdk/initial.py` | +35 / -3 |
| Activator nesting | `src/traceml/sdk/instrumentation.py` | +8 / -1 |
| Public API | `src/traceml/api.py` | +7 |
| Test extensions | `tests/test_init_and_wrappers.py`, `tests/test_initialization_and_wrappers.py`, `tests/test_instrumentation_namespace.py` | +43 / -2 |

7 atomic commits on top of `upstream/main` HEAD `2dd0b28` (V0.2.13).

## Test plan

- [x] `pytest tests/test_all_reduce_patch.py -v` → 13 passed, 1 skipped (DDP smoke gated on `TRACEML_RUN_DIST_TESTS=1`)
- [x] `TRACEML_RUN_DIST_TESTS=1 pytest tests/test_all_reduce_patch.py -v` → **14 passed** including the 2-rank gloo torchrun smoke that confirms DDP Reducer bypasses the Python symbol
- [x] Full suite: 172 passed, 1 skipped, 2 pre-existing unrelated failures (`test_wrap_optimizer_*` — TRA-28; reproduced on `upstream/main`)
- [x] CUDA-event timing verified on T4 NCCL: `gpu_time_ms` non-zero, tracks `cpu_ms` within ~10% across 3 calls (5.59 / 0.56 / 0.31 ms — first call includes NCCL warmup)
- [x] End-to-end: `traceml run examples/all_reduce_demo.py` → 5000/5000 step rows in SQLite contain `_traceml_comm:all_reduce` events
- [x] `pre-commit run --all-files` clean

## Out of scope (intentional v0 boundaries)

- DDP gradient-sync capture via `register_comm_hook` — v1 architectural follow-up
- Other collectives (`reduce_scatter_tensor`, `all_gather`, `barrier`) — TRA-26 candidate
- Renderer / summary `comm` bucket — TRA-30
- Generic `wrap_callable(...)` manual helper — defer until a second free-function target exists
- `principles.md` §8 namespace docs update — separate study-branch PR
