### PR TITLE
distributed identity

### DIFF
--- a/src/traceml/database/database_sender.py
+++ b/src/traceml/database/database_sender.py
@@ -1,8 +1,27 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import time
+from typing import Any, Optional, Protocol
 
 from traceml.loggers.error_log import get_error_logger
+
+
+class AppendOnlyDatabase(Protocol):
+    """Minimal database surface needed by DBIncrementalSender."""
+
+    def all_tables(self) -> dict[str, Any]:
+        """Return table-name to rows mapping."""
+        ...
+
+    def get_append_count(self, table_name: str) -> int:
+        """Return the monotonic append count for a table."""
+        ...
 
 
 class DBIncrementalSender:
@@ -31,7 +50,7 @@ class DBIncrementalSender:
     This class returns a single payload dict from `collect_payload()`:
 
     {
-        "rank": <int>,
+        "rank": <int>,          # globally unique runtime rank
         "sampler": <str>,
         "timestamp": <float>,
         "tables": {
@@ -45,23 +64,42 @@ class DBIncrementalSender:
 
     def __init__(
         self,
-        db,
-        sampler_name,
-        sender=None,
-        rank=None,
+        db: AppendOnlyDatabase,
+        sampler_name: str,
+        sender: Optional[Any] = None,
+        rank: Optional[int] = None,
         max_rows_per_flush: int = -1,
-    ):
+    ) -> None:
         """
         Initialize the incremental sender.
+
+        ``rank`` is usually attached by TelemetryPublisher after sampler
+        construction. New runtime code should attach the global rank so
+        downstream storage can group multi-node telemetry without collisions.
         """
         self.db = db
-        self.sampler_name = sampler_name
+        self.sampler_name = str(sampler_name)
         self.sender = sender
         self.rank = rank
         self.max_rows_per_flush = int(max_rows_per_flush)
 
         self._last_sent_seq: dict[str, int] = {}
         self.logger = get_error_logger("DBIncrementalSender")
+
+    def _payload_rank(self) -> int:
+        """
+        Return the globally unique rank for outbound payloads.
+
+        A missing rank means the sender was not attached by the runtime
+        publisher. Failing fast here prevents malformed telemetry from reaching
+        the aggregator with ``rank=None``.
+        """
+        if self.rank is None:
+            raise RuntimeError(
+                "DBIncrementalSender requires an attached runtime rank before "
+                "collecting payloads."
+            )
+        return int(self.rank)
 
     def collect_payload(self) -> dict | None:
         """
@@ -101,7 +139,7 @@ class DBIncrementalSender:
             return None
 
         return {
-            "rank": self.rank,
+            "rank": self._payload_rank(),
             "sampler": self.sampler_name,
             "timestamp": time.time(),
             "tables": tables_payload,

--- a/src/traceml/database/database_sender.py
+++ b/src/traceml/database/database_sender.py
@@ -10,6 +10,7 @@ import time
 from typing import Any, Optional, Protocol
 
 from traceml.loggers.error_log import get_error_logger
+from traceml.runtime.sender import SenderIdentity
 
 
 class AppendOnlyDatabase(Protocol):
@@ -51,6 +52,8 @@ class DBIncrementalSender:
 
     {
         "rank": <int>,          # globally unique runtime rank
+        "global_rank": <int>,
+        "local_rank": <int>,
         "sampler": <str>,
         "timestamp": <float>,
         "tables": {
@@ -81,6 +84,7 @@ class DBIncrementalSender:
         self.sampler_name = str(sampler_name)
         self.sender = sender
         self.rank = rank
+        self.identity: Optional[SenderIdentity] = None
         self.max_rows_per_flush = int(max_rows_per_flush)
 
         self._last_sent_seq: dict[str, int] = {}
@@ -100,6 +104,20 @@ class DBIncrementalSender:
                 "collecting payloads."
             )
         return int(self.rank)
+
+    def _payload_identity(self) -> SenderIdentity:
+        """
+        Return the rank identity for outbound payloads.
+
+        ``identity`` is attached by TelemetryPublisher. The ``rank`` fallback
+        keeps direct unit-test and legacy construction paths working, but new
+        runtime payloads should always include explicit global/local rank.
+        """
+        if self.identity is not None:
+            return self.identity
+
+        rank = self._payload_rank()
+        return SenderIdentity(global_rank=rank, local_rank=rank)
 
     def collect_payload(self) -> dict | None:
         """
@@ -137,9 +155,12 @@ class DBIncrementalSender:
 
         if not tables_payload:
             return None
+        identity = self._payload_identity()
 
         return {
-            "rank": self._payload_rank(),
+            "rank": identity.rank,
+            "global_rank": identity.global_rank,
+            "local_rank": identity.local_rank,
             "sampler": self.sampler_name,
             "timestamp": time.time(),
             "tables": tables_payload,

--- a/src/traceml/diagnostics/step_time/adapters.py
+++ b/src/traceml/diagnostics/step_time/adapters.py
@@ -1,3 +1,9 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 """Adapters that feed summary step-time data into shared diagnosis rules."""
 
 from dataclasses import dataclass
@@ -9,6 +15,7 @@ from traceml.diagnostics.common import DiagnosticResult, diagnosis_to_dict
 from traceml.diagnostics.step_time.api import (
     StepDiagnosis,
     build_step_diagnosis_result,
+    build_step_warmup_diagnosis,
 )
 from traceml.diagnostics.step_time.policy import (
     SUMMARY_STEP_TIME_POLICY,
@@ -259,8 +266,13 @@ def build_summary_step_diagnosis_result(
 
     ranks = sorted(rank_signals.keys())
     min_steps = min(s.steps_analyzed for s in rank_signals.values())
+    max_steps = max(s.steps_analyzed for s in rank_signals.values())
     if min_steps < int(policy.min_steps_for_diag):
-        return None
+        return build_step_warmup_diagnosis(
+            steps_used=int(min_steps),
+            max_steps_used=int(max_steps),
+            required_steps=int(policy.min_steps_for_diag),
+        )
 
     # Optional step-aligned series support (for trend notes).
     common_steps: List[int] = []

--- a/src/traceml/diagnostics/step_time/api.py
+++ b/src/traceml/diagnostics/step_time/api.py
@@ -1,3 +1,9 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 """Step-time diagnosis shared by live renderers and summaries."""
 
 from __future__ import annotations
@@ -34,6 +40,7 @@ from .trend import DEFAULT_STEP_TREND_HEURISTICS, build_step_trend_note
 
 DiagnosisKind = Literal[
     "NO_DATA",
+    "WARMUP",
     "BALANCED",
     "STRAGGLER",
     "INPUT_STRAGGLER",
@@ -45,6 +52,7 @@ DiagnosisKind = Literal[
 
 _STATUS_BY_KIND: dict[DiagnosisKind, str] = {
     "NO_DATA": "NO DATA",
+    "WARMUP": "WARMUP",
     "BALANCED": "BALANCED",
     "STRAGGLER": "STRAGGLER",
     "INPUT_STRAGGLER": "INPUT STRAGGLER",
@@ -100,6 +108,37 @@ def _mk_diag(
         worst_rank=worst_rank,
         note=note,
     )
+
+
+def build_step_warmup_diagnosis(
+    *,
+    steps_used: int,
+    required_steps: int,
+    max_steps_used: Optional[int] = None,
+) -> DiagnosticResult[StepDiagnosis]:
+    """
+    Build the explicit partial-data diagnosis for a non-empty timing window.
+
+    ``NO_DATA`` is reserved for missing or unusable timing data. ``WARMUP``
+    means TraceML has timing samples, but fewer than the configured minimum for
+    a stable summary diagnosis.
+    """
+    low = max(0, int(steps_used))
+    high = max(low, int(max_steps_used if max_steps_used is not None else low))
+    required = max(1, int(required_steps))
+    available = f"{low}" if low == high else f"{low}-{high}"
+    suffix = "step" if high == 1 else "steps"
+    primary = _mk_diag(
+        kind="WARMUP",
+        severity="info",
+        reason=(
+            f"Only {available} {suffix} per rank available; summary "
+            f"diagnosis requires {required}."
+        ),
+        action="Use a longer run for a stable timing diagnosis.",
+        steps_used=low,
+    )
+    return DiagnosticResult(primary=primary)
 
 
 def _merge_note(base: Optional[str], extra: Optional[str]) -> Optional[str]:
@@ -475,15 +514,13 @@ def build_step_diagnosis_result(
         return DiagnosticResult(primary=primary)
 
     if steps_used < thresholds.min_steps_for_confident_diag:
-        primary = _mk_diag(
-            kind="NO_DATA",
-            severity="info",
-            reason=f"Only {steps_used} steps available.",
-            action="Wait for a fuller window.",
+        result = build_step_warmup_diagnosis(
             steps_used=steps_used,
-            worst_rank=overall_worst_rank,
+            required_steps=thresholds.min_steps_for_confident_diag,
         )
-        return DiagnosticResult(primary=primary)
+        return DiagnosticResult(
+            primary=replace(result.primary, worst_rank=overall_worst_rank)
+        )
 
     context = build_step_time_context(
         metrics=metrics,
@@ -797,6 +834,7 @@ __all__ = [
     "DEFAULT_THRESHOLDS",
     "StepDiagnosis",
     "ComputeSignal",
+    "build_step_warmup_diagnosis",
     "build_step_diagnosis",
     "build_step_diagnosis_result",
 ]

--- a/src/traceml/diagnostics/step_time/formatters.py
+++ b/src/traceml/diagnostics/step_time/formatters.py
@@ -1,3 +1,9 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Formatting helpers for step-time diagnosis.
 
@@ -13,7 +19,7 @@ def _styled_status(diagnosis: StepDiagnosis) -> str:
     """Render a colored status label for Rich CLI output."""
     if diagnosis.kind == "BALANCED":
         style = "bold green"
-    elif diagnosis.kind == "NO_DATA":
+    elif diagnosis.kind in {"NO_DATA", "WARMUP"}:
         style = "bold bright_black"
     elif diagnosis.kind in {"INPUT_BOUND", "COMPUTE_BOUND"}:
         style = "bold yellow"

--- a/src/traceml/reporting/compare/policy.py
+++ b/src/traceml/reporting/compare/policy.py
@@ -1,3 +1,9 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Policy helpers for decision-grade TraceML run comparison.
 
@@ -25,6 +31,7 @@ _SIGNIFICANCE_ORDER = {
 
 _STEP_TIME_STATUS_RANK = {
     "NO DATA": 0,
+    "WARMUP": 0,
     "BALANCED": 1,
     "INPUT-BOUND": 2,
     "COMPUTE-BOUND": 2,

--- a/src/traceml/reporting/sections/step_time/builder.py
+++ b/src/traceml/reporting/sections/step_time/builder.py
@@ -1,3 +1,9 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 """Payload builder for the final-report step-time section."""
 
 from __future__ import annotations
@@ -219,6 +225,8 @@ def _step_time_card_reason(
     kind = str(getattr(diagnosis, "kind", "") or "")
     if diagnosis is None or kind == "NO_DATA":
         return "Need more step-time samples."
+    if kind == "WARMUP":
+        return str(getattr(diagnosis, "reason", "") or "").strip()
     if stats is None:
         return str(getattr(diagnosis, "reason", "") or "n/a")
 

--- a/src/traceml/reporting/summaries/diagnosis_presentation.py
+++ b/src/traceml/reporting/summaries/diagnosis_presentation.py
@@ -1,3 +1,9 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 End-of-run diagnosis presentation helpers.
 
@@ -79,6 +85,8 @@ def present_step_time_summary_diagnosis(
     note = getattr(diagnosis, "note", None)
 
     if status == "NO DATA":
+        action = "Run longer for a stable timing diagnosis."
+    elif status == "WARMUP":
         action = "Run longer for a stable timing diagnosis."
     elif action in {
         "Wait for a fuller window.",

--- a/src/traceml/runtime/identity.py
+++ b/src/traceml/runtime/identity.py
@@ -1,0 +1,255 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical runtime identity for TraceML training processes.
+
+This module owns the answer to "which training process am I?". Keeping that
+logic here avoids scattering launcher-specific environment parsing through the
+runtime, samplers, and telemetry layers.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional
+
+EnvMapping = Mapping[str, str]
+TorchLoader = Callable[[], Optional[Any]]
+
+
+def _load_torch() -> Optional[Any]:
+    """Import torch only when distributed state needs it."""
+    try:
+        import torch
+    except ModuleNotFoundError:
+        return None
+    return torch
+
+
+def _env_int(
+    env: EnvMapping,
+    name: str,
+    default: Optional[int] = None,
+) -> Optional[int]:
+    """Read an integer environment variable best-effort."""
+    raw = env.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        return int(raw)
+    except Exception:
+        return default
+
+
+def _torch_distributed_ready(torch: Optional[Any]) -> bool:
+    """Return True when torch.distributed is initialized."""
+    if torch is None:
+        return False
+    try:
+        return bool(
+            torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+        )
+    except Exception:
+        return False
+
+
+def _torch_distributed_int(
+    torch: Optional[Any],
+    method_name: str,
+) -> Optional[int]:
+    """Read an integer from torch.distributed when initialized."""
+    if not _torch_distributed_ready(torch):
+        return None
+    try:
+        method = getattr(torch.distributed, method_name)
+        return int(method())
+    except Exception:
+        return None
+
+
+def _default_node_rank(
+    *,
+    global_rank: int,
+    local_world_size: int,
+) -> int:
+    """Infer node rank from global rank when no launcher value is present."""
+    if local_world_size <= 0:
+        return 0
+    return max(0, int(global_rank) // int(local_world_size))
+
+
+@dataclass(frozen=True)
+class RuntimeIdentity:
+    """Process identity resolved from distributed launcher metadata."""
+
+    global_rank: int
+    local_rank: int
+    world_size: int
+    local_world_size: int
+    node_rank: int
+    hostname: str
+    pid: int
+
+    @property
+    def rank(self) -> int:
+        """
+        Backward-compatible TraceML rank.
+
+        Current TraceML runtime paths historically use local rank for sampler
+        selection, sender metadata, and rank-local directories. Multi-node
+        storage/reporting will migrate to ``global_rank`` in follow-up work.
+        """
+        return self.local_rank
+
+    @property
+    def is_distributed(self) -> bool:
+        """Return True when the identity describes a multi-process job."""
+        return self.world_size > 1
+
+    @property
+    def is_multinode(self) -> bool:
+        """Return True when world size exceeds local world size."""
+        return self.world_size > self.local_world_size
+
+    def to_meta(self) -> dict[str, Any]:
+        """Serialize identity for telemetry metadata envelopes."""
+        return {
+            "rank": self.rank,
+            "global_rank": self.global_rank,
+            "local_rank": self.local_rank,
+            "world_size": self.world_size,
+            "local_world_size": self.local_world_size,
+            "node_rank": self.node_rank,
+            "hostname": self.hostname,
+            "pid": self.pid,
+        }
+
+
+@dataclass(frozen=True)
+class RuntimeIdentityResolver:
+    """
+    Resolve process identity from launcher and distributed runtime metadata.
+
+    The resolver is dependency-injected so tests and future launchers can supply
+    their own environment/runtime source without changing TraceMLRuntime.
+    """
+
+    env: EnvMapping
+    torch_loader: TorchLoader = _load_torch
+
+    def resolve(self) -> RuntimeIdentity:
+        """
+        Build a RuntimeIdentity with single-process-safe defaults.
+
+        Resolution order is intentionally conservative:
+        1. launcher environment variables
+        2. initialized torch.distributed state
+        3. safe local defaults
+        """
+        torch = self.torch_loader()
+
+        global_rank = self._global_rank(torch)
+        world_size = self._world_size(torch)
+        local_world_size = self._local_world_size(world_size)
+        local_rank = self._local_rank(
+            torch=torch,
+            global_rank=global_rank,
+            world_size=world_size,
+            local_world_size=local_world_size,
+        )
+        node_rank = self._node_rank(
+            global_rank=global_rank,
+            local_world_size=local_world_size,
+        )
+
+        return RuntimeIdentity(
+            global_rank=int(global_rank),
+            local_rank=int(local_rank),
+            world_size=int(world_size),
+            local_world_size=int(local_world_size),
+            node_rank=int(node_rank),
+            hostname=socket.gethostname(),
+            pid=os.getpid(),
+        )
+
+    def _global_rank(self, torch: Optional[Any]) -> int:
+        value = _env_int(self.env, "RANK", None)
+        if value is None:
+            value = _torch_distributed_int(torch, "get_rank")
+        return int(value) if value is not None else 0
+
+    def _world_size(self, torch: Optional[Any]) -> int:
+        value = _env_int(self.env, "WORLD_SIZE", None)
+        if value is None:
+            value = _torch_distributed_int(torch, "get_world_size")
+        if value is None:
+            value = 1
+        return max(1, int(value))
+
+    def _local_world_size(
+        self,
+        world_size: int,
+    ) -> int:
+        value = _env_int(self.env, "LOCAL_WORLD_SIZE", None)
+        if value is None:
+            value = int(world_size) if int(world_size) == 1 else 1
+        return max(1, int(value))
+
+    def _local_rank(
+        self,
+        *,
+        torch: Optional[Any],
+        global_rank: int,
+        world_size: int,
+        local_world_size: int,
+    ) -> int:
+        value = _env_int(self.env, "LOCAL_RANK", None)
+        if value is None:
+            if world_size > 1 or _torch_distributed_ready(torch):
+                value = int(global_rank) % int(local_world_size)
+            else:
+                value = 0
+        return max(0, int(value))
+
+    def _node_rank(
+        self,
+        *,
+        global_rank: int,
+        local_world_size: int,
+    ) -> int:
+        value = _env_int(self.env, "GROUP_RANK", None)
+        if value is None:
+            value = _env_int(self.env, "NODE_RANK", None)
+        if value is None:
+            value = _default_node_rank(
+                global_rank=global_rank,
+                local_world_size=local_world_size,
+            )
+        return int(value)
+
+
+def resolve_runtime_identity(
+    *,
+    env: Optional[EnvMapping] = None,
+    torch_loader: Optional[TorchLoader] = None,
+) -> RuntimeIdentity:
+    """Resolve the current process identity using the default resolver."""
+    resolver = RuntimeIdentityResolver(
+        env=env if env is not None else os.environ,
+        torch_loader=torch_loader if torch_loader is not None else _load_torch,
+    )
+    return resolver.resolve()
+
+
+__all__ = [
+    "EnvMapping",
+    "RuntimeIdentity",
+    "RuntimeIdentityResolver",
+    "resolve_runtime_identity",
+]

--- a/src/traceml/runtime/runtime.py
+++ b/src/traceml/runtime/runtime.py
@@ -1,3 +1,9 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 """Per-rank TraceML runtime agent."""
 
 import threading
@@ -5,11 +11,11 @@ from typing import Any, Callable, List, Optional
 
 from traceml.loggers.error_log import get_error_logger, setup_error_logger
 from traceml.runtime.config import config
+from traceml.runtime.identity import resolve_runtime_identity
 from traceml.runtime.sampler_registry import build_samplers
 from traceml.runtime.sender import TelemetryPublisher
 from traceml.runtime.stdout_stderr_capture import StreamCapture
 from traceml.samplers.base_sampler import BaseSampler
-from traceml.transport.distributed import get_ddp_info
 from traceml.transport.tcp_transport import TCPClient, TCPConfig
 
 from .settings import TraceMLSettings
@@ -44,8 +50,13 @@ class TraceMLRuntime:
         setup_error_logger()
         self._logger = get_error_logger("TraceMLRuntime")
 
-        # DDP identity
-        self.is_ddp, self.local_rank, self.world_size = get_ddp_info()
+        # Runtime identity. ``rank`` remains local-rank based for now to keep
+        # current single-node behavior stable while multi-node metadata lands.
+        self.identity = resolve_runtime_identity()
+        self.is_ddp = self.identity.is_distributed
+        self.local_rank = self.identity.local_rank
+        self.global_rank = self.identity.global_rank
+        self.world_size = self.identity.world_size
 
         # Stop event shared by all internal threads in this process
         self._stop_event = threading.Event()
@@ -61,7 +72,7 @@ class TraceMLRuntime:
         )
         self._publisher = TelemetryPublisher(
             tcp_client=self._tcp_client,
-            rank=self.local_rank,
+            rank=self.identity.rank,
             logger=self._logger,
         )
         self._publisher.attach_senders(self._samplers)

--- a/src/traceml/runtime/runtime.py
+++ b/src/traceml/runtime/runtime.py
@@ -13,7 +13,7 @@ from traceml.loggers.error_log import get_error_logger, setup_error_logger
 from traceml.runtime.config import config
 from traceml.runtime.identity import resolve_runtime_identity
 from traceml.runtime.sampler_registry import build_samplers
-from traceml.runtime.sender import TelemetryPublisher
+from traceml.runtime.sender import SenderIdentity, TelemetryPublisher
 from traceml.runtime.stdout_stderr_capture import StreamCapture
 from traceml.samplers.base_sampler import BaseSampler
 from traceml.transport.tcp_transport import TCPClient, TCPConfig
@@ -73,7 +73,10 @@ class TraceMLRuntime:
         )
         self._publisher = TelemetryPublisher(
             tcp_client=self._tcp_client,
-            global_rank=self.identity.global_rank,
+            identity=SenderIdentity(
+                global_rank=self.identity.global_rank,
+                local_rank=self.identity.local_rank,
+            ),
             logger=self._logger,
         )
         self._publisher.attach_senders(self._samplers)

--- a/src/traceml/runtime/runtime.py
+++ b/src/traceml/runtime/runtime.py
@@ -50,8 +50,9 @@ class TraceMLRuntime:
         setup_error_logger()
         self._logger = get_error_logger("TraceMLRuntime")
 
-        # Runtime identity. ``rank`` remains local-rank based for now to keep
-        # current single-node behavior stable while multi-node metadata lands.
+        # Runtime identity separates local device rank from globally unique
+        # telemetry rank. Sampler selection still needs local rank, while
+        # outbound payloads must identify the worker by global rank.
         self.identity = resolve_runtime_identity()
         self.is_ddp = self.identity.is_distributed
         self.local_rank = self.identity.local_rank
@@ -72,7 +73,7 @@ class TraceMLRuntime:
         )
         self._publisher = TelemetryPublisher(
             tcp_client=self._tcp_client,
-            rank=self.identity.rank,
+            global_rank=self.identity.global_rank,
             logger=self._logger,
         )
         self._publisher.attach_senders(self._samplers)

--- a/src/traceml/runtime/sender.py
+++ b/src/traceml/runtime/sender.py
@@ -8,9 +8,23 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Iterable, List, Optional
 
 from traceml.loggers.error_log import get_error_logger
+
+
+@dataclass(frozen=True)
+class SenderIdentity:
+    """Rank identity attached to outbound sampler payloads."""
+
+    global_rank: int
+    local_rank: int
+
+    @property
+    def rank(self) -> int:
+        """Compatibility rank used by existing aggregator/storage code."""
+        return self.global_rank
 
 
 class TelemetryPublisher:
@@ -26,15 +40,11 @@ class TelemetryPublisher:
         self,
         *,
         tcp_client: Any,
-        global_rank: Optional[int] = None,
-        rank: Optional[int] = None,
+        identity: SenderIdentity,
         logger: Optional[Any] = None,
     ) -> None:
         self._tcp_client = tcp_client
-        self._rank = self._resolve_sender_rank(
-            global_rank=global_rank,
-            legacy_rank=rank,
-        )
+        self._identity = identity
         self._logger = logger or get_error_logger("TelemetryPublisher")
 
     def attach_senders(self, samplers: Iterable[Any]) -> None:
@@ -45,7 +55,8 @@ class TelemetryPublisher:
                 continue
             try:
                 sender.sender = self._tcp_client
-                sender.rank = self._rank
+                sender.identity = self._identity
+                sender.rank = self._identity.rank
             except Exception as exc:
                 self._log_exception(
                     f"{self._sampler_name(sampler)}.sender attach failed",
@@ -132,26 +143,8 @@ class TelemetryPublisher:
             )
         )
 
-    @staticmethod
-    def _resolve_sender_rank(
-        *,
-        global_rank: Optional[int],
-        legacy_rank: Optional[int],
-    ) -> int:
-        """
-        Return the rank value attached to outbound telemetry.
-
-        ``global_rank`` is the canonical argument. ``rank`` is accepted as a
-        compatibility shim for existing internal tests/callers and should not be
-        used by new code.
-        """
-        if global_rank is not None:
-            return int(global_rank)
-        if legacy_rank is not None:
-            return int(legacy_rank)
-        raise ValueError("TelemetryPublisher requires global_rank")
-
 
 __all__ = [
+    "SenderIdentity",
     "TelemetryPublisher",
 ]

--- a/src/traceml/runtime/sender.py
+++ b/src/traceml/runtime/sender.py
@@ -1,3 +1,9 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 """Telemetry publishing for the per-rank runtime agent."""
 
 from __future__ import annotations
@@ -8,17 +14,27 @@ from traceml.loggers.error_log import get_error_logger
 
 
 class TelemetryPublisher:
-    """Best-effort publisher for sampler payloads."""
+    """
+    Best-effort publisher for sampler payloads.
+
+    The publisher owns the rank identity attached to outbound sampler senders.
+    That identity must be globally unique for multi-node jobs; samplers can
+    still receive local rank separately when they need node-local device state.
+    """
 
     def __init__(
         self,
         *,
         tcp_client: Any,
-        rank: int,
+        global_rank: Optional[int] = None,
+        rank: Optional[int] = None,
         logger: Optional[Any] = None,
     ) -> None:
         self._tcp_client = tcp_client
-        self._rank = int(rank)
+        self._rank = self._resolve_sender_rank(
+            global_rank=global_rank,
+            legacy_rank=rank,
+        )
         self._logger = logger or get_error_logger("TelemetryPublisher")
 
     def attach_senders(self, samplers: Iterable[Any]) -> None:
@@ -115,6 +131,25 @@ class TelemetryPublisher:
                 sampler.__class__.__name__,
             )
         )
+
+    @staticmethod
+    def _resolve_sender_rank(
+        *,
+        global_rank: Optional[int],
+        legacy_rank: Optional[int],
+    ) -> int:
+        """
+        Return the rank value attached to outbound telemetry.
+
+        ``global_rank`` is the canonical argument. ``rank`` is accepted as a
+        compatibility shim for existing internal tests/callers and should not be
+        used by new code.
+        """
+        if global_rank is not None:
+            return int(global_rank)
+        if legacy_rank is not None:
+            return int(legacy_rank)
+        raise ValueError("TelemetryPublisher requires global_rank")
 
 
 __all__ = [

--- a/src/traceml/transport/distributed.py
+++ b/src/traceml/transport/distributed.py
@@ -1,5 +1,12 @@
-import os
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any, Optional
+
+from traceml.runtime.identity import resolve_runtime_identity
 
 
 def _load_torch() -> Optional[Any]:
@@ -20,39 +27,9 @@ def get_ddp_info():
         local_rank (int): Rank-local GPU index. -1 if not in DDP.
         world_size (int): Number of processes. 1 if not in DDP.
     """
-    # Defaults for single-GPU / single-process workloads
-    local_rank = int(os.environ.get("LOCAL_RANK", "-1"))
-    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    identity = resolve_runtime_identity(torch_loader=_load_torch)
+    is_ddp = identity.is_distributed
 
-    # Additional safety: PyTorch launcher may set RANK even if LOCAL_RANK missing
-    rank = int(os.environ.get("RANK", "-1"))
-    torch = _load_torch()
-    torch_dist_ready = False
-    if torch is not None:
-        try:
-            torch_dist_ready = bool(
-                torch.distributed.is_available()
-                and torch.distributed.is_initialized()
-            )
-        except Exception:
-            torch_dist_ready = False
-
-    is_ddp = (
-        world_size > 1 or local_rank != -1 or rank != -1 or torch_dist_ready
-    )
-
-    # local_rank assignment if missing but DDP detected
-    if is_ddp:
-        if local_rank == -1:
-            # torchrun always sets LOCAL_RANK
-            # mp.spawn often sets RANK
-            try:
-                if torch is None:
-                    raise RuntimeError("torch unavailable")
-                local_rank = (
-                    int(os.environ["RANK"]) % torch.cuda.device_count()
-                )
-            except Exception:
-                local_rank = 0
-
-    return is_ddp, local_rank, world_size
+    # Preserve the historical API: non-DDP reports local_rank=-1.
+    local_rank = identity.local_rank if is_ddp else -1
+    return is_ddp, local_rank, identity.world_size

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -1,3 +1,9 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from traceml.diagnostics.step_time.api import (
@@ -266,8 +272,12 @@ def test_summary_step_time_adapter_uses_summary_policy_by_default() -> None:
         )
     }
 
+    warmup = build_summary_step_diagnosis_result(rank_signals, max_rows=100)
+    assert warmup is not None
+    assert warmup.primary.kind == "WARMUP"
     assert (
-        build_summary_step_diagnosis_result(rank_signals, max_rows=100) is None
+        warmup.primary.reason
+        == "Only 40 steps per rank available; summary diagnosis requires 50."
     )
 
     rank_signals[0] = RankStepSignals(

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -1,3 +1,9 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from traceml.reporting.summaries.step_time import (
@@ -56,6 +62,26 @@ def test_step_time_no_data_card_is_compact() -> None:
     assert "- Diagnosis: NO DATA" in payload["card"]
     assert "- Stats: n/a" in payload["card"]
     assert "- Why: Need more step-time samples." in payload["card"]
+    _assert_compact_card(payload["card"])
+
+
+def test_step_time_warmup_card_explains_partial_summary_window() -> None:
+    payload = _summary(
+        {
+            0: _rank(steps=38),
+            1: _rank(steps=39),
+        }
+    )
+
+    assert payload["primary_diagnosis"]["status"] == "WARMUP"
+    assert "- Diagnosis: WARMUP" in payload["card"]
+    assert (
+        "- Scope: compared over last 38-39 steps per rank" in payload["card"]
+    )
+    assert (
+        "- Why: Only 38-39 steps per rank available; summary diagnosis "
+        "requires 50."
+    ) in payload["card"]
     _assert_compact_card(payload["card"])
 
 

--- a/tests/runtime/test_identity.py
+++ b/tests/runtime/test_identity.py
@@ -1,0 +1,154 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from traceml.runtime.identity import RuntimeIdentity, resolve_runtime_identity
+
+
+class _FakeDistributed:
+    def is_available(self):
+        return True
+
+    def is_initialized(self):
+        return True
+
+    def get_rank(self):
+        return 3
+
+    def get_world_size(self):
+        return 4
+
+
+class _FakeCuda:
+    def device_count(self):
+        raise AssertionError("identity resolution must not touch CUDA")
+
+
+class _FakeTorch:
+    distributed = _FakeDistributed()
+    cuda = _FakeCuda()
+
+
+def test_runtime_identity_single_process_defaults():
+    identity = resolve_runtime_identity(env={})
+
+    assert identity.global_rank == 0
+    assert identity.local_rank == 0
+    assert identity.rank == 0
+    assert identity.world_size == 1
+    assert identity.local_world_size == 1
+    assert identity.node_rank == 0
+    assert identity.hostname
+    assert identity.pid == os.getpid()
+    assert not identity.is_distributed
+    assert not identity.is_multinode
+
+
+def test_runtime_identity_resolves_single_node_torchrun_env():
+    identity = resolve_runtime_identity(
+        env={
+            "RANK": "2",
+            "LOCAL_RANK": "2",
+            "WORLD_SIZE": "4",
+            "LOCAL_WORLD_SIZE": "4",
+            "GROUP_RANK": "0",
+        }
+    )
+
+    assert identity.global_rank == 2
+    assert identity.local_rank == 2
+    assert identity.rank == 2
+    assert identity.world_size == 4
+    assert identity.local_world_size == 4
+    assert identity.node_rank == 0
+    assert identity.is_distributed
+    assert not identity.is_multinode
+
+
+def test_runtime_identity_resolves_multinode_torchrun_env():
+    identity = resolve_runtime_identity(
+        env={
+            "RANK": "5",
+            "LOCAL_RANK": "1",
+            "WORLD_SIZE": "8",
+            "LOCAL_WORLD_SIZE": "4",
+            "GROUP_RANK": "1",
+        }
+    )
+
+    assert identity.global_rank == 5
+    assert identity.local_rank == 1
+    assert identity.rank == 1
+    assert identity.world_size == 8
+    assert identity.local_world_size == 4
+    assert identity.node_rank == 1
+    assert identity.is_distributed
+    assert identity.is_multinode
+
+
+def test_runtime_identity_infers_missing_local_rank():
+    identity = resolve_runtime_identity(
+        env={
+            "RANK": "5",
+            "WORLD_SIZE": "8",
+            "LOCAL_WORLD_SIZE": "4",
+        }
+    )
+
+    assert identity.global_rank == 5
+    assert identity.local_rank == 1
+    assert identity.node_rank == 1
+
+
+def test_runtime_identity_can_fall_back_to_torch_distributed_state():
+    identity = resolve_runtime_identity(
+        env={"LOCAL_WORLD_SIZE": "2"},
+        torch_loader=lambda: _FakeTorch(),
+    )
+
+    assert identity.global_rank == 3
+    assert identity.local_rank == 1
+    assert identity.world_size == 4
+    assert identity.local_world_size == 2
+    assert identity.node_rank == 1
+    assert identity.is_distributed
+    assert identity.is_multinode
+
+
+def test_runtime_identity_does_not_probe_cuda_for_local_world_size():
+    identity = resolve_runtime_identity(
+        env={"RANK": "3", "WORLD_SIZE": "4"},
+        torch_loader=lambda: _FakeTorch(),
+    )
+
+    assert identity.global_rank == 3
+    assert identity.local_world_size == 1
+    assert identity.local_rank == 0
+    assert identity.node_rank == 3
+
+
+def test_runtime_identity_meta_shape():
+    identity = RuntimeIdentity(
+        global_rank=5,
+        local_rank=1,
+        world_size=8,
+        local_world_size=4,
+        node_rank=1,
+        hostname="worker-1",
+        pid=123,
+    )
+
+    assert identity.to_meta() == {
+        "rank": 1,
+        "global_rank": 5,
+        "local_rank": 1,
+        "world_size": 8,
+        "local_world_size": 4,
+        "node_rank": 1,
+        "hostname": "worker-1",
+        "pid": 123,
+    }

--- a/tests/runtime/test_runtime_identity_wiring.py
+++ b/tests/runtime/test_runtime_identity_wiring.py
@@ -1,0 +1,96 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+from traceml.runtime.runtime import TraceMLRuntime
+from traceml.runtime.sender import SenderIdentity
+from traceml.runtime.settings import TraceMLSettings
+
+
+class _FakeLogger:
+    def error(self, *_args, **_kwargs) -> None:
+        return None
+
+    def exception(self, *_args, **_kwargs) -> None:
+        return None
+
+
+class _FakeTCPClient:
+    def __init__(self, _config) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakePublisher:
+    instances: list["_FakePublisher"] = []
+
+    def __init__(
+        self,
+        *,
+        tcp_client,
+        identity,
+        logger,
+    ) -> None:
+        self.tcp_client = tcp_client
+        self.identity = identity
+        self.logger = logger
+        self.attached_samplers = None
+        _FakePublisher.instances.append(self)
+
+    def attach_senders(self, samplers) -> None:
+        self.attached_samplers = list(samplers)
+
+    def publish(self, samplers) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+def test_runtime_uses_local_rank_for_samplers_and_global_rank_for_publisher(
+    monkeypatch,
+):
+    build_calls: list[dict] = []
+
+    def _fake_build_samplers(**kwargs):
+        build_calls.append(kwargs)
+        return []
+
+    _FakePublisher.instances.clear()
+    monkeypatch.setenv("RANK", "5")
+    monkeypatch.setenv("LOCAL_RANK", "1")
+    monkeypatch.setenv("WORLD_SIZE", "8")
+    monkeypatch.setenv("LOCAL_WORLD_SIZE", "4")
+    monkeypatch.setenv("GROUP_RANK", "1")
+    monkeypatch.setattr(
+        "traceml.runtime.runtime.setup_error_logger",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "traceml.runtime.runtime.get_error_logger",
+        lambda _name: _FakeLogger(),
+    )
+    monkeypatch.setattr(
+        "traceml.runtime.runtime.build_samplers",
+        _fake_build_samplers,
+    )
+    monkeypatch.setattr("traceml.runtime.runtime.TCPClient", _FakeTCPClient)
+    monkeypatch.setattr(
+        "traceml.runtime.runtime.TelemetryPublisher",
+        _FakePublisher,
+    )
+
+    runtime = TraceMLRuntime(settings=TraceMLSettings(mode="summary"))
+
+    assert runtime.global_rank == 5
+    assert runtime.local_rank == 1
+    assert runtime.world_size == 8
+    assert build_calls[0]["local_rank"] == 1
+    assert _FakePublisher.instances[0].identity == SenderIdentity(
+        global_rank=5,
+        local_rank=1,
+    )

--- a/tests/runtime/test_telemetry_publisher.py
+++ b/tests/runtime/test_telemetry_publisher.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # SPDX-License-Identifier: Apache-2.0
 
-from traceml.runtime.sender import TelemetryPublisher
+from traceml.runtime.sender import SenderIdentity, TelemetryPublisher
 
 
 class _FakeLogger:
@@ -80,6 +80,7 @@ class _FakeSender:
         self.fail_collect = fail_collect
         self.sender = None
         self.rank = None
+        self.identity = None
         self.collect_count = 0
 
     def collect_payload(self) -> object | None:
@@ -108,7 +109,7 @@ def test_publisher_attaches_senders_to_tcp_client_and_rank() -> None:
     sampler = _FakeSampler("SamplerA", sender=sender)
     publisher = TelemetryPublisher(
         tcp_client=tcp_client,
-        rank=3,
+        identity=SenderIdentity(global_rank=3, local_rank=3),
         logger=_FakeLogger(),
     )
 
@@ -116,6 +117,7 @@ def test_publisher_attaches_senders_to_tcp_client_and_rank() -> None:
 
     assert sender.sender is tcp_client
     assert sender.rank == 3
+    assert sender.identity == SenderIdentity(global_rank=3, local_rank=3)
 
 
 def test_publisher_prefers_global_rank_for_sender_identity() -> None:
@@ -124,26 +126,14 @@ def test_publisher_prefers_global_rank_for_sender_identity() -> None:
     sampler = _FakeSampler("SamplerA", sender=sender)
     publisher = TelemetryPublisher(
         tcp_client=tcp_client,
-        global_rank=5,
-        rank=1,
+        identity=SenderIdentity(global_rank=5, local_rank=1),
         logger=_FakeLogger(),
     )
 
     publisher.attach_senders([sampler])
 
     assert sender.rank == 5
-
-
-def test_publisher_requires_rank_identity() -> None:
-    try:
-        TelemetryPublisher(
-            tcp_client=_FakeTCPClient(),
-            logger=_FakeLogger(),
-        )
-    except ValueError as exc:
-        assert "global_rank" in str(exc)
-    else:
-        raise AssertionError("TelemetryPublisher accepted missing rank")
+    assert sender.identity == SenderIdentity(global_rank=5, local_rank=1)
 
 
 def test_publisher_logs_sender_attach_failures_and_continues() -> None:
@@ -155,7 +145,7 @@ def test_publisher_logs_sender_attach_failures_and_continues() -> None:
     good_sampler = _FakeSampler("GoodSampler", sender=good_sender)
     publisher = TelemetryPublisher(
         tcp_client=tcp_client,
-        rank=2,
+        identity=SenderIdentity(global_rank=2, local_rank=2),
         logger=logger,
     )
 
@@ -181,7 +171,7 @@ def test_publisher_flushes_collects_and_sends_one_batch() -> None:
     )
     publisher = TelemetryPublisher(
         tcp_client=tcp_client,
-        rank=0,
+        identity=SenderIdentity(global_rank=0, local_rank=0),
         logger=_FakeLogger(),
     )
 
@@ -199,7 +189,7 @@ def test_publisher_collects_empty_mapping_payloads() -> None:
     )
     publisher = TelemetryPublisher(
         tcp_client=tcp_client,
-        rank=0,
+        identity=SenderIdentity(global_rank=0, local_rank=0),
         logger=_FakeLogger(),
     )
 
@@ -216,7 +206,7 @@ def test_publisher_does_not_send_empty_batch() -> None:
     )
     publisher = TelemetryPublisher(
         tcp_client=tcp_client,
-        rank=0,
+        identity=SenderIdentity(global_rank=0, local_rank=0),
         logger=_FakeLogger(),
     )
 
@@ -244,7 +234,7 @@ def test_publisher_logs_failures_and_continues() -> None:
     )
     publisher = TelemetryPublisher(
         tcp_client=tcp_client,
-        rank=0,
+        identity=SenderIdentity(global_rank=0, local_rank=0),
         logger=logger,
     )
 
@@ -261,7 +251,7 @@ def test_publisher_close_delegates_to_tcp_client() -> None:
     tcp_client = _FakeTCPClient()
     publisher = TelemetryPublisher(
         tcp_client=tcp_client,
-        rank=0,
+        identity=SenderIdentity(global_rank=0, local_rank=0),
         logger=_FakeLogger(),
     )
 
@@ -275,7 +265,7 @@ def test_publisher_close_failure_is_logged_not_raised() -> None:
     logger = _FakeLogger()
     publisher = TelemetryPublisher(
         tcp_client=tcp_client,
-        rank=0,
+        identity=SenderIdentity(global_rank=0, local_rank=0),
         logger=logger,
     )
 
@@ -296,7 +286,7 @@ def test_publisher_uses_error_logger_fallback_when_exception_missing() -> None:
     logger = _ErrorOnlyLogger()
     publisher = TelemetryPublisher(
         tcp_client=_FakeTCPClient(fail_send=True),
-        rank=0,
+        identity=SenderIdentity(global_rank=0, local_rank=0),
         logger=logger,
     )
 

--- a/tests/runtime/test_telemetry_publisher.py
+++ b/tests/runtime/test_telemetry_publisher.py
@@ -1,3 +1,9 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 from traceml.runtime.sender import TelemetryPublisher
 
 
@@ -110,6 +116,34 @@ def test_publisher_attaches_senders_to_tcp_client_and_rank() -> None:
 
     assert sender.sender is tcp_client
     assert sender.rank == 3
+
+
+def test_publisher_prefers_global_rank_for_sender_identity() -> None:
+    tcp_client = _FakeTCPClient()
+    sender = _FakeSender(payload={"rows": [1]})
+    sampler = _FakeSampler("SamplerA", sender=sender)
+    publisher = TelemetryPublisher(
+        tcp_client=tcp_client,
+        global_rank=5,
+        rank=1,
+        logger=_FakeLogger(),
+    )
+
+    publisher.attach_senders([sampler])
+
+    assert sender.rank == 5
+
+
+def test_publisher_requires_rank_identity() -> None:
+    try:
+        TelemetryPublisher(
+            tcp_client=_FakeTCPClient(),
+            logger=_FakeLogger(),
+        )
+    except ValueError as exc:
+        assert "global_rank" in str(exc)
+    else:
+        raise AssertionError("TelemetryPublisher accepted missing rank")
 
 
 def test_publisher_logs_sender_attach_failures_and_continues() -> None:

--- a/tests/telemetry/test_sender_sequence.py
+++ b/tests/telemetry/test_sender_sequence.py
@@ -1,3 +1,9 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Tests for the seq-counter optimisation in Database, DBIncrementalSender,
 and DatabaseWriter.
@@ -177,6 +183,31 @@ class TestDBIncrementalSender:
         assert "t1" not in payload["tables"]
         assert "t2" in payload["tables"]
         assert len(payload["tables"]["t2"]) == 1
+
+    def test_payload_rank_uses_attached_runtime_rank(self):
+        db = Database(sampler_name="test")
+        sender, transport = self._make_sender(db)
+        sender.rank = 5
+
+        db.add_record("t1", {"v": 1})
+        sender.flush()
+
+        payload = transport.send.call_args[0][0]
+        assert payload["rank"] == 5
+
+    def test_collect_payload_requires_attached_rank(self):
+        from traceml.database.database_sender import DBIncrementalSender
+
+        db = Database(sampler_name="test")
+        sender = DBIncrementalSender(
+            db=db,
+            sampler_name="test_sampler",
+            rank=None,
+        )
+        db.add_record("t1", {"v": 1})
+
+        with pytest.raises(RuntimeError, match="runtime rank"):
+            sender.collect_payload()
 
 
 # DatabaseWriter tests

--- a/tests/telemetry/test_sender_sequence.py
+++ b/tests/telemetry/test_sender_sequence.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from traceml.database.database import Database
+from traceml.runtime.sender import SenderIdentity
 from traceml.utils.msgpack_codec import Decoder as MsgpackDecoder
 
 # Database.get_append_count() tests
@@ -187,6 +188,7 @@ class TestDBIncrementalSender:
     def test_payload_rank_uses_attached_runtime_rank(self):
         db = Database(sampler_name="test")
         sender, transport = self._make_sender(db)
+        sender.identity = SenderIdentity(global_rank=5, local_rank=1)
         sender.rank = 5
 
         db.add_record("t1", {"v": 1})
@@ -194,6 +196,8 @@ class TestDBIncrementalSender:
 
         payload = transport.send.call_args[0][0]
         assert payload["rank"] == 5
+        assert payload["global_rank"] == 5
+        assert payload["local_rank"] == 1
 
     def test_collect_payload_requires_attached_rank(self):
         from traceml.database.database_sender import DBIncrementalSender


### PR DESCRIPTION
This PR adds the first distributed runtime identity plumbing for multi-node work and improves final step-time summary behavior.

- add canonical runtime identity fields for global rank, local rank, world size, local world size, node rank, hostname, and pid
- attach global/local rank metadata to telemetry payloads while preserving existing rank behavior
- add a proper `WARMUP` step-time diagnosis when partial data exists but is below the summary threshold
- keep `NO DATA` reserved for truly missing/unusable step-time data
