### PR TITLE
Init ray

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [**Quickstart**](docs/user_guide/quickstart.md) •
 [**Compare Runs**](docs/user_guide/compare.md) •
 [**How to Read Output**](docs/user_guide/reading-output.md) •
+[**Ray Train**](docs/user_guide/integrations/ray.md) •
 [**W&B / MLflow**](docs/user_guide/integrations/wandb-mlflow.md) •
 [**FAQ**](docs/user_guide/faq.md) •
 [**Issues**](https://github.com/traceopt-ai/traceml/issues) •
@@ -275,13 +276,13 @@ traceml compare before/final_summary.json after/final_summary.json
 - Single GPU training
 - Single-node multi-GPU DDP / FSDP training
 - Multi-node DDP summary reports
+- Ray Train through a thin `TorchTrainer` wrapper
 - Step Time, Step Memory, System, and Process diagnostics
 - Run-to-run comparison from `final_summary.json`
 - Custom PyTorch loops, Hugging Face, and PyTorch Lightning
 
 **Next:**
 
-- Ray Train integration
 - Slurm launch examples
 - Broader multi-node FSDP validation
 - Multi-node live CLI / dashboard
@@ -305,6 +306,7 @@ traceml compare before/final_summary.json after/final_summary.json
 - [Use TraceML with W&B / MLflow](docs/user_guide/integrations/wandb-mlflow.md)
 - [Hugging Face integration](docs/user_guide/integrations/huggingface.md)
 - [PyTorch Lightning integration](docs/user_guide/integrations/lightning.md)
+- [Ray Train integration](docs/user_guide/integrations/ray.md)
 
 ---
 

--- a/docs/developer_guide/architecture.md
+++ b/docs/developer_guide/architecture.md
@@ -35,7 +35,7 @@ Samplers maintain an incremental append counter per rank per table. The sender s
 | Renderers | `src/traceml/renderers/` | Transform stored data into Rich/Plotly output |
 | Display drivers | `src/traceml/aggregator/display_drivers/` | CLI vs NiceGUI output medium |
 | Decorators | `src/traceml/decorators.py` | User-facing instrumentation entry points |
-| Integrations | `src/traceml/integrations/` | Hugging Face + Lightning adapters |
+| Integrations | `src/traceml/integrations/` | Hugging Face, Lightning, and Ray adapters |
 | Utils | `src/traceml/utils/` | Hooks, patches, memory/timing helpers |
 
 For the user-facing API surface (`trace_step`, `TraceMLTrainer`, `TraceMLCallback`, CLI usage), see the [Public API](../user_guide/public-api.md). The source tree above is the canonical reference for internals — start from the entry points and follow the imports.

--- a/docs/developer_guide/extending.md
+++ b/docs/developer_guide/extending.md
@@ -36,6 +36,22 @@ run them inside Ray actors or worker processes. Both paths should use
 The owner that starts a component must stop it. Use `try/finally` around
 training work, and make stop paths safe to call more than once.
 
+## Ray Integration
+
+Ray support lives in `traceml.integrations.ray` and should stay separate from
+the core runtime. Do not import Ray from `traceml.runtime`, `traceml.aggregator`,
+or the top-level `traceml` package.
+
+The integration has two owners:
+
+- the Ray aggregator actor owns `start_aggregator(...)` and `handle.stop(...)`
+- the Ray worker wrapper owns `start_runtime(...)` and `handle.stop(...)`
+
+Ray owns scheduling, process groups, ranks, and DDP/NCCL/Gloo communication.
+TraceML only starts telemetry components inside the processes Ray already
+created. Keep future Ray changes in that shape: no second launcher, no Ray Train
+internals, and no duplicated aggregator/runtime lifecycle code.
+
 
 ## Add a Diagnostic Rule
 

--- a/docs/developer_guide/extending.md
+++ b/docs/developer_guide/extending.md
@@ -20,6 +20,23 @@ Live UI and final summaries are separate paths. They can share diagnostics, but
 they should pass explicit policies such as `LIVE_STEP_TIME_POLICY` or
 `SUMMARY_STEP_TIME_POLICY` when thresholds differ.
 
+## TraceML Lifecycle
+
+TraceML has two runtime pieces:
+
+- one aggregator, which receives TCP telemetry, writes SQLite history, and
+  creates the final summary
+- one runtime per training process, which samples local telemetry and sends
+  batches to the aggregator
+
+CLI launchers may run these pieces as subprocesses. Framework integrations may
+run them inside Ray actors or worker processes. Both paths should use
+`traceml.runtime.lifecycle` so startup and shutdown stay consistent.
+
+The owner that starts a component must stop it. Use `try/finally` around
+training work, and make stop paths safe to call more than once.
+
+
 ## Add a Diagnostic Rule
 
 Diagnostics live under `src/traceml/diagnostics/<domain>/`.

--- a/docs/user_guide/integrations/ray.md
+++ b/docs/user_guide/integrations/ray.md
@@ -1,0 +1,125 @@
+# Ray Train
+
+TraceML's Ray integration is intentionally thin: Ray launches and manages the
+training workers, while TraceML observes those workers over its normal TCP
+telemetry path.
+
+```text
+driver process
+  -> starts one TraceML aggregator actor
+  -> runs Ray TorchTrainer
+       -> Ray starts training workers
+            -> each worker starts one TraceML runtime
+            -> each worker sends telemetry to the aggregator actor
+```
+
+Ray still owns scheduling, worker placement, ranks, process groups, and
+DDP/NCCL/Gloo communication. TraceML does not replace Ray's launcher or reach
+into Ray Train internals.
+
+## Install
+
+```bash
+pip install "traceml-ai[ray]"
+```
+
+## Minimal Usage
+
+```python
+import ray
+from ray.train import ScalingConfig
+
+from traceml.integrations.ray import TraceMLRayConfig, TraceMLTorchTrainer
+
+
+def train_loop_per_worker(config):
+    import torch
+    import torch.nn as nn
+    import torch.optim as optim
+
+    import traceml
+
+    model = nn.Sequential(nn.Linear(32, 64), nn.ReLU(), nn.Linear(64, 4))
+    optimizer = optim.AdamW(model.parameters(), lr=1e-3)
+    criterion = nn.CrossEntropyLoss()
+
+    traceml.trace_model_instance(model)
+
+    for _ in range(config["steps"]):
+        with traceml.trace_step(model):
+            x = torch.randn(64, 32)
+            y = torch.randint(0, 4, (64,))
+
+            optimizer.zero_grad(set_to_none=True)
+            loss = criterion(model(x), y)
+            loss.backward()
+            optimizer.step()
+
+
+ray.init()
+
+trainer = TraceMLTorchTrainer(
+    train_loop_per_worker,
+    train_loop_config={"steps": 10},
+    scaling_config=ScalingConfig(num_workers=4, use_gpu=False),
+    traceml_config=TraceMLRayConfig(mode="summary"),
+)
+
+trainer.fit()
+```
+
+Use the same ``train_loop_per_worker`` shape you would pass to Ray's
+``TorchTrainer``. The wrapper starts TraceML before your loop runs and stops it
+after the loop exits.
+
+## Network Model
+
+The aggregator runs as a normal Ray actor and binds a TCP server. By default it
+binds ``0.0.0.0`` on port ``0``:
+
+- ``0.0.0.0`` lets workers on other Ray nodes connect to the actor node.
+- port ``0`` lets the operating system choose a free port.
+- workers receive the actor's reachable node IP and chosen port through the
+  wrapped trainer.
+
+If your cluster requires a fixed open port, set it explicitly:
+
+```python
+TraceMLRayConfig(port=29765)
+```
+
+## Configuration
+
+```python
+TraceMLRayConfig(
+    mode="summary",
+    profile="run",
+    init_mode="auto",
+    patch_dataloader=None,
+    patch_forward=None,
+    patch_backward=None,
+    patch_h2d=None,
+    logs_dir="./logs",
+    session_id="",
+    sampler_interval_sec=1.0,
+    bind_host="0.0.0.0",
+    port=0,
+)
+```
+
+The default ``mode="summary"`` is recommended for Ray because distributed worker
+logs are noisy. Use ``mode="cli"`` only when you specifically want live terminal
+rendering from the aggregator actor.
+
+``init_mode`` is passed to ``traceml.init()`` inside each Ray worker. Use
+``init_mode="manual"`` if your training loop wraps dataloader, forward,
+backward, and optimizer timing explicitly. Use ``init_mode="selective"`` with
+the ``patch_*`` options when you only want some automatic patches.
+
+## Lifecycle
+
+``TraceMLTorchTrainer.fit()`` starts the aggregator actor, runs Ray Train, and
+then stops the actor in a ``finally`` block. Each worker also stops its local
+TraceML runtime in a ``finally`` block. Normal exceptions and keyboard
+interrupts should therefore release TraceML resources. A hard ``SIGKILL`` cannot
+run Python cleanup code in any framework.

--- a/docs/user_guide/public-api.md
+++ b/docs/user_guide/public-api.md
@@ -23,6 +23,18 @@ The stable surface that user code imports and calls. Everything in this page is 
       show_root_heading: true
       show_source: true
 
+## Ray Train integration
+
+::: traceml.integrations.ray.TraceMLTorchTrainer
+    options:
+      show_root_heading: true
+      show_source: true
+
+::: traceml.integrations.ray.TraceMLRayConfig
+    options:
+      show_root_heading: true
+      show_source: true
+
 ## CLI
 
 TraceML ships with a CLI entry point installed as `traceml`.

--- a/docs/user_guide/quickstart.md
+++ b/docs/user_guide/quickstart.md
@@ -129,7 +129,33 @@ Three minimal paths to a first TraceML run, depending on how your training code 
     !!! note
         For full Lightning details, see the [PyTorch Lightning integration](integrations/lightning.md).
 
-Everything below this point applies to all three stacks — reading output, compare runs, DDP, troubleshooting.
+=== "Ray Train"
+
+    ```bash
+    pip install "traceml-ai[ray]"
+    ```
+
+    Wrap Ray's `TorchTrainer` with `TraceMLTorchTrainer`:
+
+    ```python
+    from ray.train import ScalingConfig
+    from traceml.integrations.ray import TraceMLTorchTrainer
+
+    trainer = TraceMLTorchTrainer(
+        train_loop_per_worker,
+        train_loop_config={"steps": 100},
+        scaling_config=ScalingConfig(num_workers=4, use_gpu=True),
+    )
+    trainer.fit()
+    ```
+
+    Ray still launches workers and owns distributed communication. TraceML
+    starts one aggregator actor and one runtime inside each Ray worker.
+
+    !!! note
+        For full Ray details, see the [Ray Train integration](integrations/ray.md).
+
+Everything below this point applies to all four stacks — reading output, compare runs, DDP, troubleshooting.
 
 ---
 

--- a/examples/ray_torchtrainer_minimal.py
+++ b/examples/ray_torchtrainer_minimal.py
@@ -1,0 +1,89 @@
+"""Minimal TraceML + Ray Train example.
+
+Run locally:
+    python examples/ray_torchtrainer_minimal.py
+
+Run with GPUs:
+    python examples/ray_torchtrainer_minimal.py --use-gpu --num-workers 4
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def train_loop_per_worker(config):
+    import torch
+    import torch.nn as nn
+    import torch.optim as optim
+    from ray import train
+
+    import traceml
+
+    ctx = train.get_context()
+    device = torch.device(
+        "cuda"
+        if bool(config["use_gpu"]) and torch.cuda.is_available()
+        else "cpu"
+    )
+
+    model = nn.Sequential(
+        nn.Linear(32, 64),
+        nn.ReLU(),
+        nn.Linear(64, 4),
+    ).to(device)
+    optimizer = optim.AdamW(model.parameters(), lr=1e-3)
+    criterion = nn.CrossEntropyLoss()
+
+    traceml.trace_model_instance(model)
+
+    for step in range(int(config["steps"])):
+        with traceml.trace_step(model):
+            x = torch.randn(64, 32, device=device)
+            y = torch.randint(0, 4, (64,), device=device)
+
+            optimizer.zero_grad(set_to_none=True)
+            logits = model(x)
+            loss = criterion(logits, y)
+            loss.backward()
+            optimizer.step()
+
+        if ctx.get_world_rank() == 0:
+            print(f"step={step + 1} loss={loss.detach().item():.4f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-workers", type=int, default=2)
+    parser.add_argument("--steps", type=int, default=10)
+    parser.add_argument("--use-gpu", action="store_true")
+    parser.add_argument("--ray-address", default=None)
+    args = parser.parse_args()
+
+    import ray
+    from ray.train import ScalingConfig
+
+    from traceml.integrations.ray import (
+        TraceMLRayConfig,
+        TraceMLTorchTrainer,
+    )
+
+    ray.init(address=args.ray_address)
+
+    trainer = TraceMLTorchTrainer(
+        train_loop_per_worker,
+        train_loop_config={
+            "steps": args.steps,
+            "use_gpu": args.use_gpu,
+        },
+        scaling_config=ScalingConfig(
+            num_workers=args.num_workers,
+            use_gpu=args.use_gpu,
+        ),
+        traceml_config=TraceMLRayConfig(mode="summary"),
+    )
+    trainer.fit()
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - Integrations:
           - Hugging Face: user_guide/integrations/huggingface.md
           - PyTorch Lightning: user_guide/integrations/lightning.md
+          - Ray Train: user_guide/integrations/ray.md
           - W&B / MLflow: user_guide/integrations/wandb-mlflow.md
       - FAQ: user_guide/faq.md
       - Compare Runs: user_guide/compare.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ lightning = [
     "lightning>=2.6.0",
 ]
 
+ray = [
+    "ray[train]>=2.0.0",
+]
+
 docs = [
     "mkdocs>=1.6",
     "mkdocs-material>=9.5",

--- a/src/dev/probe/ray_tcp_probe.py
+++ b/src/dev/probe/ray_tcp_probe.py
@@ -1,0 +1,118 @@
+"""Minimal Ray actor TCP probe.
+
+Run:
+    python src/dev/probe/ray_tcp_probe.py
+    python src/dev/probe/ray_tcp_probe.py --num-workers 4 --use-gpu
+"""
+
+import argparse
+import json
+import os
+import socket
+import threading
+import time
+
+
+class TcpActor:
+    def __init__(self, port=0):
+        import ray
+
+        self.host = ray.util.get_node_ip_address()
+        self.messages = []
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind(("0.0.0.0", int(port)))
+        self.sock.listen()
+        self.port = self.sock.getsockname()[1]
+        self.closed = False
+        threading.Thread(target=self._serve, daemon=True).start()
+
+    def endpoint(self):
+        return {"host": self.host, "port": self.port}
+
+    def wait_for_messages(self, count, timeout_sec=20):
+        deadline = time.time() + timeout_sec
+        while time.time() < deadline and len(self.messages) < count:
+            time.sleep(0.05)
+        return list(self.messages)
+
+    def close(self):
+        self.closed = True
+        self.sock.close()
+
+    def _serve(self):
+        while not self.closed:
+            try:
+                conn, _ = self.sock.accept()
+                data = conn.recv(65536)
+                conn.close()
+                self.messages.append(json.loads(data.decode("utf-8")))
+            except OSError:
+                break
+
+
+def train_loop(config):
+    import ray
+    from ray import train
+
+    endpoint = config["endpoint"]
+    ctx = train.get_context()
+    msg = {
+        "rank": ctx.get_world_rank(),
+        "local_rank": ctx.get_local_rank(),
+        "world_size": ctx.get_world_size(),
+        "pid": os.getpid(),
+        "node_ip": ray.util.get_node_ip_address(),
+    }
+
+    with socket.create_connection((endpoint["host"], endpoint["port"])) as s:
+        s.sendall(json.dumps(msg).encode("utf-8"))
+
+    print(f"sent rank={msg['rank']} to {endpoint['host']}:{endpoint['port']}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--use-gpu", action="store_true")
+    parser.add_argument("--ray-address", default=None)
+    parser.add_argument("--port", type=int, default=0)
+    args = parser.parse_args()
+
+    import ray
+    from ray.train import ScalingConfig
+    from ray.train.torch import TorchTrainer
+
+    ray.init(address=args.ray_address)
+
+    Actor = ray.remote(num_cpus=1)(TcpActor)
+    actor = Actor.remote(args.port)
+    endpoint = ray.get(actor.endpoint.remote())
+    print("actor endpoint:", endpoint)
+
+    trainer = TorchTrainer(
+        train_loop,
+        train_loop_config={"endpoint": endpoint},
+        scaling_config=ScalingConfig(
+            num_workers=args.num_workers,
+            use_gpu=args.use_gpu,
+        ),
+    )
+    trainer.fit()
+
+    messages = ray.get(actor.wait_for_messages.remote(args.num_workers))
+    ray.get(actor.close.remote())
+
+    for msg in sorted(messages, key=lambda item: item.get("rank", 999)):
+        print(msg)
+
+    ranks = sorted(msg["rank"] for msg in messages if "rank" in msg)
+    expected = list(range(args.num_workers))
+    if ranks != expected:
+        raise SystemExit(f"FAILED: expected ranks {expected}, got {ranks}")
+
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/traceml/aggregator/aggregator_main.py
+++ b/src/traceml/aggregator/aggregator_main.py
@@ -34,9 +34,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
-from traceml.aggregator.trace_aggregator import TraceMLAggregator
 from traceml.loggers.error_log import get_error_logger, setup_error_logger
 from traceml.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
+from traceml.runtime.lifecycle import start_aggregator
 from traceml.runtime.settings import (
     AggregatorTransportSettings,
     TraceMLSettings,
@@ -181,7 +181,7 @@ def main() -> None:
     stop_event = threading.Event()
     _install_signal_handlers(stop_event)
 
-    agg: Optional[TraceMLAggregator] = None
+    handle = None
     err: Optional[BaseException] = None
 
     try:
@@ -204,24 +204,22 @@ def main() -> None:
             db_path=str(db_path),
         )
 
-        agg = TraceMLAggregator(
+        logger.info("[TraceML] Starting aggregator")
+        handle = start_aggregator(
+            settings,
             logger=logger,
             stop_event=stop_event,
-            settings=settings,
         )
-        logger.info("[TraceML] Starting aggregator")
-        agg.start()
-
         stop_event.wait()
 
     except BaseException as exc:
         err = exc
 
     finally:
-        if agg is not None:
+        if handle is not None:
             try:
                 logger.info("[TraceML] Stopping aggregator")
-                agg.stop(timeout_sec=5.0)
+                handle.stop(timeout_sec=5.0)
             except Exception:
                 pass
 

--- a/src/traceml/aggregator/trace_aggregator.py
+++ b/src/traceml/aggregator/trace_aggregator.py
@@ -22,7 +22,7 @@ from traceml.aggregator.sqlite_writer import (
 from traceml.aggregator.summary_service import FinalSummaryService
 from traceml.database.remote_database_store import RemoteDBStore
 from traceml.reporting.final import generate_summary
-from traceml.runtime.settings import TraceMLSettings
+from traceml.runtime.settings import AggregatorEndpoint, TraceMLSettings
 from traceml.transport.tcp_transport import TCPConfig, TCPServer
 
 
@@ -152,6 +152,15 @@ class TraceMLAggregator:
         except Exception:
             self._logger.exception("[TraceML] Aggregator thread start failed")
             raise
+
+    @property
+    def endpoint(self) -> AggregatorEndpoint:
+        """Return the reachable endpoint after the TCP server has started."""
+        return AggregatorEndpoint(
+            host=str(self._settings.aggregator.connect_host),
+            port=int(self._tcp_server.port),
+            session_id=str(self._settings.session_id or "default"),
+        )
 
     def stop(self, timeout_sec: float) -> None:
         """

--- a/src/traceml/integrations/ray.py
+++ b/src/traceml/integrations/ray.py
@@ -1,0 +1,343 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ray Train integration for TraceML.
+
+Ray remains responsible for scheduling, worker startup, rank setup, and
+distributed training communication. TraceML starts one lightweight aggregator
+actor and one TraceML runtime inside each Ray Train worker. Worker runtimes send
+telemetry to the aggregator over the same TCP path used by the CLI launcher.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Mapping, Optional
+
+from traceml.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
+from traceml.runtime.lifecycle import RuntimeHandle, start_aggregator
+from traceml.runtime.lifecycle import start_runtime as start_runtime_handle
+from traceml.runtime.settings import (
+    AggregatorEndpoint,
+    AggregatorTransportSettings,
+    TraceMLSettings,
+)
+
+TrainLoop = Callable[[Dict[str, Any]], Any]
+
+
+@dataclass(frozen=True)
+class TraceMLRayConfig:
+    """TraceML settings used by the Ray Train integration.
+
+    Parameters
+    ----------
+    mode:
+        TraceML display/reporting mode. ``"summary"`` is the default for Ray
+        because distributed worker logs are often noisy.
+    profile:
+        TraceML sampler profile. Public Ray integration uses the normal
+        ``"run"`` profile.
+    init_mode:
+        Instrumentation mode passed to ``traceml.init()`` inside each worker.
+    patch_dataloader:
+        Selective-mode-only override for DataLoader fetch patching.
+    patch_forward:
+        Selective-mode-only override for forward-pass patching.
+    patch_backward:
+        Selective-mode-only override for backward-pass patching.
+    patch_h2d:
+        Selective-mode-only override for host-to-device transfer patching.
+    logs_dir:
+        Directory where TraceML writes session logs and summary artifacts.
+    session_id:
+        Optional explicit TraceML session id. If omitted, a unique Ray session
+        id is generated for each ``fit()`` call.
+    sampler_interval_sec:
+        Background sampler cadence in seconds.
+    summary_window_rows:
+        Number of recent history rows used by final summary generation.
+    bind_host:
+        Host interface used by the aggregator actor. Use ``"0.0.0.0"`` for
+        multi-node Ray clusters so workers on other nodes can connect.
+    port:
+        Aggregator TCP port. ``0`` asks the OS to pick a free port.
+    stop_timeout_sec:
+        Best-effort timeout for aggregator shutdown.
+    """
+
+    mode: str = "summary"
+    profile: str = "run"
+    init_mode: str = "auto"
+    patch_dataloader: Optional[bool] = None
+    patch_forward: Optional[bool] = None
+    patch_backward: Optional[bool] = None
+    patch_h2d: Optional[bool] = None
+    logs_dir: str = "./logs"
+    session_id: str = ""
+    sampler_interval_sec: float = 1.0
+    summary_window_rows: int = DEFAULT_SUMMARY_WINDOW_ROWS
+    bind_host: str = "0.0.0.0"
+    port: int = 0
+    stop_timeout_sec: float = 5.0
+
+
+def _require_ray() -> tuple[Any, Any]:
+    """Import Ray only when the Ray integration is actually used."""
+    try:
+        import ray
+        from ray.train.torch import TorchTrainer
+    except ImportError as exc:
+        raise ImportError(
+            "TraceML Ray integration requires Ray. Install it with "
+            "`pip install traceml-ai[ray]`."
+        ) from exc
+    return ray, TorchTrainer
+
+
+def _new_session_id() -> str:
+    """Return a readable unique TraceML session id for one Ray fit call."""
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    suffix = uuid.uuid4().hex[:8]
+    return f"ray_{stamp}_{suffix}"
+
+
+def _normalize_config(config: Optional[TraceMLRayConfig]) -> TraceMLRayConfig:
+    """Return a Ray config with a concrete session id."""
+    current = config or TraceMLRayConfig()
+    session_id = str(current.session_id or "").strip()
+    if session_id:
+        return current
+    return replace(current, session_id=_new_session_id())
+
+
+def _endpoint_from_mapping(endpoint: Mapping[str, Any]) -> AggregatorEndpoint:
+    """Validate and convert a Ray-serializable endpoint mapping."""
+    return AggregatorEndpoint(
+        host=str(endpoint["host"]),
+        port=int(endpoint["port"]),
+        session_id=str(endpoint["session_id"]),
+    )
+
+
+def _build_aggregator_settings(
+    *,
+    config: TraceMLRayConfig,
+    connect_host: str,
+) -> TraceMLSettings:
+    """Build settings for the TraceML aggregator actor process."""
+    return TraceMLSettings(
+        mode=str(config.mode),
+        profile=str(config.profile),
+        sampler_interval_sec=float(config.sampler_interval_sec),
+        logs_dir=str(config.logs_dir),
+        session_id=str(config.session_id),
+        summary_window_rows=int(config.summary_window_rows),
+        aggregator=AggregatorTransportSettings(
+            connect_host=str(connect_host),
+            bind_host=str(config.bind_host),
+            port=int(config.port),
+        ),
+    )
+
+
+def _build_worker_settings(
+    *,
+    config: TraceMLRayConfig,
+    endpoint: AggregatorEndpoint,
+) -> TraceMLSettings:
+    """Build settings for one TraceML runtime inside a Ray Train worker."""
+    return TraceMLSettings(
+        mode=str(config.mode),
+        profile=str(config.profile),
+        sampler_interval_sec=float(config.sampler_interval_sec),
+        logs_dir=str(config.logs_dir),
+        session_id=str(endpoint.session_id),
+        summary_window_rows=int(config.summary_window_rows),
+        aggregator=AggregatorTransportSettings(
+            connect_host=str(endpoint.host),
+            bind_host=str(config.bind_host),
+            port=int(endpoint.port),
+        ),
+    )
+
+
+def _apply_ray_train_identity_env() -> None:
+    """Mirror Ray Train worker identity into torchrun-style environment vars.
+
+    TraceML's runtime identity resolver already understands ``RANK``,
+    ``WORLD_SIZE``, ``LOCAL_RANK``, ``LOCAL_WORLD_SIZE``, and node rank
+    variables. Ray Train exposes the same concepts through its context object,
+    so this bridge keeps the core runtime launcher-agnostic.
+    """
+    try:
+        from ray import train
+
+        context = train.get_context()
+    except Exception:
+        return
+
+    methods = {
+        "RANK": "get_world_rank",
+        "WORLD_SIZE": "get_world_size",
+        "LOCAL_RANK": "get_local_rank",
+        "LOCAL_WORLD_SIZE": "get_local_world_size",
+        "NODE_RANK": "get_node_rank",
+    }
+    for env_name, method_name in methods.items():
+        method = getattr(context, method_name, None)
+        if method is None:
+            continue
+        try:
+            value = method()
+        except Exception:
+            continue
+        if value is not None:
+            os.environ[env_name] = str(value)
+
+
+class _TraceMLAggregatorActor:
+    """Ray actor implementation that owns one TraceML aggregator lifecycle."""
+
+    def __init__(self, config: TraceMLRayConfig) -> None:
+        import ray
+
+        self._config = config
+        self._closed = False
+        self._node_ip = str(ray.util.get_node_ip_address())
+        self._handle = start_aggregator(
+            _build_aggregator_settings(
+                config=config,
+                connect_host=self._node_ip,
+            )
+        )
+
+    def endpoint(self) -> dict[str, Any]:
+        """Return the reachable aggregator endpoint for Ray Train workers."""
+        endpoint = self._handle.endpoint
+        return {
+            "host": str(self._node_ip),
+            "port": int(endpoint.port),
+            "session_id": str(endpoint.session_id),
+        }
+
+    def stop(self) -> None:
+        """Stop the TraceML aggregator once."""
+        if self._closed:
+            return
+        self._closed = True
+        self._handle.stop(timeout_sec=float(self._config.stop_timeout_sec))
+
+
+@dataclass(frozen=True)
+class _TraceMLWorkerLoop:
+    """Callable Ray Train loop wrapper that owns worker runtime lifecycle."""
+
+    train_loop_per_worker: TrainLoop
+    endpoint: AggregatorEndpoint
+    config: TraceMLRayConfig
+
+    def __call__(self, train_loop_config: Dict[str, Any]) -> Any:
+        import traceml
+
+        _apply_ray_train_identity_env()
+
+        settings = _build_worker_settings(
+            config=self.config,
+            endpoint=self.endpoint,
+        )
+        handle: Optional[RuntimeHandle] = None
+        try:
+            handle = start_runtime_handle(settings, fail_open=True)
+            traceml.init(
+                mode=str(self.config.init_mode),
+                patch_dataloader=self.config.patch_dataloader,
+                patch_forward=self.config.patch_forward,
+                patch_backward=self.config.patch_backward,
+                patch_h2d=self.config.patch_h2d,
+            )
+            return self.train_loop_per_worker(train_loop_config)
+        finally:
+            if handle is not None:
+                handle.stop()
+
+
+def _stop_actor_best_effort(ray: Any, actor: Any) -> None:
+    """Stop and kill a Ray actor without masking the caller's original error."""
+    try:
+        ray.get(actor.stop.remote())
+    except Exception:
+        pass
+
+    try:
+        ray.kill(actor, no_restart=True)
+    except Exception:
+        pass
+
+
+class TraceMLTorchTrainer:
+    """TraceML wrapper for ``ray.train.torch.TorchTrainer``.
+
+    The wrapper deliberately uses composition instead of subclassing. Ray's
+    ``TorchTrainer`` still owns training orchestration; TraceML only adds:
+
+    - one aggregator actor before ``fit()``
+    - one runtime wrapper inside each worker
+    - best-effort aggregator shutdown after ``fit()`` completes or fails
+    """
+
+    def __init__(
+        self,
+        train_loop_per_worker: TrainLoop,
+        *,
+        train_loop_config: Optional[Dict[str, Any]] = None,
+        traceml_config: Optional[TraceMLRayConfig] = None,
+        **torch_trainer_kwargs: Any,
+    ) -> None:
+        self._train_loop_per_worker = train_loop_per_worker
+        self._train_loop_config = dict(train_loop_config or {})
+        self._traceml_config = traceml_config or TraceMLRayConfig()
+        self._torch_trainer_kwargs = dict(torch_trainer_kwargs)
+        self._last_endpoint: Optional[AggregatorEndpoint] = None
+
+    @property
+    def last_endpoint(self) -> Optional[AggregatorEndpoint]:
+        """Aggregator endpoint used by the most recent ``fit()`` call."""
+        return self._last_endpoint
+
+    def fit(self) -> Any:
+        """Run Ray Train with TraceML telemetry enabled."""
+        ray, TorchTrainer = _require_ray()
+        config = _normalize_config(self._traceml_config)
+
+        Actor = ray.remote(num_cpus=1)(_TraceMLAggregatorActor)
+        actor = Actor.remote(config)
+
+        try:
+            endpoint = _endpoint_from_mapping(ray.get(actor.endpoint.remote()))
+            self._last_endpoint = endpoint
+            wrapped_loop = _TraceMLWorkerLoop(
+                train_loop_per_worker=self._train_loop_per_worker,
+                endpoint=endpoint,
+                config=config,
+            )
+            trainer = TorchTrainer(
+                wrapped_loop,
+                train_loop_config=dict(self._train_loop_config),
+                **self._torch_trainer_kwargs,
+            )
+            return trainer.fit()
+        finally:
+            _stop_actor_best_effort(ray, actor)
+
+
+__all__ = [
+    "TraceMLRayConfig",
+    "TraceMLTorchTrainer",
+]

--- a/src/traceml/runtime/executor.py
+++ b/src/traceml/runtime/executor.py
@@ -19,6 +19,8 @@ from traceml.runtime.launch_context import (
     LaunchContext,
     script_execution_context,
 )
+from traceml.runtime.lifecycle import NoOpRuntime
+from traceml.runtime.lifecycle import start_runtime as start_runtime_handle
 from traceml.runtime.runtime import TraceMLRuntime
 from traceml.runtime.settings import (
     AggregatorTransportSettings,
@@ -153,23 +155,6 @@ def write_runtime_error_log(
         error=error,
         include_execution_layer=False,
     )
-
-
-class NoOpRuntime:
-    """
-    Fallback runtime used when TraceML is disabled or runtime startup fails.
-
-    This preserves the executor control flow and avoids additional branching
-    in the main execution path.
-    """
-
-    def start(self) -> None:
-        """No-op start hook."""
-        return None
-
-    def stop(self) -> None:
-        """No-op stop hook."""
-        return None
 
 
 def read_traceml_env() -> Dict[str, Any]:
@@ -307,10 +292,8 @@ def start_runtime(cfg: Dict[str, Any]) -> Union[TraceMLRuntime, NoOpRuntime]:
 
     try:
         settings = build_runtime_settings(cfg)
-        runtime = TraceMLRuntime(settings=settings)
-        runtime.start()
-        return runtime
-
+        handle = start_runtime_handle(settings, fail_open=False)
+        return handle.runtime
     except Exception as error:
         write_runtime_error_log(
             cfg,

--- a/src/traceml/runtime/lifecycle.py
+++ b/src/traceml/runtime/lifecycle.py
@@ -1,0 +1,215 @@
+"""Start/stop TraceML components in the current Python process.
+
+CLI launchers, Ray actors, and future framework integrations should use this
+module instead of hand-building TraceMLAggregator or TraceMLRuntime directly.
+The caller still owns process orchestration; this module owns component
+lifecycle inside one process.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+from traceml.loggers.error_log import get_error_logger, setup_error_logger
+from traceml.runtime.runtime import TraceMLRuntime
+from traceml.runtime.settings import AggregatorEndpoint, TraceMLSettings
+
+if TYPE_CHECKING:
+    from traceml.aggregator.trace_aggregator import TraceMLAggregator
+
+
+class NoOpRuntime:
+    """Fallback runtime used when TraceML is disabled or startup fails."""
+
+    def start(self) -> None:
+        return None
+
+    def stop(self) -> None:
+        return None
+
+
+@dataclass
+class AggregatorHandle:
+    """Owns one in-process TraceML aggregator lifecycle."""
+
+    settings: TraceMLSettings
+    session_root: Path
+    db_path: Path
+    stop_event: threading.Event
+    aggregator: "TraceMLAggregator"
+
+    _stopped: bool = False
+
+    @property
+    def endpoint(self) -> AggregatorEndpoint:
+        return AggregatorEndpoint(
+            host=str(self.settings.aggregator.connect_host),
+            port=int(self.aggregator.endpoint.port),
+            session_id=str(self.settings.session_id),
+        )
+
+    def stop(self, timeout_sec: float = 5.0) -> None:
+        """Stop the aggregator once, flushing history and final summary."""
+        if self._stopped:
+            return
+        self._stopped = True
+        self.stop_event.set()
+        self.aggregator.stop(timeout_sec=float(timeout_sec))
+
+
+@dataclass
+class RuntimeHandle:
+    """Owns one per-worker TraceML runtime lifecycle."""
+
+    runtime: TraceMLRuntime | NoOpRuntime
+    _stopped: bool = False
+
+    def stop(self) -> None:
+        if self._stopped:
+            return
+        self._stopped = True
+        self.runtime.stop()
+
+
+def _apply_settings_env(
+    settings: TraceMLSettings, *, disabled: bool = False
+) -> None:
+    """
+    Mirror in-process lifecycle settings into TRACEML_* environment variables.
+
+    Some lower-level utilities still read process environment, because the CLI
+    launcher historically configured TraceML that way. Framework integrations
+    that start TraceML in-process use this bridge so those paths keep working
+    without depending on the CLI launcher.
+    """
+    os.environ["TRACEML_DISABLED"] = "1" if disabled else "0"
+    os.environ["TRACEML_PROFILE"] = str(settings.profile)
+    os.environ["TRACEML_UI_MODE"] = str(settings.mode)
+    os.environ["TRACEML_INTERVAL"] = str(settings.sampler_interval_sec)
+    os.environ["TRACEML_LOGS_DIR"] = str(settings.logs_dir)
+    os.environ["TRACEML_SESSION_ID"] = str(settings.session_id or "default")
+    os.environ["TRACEML_AGGREGATOR_HOST"] = str(
+        settings.aggregator.connect_host
+    )
+    os.environ["TRACEML_AGGREGATOR_BIND_HOST"] = str(
+        settings.aggregator.bind_host
+    )
+    os.environ["TRACEML_AGGREGATOR_PORT"] = str(settings.aggregator.port)
+    os.environ["TRACEML_REMOTE_MAX_ROWS"] = str(settings.remote_max_rows)
+    os.environ["TRACEML_HISTORY_ENABLED"] = (
+        "1" if settings.history_enabled else "0"
+    )
+    os.environ["TRACEML_SUMMARY_WINDOW_ROWS"] = str(
+        settings.summary_window_rows
+    )
+
+
+def _build_aggregator(
+    *,
+    logger: Any,
+    stop_event: threading.Event,
+    settings: TraceMLSettings,
+) -> "TraceMLAggregator":
+    """Build the aggregator lazily so worker runtime imports stay lightweight."""
+    from traceml.aggregator.trace_aggregator import TraceMLAggregator
+
+    return TraceMLAggregator(
+        logger=logger,
+        stop_event=stop_event,
+        settings=settings,
+    )
+
+
+def start_aggregator(
+    settings: TraceMLSettings,
+    *,
+    logger: Optional[Any] = None,
+    stop_event: Optional[threading.Event] = None,
+) -> AggregatorHandle:
+    """Start a TraceML aggregator in the current process."""
+    session_id = str(settings.session_id or "default")
+    normalized = replace(settings, session_id=session_id)
+    _apply_settings_env(normalized)
+
+    if logger is None:
+        setup_error_logger(is_aggregator=True)
+        logger = get_error_logger("TraceMLAggregatorLifecycle")
+
+    session_root = Path(str(normalized.logs_dir)).resolve() / session_id
+    aggregator_dir = session_root / "aggregator"
+    aggregator_dir.mkdir(parents=True, exist_ok=True)
+
+    db_path = (
+        Path(str(normalized.db_path))
+        if normalized.db_path
+        else aggregator_dir / "telemetry"
+    )
+    normalized = replace(normalized, db_path=str(db_path))
+
+    event = stop_event or threading.Event()
+    aggregator = _build_aggregator(
+        logger=logger,
+        stop_event=event,
+        settings=normalized,
+    )
+    try:
+        aggregator.start()
+    except BaseException:
+        event.set()
+        try:
+            aggregator.stop(timeout_sec=1.0)
+        except Exception:
+            pass
+        raise
+
+    os.environ["TRACEML_AGGREGATOR_PORT"] = str(aggregator.endpoint.port)
+
+    return AggregatorHandle(
+        settings=normalized,
+        session_root=session_root,
+        db_path=db_path,
+        stop_event=event,
+        aggregator=aggregator,
+    )
+
+
+def start_runtime(
+    settings: TraceMLSettings,
+    *,
+    disabled: bool = False,
+    fail_open: bool = True,
+    on_error: Optional[Callable[[BaseException], None]] = None,
+) -> RuntimeHandle:
+    """Start a per-worker TraceML runtime in the current process."""
+    normalized = replace(
+        settings,
+        session_id=str(settings.session_id or "default"),
+    )
+    _apply_settings_env(normalized, disabled=disabled)
+
+    if disabled:
+        return RuntimeHandle(NoOpRuntime())
+
+    try:
+        runtime = TraceMLRuntime(settings=normalized)
+        runtime.start()
+        return RuntimeHandle(runtime)
+    except BaseException as exc:
+        if on_error is not None:
+            on_error(exc)
+        if not fail_open:
+            raise
+        return RuntimeHandle(NoOpRuntime())
+
+
+__all__ = [
+    "AggregatorHandle",
+    "NoOpRuntime",
+    "RuntimeHandle",
+    "start_aggregator",
+    "start_runtime",
+]

--- a/src/traceml/runtime/settings.py
+++ b/src/traceml/runtime/settings.py
@@ -21,6 +21,15 @@ from traceml.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
 
 
 @dataclass(frozen=True)
+class AggregatorEndpoint:
+    """Reachable TraceML aggregator endpoint for worker runtimes."""
+
+    host: str
+    port: int
+    session_id: str
+
+
+@dataclass(frozen=True)
 class AggregatorTransportSettings:
     """
     Aggregator endpoint used by workers and the aggregator process.

--- a/src/traceml/transport/tcp_transport.py
+++ b/src/traceml/transport/tcp_transport.py
@@ -30,6 +30,7 @@ class TCPServer:
 
     def __init__(self, cfg: TCPConfig):
         self.cfg = cfg
+        self._port = int(cfg.port)
         self._sock: Optional[socket.socket] = None
         self._thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
@@ -39,11 +40,17 @@ class TCPServer:
         )  # set by _handle_client on every new message
         self.logger = get_error_logger("TraceML-TCPServer")
 
+    @property
+    def port(self) -> int:
+        """Actual bound TCP port. Differs from config when cfg.port == 0."""
+        return int(self._port)
+
     def start(self) -> None:
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         self._sock.bind((self.cfg.host, self.cfg.port))
+        self._port = int(self._sock.getsockname()[1])
         self._sock.listen(self.cfg.backlog)
 
         self._thread = threading.Thread(

--- a/tests/integrations/test_ray.py
+++ b/tests/integrations/test_ray.py
@@ -1,0 +1,88 @@
+import importlib
+import sys
+
+from traceml.integrations.ray import (
+    TraceMLRayConfig,
+    _build_aggregator_settings,
+    _build_worker_settings,
+    _endpoint_from_mapping,
+    _normalize_config,
+)
+from traceml.runtime.settings import AggregatorEndpoint
+
+
+def test_ray_integration_module_import_is_lazy():
+    """
+    Importing the TraceML Ray module should not import Ray itself.
+
+    Ray is an optional dependency, so users without Ray installed must still be
+    able to import the rest of TraceML and inspect integration modules.
+    """
+    sys.modules.pop("traceml.integrations.ray", None)
+    sys.modules.pop("ray", None)
+
+    importlib.import_module("traceml.integrations.ray")
+
+    assert "ray" not in sys.modules
+
+
+def test_normalize_config_generates_session_id():
+    config = _normalize_config(TraceMLRayConfig())
+
+    assert config.session_id.startswith("ray_")
+    assert config.mode == "summary"
+    assert config.port == 0
+
+
+def test_normalize_config_preserves_explicit_session_id():
+    config = _normalize_config(TraceMLRayConfig(session_id="run-123"))
+
+    assert config.session_id == "run-123"
+
+
+def test_endpoint_from_mapping_validates_types():
+    endpoint = _endpoint_from_mapping(
+        {
+            "host": "10.0.0.4",
+            "port": "12345",
+            "session_id": "ray-run",
+        }
+    )
+
+    assert endpoint == AggregatorEndpoint(
+        host="10.0.0.4",
+        port=12345,
+        session_id="ray-run",
+    )
+
+
+def test_aggregator_settings_use_actor_node_as_connect_host():
+    settings = _build_aggregator_settings(
+        config=TraceMLRayConfig(session_id="ray-run", port=0),
+        connect_host="10.0.0.9",
+    )
+
+    assert settings.session_id == "ray-run"
+    assert settings.mode == "summary"
+    assert settings.aggregator.connect_host == "10.0.0.9"
+    assert settings.aggregator.bind_host == "0.0.0.0"
+    assert settings.aggregator.port == 0
+
+
+def test_worker_settings_connect_to_actor_endpoint():
+    settings = _build_worker_settings(
+        config=TraceMLRayConfig(
+            session_id="ignored-on-worker",
+            sampler_interval_sec=2.0,
+        ),
+        endpoint=AggregatorEndpoint(
+            host="10.0.0.9",
+            port=34567,
+            session_id="actor-session",
+        ),
+    )
+
+    assert settings.session_id == "actor-session"
+    assert settings.sampler_interval_sec == 2.0
+    assert settings.aggregator.connect_host == "10.0.0.9"
+    assert settings.aggregator.port == 34567

--- a/tests/runtime/test_lifecycle.py
+++ b/tests/runtime/test_lifecycle.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from traceml.runtime import lifecycle
+from traceml.runtime.settings import AggregatorEndpoint, TraceMLSettings
+
+
+@dataclass
+class _FakeAggregator:
+    logger: Any
+    stop_event: Any
+    settings: TraceMLSettings
+    starts: int = 0
+    stops: int = 0
+
+    @property
+    def endpoint(self) -> AggregatorEndpoint:
+        return AggregatorEndpoint(
+            host=self.settings.aggregator.connect_host,
+            port=43210,
+            session_id=self.settings.session_id or "default",
+        )
+
+    def start(self) -> None:
+        self.starts += 1
+
+    def stop(self, timeout_sec: float) -> None:
+        self.stops += 1
+
+
+def test_start_aggregator_returns_idempotent_handle(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    created: list[_FakeAggregator] = []
+
+    def _factory(*, logger, stop_event, settings):
+        agg = _FakeAggregator(
+            logger=logger,
+            stop_event=stop_event,
+            settings=settings,
+        )
+        created.append(agg)
+        return agg
+
+    monkeypatch.setattr(lifecycle, "_build_aggregator", _factory)
+
+    handle = lifecycle.start_aggregator(
+        TraceMLSettings(
+            mode="summary",
+            logs_dir=str(tmp_path),
+            session_id="ray-test",
+        )
+    )
+
+    assert handle.endpoint.host == "127.0.0.1"
+    assert handle.endpoint.port == 43210
+    assert handle.endpoint.session_id == "ray-test"
+    assert handle.session_root == tmp_path / "ray-test"
+    assert handle.db_path == tmp_path / "ray-test" / "aggregator" / "telemetry"
+    assert created[0].starts == 1
+
+    handle.stop()
+    handle.stop()
+
+    assert handle.stop_event.is_set()
+    assert created[0].stops == 1

--- a/tests/runtime/test_tcp_transport.py
+++ b/tests/runtime/test_tcp_transport.py
@@ -1,0 +1,43 @@
+from traceml.transport.tcp_transport import TCPConfig, TCPServer
+
+
+class _FakeSocket:
+    def __init__(self):
+        self.bound_to = None
+        self.closed = False
+
+    def setsockopt(self, *_args):
+        return None
+
+    def bind(self, address):
+        self.bound_to = address
+
+    def getsockname(self):
+        host, _port = self.bound_to
+        return (host, 54321)
+
+    def listen(self, _backlog):
+        return None
+
+    def accept(self):
+        raise OSError("closed")
+
+    def close(self):
+        self.closed = True
+
+
+def test_tcp_server_exposes_actual_port_for_dynamic_bind(monkeypatch) -> None:
+    fake = _FakeSocket()
+    monkeypatch.setattr(
+        "traceml.transport.tcp_transport.socket.socket",
+        lambda *_args, **_kwargs: fake,
+    )
+
+    server = TCPServer(TCPConfig(host="127.0.0.1", port=0))
+    server.start()
+    try:
+        assert fake.bound_to == ("127.0.0.1", 0)
+        assert server.port == 54321
+    finally:
+        server.stop()
+    assert fake.closed


### PR DESCRIPTION
This PR adds Ray Train support via a thin TraceMLTorchTrainer wrapper. Ray still owns worker launch, scheduling, ranks, and distributed communication; TraceML starts one aggregator actor plus one runtime per Ray worker and sends telemetry through the existing TCP path.

It also adds reusable in-process lifecycle helpers for starting/stopping TraceML aggregators and runtimes, dynamic TCP port discovery for port=0, a traceml-ai[ray] extra, Ray docs, a minimal example, and tests for the Ray integration/lifecycle/TCP behavior.