### PR TITLE
h2d made consistent

### DIFF
--- a/src/traceml/instrumentation/h2d.py
+++ b/src/traceml/instrumentation/h2d.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+
+
+def device_type(value: Any) -> Optional[str]:
+    """Return the device type for a .to(...) argument, if it encodes one."""
+    if isinstance(value, torch.device):
+        return value.type
+
+    if isinstance(value, torch.Tensor):
+        return value.device.type
+
+    if isinstance(value, str):
+        try:
+            return torch.device(value).type
+        except (RuntimeError, TypeError):
+            return None
+
+    return None
+
+
+def is_cuda_target(args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
+    """
+    Return True when a .to(...) call targets CUDA.
+
+    Handles:
+      x.to("cuda")
+      x.to(torch.device("cuda"))
+      x.to(device="cuda")
+      x.to(other_cuda_tensor)
+    """
+    first = args[0] if args else None
+
+    if device_type(first) == "cuda":
+        return True
+
+    if device_type(kwargs.get("device")) == "cuda":
+        return True
+
+    return False
+
+
+def should_time_h2d(
+    obj: Any, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> bool:
+    """
+    Return True when a .to(...) call should be timed as H2D.
+
+    H2D means host/input tensor movement to CUDA inside the training step.
+    It intentionally excludes CPU-only moves, dtype-only casts, D2H, D2D, and
+    Parameter movement from model.to(...).
+    """
+    if not is_cuda_target(args, kwargs):
+        return False
+
+    if isinstance(obj, torch.nn.Parameter):
+        return False
+
+    if isinstance(obj, torch.Tensor):
+        return not obj.is_cuda
+
+    # Manual custom batch wrappers: user explicitly wrapped this object and the
+    # target is CUDA, but we cannot inspect internal tensor locations safely.
+    return True

--- a/src/traceml/instrumentation/patches/h2d_auto_timer_patch.py
+++ b/src/traceml/instrumentation/patches/h2d_auto_timer_patch.py
@@ -41,10 +41,11 @@ Event name
 from __future__ import annotations
 
 import threading
-from typing import Any, Optional
+from typing import Any
 
 import torch
 
+from traceml.instrumentation.h2d import should_time_h2d
 from traceml.utils.timing import timed_region
 
 _H2D_TLS = threading.local()
@@ -58,57 +59,16 @@ def _enabled() -> bool:
     return bool(getattr(_H2D_TLS, "_traceml_h2d_enabled", False))
 
 
-# Device-target detection
-
-
-def _device_type(value: Any) -> Optional[str]:
-    """Return the device type string for a value, or None if not recognisable."""
-    if isinstance(value, torch.device):
-        return value.type
-    if isinstance(value, torch.Tensor):
-        return value.device.type
-    if isinstance(value, str):
-        try:
-            return torch.device(value).type
-        except (RuntimeError, TypeError):
-            return None
-    return None
-
-
-def _is_cuda_target(args: tuple, kwargs: dict) -> bool:
-    """
-    Return True when the ``.to()`` call is moving data to a CUDA device.
-
-    Handles the common calling conventions:
-      tensor.to("cuda:0")
-      tensor.to(torch.device("cuda"))
-      tensor.to(device="cuda:0")
-      tensor.to(other_cuda_tensor)   # copies device from other_tensor
-    """
-    first = args[0] if args else None
-    if _device_type(first) == "cuda":
-        return True
-    if _device_type(kwargs.get("device")) == "cuda":
-        return True
-    return False
-
-
 # Patched method
 
 
 def _traceml_tensor_to(self: torch.Tensor, *args: Any, **kwargs: Any) -> Any:
     if not _enabled():
         return _ORIG_TENSOR_TO(self, *args, **kwargs)
-    # D2D — source is already on CUDA; skip before parsing the destination.
-    if self.is_cuda:
+
+    if not should_time_h2d(self, args, kwargs):
         return _ORIG_TENSOR_TO(self, *args, **kwargs)
-    #  _apply traversal — model.to(device) calls tensor.to() once per
-    # Parameter, inflating n_calls by the parameter count.
-    if isinstance(self, torch.nn.Parameter):
-        return _ORIG_TENSOR_TO(self, *args, **kwargs)
-    # Destination check last — involves torch.device() parsing.
-    if not _is_cuda_target(args, kwargs):
-        return _ORIG_TENSOR_TO(self, *args, **kwargs)
+
     with timed_region(
         "_traceml_internal:h2d_time",
         scope="step",

--- a/src/traceml/sdk/wrappers.py
+++ b/src/traceml/sdk/wrappers.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
+from traceml.instrumentation.h2d import should_time_h2d
 from traceml.utils.timing import TimeScope, timed_region
 
 
@@ -289,8 +290,11 @@ class _WrappedH2D:
     def to(self, *args: Any, **kwargs: Any) -> Any:
         # If the auto-patch was installed after this wrapper was created
         # (wrap-then-init race), defer to avoid double-counting: the patch
-        # will time this call.
+        # will time this call if it qualifies as H2D.
         if getattr(torch.Tensor, "_traceml_h2d_patched", False):
+            return self._obj.to(*args, **kwargs)
+
+        if not should_time_h2d(self._obj, args, kwargs):
             return self._obj.to(*args, **kwargs)
 
         with timed_region(
@@ -321,7 +325,7 @@ class _WrappedH2D:
 
 def wrap_h2d(obj: Any) -> "_WrappedH2D":
     """
-    Wrap a tensor or batch object so the next ``.to(...)`` call is timed.
+    Wrap a tensor or batch object so qualifying CPU-to-CUDA .to(...) calls are timed.
 
     Intended for ``manual`` or ``selective`` initialization modes where the
     automatic ``torch.Tensor.to()`` patch is not installed.


### PR DESCRIPTION
This PR makes H2D timing semantics consistent across automatic patching and manual `wrap_h2d(...)`.

A shared H2D detection helper now decides whether a `.to(...)` call should emit `_traceml_internal:h2d_time`, limiting it to CPU/input-to-CUDA movement and skipping CPU-only, dtype-only, D2H/D2D, and parameter/model movement cases.

This keeps raw telemetry sparse and honest while avoiding misleading H2D timings on CPU-compatible training loops.