### PR TITLE
H2d summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](./LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/traceopt-ai/traceml?style=social)](https://github.com/traceopt-ai/traceml)
 
-[**Quickstart**](docs/user_guide/quickstart.md) • [**Compare Runs**](docs/user_guide/compare.md) • [**How to Read Output**](docs/user_guide/reading-output.md) • [**W&B / MLflow**](docs/user_guide/integrations/wandb-mlflow.md) • [**FAQ**](docs/user_guide/faq.md) • [**Issues**](https://github.com/traceopt-ai/traceml/issues)
+[**Quickstart**](docs/user_guide/quickstart.md) •
+[**Compare Runs**](docs/user_guide/compare.md) •
+[**How to Read Output**](docs/user_guide/reading-output.md) •
+[**W&B / MLflow**](docs/user_guide/integrations/wandb-mlflow.md) •
+[**FAQ**](docs/user_guide/faq.md) •
+[**Issues**](https://github.com/traceopt-ai/traceml/issues) •
+[**Discussions**](https://github.com/traceopt-ai/traceml/discussions)
 
 </div>
 

--- a/docs/user_guide/quickstart.md
+++ b/docs/user_guide/quickstart.md
@@ -319,7 +319,7 @@ Typical next steps:
 
 ### `WAIT-HEAVY`
 
-A meaningful part of the step is not attributed to dataloader, forward,
+A meaningful part of the step is not attributed to dataloader, H2D, forward,
 backward, or optimizer work.
 
 Typical next steps:

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -278,12 +278,12 @@ What to do next:
 Meaning:
 
 - a meaningful part of the typical step is not attributed to dataloader,
-  forward, backward, or optimizer work
+  H2D, forward, backward, or optimizer work
 
 In TraceML:
 
 - `compute = forward + backward + optimizer`
-- `wait = total_step - dataloader - compute`
+- `wait = total_step - dataloader - h2d - compute`
 
 This is residual unattributed time in the reported total step, not direct
 collective, NCCL, or all-reduce timing.
@@ -294,7 +294,7 @@ Common causes:
 - checkpointing or logging work
 - framework orchestration outside the traced phases
 - CPU stalls
-- transfer / orchestration overhead
+- unobserved transfer or orchestration overhead
 
 What to look at:
 
@@ -305,7 +305,7 @@ What to do next:
 
 - inspect work happening around the traced training step
 - inspect rank imbalance
-- inspect CPU-side delays, logging, checkpointing, validation, and transfer paths
+- inspect CPU-side delays, logging, checkpointing, validation, and unobserved transfer paths
 
 ---
 
@@ -648,7 +648,7 @@ Use these as context cards:
 | `INPUT STRAGGLER` | inspect input path on the worst rank |
 | `COMPUTE STRAGGLER` | inspect compute path on the worst rank |
 | `STRAGGLER` | inspect both input and compute unevenness |
-| `WAIT-HEAVY` | inspect logging, checkpointing, validation, CPU stalls, and transfer paths |
+| `WAIT-HEAVY` | inspect logging, checkpointing, validation, CPU stalls, and unobserved transfer paths |
 | `MEMORY CREEP (EARLY)` | inspect retained state and watch the next window |
 | `MEMORY CREEP` | inspect retained tensors and growing caches |
 | `HIGH PRESSURE` | reduce memory load |

--- a/src/traceml/diagnostics/DIAGNOSIS.md
+++ b/src/traceml/diagnostics/DIAGNOSIS.md
@@ -54,14 +54,16 @@ unattributed step time:
 
 ```text
 compute_ms = forward_ms + backward_ms + optimizer_ms
-traced_step_ms = max(raw_trace_step_wall_ms, compute_ms)
-wait_ms = traced_step_ms - compute_ms
+known_step_ms = h2d_ms + compute_ms
+traced_step_ms = max(raw_trace_step_wall_ms, known_step_ms)
+wait_ms = traced_step_ms - known_step_ms
 total_step_ms = dataloader_ms + traced_step_ms
 ```
 
 It can include validation, checkpointing, logging, framework orchestration, CPU
-stalls, transfer stalls, or other work inside the timed step but outside the
-compute phases. It is not direct NCCL, all-reduce, or synchronization timing.
+stalls, unobserved transfer stalls, or other work inside the timed step but
+outside the traced H2D and compute phases. It is not direct NCCL, all-reduce,
+or synchronization timing.
 
 ## Step Memory
 

--- a/src/traceml/diagnostics/step_time/adapters.py
+++ b/src/traceml/diagnostics/step_time/adapters.py
@@ -44,6 +44,7 @@ class RankStepSignals:
 
     steps_analyzed: int
     dataloader_ms: float
+    h2d_ms: float
     forward_ms: float
     backward_ms: float
     optimizer_ms: float
@@ -210,16 +211,20 @@ def _build_summary_per_rank_timing(
     out: Dict[int, Dict[str, float]] = {}
     for rank, item in rank_signals.items():
         dataloader = _finite_float(item.dataloader_ms)
+        h2d = _finite_float(item.h2d_ms)
         forward = _finite_float(item.forward_ms)
         backward = _finite_float(item.backward_ms)
         optimizer = _finite_float(item.optimizer_ms)
         step_cpu = _finite_float(item.step_cpu_ms)
+
         compute = forward + backward + optimizer
-        step_effective = max(step_cpu, compute)
-        wait = max(0.0, step_effective - compute)
+        known_step = h2d + compute
+        step_effective = max(step_cpu, known_step)
+        wait = max(0.0, step_effective - known_step)
 
         out[int(rank)] = {
             "dataloader_fetch": dataloader,
+            "h2d": h2d,
             "forward": forward,
             "backward": backward,
             "optimizer_step": optimizer,
@@ -272,6 +277,7 @@ def build_summary_step_diagnosis_result(
             common_steps = []
         for mk in (
             "dataloader_fetch",
+            "h2d",
             "forward",
             "backward",
             "optimizer_step",
@@ -298,6 +304,7 @@ def build_summary_step_diagnosis_result(
     )
 
     dl = {r: _finite_float(s.dataloader_ms) for r, s in rank_signals.items()}
+    h2d = {r: _finite_float(s.h2d_ms) for r, s in rank_signals.items()}
     fwd = {r: _finite_float(s.forward_ms) for r, s in rank_signals.items()}
     bwd = {r: _finite_float(s.backward_ms) for r, s in rank_signals.items()}
     opt = {r: _finite_float(s.optimizer_ms) for r, s in rank_signals.items()}
@@ -306,8 +313,9 @@ def build_summary_step_diagnosis_result(
     }
 
     compute = {r: fwd[r] + bwd[r] + opt[r] for r in ranks}
-    step_effective = {r: max(step_raw[r], compute[r]) for r in ranks}
-    wait = {r: max(0.0, step_effective[r] - compute[r]) for r in ranks}
+    known_step = {r: h2d[r] + compute[r] for r in ranks}
+    step_effective = {r: max(step_raw[r], known_step[r]) for r in ranks}
+    wait = {r: max(0.0, step_effective[r] - known_step[r]) for r in ranks}
 
     # Keep overall rank identity aligned with summary-card semantics.
     overall_rank_scores = {r: dl[r] + step_effective[r] for r in ranks}
@@ -317,6 +325,7 @@ def build_summary_step_diagnosis_result(
 
     metric_values = {
         "dataloader_fetch": dl,
+        "h2d": h2d,
         "forward": fwd,
         "backward": bwd,
         "optimizer_step": opt,
@@ -327,6 +336,7 @@ def build_summary_step_diagnosis_result(
     metrics: List[StepCombinedTimeMetric] = []
     for key in (
         "dataloader_fetch",
+        "h2d",
         "forward",
         "backward",
         "optimizer_step",

--- a/src/traceml/diagnostics/step_time/api.py
+++ b/src/traceml/diagnostics/step_time/api.py
@@ -504,7 +504,10 @@ def build_step_diagnosis_result(
             worst_rank=(
                 None if context.single_rank else context.overall_worst_rank
             ),
-            note="wait_ms = total_step_ms - dataloader_ms - compute_ms.",
+            note=(
+                "wait_ms = total_step_ms - dataloader_ms - h2d_ms - "
+                "compute_ms."
+            ),
         )
     elif primary_issue is not None and primary_issue.kind == "COMPUTE_BOUND":
         primary = _mk_diag(

--- a/src/traceml/diagnostics/step_time/rules.py
+++ b/src/traceml/diagnostics/step_time/rules.py
@@ -231,7 +231,7 @@ class WaitHeavyRule(_BaseStepTimeRule):
             summary=f"WAIT* is {_pct(context.wait_share)} of the typical step.",
             action=(
                 "Inspect work outside traced phases, CPU stalls, logging, "
-                "checkpointing, validation, or transfers."
+                "checkpointing, validation, or unobserved transfers."
             ),
             metric="wait_proxy",
             phase="wait",

--- a/src/traceml/reporting/SCHEMA.md
+++ b/src/traceml/reporting/SCHEMA.md
@@ -115,6 +115,7 @@ in `global_ranks_used`.
   "step_time": [
     "total_step_ms",
     "dataloader_ms",
+    "h2d_ms",
     "compute_ms",
     "wait_ms",
     "forward_ms",
@@ -142,19 +143,21 @@ Metric suffixes are units:
 
 ```text
 compute_ms = forward_ms + backward_ms + optimizer_ms
-traced_step_ms = max(raw_trace_step_wall_ms, compute_ms)
-wait_ms = traced_step_ms - compute_ms
+known_step_ms = h2d_ms + compute_ms
+traced_step_ms = max(raw_trace_step_wall_ms, known_step_ms)
+wait_ms = traced_step_ms - known_step_ms
 total_step_ms = dataloader_ms + traced_step_ms
 ```
 
 The public contract is:
 
 ```text
-total_step_ms = dataloader_ms + compute_ms + wait_ms
+total_step_ms = dataloader_ms + h2d_ms + compute_ms + wait_ms
 ```
 
 `traced_step_ms` and the raw `trace_step` wall timer are internal measurement
 details and are not emitted in final-summary JSON. `wait_ms` can include
 validation, checkpointing, logging, framework orchestration, CPU stalls,
-transfer stalls, or other work outside the traced compute phases. Do not treat
-it as NCCL, all-reduce, or synchronization overhead without profiler evidence.
+unobserved transfer stalls, or other work outside the traced H2D and compute
+phases. Do not treat it as NCCL, all-reduce, or synchronization overhead
+without profiler evidence.

--- a/src/traceml/reporting/compare/formatters.py
+++ b/src/traceml/reporting/compare/formatters.py
@@ -109,6 +109,7 @@ def _rows_for_section(
         "step_time": (
             "total_step_ms",
             "input_ms",
+            "h2d_ms",
             "compute_ms",
             "wait_ms",
             "forward_ms",

--- a/src/traceml/reporting/compare/sections/step_time.py
+++ b/src/traceml/reporting/compare/sections/step_time.py
@@ -52,6 +52,14 @@ class StepTimeComparer:
                     rhs=self._value(rhs, "dataloader_ms"),
                     direction="higher_is_worse",
                 ),
+                "h2d_ms": numeric_metric(
+                    key="h2d_ms",
+                    label="H2D",
+                    unit="ms",
+                    lhs=self._value(lhs, "h2d_ms"),
+                    rhs=self._value(rhs, "h2d_ms"),
+                    direction="higher_is_worse",
+                ),
                 "compute_ms": numeric_metric(
                     key="compute_ms",
                     label="Compute",
@@ -107,6 +115,7 @@ class StepTimeComparer:
     def _dominant_phase(self, section: Any) -> Any:
         phases = {
             "dataloader": as_float(self._value(section, "dataloader_ms")),
+            "h2d": as_float(self._value(section, "h2d_ms")),
             "forward": as_float(self._value(section, "forward_ms")),
             "backward": as_float(self._value(section, "backward_ms")),
             "optimizer": as_float(self._value(section, "optimizer_ms")),

--- a/src/traceml/reporting/final.py
+++ b/src/traceml/reporting/final.py
@@ -252,7 +252,7 @@ class FinalReportGenerator:
         )
 
         return {
-            "schema_version": 1.2,
+            "schema_version": 1.3,
             "generated_at": utc_now_iso(),
             "duration_s": _summary_duration_s(
                 step_time_summary,

--- a/src/traceml/reporting/sections/step_time/alignment.py
+++ b/src/traceml/reporting/sections/step_time/alignment.py
@@ -50,6 +50,7 @@ def _summary_from_step_metrics(
 
     sum_dl = 0.0
     sum_fwd = 0.0
+    sum_h2d = 0.0
     sum_bwd = 0.0
     sum_opt = 0.0
     sum_step_cpu = 0.0
@@ -59,18 +60,21 @@ def _summary_from_step_metrics(
 
     for metrics in step_metrics.values():
         dataloader = finite_float(metrics.get("dataloader_fetch"))
+        h2d = finite_float(metrics.get("h2d"))
         forward = finite_float(metrics.get("forward"))
         backward = finite_float(metrics.get("backward"))
         optimizer = finite_float(metrics.get("optimizer_step"))
         step_time = finite_float(metrics.get("step_time"))
         compute = forward + backward + optimizer
+        known_step = h2d + compute
 
         sum_dl += dataloader
+        sum_h2d += h2d
         sum_fwd += forward
         sum_bwd += backward
         sum_opt += optimizer
         sum_step_cpu += max(0.0, step_time)
-        traced_step = max(step_time, compute)
+        traced_step = max(step_time, known_step)
         sum_traced_step += traced_step
         sum_total += dataloader + traced_step
         n += 1
@@ -81,6 +85,7 @@ def _summary_from_step_metrics(
     return RankStepSummary(
         steps_analyzed=n,
         avg_dataloader_ms=sum_dl / n,
+        avg_h2d_ms=sum_h2d / n,
         avg_forward_ms=sum_fwd / n,
         avg_backward_ms=sum_bwd / n,
         avg_optimizer_ms=sum_opt / n,

--- a/src/traceml/reporting/sections/step_time/builder.py
+++ b/src/traceml/reporting/sections/step_time/builder.py
@@ -58,6 +58,7 @@ class StepTimeCardStats:
 
     global_rank_count: int
     total_step: StepTimeMetricPair
+    h2d: StepTimeMetricPair
     compute: StepTimeMetricPair
     wait: StepTimeMetricPair
     input: StepTimeMetricPair
@@ -152,6 +153,12 @@ def _build_card_stats(
                 for rank, summary in per_global_rank_summary.items()
             }
         ),
+        h2d=_metric_pair_from_rank_values(
+            {
+                int(rank): finite_float(summary.avg_h2d_ms)
+                for rank, summary in per_global_rank_summary.items()
+            }
+        ),
     )
 
 
@@ -171,9 +178,13 @@ def _format_card_stats(stats: StepTimeCardStats) -> str:
             stats.input.median_ms,
             stats.input.worst_ms,
         )
+        h2d_ms = _format_ms_pair(
+            stats.h2d.median_ms,
+            stats.h2d.worst_ms,
+        )
         return (
             "- Stats: median/worst | "
-            f"total {total} | input {input_ms} | compute {compute} | "
+            f"total {total} | input {input_ms} | H2D {h2d_ms} | compute {compute} | "
             f"wait {wait}"
         )
 
@@ -181,6 +192,7 @@ def _format_card_stats(stats: StepTimeCardStats) -> str:
         "- Stats: "
         f"total {format_ms(stats.total_step.worst_ms)} | "
         f"input {format_ms(stats.input.worst_ms)} | "
+        f"H2D {format_ms(stats.h2d.worst_ms)} | "
         f"compute {format_ms(stats.compute.worst_ms)} | "
         f"wait {format_ms(stats.wait.worst_ms)}"
     )
@@ -206,9 +218,13 @@ def _format_card_ranks(stats: StepTimeCardStats) -> Optional[str]:
         stats.input.median_global_rank,
         stats.input.worst_global_rank,
     )
+    h2d_rank = _format_rank_pair(
+        stats.h2d.median_global_rank,
+        stats.h2d.worst_global_rank,
+    )
     return (
         "- Ranks: median/worst | "
-        f"total {total} | input {input_rank} | compute {compute} | "
+        f"total {total} | input {input_rank} | H2D {h2d_rank} | compute {compute} | "
         f"wait {wait}"
     )
 

--- a/src/traceml/reporting/sections/step_time/model.py
+++ b/src/traceml/reporting/sections/step_time/model.py
@@ -20,6 +20,7 @@ MAX_SUMMARY_WINDOW_ROWS = DEFAULT_SUMMARY_WINDOW_ROWS
 STEP_TIME_METRIC_NAMES = [
     "total_step_ms",
     "dataloader_ms",
+    "h2d_ms",
     "compute_ms",
     "wait_ms",
     "forward_ms",
@@ -55,6 +56,8 @@ def _event_bucket(name: str) -> Optional[str]:
         return "step_time"
     if "dataloader_next" in n:
         return "dataloader"
+    if "h2d_time" in n or "host_to_device" in n:
+        return "h2d"
     if "forward_time" in n:
         return "forward"
     if "backward_time" in n:
@@ -111,6 +114,7 @@ class RankStepSummary:
 
     steps_analyzed: int
     avg_dataloader_ms: float
+    avg_h2d_ms: float
     avg_forward_ms: float
     avg_backward_ms: float
     avg_optimizer_ms: float
@@ -150,6 +154,7 @@ def to_rank_signals(
         int(rank): RankStepSignals(
             steps_analyzed=int(s.steps_analyzed),
             dataloader_ms=finite_float(s.avg_dataloader_ms),
+            h2d_ms=finite_float(s.avg_h2d_ms),
             forward_ms=finite_float(s.avg_forward_ms),
             backward_ms=finite_float(s.avg_backward_ms),
             optimizer_ms=finite_float(s.avg_optimizer_ms),
@@ -176,6 +181,7 @@ def _row_metrics(events: Dict[str, Any]) -> Optional[Dict[str, float]]:
     """
     metrics = {
         "dataloader": 0.0,
+        "h2d": 0.0,
         "forward": 0.0,
         "backward": 0.0,
         "optimizer": 0.0,
@@ -207,15 +213,15 @@ def build_rank_summary(
     Build a per-rank summary and per-step canonical metrics over provided rows.
 
     For each step:
-        gpu_compute = forward + backward + optimizer
-        step_effective = max(step_time, gpu_compute)
-        total_step = dataloader + step_effective
-        wait_proxy = max(0, step_effective - gpu_compute)
+        known_step_ms = h2d_ms + forward_ms + backward_ms + optimizer_ms
+        wait_ms = traced_step_ms - known_step_ms
+        total_step_ms = dataloader_ms + traced_step_ms
     """
     if not step_rows:
         return None
 
     sum_dl = 0.0
+    sum_h2d = 0.0
     sum_fwd = 0.0
     sum_bwd = 0.0
     sum_opt = 0.0
@@ -233,21 +239,24 @@ def build_rank_summary(
             continue
 
         dl = finite_float(metrics["dataloader"])
+        h2d = finite_float(metrics["h2d"])
         fwd = finite_float(metrics["forward"])
         bwd = finite_float(metrics["backward"])
         opt = finite_float(metrics["optimizer"])
         step_cpu = finite_float(metrics["step_time"])
 
         compute_ms = fwd + bwd + opt
+        known_step_ms = h2d + compute_ms
         # raw step = the direct trace_step wall timer.
-        # traced step = max(raw step, compute) to avoid impossible negative wait
+        # traced step = max(raw step, known_step_ms) to avoid impossible negative wait
         # when CPU wall timing and CUDA event timing differ slightly.
-        traced_step = max(step_cpu, compute_ms)
-        wait_proxy = max(0.0, traced_step - compute_ms)
+        traced_step = max(step_cpu, known_step_ms)
+        wait_proxy = max(0.0, traced_step - known_step_ms)
         total_step = dl + traced_step
 
         per_step_metrics[int(step_id)] = {
             "dataloader_fetch": dl,
+            "h2d": h2d,
             "forward": fwd,
             "backward": bwd,
             "optimizer_step": opt,
@@ -256,6 +265,7 @@ def build_rank_summary(
         }
 
         sum_dl += dl
+        sum_h2d += h2d
         sum_fwd += fwd
         sum_bwd += bwd
         sum_opt += opt
@@ -270,6 +280,7 @@ def build_rank_summary(
     summary = RankStepSummary(
         steps_analyzed=n,
         avg_dataloader_ms=sum_dl / n,
+        avg_h2d_ms=sum_h2d / n,
         avg_forward_ms=sum_fwd / n,
         avg_backward_ms=sum_bwd / n,
         avg_optimizer_ms=sum_opt / n,
@@ -285,22 +296,16 @@ def compute_wait_avg_ms(s: RankStepSummary) -> float:
     """
     Return average wait proxy for one rank summary.
 
-    Public Step Time uses:
-        total_step_ms = dataloader_ms + compute_ms + wait_ms
-        compute_ms = forward_ms + backward_ms + optimizer_ms
-
-    Internally, wait is derived from:
-        traced_step_ms - compute_ms
-
-    where traced_step_ms is max(raw trace_step wall timer, compute_ms).
-    The traced-step value is intentionally internal so the public JSON remains
-    the simpler total/input/compute/wait model.
+    known_step_ms = h2d_ms + forward_ms + backward_ms + optimizer_ms
+    wait_ms = traced_step_ms - known_step_ms
+    total_step_ms = dataloader_ms + traced_step_ms
     """
     return max(
         0.0,
         finite_float(s.avg_traced_step_ms)
         - (
-            finite_float(s.avg_forward_ms)
+            finite_float(s.avg_h2d_ms)
+            + finite_float(s.avg_forward_ms)
             + finite_float(s.avg_backward_ms)
             + finite_float(s.avg_optimizer_ms)
         ),
@@ -318,6 +323,10 @@ def _rank_metric_values(
         },
         "dataloader_ms": {
             int(rank): finite_float(summary.avg_dataloader_ms)
+            for rank, summary in per_global_rank_summary.items()
+        },
+        "h2d_ms": {
+            int(rank): finite_float(summary.avg_h2d_ms)
             for rank, summary in per_global_rank_summary.items()
         },
         "compute_ms": {
@@ -348,6 +357,7 @@ def summary_metric_values(summary: RankStepSummary) -> Dict[str, float]:
     return {
         "total_step_ms": finite_float(summary.avg_total_step_ms),
         "dataloader_ms": finite_float(summary.avg_dataloader_ms),
+        "h2d_ms": finite_float(summary.avg_h2d_ms),
         "compute_ms": finite_float(summary.avg_gpu_compute_ms),
         "wait_ms": compute_wait_avg_ms(summary),
         "forward_ms": finite_float(summary.avg_forward_ms),

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -265,6 +265,7 @@ def test_summary_step_time_adapter_uses_summary_policy_by_default() -> None:
         0: RankStepSignals(
             steps_analyzed=40,
             dataloader_ms=1.0,
+            h2d_ms=0.0,
             forward_ms=20.0,
             backward_ms=60.0,
             optimizer_ms=10.0,
@@ -283,6 +284,7 @@ def test_summary_step_time_adapter_uses_summary_policy_by_default() -> None:
     rank_signals[0] = RankStepSignals(
         steps_analyzed=60,
         dataloader_ms=1.0,
+        h2d_ms=0.0,
         forward_ms=20.0,
         backward_ms=60.0,
         optimizer_ms=10.0,

--- a/tests/reporting/summary/test_final.py
+++ b/tests/reporting/summary/test_final.py
@@ -54,7 +54,7 @@ def test_final_report_generator_preserves_summary_schema_and_order():
         ),
     )
 
-    assert payload["schema_version"] == 1.2
+    assert payload["schema_version"] == 1.3
     assert payload["duration_s"] == 10.0
     assert list(payload.keys()) == [
         "schema_version",

--- a/tests/reporting/summary/test_fixtures.py
+++ b/tests/reporting/summary/test_fixtures.py
@@ -831,7 +831,7 @@ def test_final_summary_fixture_schema_contains_all_sections(
 
     payload = build_summary_payload(str(db_path))
 
-    assert payload["schema_version"] == 1.2
+    assert payload["schema_version"] == 1.3
     assert set(payload) == {
         "schema_version",
         "generated_at",

--- a/tests/reporting/summary/test_step_time.py
+++ b/tests/reporting/summary/test_step_time.py
@@ -187,6 +187,7 @@ def test_distributed_step_time_scope_shows_actual_analyzed_steps() -> None:
         rank: RankStepSummary(
             steps_analyzed=128,
             avg_dataloader_ms=1.0,
+            avg_h2d_ms=0.0,
             avg_forward_ms=2.0,
             avg_backward_ms=3.0,
             avg_optimizer_ms=1.0,

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -37,6 +37,7 @@ def _rank(
     return RankStepSummary(
         steps_analyzed=steps,
         avg_dataloader_ms=dataloader,
+        avg_h2d_ms=0.0,
         avg_forward_ms=forward,
         avg_backward_ms=backward,
         avg_optimizer_ms=optimizer,
@@ -141,7 +142,7 @@ def test_step_time_compute_bound_card_uses_short_reason() -> None:
 
     assert payload["diagnosis"]["status"] == "COMPUTE-BOUND"
     assert (
-        "- Stats: total 97.0ms | input 2.0ms | compute 90.0ms"
+        "- Stats: total 97.0ms | input 2.0ms | H2D 0.0ms | compute 90.0ms"
         in payload["card"]
     )
     assert (


### PR DESCRIPTION
Adds H2D timing as a first-class step-time metric in final summary and compare output.

This wires h2d_ms through the summary pipeline from raw step events to aligned rank summaries, diagnosis inputs, final_summary.json, human summary cards, schema docs, and traceml compare. Wait math now subtracts observed H2D correctly, so H2D is no longer misclassified as residual wait time.

Also bumps final summary schema version to 1.3 and refreshes README positioning copy.

