### PR TITLE
h2d in compute and cli rendering

### DIFF
--- a/src/traceml/renderers/step_time/compute.py
+++ b/src/traceml/renderers/step_time/compute.py
@@ -23,6 +23,7 @@ WAIT_STEP_KEY = "step_time"
 
 EVENT_ALIASES = {
     "dataloader_fetch": "_traceml_internal:dataloader_next",
+    "h2d": "_traceml_internal:h2d_time",
     "forward": "_traceml_internal:forward_time",
     "backward": "_traceml_internal:backward_time",
     "optimizer_step": "_traceml_internal:optimizer_step",
@@ -31,6 +32,7 @@ EVENT_ALIASES = {
 
 DEFAULT_METRIC_KEYS: Tuple[str, ...] = (
     "dataloader_fetch",
+    "h2d",
     "forward",
     "backward",
     "optimizer_step",
@@ -39,6 +41,7 @@ DEFAULT_METRIC_KEYS: Tuple[str, ...] = (
 
 DEFAULT_HEATMAP_KEYS: Tuple[str, ...] = (
     "dataloader_fetch",
+    "h2d",
     "forward",
     "backward",
     "optimizer_step",
@@ -180,6 +183,7 @@ class StepCombinedComputer:
         )
 
         step_sums = per_metric_rank_sums.get("step_time", {})
+        h2d_sums = per_metric_rank_sums.get("h2d", {})
         fwd_sums = per_metric_rank_sums.get("forward", {})
         bwd_sums = per_metric_rank_sums.get("backward", {})
         opt_sums = per_metric_rank_sums.get("optimizer_step", {})
@@ -188,6 +192,7 @@ class StepCombinedComputer:
             r: max(
                 0.0,
                 step_sums.get(r, 0.0)
+                - h2d_sums.get(r, 0.0)
                 - fwd_sums.get(r, 0.0)
                 - bwd_sums.get(r, 0.0)
                 - opt_sums.get(r, 0.0),
@@ -615,11 +620,12 @@ class StepCombinedComputer:
         """
         Compute overall rank "badness" score used for dashboard identity.
 
-        Same definition as before:
-            dataloader_fetch + max(step_time, forward + backward + optimizer_step)
+        Overall score:
+            dataloader_fetch + max(step_time, h2d + forward + backward + optimizer_step)
         """
         step_sums = per_metric_rank_sums.get("step_time", {})
         dl_sums = per_metric_rank_sums.get("dataloader_fetch", {})
+        h2d_sums = per_metric_rank_sums.get("h2d", {})
         fwd_sums = per_metric_rank_sums.get("forward", {})
         bwd_sums = per_metric_rank_sums.get("backward", {})
         opt_sums = per_metric_rank_sums.get("optimizer_step", {})
@@ -629,7 +635,8 @@ class StepCombinedComputer:
                 self._safe_float(dl_sums.get(r, 0.0))
                 + max(
                     self._safe_float(step_sums.get(r, 0.0)),
-                    self._safe_float(fwd_sums.get(r, 0.0))
+                    self._safe_float(h2d_sums.get(r, 0.0))
+                    + self._safe_float(fwd_sums.get(r, 0.0))
                     + self._safe_float(bwd_sums.get(r, 0.0))
                     + self._safe_float(opt_sums.get(r, 0.0)),
                 )

--- a/src/traceml/renderers/step_time/renderer.py
+++ b/src/traceml/renderers/step_time/renderer.py
@@ -32,6 +32,16 @@ from traceml.renderers.utils import fmt_time_run
 from .compute import StepCombinedComputer
 from .schema import StepCombinedTimeResult
 
+METRIC_LABELS = {
+    "dataloader_fetch": "DL",
+    "h2d": "H2D",
+    "forward": "FWD",
+    "backward": "BWD",
+    "optimizer_step": "OPT",
+    "step_time": "STEP",
+    "wait_proxy": "WAIT",
+}
+
 
 class StepCombinedRenderer(BaseRenderer):
     """
@@ -94,10 +104,9 @@ class StepCombinedRenderer(BaseRenderer):
         table.add_column("Metric", style="magenta")
 
         for m in metrics:
-            title = (
-                "Wait*"
-                if m.metric == "wait_proxy"
-                else m.metric.replace("_", " ").title()
+            title = METRIC_LABELS.get(
+                m.metric,
+                m.metric.replace("_", " ").title(),
             )
             table.add_column(title, justify="right")
 
@@ -173,7 +182,13 @@ class StepCombinedRenderer(BaseRenderer):
         cols, _ = shutil.get_terminal_size()
         width = min(max(100, int(cols * 0.75)), 120)
 
-        footer = "\n\n[dim]* WAIT = step time − model execution (mixed CPU/GPU proxy)[/dim]"
+        footer = (
+            "\n\n[dim]"
+            "DL=dataloader fetch | H2D=host-to-device | FWD=forward | "
+            "BWD=backward | OPT=optimizer | STEP=traced step | "
+            "WAIT=STEP−H2D−FWD−BWD−OPT"
+            "[/dim]"
+        )
         return Panel(
             Group(diag_text, "", table, footer),
             title=f"Model Step Summary ({subtitle})",


### PR DESCRIPTION
This PR surfaces H2D timing in the live step-time renderer.

The renderer now reads `_traceml_internal:h2d_time` from `events_json`, shows it as an `H2D` phase, treats missing H2D events as `0.0`, and subtracts H2D from the live `WAIT` proxy.

It also shortens CLI phase labels to `DL`, `H2D`, `FWD`, `BWD`, `OPT`, `STEP`, and `WAIT` to keep the live table compact.