### PR TITLE
Diagnosis cleaning

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,7 @@ body:
     id: traceml-version
     attributes:
       label: TraceML version
-      description: Run `python -c "import traceml; print(traceml.__version__)"` if you are not sure.
+      description: Run `python -c "import traceml_ai; print(traceml_ai.__version__)"` if you are not sure.
       placeholder: "Example: 0.2.15"
     validations:
       required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,48 @@
+## What changed
+
+<!-- Briefly describe the user-visible change. -->
+
+## Why
+
+<!-- What problem does this solve for TraceML users or contributors? -->
+
+## How I tested
+
+<!-- Include exact commands, examples, or environments used. -->
+
+- [ ] Unit tests
+- [ ] Integration or smoke test
+- [ ] Example training script
+- [ ] Docs-only change
+- [ ] Not run; reason:
+
+## Runtime impact
+
+<!-- Required for tracing, sampler, transport, aggregator, or reporting changes. -->
+
+- [ ] No training-path runtime impact
+- [ ] May affect training-path overhead
+- [ ] May affect distributed launch, telemetry, or aggregator behavior
+- [ ] Not applicable
+
+Notes:
+
+## Documentation
+
+- [ ] README updated
+- [ ] User docs updated
+- [ ] Examples updated
+- [ ] API docs updated
+- [ ] Not needed
+
+## Risk checklist
+
+- [ ] Does not add unnecessary CUDA synchronizations
+- [ ] Does not add blocking I/O on the training path
+- [ ] Fails safely without crashing user training
+- [ ] Keeps new dependencies optional unless discussed
+- [ ] Redacts or avoids sensitive training-environment data in examples
+
+## Screenshots or output
+
+<!-- Paste relevant CLI output, final_summary text, viewer screenshot, or compare output. -->

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,22 @@ htmlcov/
 # Local training outputs / generated telemetry
 
 logs/
+compare/
+
+
+# Local ML datasets, checkpoints, model weights, and export archives
+
+data/
+mnist/
+checkpoints/
+*_agnews_ddp/
+*_agnews_full/
+*.safetensors
+*.ckpt
+*.pt
+*.pth
+*.onnx
+*.zip
 
 
 # IDE / Editor

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pip install traceml-ai
 ```python
 import traceml_ai as traceml
 
-traceml.init()
+traceml.init(mode="auto")
 
 for batch in dataloader:
     with traceml.trace_step(model):

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@
 [**Quickstart**](docs/user_guide/quickstart.md) •
 [**Compare Runs**](docs/user_guide/compare.md) •
 [**How to Read Output**](docs/user_guide/reading-output.md) •
-[**Ray Train**](docs/user_guide/integrations/ray.md) •
-[**W&B / MLflow**](docs/user_guide/integrations/wandb-mlflow.md) •
+[**Use With Your Stack**](docs/user_guide/integrations.md) •
 [**FAQ**](docs/user_guide/faq.md) •
 [**Security**](SECURITY.md) •
 [**Issues**](https://github.com/traceopt-ai/traceml/issues) •
@@ -22,40 +21,39 @@
 
 </div>
 
-TraceML gives every PyTorch training run a structured performance fingerprint: where time went, whether ranks skewed, and whether memory drifted. It answers the questions that usually come before operator-level profiling:
+TraceML gives every PyTorch training run a **structured performance fingerprint**
+with low overhead (<2% in our current benchmark runs). It answers the questions
+that usually come before heavyweight operator-level profiling:
 
-- Is the run input-bound, compute-bound, wait-heavy, or memory-constrained?
-- How much time is spent in dataloader, forward, backward, and optimizer?
-- Are some distributed ranks consistently slower than others?
-- Did memory usage drift upward during the run?
-- Did a recent change cause a regression?
+- Are my GPUs waiting on a slow dataloader (input-bound)?
+- Is one distributed rank consistently slower than the others (straggler)?
+- Is memory usage silently creeping upward during the run (memory creep)?
+- Did a recent code or infrastructure change slow training down (regression)?
 
-## How TraceML Fits
+## Where TraceML Fits in the Stack
 
-TraceML is the first pass before heavyweight profiling. It tells you which
-class of bottleneck to investigate next.
+TraceML does not replace `torch.profiler`. It is the low-overhead, always-on
+first pass that tells you where to aim heavier profiling tools.
 
-| Tool                              | Use it for | Output | Cost |
-|-----------------------------------|---|---|---|
-| **TraceML**                       | Classify training bottlenecks: input, compute, wait, memory, rank skew | `final_summary.json`, text summary, live views | Small code wrapper |
-| `torch.profiler`                  | Inspect expensive ops, kernels, and CUDA activity | Profiler trace | Profiler schedule/context |
-| Nsight Systems / Compute          | Debug low-level CUDA and kernel behavior | GPU timeline and kernel detail | Separate profiler run |
-| W&B / MLflow / TensorBoard        | Track experiments and metrics over time | Dashboards and metric history | Logging integration |
-| `nvidia-smi` / cluster dashboards | Check machine health and utilization | System-level metrics | No code changes |
-
-TraceML does not replace these tools. It is the cheap first pass that tells you where to look.
+| Tool | Best used for | Output | Cost / overhead |
+|---|---|---|---|
+| TraceML | Classifying high-level bottlenecks: input, compute, wait, memory, rank skew | JSON fingerprint, text summary, live views | <2% in current benchmark runs; small code wrapper |
+| `torch.profiler` | Inspecting expensive ops, kernels, and CUDA activity | Profiler trace | Higher overhead; requires profiler context |
+| Nsight Systems | Debugging low-level CUDA and kernel behavior | GPU timeline | Separate profiler run |
+| W&B / MLflow | Tracking training metrics and experiment history | Metrics dashboard / run history | Logging integration |
+| `nvidia-smi` | Checking machine-level GPU health and utilization | Terminal metrics | No code changes |
 
 ---
 
-## Quickstart
+## 3-Minute Quickstart
 
-Install:
+### 1. Install the package
 
 ```bash
 pip install traceml-ai
 ```
 
-Initialize TraceML and wrap your training step:
+### 2. Wrap your training step
 
 ```python
 import traceml_ai as traceml
@@ -71,15 +69,16 @@ for batch in dataloader:
         optimizer.step()
 ```
 
-Run your script with the `traceml` CLI:
+### 3. Run your script
 
 ```bash
 traceml run train.py
 ```
 
-> The CLI command is `traceml`. New Python code should use
-> `import traceml_ai as traceml`. The old `import traceml` path still works for
-> now, but emits a `FutureWarning` and will be removed in a future release.
+For DDP, FSDP, and multi-node runs, see
+[Distributed Training](docs/user_guide/distributed-training.md).
+
+## What You Get: The Output
 
 TraceML writes two end-of-run artifacts:
 
@@ -88,49 +87,21 @@ logs/<run_name>/final_summary.json
 logs/<run_name>/final_summary.txt
 ```
 
-## Example Output
+Instead of guessing why training feels slow, you get a compact diagnosis of
+where step time and memory went:
 
-### End-of-run summary
-
-At the end of training, TraceML prints the same compact text report written to
-`final_summary.txt`.
-
-Example from a 4-rank DDP run configured as 2 nodes x 2 GPUs:
-
-```
+```text
 +----------------------------------------------------------------------------+
-|  TraceML Run Summary | duration 122.5s                                     |
-+----------------------------------------------------------------------------+
-|                                                                            |
-|  System                                                                    |
-|  - Diagnosis: NORMAL                                                       |
-|  - Scope: nodes 2/2 | samples 124                                          |
-|  - Stats: CPU med/worst 3%/3% n0 | RAM med/worst 4%/4% n1 | GPU util       |
-|  med/worst 74%/74% n0 | GPU temp med/worst 47.9C/47.9C n1                  |
-|  - Why: CPU, RAM, and GPU showed no system pressure.                       |
-|                                                                            |
-|  Process                                                                   |
-|  - Diagnosis: GPU MEMORY RESERVED OVERHANG                                 |
-|  - Stats: global ranks 4 | CPU avg 75% | RSS peak 1.3 / 540.7 GB | GPU     |
-|  reserved peak 1%                                                          |
-|  - Why: Reserved GPU memory was 1.70x active use.                          |
-|                                                                            |
 |  Step Time                                                                 |
 |  - Diagnosis: INPUT STRAGGLER                                              |
 |  - Scope: compared over last 460 aligned steps across 4 global ranks       |
-|  - Stats: median/worst | total 303.7/303.7ms | input 3.8/254.5ms |         |
-|  compute 259.5/259.5ms | wait 40.5/40.5ms                                  |
-|  - Ranks: median/worst | total r3/r2 | input r2/r0 | compute r3/r1 | wait  |
-|  r2/r1                                                                     |
+|  - Stats: total 303.7ms | input 254.5ms | compute 259.5ms | wait 40.5ms    |
 |  - Why: r0 input was slower than median global rank (254.5/3.8ms).         |
-|                                                                            |
-|  Step Memory                                                               |
-|  - Diagnosis: BALANCED                                                     |
-|  - Scope: last 460 aligned steps                                           |
-|  - Stats: peak reserved worst 192 MB on r0 | skew 0.0%                     |
-|  - Why: No clear pressure, imbalance, or creep signal.                     |
 +----------------------------------------------------------------------------+
 ```
+
+In this example, rank 0 is the slow input rank, which can hold back the aligned
+distributed step.
 
 For experiment trackers, call `traceml.summary()` near the end of your script
 to get a flat dict of diagnosis statuses and average metrics. Keep
@@ -139,151 +110,40 @@ to get a flat dict of diagnosis statuses and average metrics. Keep
 
 ---
 
-### Compare two runs
+### Catching Regressions (Compare Mode)
 
-Compare a slow or suspicious run against a baseline or fixed run:
+Compare a slow run against a known good baseline to identify which metrics
+changed:
 
 ```bash
 traceml compare input_slow/final_summary.json input_fixed/final_summary.json
 ```
 
-The compact text report shows the verdict first, then the changed metrics:
-
-```
+```text
 +--------------------------------------------------------------------------------------+
 |  TraceML Compare                                                                     |
 +--------------------------------------------------------------------------------------+
-|                                                                                      |
-|  A: input_slow                                                                       |
-|  B: input_fixed                                                                      |
-|  Delta: B - A                                                                        |
-|                                                                                      |
 |  Verdict: IMPROVEMENT                                                                |
 |  Why: Step time decreased by 95.6%.                                                  |
 |                                                                                      |
-|  Step Time                                                                           |
 |  Metric                         A                B                Delta              |
-|  Step time diagnosis            INPUT STRAGGLER  BALANCED         changed            |
 |  Total step                     294.0 ms         13.0 ms          -280.9 ms (-95.6%) |
 |  Input                          66.4 ms          2.7 ms           -63.7 ms (-95.9%)  |
-|  Compute                        197.2 ms         8.6 ms           -188.6 ms (-95.6%) |
-|  Wait                           30.4 ms          1.7 ms           -28.6 ms (-94.3%)  |
-|  Forward                        45.0 ms          2.1 ms           -42.9 ms (-95.3%)  |
-|  Backward                       130.0 ms         5.4 ms           -124.6 ms (-95.8%) |
-|  Optimizer                      22.2 ms          1.1 ms           -21.1 ms (-95.0%)  |
 +--------------------------------------------------------------------------------------+
 ```
 
-The full compare report also includes Step Memory, Process, and System sections
-when those signals are available. TraceML writes both a structured compare JSON
-and a compact text report.
+See [Compare Runs](docs/user_guide/compare.md) for the full report format.
 
-See [Compare Runs](docs/user_guide/compare.md).
+## Display Modes
 
-### Live CLI view
+TraceML controls what you see during training with the `--mode` flag, without
+changing the final saved artifacts.
 
-![TraceML live CLI view](docs/assets/cli_demo_v1.png)
-
-Live CLI view while TraceML collects the same signals used for `final_summary.json`.
-
----
-
-## Modes
-
-All modes write `final_summary.json` and `final_summary.txt` at the end of the run. The mode controls only what you see during training.
-
-| Mode | During training | Topology |
-|------|----------------|----------|
-| `--mode=summary` | Silent | single-node and multi-node multi-GPU |
-| `--mode=cli` | Live terminal display | single-node, including multi-GPU |
-| `--mode=dashboard` | Live browser display | single-node, including multi-GPU |
-
-Summary mode is the default and works across all topologies. Use `--mode=cli` or `--mode=dashboard` when you want live feedback on a single-node job.
-Dashboard mode requires the optional dashboard extra:
-
-```bash
-pip install "traceml-ai[dashboard]"
-```
-
-Multi-node live views are on the roadmap.
-
-For very long jobs, tune the final-summary window with
-`--summary-window-rows N`. TraceML analyzes the latest `N` rows per node or
-rank and retains a small alignment buffer internally.
-
----
-
-## Common Workflows
-
-### Diagnose one run
-
-```bash
-traceml run train.py
-```
-
-### Multi-node distributed run
-
-On node 0:
-
-```bash
-traceml run train.py \
-  --nnodes=2 \
-  --node-rank=0 \
-  --nproc-per-node=4 \
-  --master-addr=<node0-ip> \
-  --run-name=my-run
-```
-
-On node 1:
-
-```bash
-traceml run train.py \
-  --nnodes=2 \
-  --node-rank=1 \
-  --nproc-per-node=4 \
-  --master-addr=<node0-ip> \
-  --run-name=my-run
-```
-
-Use the same `--run-name`, `--nnodes`, `--nproc-per-node`, and
-`--master-addr` on every node. Node 0 starts the TraceML aggregator. Other
-nodes connect to `<node0-ip>:29765` by default. If workers need a different
-reachable address or port for TraceML telemetry, add
-`--aggregator-host=<host>` or `--aggregator-port=<port>` on every node. For
-multi-node runs, node 0 binds the aggregator to `0.0.0.0` by default; override
-that only when needed with `--aggregator-bind-host=<bind-host>`.
-
-`--session-id` remains accepted as a backward-compatible alias for
-`--run-name`.
-
-### Watch mode (no code changes)
-
-```bash
-traceml watch train.py
-```
-
-System and process telemetry only. No step instrumentation needed.
-
-### Compare two runs
-
-```bash
-traceml compare before/final_summary.json after/final_summary.json
-```
-
----
-
-## What TraceML measures
-
-| Signal | What it means |
-|--------|--------------|
-| Input-bound | Dataloader is the bottleneck — GPU is waiting on data |
-| Compute-bound | GPU is saturated — expected in a healthy run |
-| Wait-heavy | Unattributed step time outside the traced phases |
-| Rank imbalance | One rank consistently slower — straggler or uneven data |
-| Memory creep | Peak allocation growing step-over-step |
-| High pressure | Memory near capacity — risk of OOM |
-
-`wait` is residual step time, not direct NCCL or all-reduce timing. In DDP, communication may overlap with backward. Use PyTorch Profiler or Nsight when you need explicit collective or kernel-level timing.
+| Mode flag | Experience during training | Supported topology |
+|---|---|---|
+| `--mode=summary` (default) | Silent execution | Single-node and multi-node multi-GPU |
+| `--mode=cli` | Live terminal display | Single-node, including multi-GPU |
+| `--mode=dashboard` | Live browser display | Single-node; requires `pip install "traceml-ai[dashboard]"` |
 
 ---
 
@@ -292,18 +152,15 @@ traceml compare before/final_summary.json after/final_summary.json
 **Works today:**
 
 - Single GPU training
-- Single-node multi-GPU DDP / FSDP training
+- Single-node multi-GPU DDP / FSDP
 - Multi-node DDP summary reports
-- Ray Train through a thin `TorchTrainer` wrapper
-- Step Time, Step Memory, System, and Process diagnostics
 - Run-to-run comparison from `final_summary.json`
-- Custom PyTorch loops, Hugging Face, and PyTorch Lightning
+- Custom PyTorch loops, Hugging Face, PyTorch Lightning, and Ray Train
 
-**Next:**
+**On the roadmap:**
 
 - Slurm launch examples
-- Broader multi-node FSDP validation
-- Multi-node live CLI / dashboard
+- Multi-node live CLI / browser dashboard
 - Explicit collective / NCCL timing
 
 ---
@@ -314,33 +171,29 @@ traceml compare before/final_summary.json after/final_summary.json
 
 ---
 
-## Learn more
+## Learn More
 
 - [Quickstart](docs/user_guide/quickstart.md)
+- [Distributed Training](docs/user_guide/distributed-training.md)
+- [Use With Your Stack](docs/user_guide/integrations.md)
 - [Compare Runs](docs/user_guide/compare.md)
-- [How to Read TraceML Output](docs/user_guide/reading-output.md)
-- [Examples](examples/README.md)
+- [How to Read Output](docs/user_guide/reading-output.md)
 - [FAQ](docs/user_guide/faq.md)
-- [Use TraceML with W&B / MLflow](docs/user_guide/integrations/wandb-mlflow.md)
-- [Hugging Face integration](docs/user_guide/integrations/huggingface.md)
-- [PyTorch Lightning integration](docs/user_guide/integrations/lightning.md)
-- [Ray Train integration](docs/user_guide/integrations/ray.md)
 
 ---
 
 ## Feedback
 
-If TraceML helped, a GitHub star helps others find it.
-
-If you hit a problem or unexpected result, open an issue and include:
-
-- hardware / CUDA / PyTorch versions
-- single GPU or multi-GPU setup
-- training framework
-- the end-of-run summary
-- a minimal repro if possible
+For bugs, unexpected results, or feature requests, open a GitHub issue and use
+the matching issue template. The templates ask for the details we need to
+reproduce training-environment problems, including hardware, topology, launch
+command, TraceML version, PyTorch/CUDA versions, and redacted summary output.
 
 GitHub issues: [open an issue](https://github.com/traceopt-ai/traceml/issues)
+
+If TraceML helped you find a real bottleneck, use the "I found a bottleneck"
+issue template. These reports help other training teams recognize similar
+problems.
 
 Security reports: see [SECURITY.md](SECURITY.md)
 
@@ -356,6 +209,8 @@ Contributions are welcome, especially:
 - distributed training edge cases
 - docs improvements
 - framework integrations
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and contribution guidelines.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,15 +32,16 @@ TraceML gives every PyTorch training run a structured performance fingerprint: w
 
 ## How TraceML Fits
 
-TraceML fits between experiment tracking and heavyweight profiling. It gives you a first-pass diagnosis of where a training run is likely wasting time.
+TraceML is the first pass before heavyweight profiling. It tells you which
+class of bottleneck to investigate next.
 
-| Tool | Setup cost | Output | Best for | When to use |
-|---|---|---|---|---|
-| TraceML | Small training-step wrapper | Live step breakdown + `final_summary.json` | Classifying input, compute, wait, memory, and rank-skew issues | First pass on normal training jobs |
-| `torch.profiler` | Profiler schedule/context | Operator and CUDA activity traces | Finding expensive PyTorch ops/kernels | When compute/model path needs deep inspection |
-| Nsight Systems / Compute | External profiler run | CUDA timeline / kernel-level detail | Kernel scheduling, CUDA stalls, low-level GPU analysis | Deep dive on a specific GPU performance issue |
-| W&B / MLflow / TensorBoard | Metric logging/integration | Loss, accuracy, throughput, experiment history | Tracking outcomes across runs | Experiment management and dashboards |
-| `nvidia-smi` / cluster dashboards | No code changes | GPU/CPU utilization and memory | Machine-level health and capacity signals | Sanity checks and cluster monitoring |
+| Tool                              | Use it for | Output | Cost |
+|-----------------------------------|---|---|---|
+| **TraceML**                       | Classify training bottlenecks: input, compute, wait, memory, rank skew | `final_summary.json`, text summary, live views | Small code wrapper |
+| `torch.profiler`                  | Inspect expensive ops, kernels, and CUDA activity | Profiler trace | Profiler schedule/context |
+| Nsight Systems / Compute          | Debug low-level CUDA and kernel behavior | GPU timeline and kernel detail | Separate profiler run |
+| W&B / MLflow / TensorBoard        | Track experiments and metrics over time | Dashboards and metric history | Logging integration |
+| `nvidia-smi` / cluster dashboards | Check machine health and utilization | System-level metrics | No code changes |
 
 TraceML does not replace these tools. It is the cheap first pass that tells you where to look.
 
@@ -57,12 +58,12 @@ pip install traceml-ai
 Initialize TraceML and wrap your training step:
 
 ```python
-import traceml_ai as tml
+import traceml_ai as traceml
 
-tml.init()
+traceml.init()
 
 for batch in dataloader:
-    with tml.trace_step(model):
+    with traceml.trace_step(model):
         optimizer.zero_grad(set_to_none=True)
         outputs = model(batch["x"])
         loss = criterion(outputs, batch["y"])
@@ -77,7 +78,7 @@ traceml run train.py
 ```
 
 > The CLI command is `traceml`. New Python code should use
-> `import traceml_ai as tml`. The old `import traceml` path still works for
+> `import traceml_ai as traceml`. The old `import traceml` path still works for
 > now, but emits a `FutureWarning` and will be removed in a future release.
 
 TraceML writes two end-of-run artifacts:
@@ -131,7 +132,7 @@ Example from a 4-rank DDP run configured as 2 nodes x 2 GPUs:
 +----------------------------------------------------------------------------+
 ```
 
-For experiment trackers, call `tml.summary()` near the end of your script
+For experiment trackers, call `traceml.summary()` near the end of your script
 to get a flat dict of diagnosis statuses and average metrics. Keep
 `final_summary.json` when you want the full run artifact or an input for
 `traceml compare`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [**Ray Train**](docs/user_guide/integrations/ray.md) •
 [**W&B / MLflow**](docs/user_guide/integrations/wandb-mlflow.md) •
 [**FAQ**](docs/user_guide/faq.md) •
+[**Security**](SECURITY.md) •
 [**Issues**](https://github.com/traceopt-ai/traceml/issues) •
 [**Discussions**](https://github.com/traceopt-ai/traceml/discussions)
 
@@ -339,6 +340,8 @@ If you hit a problem or unexpected result, open an issue and include:
 - a minimal repro if possible
 
 GitHub issues: [open an issue](https://github.com/traceopt-ai/traceml/issues)
+
+Security reports: see [SECURITY.md](SECURITY.md)
 
 Email: [support@traceopt.ai](mailto:support@traceopt.ai)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,120 @@
+# Security Policy
+
+TraceML runs inside ML training jobs and collects local runtime telemetry. Security
+reports are important to us, especially when they involve training environments,
+distributed launch paths, local report artifacts, or dependency behavior.
+
+## Supported Versions
+
+Security fixes are applied to the latest released version of `traceml-ai`.
+
+| Version | Supported |
+| --- | --- |
+| Latest PyPI release | Yes |
+| Older releases | Best effort |
+| Unreleased `main` branch | Best effort |
+
+If you are unsure whether a finding affects a supported version, report it
+anyway and include the TraceML version or commit SHA you tested.
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub issue for a suspected vulnerability.
+
+Report security issues by email:
+
+```text
+support@traceopt.ai
+```
+
+Use the subject:
+
+```text
+[TraceML Security] <short description>
+```
+
+If GitHub private vulnerability reporting is enabled for this repository, you
+may use that instead.
+
+## What To Include
+
+Useful reports include:
+
+- affected TraceML version or commit SHA
+- operating system, Python, PyTorch, CUDA, and launcher details if relevant
+- whether the issue affects `traceml run`, `traceml watch`, `traceml compare`,
+  dashboard mode, integrations, or generated artifacts
+- minimal reproduction steps or proof of concept
+- expected impact, such as data exposure, command execution, path traversal,
+  unsafe network binding, dependency confusion, denial of service, or privilege
+  boundary concerns
+- whether the issue is already public
+
+Please remove secrets, tokens, private dataset paths, customer names, cluster
+hostnames, and proprietary model details from logs and reports before sending
+them unless they are necessary to demonstrate the issue.
+
+## Scope
+
+We are especially interested in reports involving:
+
+- unintended exposure of training metadata, logs, hostnames, paths, or
+  environment details
+- unsafe handling of `final_summary.json`, compare artifacts, SQLite telemetry,
+  or local dashboard inputs
+- command injection, path traversal, unsafe file writes, or unsafe process
+  launching in the TraceML CLI
+- unsafe network behavior in the aggregator, worker telemetry transport, or
+  distributed launch configuration
+- vulnerabilities in required runtime dependencies that affect TraceML users
+- cases where TraceML can crash, hang, or materially interfere with a user's
+  training job because of malformed telemetry or report input
+
+Out of scope:
+
+- vulnerabilities in a user's training script, model code, dataset, cluster
+  scheduler, CUDA driver, PyTorch installation, or experiment tracker unless
+  TraceML materially enables or worsens the issue
+- reports that rely only on local machine access without a TraceML-specific
+  privilege boundary impact
+- social engineering, spam, or denial-of-service against project maintainers
+
+## Response Expectations
+
+We aim to acknowledge valid security reports within 2 business days.
+
+After acknowledgement, we will:
+
+- confirm the affected versions and severity
+- ask for more detail if the report is not reproducible
+- coordinate a fix and release when needed
+- credit the reporter if desired
+- publish a public advisory or release note when appropriate
+
+Timelines depend on severity and complexity, but we will keep reporters updated
+while a fix is in progress.
+
+## Disclosure
+
+Please give us a reasonable opportunity to investigate and release a fix before
+public disclosure. We prefer coordinated disclosure and will work with reporters
+on timing when users need to take action.
+
+## Security Design Notes
+
+TraceML is designed to be local-first and low overhead. By default, it writes
+local artifacts such as:
+
+```text
+logs/<run_name>/final_summary.json
+logs/<run_name>/final_summary.txt
+```
+
+These artifacts can contain operational metadata from the training environment.
+Before sharing them publicly, review and redact sensitive fields such as
+hostnames, usernames, paths, cluster names, dataset names, and internal run
+identifiers.
+
+For multi-node runs, TraceML starts an aggregator on the owner node and workers
+send telemetry to it. Only bind the aggregator to interfaces reachable by the
+intended workers, and prefer trusted networks for distributed training traffic.

--- a/docs/developer_guide/architecture.md
+++ b/docs/developer_guide/architecture.md
@@ -38,6 +38,9 @@ Samplers maintain an incremental append counter per rank per table. The sender s
 | Integrations | `src/traceml_ai/integrations/` | Hugging Face, Lightning, and Ray adapters |
 | Utils | `src/traceml_ai/utils/` | Hooks, patches, memory/timing helpers |
 
+The deprecated `src/traceml/` package is a compatibility shim for older import
+paths. New implementation work should go under `src/traceml_ai/`.
+
 For the user-facing API surface (`trace_step`, `TraceMLTrainer`, `TraceMLCallback`, CLI usage), see the [Public API](../user_guide/public-api.md). The source tree above is the canonical reference for internals — start from the entry points and follow the imports.
 
 ## Design principles

--- a/docs/developer_guide/contributing.md
+++ b/docs/developer_guide/contributing.md
@@ -84,7 +84,7 @@ If a code change affects user-facing behavior, update the relevant doc in the sa
 Use `autorefs` to link to API symbols in prose:
 
 ```markdown
-Use `import traceml_ai as tml` and link to the public API guide for user-facing
+Use `import traceml_ai as traceml` and link to the public API guide for user-facing
 instrumentation examples.
 ```
 

--- a/docs/developer_guide/extending.md
+++ b/docs/developer_guide/extending.md
@@ -40,7 +40,7 @@ training work, and make stop paths safe to call more than once.
 
 Ray support lives in `traceml_ai.integrations.ray` and should stay separate from
 the core runtime. Do not import Ray from `traceml_ai.runtime`, `traceml_ai.aggregator`,
-or the top-level `traceml` package.
+or the public package surfaces (`traceml_ai` or the deprecated `traceml` shim).
 
 The integration has two owners:
 
@@ -53,9 +53,13 @@ created. Keep future Ray changes in that shape: no second launcher, no Ray Train
 internals, and no duplicated aggregator/runtime lifecycle code.
 
 
+The live implementation tree is `src/traceml_ai/`. The `src/traceml/` package is
+a deprecated compatibility shim for older imports and should not receive new
+implementation code.
+
 ## Add a Diagnostic Rule
 
-Diagnostics live under `src/traceml/diagnostics/<domain>/`.
+Diagnostics live under `src/traceml_ai/diagnostics/<domain>/`.
 
 Current domains include:
 
@@ -84,7 +88,7 @@ Tests should live in `tests/diagnostics/` and cover:
 
 ## Add a Summary Section
 
-Final-report sections live under `src/traceml/reporting/sections/`.
+Final-report sections live under `src/traceml_ai/reporting/sections/`.
 
 Current sections:
 
@@ -102,7 +106,7 @@ formatter.py  render section text
 model.py      section-local data helpers
 ```
 
-Register sections through `src/traceml/reporting/final.py`. Keep the aggregator
+Register sections through `src/traceml_ai/reporting/final.py`. Keep the aggregator
 as a caller only; report assembly belongs in `reporting`.
 
 Tests should live in `tests/reporting/summary/`. Prefer small SQLite fixtures
@@ -111,11 +115,11 @@ lines.
 
 ## Add a Sampler
 
-Runtime sampler selection is in `src/traceml/runtime/sampler_registry.py`.
+Runtime sampler selection is in `src/traceml_ai/runtime/sampler_registry.py`.
 
 To add a sampler:
 
-1. Implement a `BaseSampler` subclass under `src/traceml/samplers/`.
+1. Implement a `BaseSampler` subclass under `src/traceml_ai/samplers/`.
 2. Add a `SamplerSpec` to `DEFAULT_SAMPLER_REGISTRY`.
 3. Restrict it by `profiles` and `modes` so it only runs where needed.
 4. Add SQLite projection, renderer, or summary code only if the data is
@@ -130,7 +134,7 @@ specific folder if the sampler has domain logic.
 
 ## Add a Compare Metric
 
-Compare code lives under `src/traceml/reporting/compare/`.
+Compare code lives under `src/traceml_ai/reporting/compare/`.
 
 Important files:
 
@@ -155,8 +159,8 @@ Live display code is renderer-driven. CLI and dashboard renderers may differ.
 
 Relevant paths:
 
-- `src/traceml/renderers/`
-- `src/traceml/aggregator/display_drivers/`
+- `src/traceml_ai/renderers/`
+- `src/traceml_ai/aggregator/display_drivers/`
 
 Keep renderer methods focused on presentation. Put data shaping in a compute
 object or formatter when the logic is reusable or non-trivial.

--- a/docs/user_guide/distributed-training.md
+++ b/docs/user_guide/distributed-training.md
@@ -1,0 +1,53 @@
+# Distributed Training
+
+TraceML uses launch flags similar to `torchrun` and writes the same
+`final_summary.json` artifact for single-node and multi-node summary runs.
+
+## Single-node DDP/FSDP
+
+Use `--nproc-per-node` for a single machine with multiple local workers:
+
+```bash
+traceml run train.py --nproc-per-node=4
+```
+
+Live CLI and dashboard modes are intended for single-node runs. Summary mode is
+the default and works for both single-node and multi-node summary reports.
+
+## Multi-node DDP
+
+Use the same `--run-name`, `--nnodes`, `--nproc-per-node`, and
+`--master-addr` on every node. Set `--node-rank` to the current node's rank.
+
+On node 0:
+
+```bash
+traceml run train.py \
+  --nnodes=2 \
+  --node-rank=0 \
+  --nproc-per-node=4 \
+  --master-addr=<node0-ip> \
+  --run-name=my-run
+```
+
+On node 1:
+
+```bash
+traceml run train.py \
+  --nnodes=2 \
+  --node-rank=1 \
+  --nproc-per-node=4 \
+  --master-addr=<node0-ip> \
+  --run-name=my-run
+```
+
+Node 0 starts the TraceML aggregator. Other nodes connect to
+`<node0-ip>:29765` by default. If workers need a different reachable address or
+port for TraceML telemetry, add `--aggregator-host=<host>` or
+`--aggregator-port=<port>` on every node.
+
+For multi-node runs, node 0 binds the aggregator to `0.0.0.0` by default.
+Override that only when needed with `--aggregator-bind-host=<bind-host>`.
+
+`--session-id` remains accepted as a backward-compatible alias for
+`--run-name`.

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -55,11 +55,11 @@ A simple rule:
 Usually just this:
 
 ```python
-import traceml_ai as tml
+import traceml_ai as traceml
 
-tml.init(mode="auto")
+traceml.init(mode="auto")
 
-with tml.trace_step(model):
+with traceml.trace_step(model):
     ...
 ```
 
@@ -68,24 +68,24 @@ For supported integrations:
 - Hugging Face: use `TraceMLTrainer`
 - Lightning: add `TraceMLCallback()`
 
-The preferred public API is the top-level `tml.*` from `import traceml_ai as tml`.
+The preferred public API is the top-level `traceml.*` from `import traceml_ai as traceml`.
 
 ---
 
-## Should I use `tml.trace_step()` or `trace_step()`?
+## Should I use `traceml.trace_step()` or `trace_step()`?
 
 Prefer:
 
 ```python
-import traceml_ai as tml
+import traceml_ai as traceml
 
-tml.init(mode="auto")
+traceml.init(mode="auto")
 
-with tml.trace_step(model):
+with traceml.trace_step(model):
     ...
 ```
 
-Use the top-level `tml.*` API from `import traceml_ai as tml`.
+Use the top-level `traceml.*` API from `import traceml_ai as traceml`.
 
 ---
 
@@ -93,9 +93,9 @@ Use the top-level `tml.*` API from `import traceml_ai as tml`.
 
 Use:
 
-- `tml.init(mode="auto")` for the default TraceML workflow
-- `tml.init(mode="manual")` when you want fully explicit wrappers
-- `tml.init(mode="selective", ...)` when you want some automatic patching
+- `traceml.init(mode="auto")` for the default TraceML workflow
+- `traceml.init(mode="manual")` when you want fully explicit wrappers
+- `traceml.init(mode="selective", ...)` when you want some automatic patching
   and some explicit wrapping
 
 Start with `auto` unless you already know you need more control.
@@ -109,10 +109,10 @@ part of your training loop is custom.
 
 The main wrapper entrypoints are:
 
-- `tml.wrap_dataloader_fetch(...)`
-- `tml.wrap_forward(...)`
-- `tml.wrap_backward(...)`
-- `tml.wrap_optimizer(...)`
+- `traceml.wrap_dataloader_fetch(...)`
+- `traceml.wrap_forward(...)`
+- `traceml.wrap_backward(...)`
+- `traceml.wrap_optimizer(...)`
 
 This is most relevant in `manual` or `selective` mode. Most users should start
 with `mode="auto"` and only move to wrappers if they need explicit control.
@@ -279,10 +279,10 @@ TraceML is designed to work alongside your existing tracking stack. The
 recommended low-noise path is:
 
 1. launch with `traceml run train.py`
-2. call `tml.summary()` near the end of your script
+2. call `traceml.summary()` near the end of your script
 3. log the returned flat dict into W&B or MLflow
 
-Use `tml.final_summary()` if you need the full structured JSON payload.
+Use `traceml.final_summary()` if you need the full structured JSON payload.
 
 See:
 

--- a/docs/user_guide/integrations.md
+++ b/docs/user_guide/integrations.md
@@ -1,0 +1,13 @@
+# Use TraceML With Your Stack
+
+TraceML can be added to a normal PyTorch training loop or used through a
+framework-specific entry point. Pick the path that matches how your training
+job already runs.
+
+| Stack | TraceML entry point | Start here |
+|---|---|---|
+| Plain PyTorch loop | `traceml.trace_step(...)` | [Quickstart](quickstart.md) |
+| Hugging Face Trainer | `TraceMLTrainer` | [Hugging Face](integrations/huggingface.md) |
+| PyTorch Lightning | `TraceMLCallback` | [PyTorch Lightning](integrations/lightning.md) |
+| Ray Train | `TraceMLTorchTrainer` | [Ray Train](integrations/ray.md) |
+| W&B / MLflow | `traceml.summary()` | [W&B / MLflow](integrations/wandb-mlflow.md) |

--- a/docs/user_guide/integrations/huggingface.md
+++ b/docs/user_guide/integrations/huggingface.md
@@ -1,38 +1,27 @@
-# Hugging Face Trainer
+# Hugging Face Trainer Integration
 
-Use TraceML with Hugging Face `Trainer` to find training bottlenecks without rewriting your training loop.
+Use TraceML with Hugging Face `Trainer` without rewriting your training loop.
 
-`TraceMLTrainer` is a drop-in replacement for `transformers.Trainer`. It adds step-aware diagnosis so you can quickly tell whether a run is input-bound, compute-bound, straggler-heavy, or showing memory drift.
+`TraceMLTrainer` is a drop-in replacement for `transformers.Trainer`. It wraps
+the training step automatically and writes the same TraceML
+`final_summary.json` and `final_summary.txt` artifacts.
 
-> Start with the [Quickstart](../quickstart.md) if you have not used TraceML yet.
-
----
-
-## Install
-
-Install TraceML with Hugging Face support:
+## 1. Install
 
 ```bash
 pip install "traceml-ai[hf]"
 ```
 
-If your example uses datasets:
+If you are running the full examples below, install their optional dependencies:
 
 ```bash
-pip install datasets
+pip install datasets torchvision
 ```
 
-For vision examples:
+## 2. Replace `Trainer` With `TraceMLTrainer`
 
-```bash
-pip install torchvision
-```
-
----
-
-## Basic usage
-
-Replace `Trainer` with `TraceMLTrainer`. Everything else stays the same.
+Change the import and instantiate `TraceMLTrainer` instead of
+`transformers.Trainer`:
 
 ```python
 from traceml_ai.integrations.huggingface import TraceMLTrainer
@@ -40,8 +29,6 @@ from transformers import TrainingArguments
 
 training_args = TrainingArguments(
     output_dir="./output",
-    per_device_train_batch_size=32,
-    num_train_epochs=3,
     report_to="none",
     disable_tqdm=True,
 )
@@ -57,110 +44,81 @@ trainer = TraceMLTrainer(
 trainer.train()
 ```
 
-Run with:
+You do not need to add `traceml.trace_step(...)` manually. If
+`traceml_enabled=False`, `TraceMLTrainer` behaves like a normal
+`transformers.Trainer`.
+
+## 3. Launch The Run
+
+Single GPU:
 
 ```bash
 traceml run fine_tune.py
 ```
 
-Or open the local UI:
+Single-node multi-GPU DDP:
+
+```bash
+traceml run fine_tune.py --nproc-per-node=4
+```
+
+For multi-node DDP launch commands, see
+[Distributed Training](../distributed-training.md).
+
+## Recommended `TrainingArguments`
+
+These settings are optional, but they make local TraceML diagnostic runs easier
+to read:
+
+| Setting | Why it helps |
+|---|---|
+| `disable_tqdm=True` | Prevents the Hugging Face progress bar from fighting with the TraceML live CLI. |
+| `report_to="none"` | Keeps tracker output out of the terminal during local diagnosis. |
+| `save_strategy="no"` | Avoids checkpoint files during short diagnostic runs. |
+
+TraceML can still run alongside W&B, MLflow, and TensorBoard. For tracker
+logging patterns, see [W&B / MLflow](wandb-mlflow.md).
+
+## Troubleshooting
+
+### Terminal output overlaps with TraceML
+
+Set `disable_tqdm=True` in `TrainingArguments`.
+
+If output is still noisy, use browser dashboard mode on single-node runs:
 
 ```bash
 pip install "traceml-ai[dashboard]"
 traceml run fine_tune.py --mode=dashboard
 ```
 
-Dashboard mode is intended for single-node runs, including single-node
-multi-GPU.
+### Multi-GPU run only shows one rank
 
----
-
-## What TraceML will show
-
-In Hugging Face runs, TraceML helps you spot:
-
-- input-bound training
-- compute-bound steps
-- DDP rank stragglers
-- wait-heavy behavior
-- memory creep over time
-
-You keep the normal Hugging Face workflow. TraceML adds diagnosis around the training step.
-
----
-
-## How it works
-
-`TraceMLTrainer` subclasses `transformers.Trainer` and wraps the training step automatically.
-
-That means you do not need to add `traceml.trace_step(...)` manually in your
-Hugging Face training loop.
-
-If `traceml_enabled=False`, it behaves like a normal `Trainer`.
-
----
-
-## Use with your existing tracking stack
-
-TraceML is designed to work alongside tools like W&B, MLflow, and TensorBoard.
-
-A common setup is:
-
-- Hugging Face Trainer for training
-- W&B / TensorBoard for experiment tracking
-- TraceML for bottleneck diagnosis
-
-For the cleanest terminal experience, you can set:
-
-```python
-report_to="none"
-disable_tqdm=True
-```
-
-This is optional. TraceML does not require you to replace your existing logger stack.
-
----
-
-## Multi-GPU DDP
-
-`TraceMLTrainer` inherits DDP support from Hugging Face `Trainer`.
-
-For a single-node run, launch with:
+Make sure you launched through TraceML with `--nproc-per-node`, not plain
+`python`:
 
 ```bash
 traceml run fine_tune.py --nproc-per-node=4
 ```
 
-For a multi-node summary run, use the same `--run-name`, `--nnodes`,
-`--nproc-per-node`, and `--master-addr` on every node, changing only
-`--node-rank`:
+### I want a baseline without TraceML
+
+Run the same script with TraceML disabled:
 
 ```bash
-traceml run fine_tune.py \
-  --nnodes=2 \
-  --node-rank=0 \
-  --nproc-per-node=4 \
-  --master-addr=<node0-ip> \
-  --run-name=my-run
+traceml run fine_tune.py --disable-traceml
 ```
 
-Run the same command on each node, changing only `--node-rank`.
-`--session-id` remains accepted as a backward-compatible alias for
-`--run-name`.
+This launches your script natively through `torchrun` without TraceML telemetry.
 
-TraceML can help surface:
+## Full Examples
 
-- rank imbalance
-- input stragglers
-- compute stragglers
-- memory skew
+Use these examples when you want a complete runnable script. If you already
+have a Hugging Face training script, start with the smaller replacement pattern
+above.
 
-> Multi-node runs currently produce end-of-run summary reports. Live CLI and
-> dashboard views are intended for single-node runs.
-
----
-
-## Full NLP example
+<details>
+<summary>NLP classification example</summary>
 
 Save as `fine_tune_nlp.py`:
 
@@ -184,8 +142,6 @@ def main():
     os.makedirs(output_dir, exist_ok=True)
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    print(f"Using device: {device}")
-
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     model = AutoModelForSequenceClassification.from_pretrained(
         model_name,
@@ -223,7 +179,6 @@ def main():
     )
 
     trainer.train()
-    print("Done.")
 
 
 if __name__ == "__main__":
@@ -236,9 +191,10 @@ Run with:
 traceml run fine_tune_nlp.py
 ```
 
----
+</details>
 
-## Full vision example
+<details>
+<summary>Vision classification example</summary>
 
 Save as `fine_tune_vision.py`:
 
@@ -264,8 +220,6 @@ def main():
     os.makedirs(output_dir, exist_ok=True)
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    print(f"Using device: {device}")
-
     image_processor = AutoImageProcessor.from_pretrained(model_name)
     model = AutoModelForImageClassification.from_pretrained(
         model_name,
@@ -273,7 +227,6 @@ def main():
     ).to(device)
 
     dataset = load_dataset("cifar10", split="train[:2000]")
-
     transform = Compose(
         [
             RandomResizedCrop(
@@ -315,7 +268,6 @@ def main():
     )
 
     trainer.train()
-    print("Done.")
 
 
 if __name__ == "__main__":
@@ -328,65 +280,7 @@ Run with:
 traceml run fine_tune_vision.py
 ```
 
----
-
-## Recommended `TrainingArguments` settings
-
-These settings make the terminal output cleaner when using TraceML:
-
-| Setting | Recommended value | Why |
-|---|---|---|
-| `disable_tqdm=True` | Yes | Prevents tqdm from fighting with the TraceML CLI |
-| `report_to="none"` | Optional | Keeps W&B / TensorBoard output out of the terminal for local diagnosis |
-| `save_strategy="no"` | Optional | Useful for short local diagnostic runs |
-
----
-
-## Troubleshooting
-
-### Terminal output overlaps with TraceML
-
-Set:
-
-```python
-disable_tqdm=True
-```
-
-This gives the TraceML CLI cleaner terminal control.
-
-### I still want W&B or TensorBoard
-
-That is fine. TraceML is designed to work alongside them.
-
-If terminal output gets noisy, use:
-
-```bash
-pip install "traceml-ai[dashboard]"
-traceml run fine_tune.py --mode=dashboard
-```
-
-Dashboard mode is intended for single-node runs. For multi-node runs, use the
-default final summary path.
-
-### Multi-GPU run only shows one rank
-
-Make sure you launch through TraceML, not plain `python`:
-
-```bash
-traceml run fine_tune.py --nproc-per-node=4
-```
-
-### I want a baseline without TraceML
-
-Run:
-
-```bash
-traceml run fine_tune.py --disable-traceml
-```
-
-This launches your script natively through `torchrun` without TraceML telemetry.
-
----
+</details>
 
 ## Reference
 
@@ -395,10 +289,9 @@ This launches your script natively through `torchrun` without TraceML telemetry.
 - everything that normal `transformers.Trainer` accepts
 - `traceml_enabled=True|False`
 
----
+## Next Steps
 
-## Next steps
-
-- Read the [Quickstart](../quickstart.md) for plain PyTorch training loops
-- Read [lightning.md](lightning.md) for the PyTorch Lightning integration
-- Open an issue if you hit a problem: https://github.com/traceopt-ai/traceml/issues
+- [How to Read Output](../reading-output.md)
+- [Distributed Training](../distributed-training.md)
+- [W&B / MLflow](wandb-mlflow.md)
+- [Open an issue](https://github.com/traceopt-ai/traceml/issues)

--- a/docs/user_guide/integrations/huggingface.md
+++ b/docs/user_guide/integrations/huggingface.md
@@ -93,7 +93,7 @@ You keep the normal Hugging Face workflow. TraceML adds diagnosis around the tra
 
 `TraceMLTrainer` subclasses `transformers.Trainer` and wraps the training step automatically.
 
-That means you do not need to add `tml.trace_step(...)` manually in your
+That means you do not need to add `traceml.trace_step(...)` manually in your
 Hugging Face training loop.
 
 If `traceml_enabled=False`, it behaves like a normal `Trainer`.

--- a/docs/user_guide/integrations/lightning.md
+++ b/docs/user_guide/integrations/lightning.md
@@ -74,7 +74,7 @@ You keep the normal Lightning workflow. TraceML adds diagnosis around the traini
 
 `TraceMLCallback` hooks into Lightning’s training lifecycle automatically.
 
-That means you do not need to wrap your code with `tml.trace_step(...)`
+That means you do not need to wrap your code with `traceml.trace_step(...)`
 manually in Lightning.
 
 ---

--- a/docs/user_guide/integrations/ray.md
+++ b/docs/user_guide/integrations/ray.md
@@ -111,7 +111,7 @@ The default ``mode="summary"`` is recommended for Ray because distributed worker
 logs are noisy. Use ``mode="cli"`` only when you specifically want live terminal
 rendering from the aggregator actor.
 
-``init_mode`` is passed to ``traceml.init()`` inside each Ray worker. Use
+``init_mode`` is passed to ``traceml.init(mode="auto")`` inside each Ray worker. Use
 ``init_mode="manual"`` if your training loop wraps dataloader, forward,
 backward, and optimizer timing explicitly. Use ``init_mode="selective"`` with
 the ``patch_*`` options when you only want some automatic patches.

--- a/docs/user_guide/integrations/ray.md
+++ b/docs/user_guide/integrations/ray.md
@@ -37,16 +37,16 @@ def train_loop_per_worker(config):
     import torch.nn as nn
     import torch.optim as optim
 
-    import traceml_ai as tml
+    import traceml_ai as traceml
 
     model = nn.Sequential(nn.Linear(32, 64), nn.ReLU(), nn.Linear(64, 4))
     optimizer = optim.AdamW(model.parameters(), lr=1e-3)
     criterion = nn.CrossEntropyLoss()
 
-    tml.trace_model_instance(model)
+    traceml.trace_model_instance(model)
 
     for _ in range(config["steps"]):
-        with tml.trace_step(model):
+        with traceml.trace_step(model):
             x = torch.randn(64, 32)
             y = torch.randint(0, 4, (64,))
 
@@ -111,7 +111,7 @@ The default ``mode="summary"`` is recommended for Ray because distributed worker
 logs are noisy. Use ``mode="cli"`` only when you specifically want live terminal
 rendering from the aggregator actor.
 
-``init_mode`` is passed to ``tml.init()`` inside each Ray worker. Use
+``init_mode`` is passed to ``traceml.init()`` inside each Ray worker. Use
 ``init_mode="manual"`` if your training loop wraps dataloader, forward,
 backward, and optimizer timing explicitly. Use ``init_mode="selective"`` with
 the ``patch_*`` options when you only want some automatic patches.

--- a/docs/user_guide/integrations/wandb-mlflow.md
+++ b/docs/user_guide/integrations/wandb-mlflow.md
@@ -84,13 +84,13 @@ You can keep using W&B logging in your training script and launch the run throug
 Example:
 
 ```python
-import traceml_ai as tml
+import traceml_ai as traceml
 import wandb
 
 wandb.init(project="my-project")
 
 for batch in dataloader:
-    with tml.trace_step(model):
+    with traceml.trace_step(model):
         optimizer.zero_grad(set_to_none=True)
         outputs = model(batch["x"])
         loss = criterion(outputs, batch["y"])
@@ -126,14 +126,14 @@ Then request TraceML's compact tracker summary near the end of your script and
 log it into W&B:
 
 ```python
-import traceml_ai as tml
+import traceml_ai as traceml
 import wandb
 
 wandb.init(project="my-project")
 
 # training loop ...
 
-summary = tml.summary(print_text=True)
+summary = traceml.summary(print_text=True)
 if summary is not None:
     wandb.log(summary)
 ```
@@ -141,7 +141,7 @@ if summary is not None:
 This lets W&B stay your experiment system of record while TraceML contributes a
 clean bottleneck diagnosis at the end of the run.
 
-`tml.summary()` returns a flat dict of diagnosis statuses and global
+`traceml.summary()` returns a flat dict of diagnosis statuses and global
 average metrics. If you also store `final_summary.json` as a run artifact, you
 can reuse it later with `traceml compare`.
 
@@ -152,13 +152,13 @@ can reuse it later with `traceml compare`.
 You can do the same with MLflow.
 
 ```python
-import traceml_ai as tml
+import traceml_ai as traceml
 import mlflow
 
 mlflow.start_run()
 
 for batch in dataloader:
-    with tml.trace_step(model):
+    with traceml.trace_step(model):
         optimizer.zero_grad(set_to_none=True)
         outputs = model(batch["x"])
         loss = criterion(outputs, batch["y"])
@@ -186,14 +186,14 @@ This gives you:
 TraceML can also return a compact tracker summary for MLflow logging:
 
 ```python
-import traceml_ai as tml
+import traceml_ai as traceml
 import mlflow
 
 mlflow.start_run()
 
 # training loop ...
 
-summary = tml.summary(print_text=True)
+summary = traceml.summary(print_text=True)
 if summary is not None:
     numeric = {
         k: v for k, v in summary.items()
@@ -210,11 +210,11 @@ if summary is not None:
 
 This is a good fit when you want a compact diagnosis in your run metadata.
 
-If you also want the full TraceML artifact, call `tml.final_summary()` and
+If you also want the full TraceML artifact, call `traceml.final_summary()` and
 attach that JSON to the run:
 
 ```python
-full = tml.final_summary()
+full = traceml.final_summary()
 if full is not None:
     mlflow.log_dict(full, "traceml/final_summary.json")
 ```

--- a/docs/user_guide/public-api.md
+++ b/docs/user_guide/public-api.md
@@ -5,17 +5,17 @@ The stable surface that user code imports and calls. Everything in this page is 
 ## Core API
 
 ```python
-import traceml_ai as tml
+import traceml_ai as traceml
 
-tml.init(mode="auto")
+traceml.init(mode="auto")
 
-with tml.trace_step(model):
+with traceml.trace_step(model):
     ...
 ```
 
 The old `import traceml` path still works for now, but emits a `FutureWarning`
 and will be removed in a future release. New code should use
-`import traceml_ai as tml`.
+`import traceml_ai as traceml`.
 
 ## Hugging Face integration
 
@@ -65,18 +65,18 @@ See `traceml --help` for the full set of options.
 
 ## Summary APIs
 
-### `tml.summary()`
+### `traceml.summary()`
 
 Returns a compact flat dict for experiment trackers such as W&B, MLflow, or
 internal dashboards.
 
 ```python
-summary = tml.summary(print_text=True)
+summary = traceml.summary(print_text=True)
 if summary is not None:
     wandb.log(summary)
 ```
 
-### `tml.final_summary()`
+### `traceml.final_summary()`
 
 Returns the full `final_summary.json` payload. Use this when you need the
 complete structured report or want to store the artifact for `traceml compare`.

--- a/docs/user_guide/quickstart.md
+++ b/docs/user_guide/quickstart.md
@@ -1,636 +1,71 @@
 # TraceML Quickstart
 
-Get from install to your first useful TraceML run in a few minutes.
+Get from install to your first TraceML diagnosis in a few minutes.
 
-This guide is for practitioners who want the fastest path to an answer.
+TraceML runs with your existing PyTorch script and writes a structured
+`final_summary.json` plus a human-readable `final_summary.txt` at the end of
+the run.
 
-TraceML is most useful when you want to know:
-
-- why training is slow
-- whether the bottleneck is input, compute, wait, or rank imbalance
-- whether memory is drifting over time
-
-If you are new to TraceML, start here.
-
----
-
-## What you will do
-
-1. Install TraceML
-2. Initialize TraceML with `traceml.init(mode="auto")`
-3. Wrap your training step with `traceml.trace_step(model)`
-4. Run `traceml run train.py`
-5. Read the diagnosis in the CLI
-6. Optionally collect a structured final summary
-7. Optionally compare two runs
-8. Optionally open the local UI
-
----
-
-## Prerequisites
-
-| Requirement | Version |
-|---|---|
-| Python | 3.10+ |
-| PyTorch | 2.5+ |
-
-TraceML works best with PyTorch training scripts that already run successfully on their own.
-
----
-
-## Pick your stack
-
-Three minimal paths to a first TraceML run, depending on how your training code is structured. Pick the tab that matches your setup — each shows install + the single change + the run command. Full details for each stack live in their integration pages.
-
-=== "Plain PyTorch"
-
-    ```bash
-    pip install "traceml-ai[torch]"
-    ```
-
-    Initialize once, then wrap the training step body:
-
-    ```python
-    import traceml_ai as traceml
-
-    traceml.init(mode="auto")
-
-    for step in range(num_steps):
-        with traceml.trace_step(model):
-            optimizer.zero_grad(set_to_none=True)
-            loss = criterion(model(x), y)
-            loss.backward()
-            optimizer.step()
-    ```
-
-    Run:
-
-    ```bash
-    traceml run train.py
-    ```
-
-    !!! note
-        For a full end-to-end example, see the [plain PyTorch walkthrough](#2-minimal-training-script) below.
-
-=== "HF Trainer"
-
-    ```bash
-    pip install "traceml-ai[hf]"
-    ```
-
-    Replace `Trainer` with `TraceMLTrainer`:
-
-    ```python
-    from traceml_ai.integrations.huggingface import TraceMLTrainer
-
-    trainer = TraceMLTrainer(
-        model=model,
-        args=training_args,
-        train_dataset=train_dataset,
-        traceml_enabled=True,
-    )
-    trainer.train()
-    ```
-
-    Run:
-
-    ```bash
-    traceml run fine_tune.py
-    ```
-
-    !!! note
-        For full HF details and multi-GPU DDP, see the [Hugging Face integration](integrations/huggingface.md).
-
-=== "Lightning"
-
-    ```bash
-    pip install "traceml-ai[lightning]"
-    ```
-
-    Add `TraceMLCallback` to your `Trainer`:
-
-    ```python
-    import lightning as L
-    from traceml_ai.integrations.lightning import TraceMLCallback
-
-    trainer = L.Trainer(
-        max_steps=500,
-        callbacks=[TraceMLCallback()],
-    )
-    trainer.fit(model, train_dataloaders=loader)
-    ```
-
-    Run:
-
-    ```bash
-    traceml run train.py
-    ```
-
-    !!! note
-        For full Lightning details, see the [PyTorch Lightning integration](integrations/lightning.md).
-
-=== "Ray Train"
-
-    ```bash
-    pip install "traceml-ai[ray]"
-    ```
-
-    Wrap Ray's `TorchTrainer` with `TraceMLTorchTrainer`:
-
-    ```python
-    from ray.train import ScalingConfig
-    from traceml_ai.integrations.ray import TraceMLTorchTrainer
-
-    trainer = TraceMLTorchTrainer(
-        train_loop_per_worker,
-        train_loop_config={"steps": 100},
-        scaling_config=ScalingConfig(num_workers=4, use_gpu=True),
-    )
-    trainer.fit()
-    ```
-
-    Ray still launches workers and owns distributed communication. TraceML
-    starts one aggregator actor and one runtime inside each Ray worker.
-
-    !!! note
-        For full Ray details, see the [Ray Train integration](integrations/ray.md).
-
-Everything below this point applies to all four stacks — reading output, compare runs, DDP, troubleshooting.
-
----
-
-## 1) Install
+## 1. Install
 
 ```bash
 pip install traceml-ai
 ```
 
-Check that the CLI is available:
+Using Hugging Face, Lightning, Ray, W&B, or MLflow? See
+[Use With Your Stack](integrations.md).
 
-```bash
-traceml --help
-```
+## 2. Instrument Your Training Step
 
-You should see commands such as:
-
-- `watch`
-- `run`
-- `compare`
-
-### Optional extras
-
-For Hugging Face Trainer support:
-
-```bash
-pip install "traceml-ai[hf]"
-```
-
-For PyTorch Lightning support:
-
-```bash
-pip install "traceml-ai[lightning]"
-```
-
-If you want the PyTorch versions TraceML is tested against:
-
-```bash
-pip install "traceml-ai[torch]"
-```
-
----
-
-## 2) Minimal training script
-
-Save this as `train.py`.
+Add TraceML initialization once, then wrap the training step body:
 
 ```python
 import traceml_ai as traceml
-import torch
-import torch.nn as nn
-import torch.optim as optim
 
-
-class MyModel(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.net = nn.Sequential(
-            nn.Linear(128, 256),
-            nn.ReLU(),
-            nn.Linear(256, 10),
-        )
-
-    def forward(self, x):
-        return self.net(x)
-
-
-def main():
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    print(f"Running on: {device}")
-
-    traceml.init(mode="auto")
-
-    model = MyModel().to(device)
-    optimizer = optim.Adam(model.parameters(), lr=1e-3)
-    criterion = nn.CrossEntropyLoss()
-
-    model.train()
-    for step in range(200):
-        with traceml.trace_step(model):
-            inputs = torch.randn(64, 128, device=device)
-            labels = torch.randint(0, 10, (64,), device=device)
-
-            optimizer.zero_grad(set_to_none=True)
-            outputs = model(inputs)
-            loss = criterion(outputs, labels)
-            loss.backward()
-            optimizer.step()
-
-        if step % 50 == 0:
-            print(f"Step {step} | loss: {loss.item():.4f}")
-
-
-if __name__ == "__main__":
-    main()
-```
-
-### The only required change
-
-In a normal PyTorch loop, the preferred minimal setup is:
-
-```python
 traceml.init(mode="auto")
 
-with traceml.trace_step(model):
-    ...
+for batch in dataloader:
+    with traceml.trace_step(model):
+        optimizer.zero_grad(set_to_none=True)
+        outputs = model(batch["x"])
+        loss = criterion(outputs, batch["y"])
+        loss.backward()
+        optimizer.step()
 ```
 
-Call `traceml.init(mode="auto")` once near the start of the script, then wrap
-the full training step body from `zero_grad(...)` through `optimizer.step()`.
+Wrap the work from `zero_grad(...)` through `optimizer.step()`.
 
-The old `import traceml` path still works for now, but emits a `FutureWarning`
-and will be removed in a future release. New code should use
-`import traceml_ai as traceml`.
-
-If you need explicit wrappers or partial auto-instrumentation, use
-`mode="manual"` or `mode="selective"`. Keep that as a second step after you
-are comfortable with the default `auto` path.
-
----
-
-## 3) Run TraceML
+## 3. Run Your Script
 
 ```bash
 traceml run train.py
 ```
 
-This is the default TraceML workflow and the best place to start. By default,
-TraceML runs in summary mode.
-
-During training, TraceML stays quiet. At the end of the run, it prints a
-compact summary you can review or share and writes `final_summary.json` plus
-`final_summary.txt` under the session log directory.
-
----
-
-## 4) How to read the output
-
-TraceML is built to answer one question quickly:
-
-**Why is this training job slow?**
-
-Common diagnoses:
-
-### `INPUT-BOUND`
-
-The dataloader or preprocessing path is taking a large share of the step.
-
-Typical next steps:
-
-- increase dataloader workers
-- improve storage throughput
-- reduce CPU preprocessing cost
-- check host-to-device transfer delays
-
-### `COMPUTE-BOUND`
-
-Model compute dominates the step.
-
-Typical next steps:
-
-- reduce compute cost
-- tune batch size, precision, or kernels
-- inspect forward, backward, or optimizer cost
-- use an operator-level profiler only after identifying the hot path
-
-### `INPUT STRAGGLER`
-
-One rank is slower in the input path than the others.
-
-Typical next steps:
-
-- inspect dataloader imbalance
-- check rank-local preprocessing
-- check host-side jitter
-- look at the worst rank called out in the summary
-
-### `COMPUTE STRAGGLER`
-
-One rank is slower in compute than the others.
-
-Typical next steps:
-
-- inspect forward, backward, or optimizer imbalance
-- check uneven data shapes or rank-local work
-- inspect the worst rank called out in the summary
-
-### `WAIT-HEAVY`
-
-A meaningful part of the step is not attributed to dataloader, H2D, forward,
-backward, or optimizer work.
-
-Typical next steps:
-
-- inspect validation, checkpointing, logging, or framework work around the step
-- check CPU stalls
-- check uneven rank progress
-- compare wait time against input and compute time
-
-### `MEMORY CREEP`
-
-Memory is rising over time instead of staying stable.
-
-Typical next steps:
-
-- inspect retained tensors
-- inspect caches and per-step state
-- compare early vs later steps
-- look for graph-backed tensors kept alive across steps
-
----
-
-## 5) Optional: tracker-friendly summary
-
-`traceml run` uses summary mode by default. If you want to make that explicit
-for a low-noise run and a structured end-of-run payload for W&B or MLflow,
-launch with:
-
-```bash
-traceml run train.py --mode=summary
-```
-
-Then call `traceml.summary()` near the end of your script:
-
-```python
-summary = traceml.summary(print_text=True)
-if summary is not None:
-    print(summary["traceml/step_time/status"])
-```
-
-This returns a flat Python dict generated by the aggregator process. It is
-intended for logging TraceML diagnosis fields and global average metrics into
-your existing tracking stack.
-
-TraceML also writes canonical end-of-run summary artifacts, including:
-
-- `final_summary.json`
-- `final_summary.txt`
-
-`final_summary.json` is the canonical machine-readable TraceML summary artifact
-and the intended input for downstream logging and run comparison.
-
-Use `traceml.final_summary()` if you need the full structured JSON payload
-instead of the compact tracker dict.
-
-For long runs, use `--summary-window-rows N` to control how much recent
-per-node/per-rank history is used for the final summary.
-
----
-
-## 6) Optional: compare two runs
-
-If you have `final_summary.json` from two runs, compare them with:
-
-```bash
-traceml compare run_a.json run_b.json
-```
-This writes:
-
-- a structured compare JSON
-- a compact text report
-
-`traceml compare` is designed to consume TraceML `final_summary.json`
-artifacts.
-
-Use compare when you want to answer questions like:
-
-
-- did the run get slower or faster?
-- did the diagnosis change?
-- did wait time increase?
-- did memory behavior get worse?
-
-See [Compare Runs](compare.md).
-
----
-
-## 7) Optional: local UI
-
-If you want a richer view, run:
-
-```bash
-pip install "traceml-ai[dashboard]"
-```
-
-```bash
-traceml run train.py --mode=dashboard
-```
-
-Live dashboard mode is intended for single-node runs, including single-node
-multi-GPU.
-
-The local UI runs at:
+TraceML writes:
 
 ```text
-http://localhost:8765
+logs/<run_name>/final_summary.json
+logs/<run_name>/final_summary.txt
 ```
 
-Use the local UI when you want:
+For DDP, FSDP, and multi-node launches, see
+[Distributed Training](distributed-training.md).
 
-- a richer run review experience
-- an easier browser-based layout
-- local comparison of runs
+## 4. Read Your Diagnosis
 
-For live terminal feedback instead, use:
-
-```bash
-traceml run train.py --mode=cli
+```text
++----------------------------------------------------------------------------+
+|  Step Time                                                                 |
+|  - Diagnosis: INPUT STRAGGLER                                              |
+|  - Stats: total 303.7ms | input 254.5ms | compute 259.5ms | wait 40.5ms    |
+|  - Why: r0 input was slower than median global rank (254.5/3.8ms).         |
++----------------------------------------------------------------------------+
 ```
 
-Live terminal mode is also intended for single-node runs.
+In this example, rank 0 is the slow input rank, which can hold back the aligned
+distributed step.
 
-If you just want the fastest path, stay with the default summary mode.
-
----
-
-## 8) Other run modes
-
-### `traceml watch`
-
-```bash
-traceml watch train.py
-```
-
-Use this when you want:
-
-- zero-code system and process visibility
-- a quick look before adding step instrumentation
-
-`watch` is lighter-weight than `run`, but it does not provide the same step-aware diagnosis.
-
-## 9) Distributed DDP
-
-TraceML supports single-node multi-GPU DDP and multi-node DDP summary reports.
-For multi-node jobs, use summary mode for the final distributed report. Live
-CLI and dashboard views are currently intended for single-node runs.
-
-Keep `traceml.trace_step(...)` inside the training loop.
-
-### Minimal DDP example
-
-```python
-import os
-
-import traceml_ai as traceml
-import torch
-import torch.distributed as dist
-import torch.nn as nn
-import torch.optim as optim
-
-
-class MyModel(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.net = nn.Sequential(
-            nn.Linear(128, 256),
-            nn.ReLU(),
-            nn.Linear(256, 10),
-        )
-
-    def forward(self, x):
-        return self.net(x)
-
-
-def main():
-    rank = int(os.environ.get("RANK", 0))
-    local_rank = int(os.environ.get("LOCAL_RANK", 0))
-    world_size = int(os.environ.get("WORLD_SIZE", 1))
-
-    use_cuda = torch.cuda.is_available()
-    backend = "nccl" if use_cuda else "gloo"
-    dist.init_process_group(
-        backend=backend,
-        rank=rank,
-        world_size=world_size,
-    )
-
-    if use_cuda:
-        torch.cuda.set_device(local_rank)
-        device = torch.device("cuda", local_rank)
-    else:
-        device = torch.device("cpu")
-
-    model = MyModel().to(device)
-    model = torch.nn.parallel.DistributedDataParallel(
-        model,
-        device_ids=[local_rank] if use_cuda else None,
-    )
-
-    optimizer = optim.Adam(model.parameters(), lr=1e-3)
-    criterion = nn.CrossEntropyLoss()
-
-    model.train()
-    for step in range(200):
-        with traceml.trace_step(model.module):
-            inputs = torch.randn(64, 128, device=device)
-            labels = torch.randint(0, 10, (64,), device=device)
-
-            optimizer.zero_grad(set_to_none=True)
-            outputs = model(inputs)
-            loss = criterion(outputs, labels)
-            loss.backward()
-            optimizer.step()
-
-    dist.destroy_process_group()
-
-
-if __name__ == "__main__":
-    main()
-```
-
-Launch with:
-
-```bash
-traceml run train.py --nproc-per-node=4
-```
-
-For a multi-node run, launch the same script on every node with a shared
-session id and the same torchrun rendezvous address.
-
-On node 0:
-
-```bash
-traceml run train.py \
-  --nnodes=2 \
-  --node-rank=0 \
-  --nproc-per-node=4 \
-  --master-addr=<node0-ip> \
-  --run-name=my-run
-```
-
-On node 1:
-
-```bash
-traceml run train.py \
-  --nnodes=2 \
-  --node-rank=1 \
-  --nproc-per-node=4 \
-  --master-addr=<node0-ip> \
-  --run-name=my-run
-```
-
-Node 0 starts the TraceML aggregator. Other nodes connect to
-`<node0-ip>:29765` by default. If workers need a different reachable address
-or port for TraceML telemetry, add `--aggregator-host=<host>` or
-`--aggregator-port=<port>` on every node. Node 0 binds the aggregator to
-`0.0.0.0` by default for multi-node runs; override that only when needed with
-`--aggregator-bind-host=<bind-host>`.
-
-`--session-id` remains accepted as a backward-compatible alias for
-`--run-name`.
-
----
-
-## 10) Deep/layer profiling status
-
-Deep/layer profiling has been removed from the public CLI for now. Start with
-the default summary path:
-
-```bash
-traceml run train.py
-```
-
-If TraceML shows you need lower-level detail, use PyTorch Profiler, Nsight, or
-another operator-level profiler for that follow-up.
-
----
-
-## 11) Common launch patterns
-
-Default summary run:
-
-```bash
-traceml run train.py
-```
+## Useful Next Commands
 
 Live terminal view:
 
@@ -638,118 +73,23 @@ Live terminal view:
 traceml run train.py --mode=cli
 ```
 
-Local UI:
+Browser view:
 
 ```bash
 pip install "traceml-ai[dashboard]"
-```
-
-```bash
 traceml run train.py --mode=dashboard
 ```
 
-Summary-only distributed run:
+Compare two runs:
 
 ```bash
-traceml run train.py \
-  --mode=summary \
-  --nnodes=2 \
-  --node-rank=0 \
-  --nproc-per-node=4 \
-  --master-addr=<node0-ip> \
-  --run-name=my-run
+traceml compare run_a/final_summary.json run_b/final_summary.json
 ```
 
-Run the same command on each node, changing only `--node-rank`.
+## Next Steps
 
-Explicit summary mode:
-
-```bash
-traceml run train.py --mode=summary
-```
-
-Compare two TraceML summary artifacts:
-
-```bash
-traceml compare run_a.json run_b.json
-```
-
-Single-node DDP:
-
-```bash
-traceml run train.py --nproc-per-node=4
-```
-
-Zero-code first look:
-
-```bash
-traceml watch train.py
-```
-
-Run without telemetry for a baseline comparison:
-
-```bash
-traceml run train.py --disable-traceml
-```
-
-Pass arguments to your training script:
-
-```bash
-traceml run train.py --args -- --epochs 10 --lr 1e-3
-```
-
----
-
-## 12) Troubleshooting
-
-### `torchrun: command not found`
-
-TraceML launches your script through:
-
-```bash
-python -m torch.distributed.run
-```
-
-Check that this works:
-
-```bash
-python -m torch.distributed.run --help
-```
-
-If that works but your environment still fails to launch, check your Python environment and PATH.
-
-### Output is messy in the terminal
-
-If your own logger, progress bar, or framework output is fighting with the TraceML CLI:
-
-- disable `tqdm`
-- reduce extra terminal logging
-- use the default summary mode if you only want final artifacts
-- try `--mode=dashboard` for browser-based viewing on a single-node run
-
-### I want the fastest path
-
-Stay with:
-
-```bash
-traceml run train.py
-```
-
-Add the local UI or compare workflow only after you get value from the default run path.
-
----
-
-## Next steps
-
+- [How to Read Output](reading-output.md)
 - [Compare Runs](compare.md)
-- Hugging Face integration: `docs/huggingface.md`
-- PyTorch Lightning integration: `docs/lightning.md`
-- GitHub issues: `https://github.com/traceopt-ai/traceml/issues`
-
-If TraceML helped you find a slowdown, please open an issue and include:
-
-- hardware / CUDA / PyTorch versions
-- single GPU or multi-GPU
-- whether you used `run` or `watch`
-- the end-of-run summary
-- a minimal repro if possible
+- [Distributed Training](distributed-training.md)
+- [Use With Your Stack](integrations.md)
+- [FAQ](faq.md)

--- a/docs/user_guide/quickstart.md
+++ b/docs/user_guide/quickstart.md
@@ -17,8 +17,8 @@ If you are new to TraceML, start here.
 ## What you will do
 
 1. Install TraceML
-2. Initialize TraceML with `tml.init(mode="auto")`
-3. Wrap your training step with `tml.trace_step(model)`
+2. Initialize TraceML with `traceml.init(mode="auto")`
+3. Wrap your training step with `traceml.trace_step(model)`
 4. Run `traceml run train.py`
 5. Read the diagnosis in the CLI
 6. Optionally collect a structured final summary
@@ -51,12 +51,12 @@ Three minimal paths to a first TraceML run, depending on how your training code 
     Initialize once, then wrap the training step body:
 
     ```python
-    import traceml_ai as tml
+    import traceml_ai as traceml
 
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     for step in range(num_steps):
-        with tml.trace_step(model):
+        with traceml.trace_step(model):
             optimizer.zero_grad(set_to_none=True)
             loss = criterion(model(x), y)
             loss.backward()
@@ -204,7 +204,7 @@ pip install "traceml-ai[torch]"
 Save this as `train.py`.
 
 ```python
-import traceml_ai as tml
+import traceml_ai as traceml
 import torch
 import torch.nn as nn
 import torch.optim as optim
@@ -227,7 +227,7 @@ def main():
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Running on: {device}")
 
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     model = MyModel().to(device)
     optimizer = optim.Adam(model.parameters(), lr=1e-3)
@@ -235,7 +235,7 @@ def main():
 
     model.train()
     for step in range(200):
-        with tml.trace_step(model):
+        with traceml.trace_step(model):
             inputs = torch.randn(64, 128, device=device)
             labels = torch.randint(0, 10, (64,), device=device)
 
@@ -258,18 +258,18 @@ if __name__ == "__main__":
 In a normal PyTorch loop, the preferred minimal setup is:
 
 ```python
-tml.init(mode="auto")
+traceml.init(mode="auto")
 
-with tml.trace_step(model):
+with traceml.trace_step(model):
     ...
 ```
 
-Call `tml.init(mode="auto")` once near the start of the script, then wrap
+Call `traceml.init(mode="auto")` once near the start of the script, then wrap
 the full training step body from `zero_grad(...)` through `optimizer.step()`.
 
 The old `import traceml` path still works for now, but emits a `FutureWarning`
 and will be removed in a future release. New code should use
-`import traceml_ai as tml`.
+`import traceml_ai as traceml`.
 
 If you need explicit wrappers or partial auto-instrumentation, use
 `mode="manual"` or `mode="selective"`. Keep that as a second step after you
@@ -378,10 +378,10 @@ launch with:
 traceml run train.py --mode=summary
 ```
 
-Then call `tml.summary()` near the end of your script:
+Then call `traceml.summary()` near the end of your script:
 
 ```python
-summary = tml.summary(print_text=True)
+summary = traceml.summary(print_text=True)
 if summary is not None:
     print(summary["traceml/step_time/status"])
 ```
@@ -398,7 +398,7 @@ TraceML also writes canonical end-of-run summary artifacts, including:
 `final_summary.json` is the canonical machine-readable TraceML summary artifact
 and the intended input for downstream logging and run comparison.
 
-Use `tml.final_summary()` if you need the full structured JSON payload
+Use `traceml.final_summary()` if you need the full structured JSON payload
 instead of the compact tracker dict.
 
 For long runs, use `--summary-window-rows N` to control how much recent
@@ -493,14 +493,14 @@ TraceML supports single-node multi-GPU DDP and multi-node DDP summary reports.
 For multi-node jobs, use summary mode for the final distributed report. Live
 CLI and dashboard views are currently intended for single-node runs.
 
-Keep `tml.trace_step(...)` inside the training loop.
+Keep `traceml.trace_step(...)` inside the training loop.
 
 ### Minimal DDP example
 
 ```python
 import os
 
-import traceml_ai as tml
+import traceml_ai as traceml
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -550,7 +550,7 @@ def main():
 
     model.train()
     for step in range(200):
-        with tml.trace_step(model.module):
+        with traceml.trace_step(model.module):
             inputs = torch.randn(64, 128, device=device)
             labels = torch.randint(0, 10, (64,), device=device)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -140,10 +140,9 @@ That includes things like:
 
 ## Related docs
 
-- [Quickstart](../docs/quickstart.md)
-- [Compare Runs](../docs/compare.md)
-- [How to Read TraceML Output](../docs/how-to-read-output.md)
-- [FAQ](../docs/faq.md)
-- [Use TraceML with W&B / MLflow](../docs/use-with-wandb-mlflow.md)
-- [Hugging Face Trainer](../docs/huggingface.md)
-- [PyTorch Lightning](../docs/lightning.md)
+- [Quickstart](../docs/user_guide/quickstart.md)
+- [Distributed Training](../docs/user_guide/distributed-training.md)
+- [Compare Runs](../docs/user_guide/compare.md)
+- [How to Read TraceML Output](../docs/user_guide/reading-output.md)
+- [Use With Your Stack](../docs/user_guide/integrations.md)
+- [FAQ](../docs/user_guide/faq.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,8 +12,8 @@ These are the main user-facing examples.
 
 | Example | What it shows | Works on | Notes |
 |---|---|---|---|
-| `pytorch_minimal.py` | Minimal plain PyTorch loop with `tml.init(mode="auto")`, `tml.trace_step(...)`, and `tml.final_summary()` | CPU / CUDA | Best first example |
-| `summary_logging_minimal.py` | Minimal tracker-friendly `tml.summary()` output for W&B or MLflow logging | CPU / CUDA | Best summary API example |
+| `pytorch_minimal.py` | Minimal plain PyTorch loop with `traceml.init(mode="auto")`, `traceml.trace_step(...)`, and `traceml.final_summary()` | CPU / CUDA | Best first example |
+| `summary_logging_minimal.py` | Minimal tracker-friendly `traceml.summary()` output for W&B or MLflow logging | CPU / CUDA | Best summary API example |
 | `manual_custom_minimal.py` | Manual TraceML instrumentation with a custom batch source and explicit wrappers | CPU / CUDA | Best starting point for `mode="manual"` |
 | `ddp_minimal.py` | Minimal single-node DDP example | CPU / CUDA | Best distributed starter |
 | `huggingface_trainer_minimal.py` | Minimal Hugging Face `TraceMLTrainer` example | CPU / CUDA | No model download required |
@@ -88,23 +88,23 @@ traceml compare run_a.json run_b.json
 
 Starter examples now prefer the top-level public API:
 
-- `tml.init(mode="auto")`
-- `tml.trace_step(...)`
-- `tml.trace_model_instance(...)`
-- `tml.summary()`
-- `tml.final_summary()`
+- `traceml.init(mode="auto")`
+- `traceml.trace_step(...)`
+- `traceml.trace_model_instance(...)`
+- `traceml.summary()`
+- `traceml.final_summary()`
 
 For explicit manual instrumentation, see:
 
-- `tml.init(mode="manual")`
-- `tml.wrap_dataloader_fetch(...)`
-- `tml.wrap_forward(...)`
-- `tml.wrap_backward(...)`
-- `tml.wrap_optimizer(...)`
+- `traceml.init(mode="manual")`
+- `traceml.wrap_dataloader_fetch(...)`
+- `traceml.wrap_forward(...)`
+- `traceml.wrap_backward(...)`
+- `traceml.wrap_optimizer(...)`
 
 The old decorator import path still works for backward compatibility, but it
 is deprecated and will be removed in a future version. New examples use the
-top-level `tml.*` API from `import traceml_ai as tml`.
+top-level `traceml.*` API from `import traceml_ai as traceml`.
 
 ---
 

--- a/examples/advanced/bert_gradient_accum.py
+++ b/examples/advanced/bert_gradient_accum.py
@@ -13,7 +13,7 @@ from transformers import (
     get_linear_schedule_with_warmup,
 )
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 SEED = 42
 MODEL_NAME = "bert-base-uncased"
@@ -87,7 +87,7 @@ def main():
     use_amp = torch.cuda.is_available()
     dtype = torch.float16 if use_amp else torch.float32
 
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     tokenizer, train_loader, _ = prepare_data()
 
@@ -136,7 +136,7 @@ def main():
             optimizer.zero_grad(set_to_none=True)
 
             # ONE TraceML step == GRAD_ACC_STEPS micro-steps + optimizer step
-            with tml.trace_step(model):
+            with traceml.trace_step(model):
                 last_logits = None
                 last_labels = None
                 total_step_loss = 0.0

--- a/examples/advanced/fsdp_minimal_cuda.py
+++ b/examples/advanced/fsdp_minimal_cuda.py
@@ -7,7 +7,7 @@ import torch.optim as optim
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.utils.data import DataLoader, DistributedSampler, TensorDataset
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 SEED = 42
 INPUT_DIM = 1024
@@ -86,7 +86,7 @@ def main():
     torch.cuda.set_device(local_rank)
     device = torch.device("cuda", local_rank)
 
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     set_seed(SEED + rank)
 
@@ -96,7 +96,7 @@ def main():
     base_model = TinyMLP().to(device)
 
     # Attach TraceML hooks to the real model before FSDP wrapping
-    tml.trace_model_instance(base_model)
+    traceml.trace_model_instance(base_model)
 
     # Wrap with FSDP
     model = FSDP(
@@ -115,7 +115,7 @@ def main():
         train_sampler.set_epoch(epoch)
 
         for batch in train_loader:
-            with tml.trace_step(base_model):
+            with traceml.trace_step(base_model):
                 batch_x, batch_y = load_batch_to_device(batch, device)
 
                 optimizer.zero_grad(set_to_none=True)

--- a/examples/ddp_minimal.py
+++ b/examples/ddp_minimal.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader, DistributedSampler, TensorDataset
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 SEED = 42
 INPUT_DIM = 128
@@ -79,7 +79,7 @@ def main() -> None:
     else:
         device = torch.device("cpu")
 
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     set_seed(SEED + rank)
 
@@ -110,7 +110,7 @@ def main() -> None:
         for batch_x, batch_y in train_loader:
             global_step += 1
 
-            with tml.trace_step(model.module):
+            with traceml.trace_step(model.module):
                 batch_x = batch_x.to(device, non_blocking=True)
                 batch_y = batch_y.to(device, non_blocking=True)
 

--- a/examples/h2d_timing_demo.py
+++ b/examples/h2d_timing_demo.py
@@ -8,7 +8,7 @@ Each training step moves a batch from CPU RAM to GPU via:
     batch_x = batch_x.to(device, non_blocking=True)
     batch_y = batch_y.to(device, non_blocking=True)
 
-Because tml.init(mode="auto") patches torch.Tensor.to(), those calls are
+Because traceml.init(mode="auto") patches torch.Tensor.to(), those calls are
 timed and stored in the SQLite DB under the event name:
     _traceml_internal:h2d_time
 
@@ -33,7 +33,7 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader, TensorDataset
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 SEED = 42
 INPUT_DIM = 512
@@ -149,7 +149,7 @@ def main():
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Device: {device}")
 
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     # Keep data on CPU so each step does a real H2D transfer
     x = torch.randn(NUM_SAMPLES, INPUT_DIM)
@@ -176,7 +176,7 @@ def main():
         if step >= NUM_STEPS:
             break
 
-        with tml.trace_step(model):
+        with traceml.trace_step(model):
             # These .to() calls happen inside trace_step so they are timed
             batch_x = batch_x.to(device, non_blocking=True)
             batch_y = batch_y.to(device, non_blocking=True)
@@ -192,7 +192,7 @@ def main():
             print(f"Step {step}/{NUM_STEPS} | loss: {loss.item():.4f}")
 
     print("\nTraining done. Waiting for final summary...")
-    tml.final_summary()
+    traceml.final_summary()
 
     # Print the DB path to stderr so it appears in the terminal AFTER the TUI
     # exits (TUI captures stdout; stderr goes to the panel but the path line

--- a/examples/input_bound_demo.py
+++ b/examples/input_bound_demo.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader, Dataset
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 SEED = 42
 INPUT_DIM = 256
@@ -58,7 +58,7 @@ def main():
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Running on: {device}")
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     dataset = SlowDataset(
         num_samples=NUM_SAMPLES,
@@ -87,7 +87,7 @@ def main():
         for batch_x, batch_y in loader:
             total_steps += 1
 
-            with tml.trace_step(model):
+            with traceml.trace_step(model):
                 batch_x = batch_x.to(device, non_blocking=True)
                 batch_y = batch_y.to(device, non_blocking=True)
                 optimizer.zero_grad(set_to_none=True)

--- a/examples/input_straggler_ddp_demo.py
+++ b/examples/input_straggler_ddp_demo.py
@@ -9,7 +9,7 @@ import torch.optim as optim
 from torch.utils.data import DataLoader, Dataset
 from torch.utils.data.distributed import DistributedSampler
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 SEED = 42
 INPUT_DIM = 1024
@@ -119,7 +119,7 @@ def main() -> None:
     else:
         device = torch.device("cpu")
 
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     set_seed(SEED + rank)
 
@@ -176,7 +176,7 @@ def main() -> None:
         for batch_x, batch_y in loader:
             total_steps += 1
 
-            with tml.trace_step(model.module):
+            with traceml.trace_step(model.module):
                 batch_x = batch_x.to(device, non_blocking=True)
                 batch_y = batch_y.to(device, non_blocking=True)
                 optimizer.zero_grad(set_to_none=True)

--- a/examples/manual_custom_minimal.py
+++ b/examples/manual_custom_minimal.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 SEED = 42
 INPUT_DIM = 128
@@ -71,7 +71,7 @@ def main() -> None:
     print(f"Running on: {device}")
 
     # Manual mode disables the default automatic patching path.
-    tml.init(mode="manual")
+    traceml.init(mode="manual")
 
     batch_source = CustomBatchSource(
         steps=STEPS,
@@ -82,20 +82,20 @@ def main() -> None:
     )
 
     # Manual wrappers are the explicit instrumentation path.
-    batch_source = tml.wrap_dataloader_fetch(batch_source)
+    batch_source = traceml.wrap_dataloader_fetch(batch_source)
 
     model = TinyMLP().to(device)
-    model = tml.wrap_forward(model)
+    model = traceml.wrap_forward(model)
 
     optimizer = optim.AdamW(model.parameters(), lr=1e-3)
-    optimizer = tml.wrap_optimizer(optimizer)
+    optimizer = traceml.wrap_optimizer(optimizer)
 
     criterion = nn.CrossEntropyLoss()
     model.train()
 
     for step, (batch_x, batch_y) in enumerate(batch_source, start=1):
 
-        with tml.trace_step(model):
+        with traceml.trace_step(model):
             batch_x = batch_x.to(device, non_blocking=True)
             batch_y = batch_y.to(device, non_blocking=True)
             optimizer.zero_grad(set_to_none=True)
@@ -104,7 +104,7 @@ def main() -> None:
             loss = criterion(logits, batch_y)
 
             # Backward timing is wrapped explicitly in manual mode.
-            tml.wrap_backward(loss).backward()
+            traceml.wrap_backward(loss).backward()
             optimizer.step()
 
         if step % 50 == 0:
@@ -114,7 +114,7 @@ def main() -> None:
 
     print("Done.")
 
-    summary = tml.final_summary(print_text=True)
+    summary = traceml.final_summary(print_text=True)
     print(summary is not None)
 
 

--- a/examples/pytorch_minimal.py
+++ b/examples/pytorch_minimal.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader, TensorDataset
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 SEED = 42
 INPUT_DIM = 1024
@@ -37,7 +37,7 @@ def main():
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Running on: {device}")
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     # Create a simple in-memory dataset
     x = torch.randn(NUM_SAMPLES, INPUT_DIM)
@@ -64,7 +64,7 @@ def main():
         for batch_x, batch_y in loader:
             total_steps += 1
 
-            with tml.trace_step(model):
+            with traceml.trace_step(model):
                 batch_x = batch_x.to(device, non_blocking=True)
                 batch_y = batch_y.to(device, non_blocking=True)
                 optimizer.zero_grad(set_to_none=True)
@@ -82,7 +82,7 @@ def main():
 
     print("Done.")
 
-    summary = tml.final_summary(print_text=True)
+    summary = traceml.final_summary(print_text=True)
     print(summary is not None)
 
 

--- a/examples/ray_torchtrainer_minimal.py
+++ b/examples/ray_torchtrainer_minimal.py
@@ -18,7 +18,7 @@ def train_loop_per_worker(config):
     import torch.optim as optim
     from ray import train
 
-    import traceml_ai as tml
+    import traceml_ai as traceml
 
     ctx = train.get_context()
     device = torch.device(
@@ -35,10 +35,10 @@ def train_loop_per_worker(config):
     optimizer = optim.AdamW(model.parameters(), lr=1e-3)
     criterion = nn.CrossEntropyLoss()
 
-    tml.trace_model_instance(model)
+    traceml.trace_model_instance(model)
 
     for step in range(int(config["steps"])):
-        with tml.trace_step(model):
+        with traceml.trace_step(model):
             x = torch.randn(64, 32, device=device)
             y = torch.randint(0, 4, (64,), device=device)
 

--- a/examples/summary_logging_minimal.py
+++ b/examples/summary_logging_minimal.py
@@ -10,7 +10,7 @@ Run with:
 
     traceml run examples/summary_logging_minimal.py
 
-At the end of the run, ``tml.summary()`` returns a flat dict designed for
+At the end of the run, ``traceml.summary()`` returns a flat dict designed for
 W&B, MLflow, and other experiment trackers.
 """
 
@@ -21,12 +21,12 @@ import time
 import torch
 from torch import nn
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 
 def main() -> None:
     """Run a tiny traced loop and print the compact TraceML summary."""
-    tml.init()
+    traceml.init()
 
     torch.manual_seed(0)
     model = nn.Linear(8, 2)
@@ -37,7 +37,7 @@ def main() -> None:
     y = torch.randint(0, 2, (32,))
 
     for _ in range(128):
-        with tml.trace_step(model):
+        with traceml.trace_step(model):
             optimizer.zero_grad(set_to_none=True)
             logits = model(x)
             loss = criterion(logits, y)
@@ -45,7 +45,7 @@ def main() -> None:
             optimizer.step()
         time.sleep(0.04)
 
-    summary = tml.summary(print_text=True)
+    summary = traceml.summary(print_text=True)
     if summary is None:
         return
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,8 +74,10 @@ markdown_extensions:
 nav:
   - User Guide:
       - Quickstart: user_guide/quickstart.md
+      - Distributed Training: user_guide/distributed-training.md
       - Reading output: user_guide/reading-output.md
       - Integrations:
+          - Overview: user_guide/integrations.md
           - Hugging Face: user_guide/integrations/huggingface.md
           - PyTorch Lightning: user_guide/integrations/lightning.md
           - Ray Train: user_guide/integrations/ray.md

--- a/src/dev/scenarios/bert_ddp.py
+++ b/src/dev/scenarios/bert_ddp.py
@@ -14,7 +14,7 @@ from transformers import (
     get_linear_schedule_with_warmup,
 )
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 SEED = 42
 MODEL_NAME = "distilbert-base-uncased"
@@ -185,7 +185,7 @@ def main():
         device = torch.device("cpu")
         dtype = torch.float32
 
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     # Different seed per rank (important for shuffling etc.)
     set_seed(SEED + rank)
@@ -208,7 +208,7 @@ def main():
     # TraceML: attach hooks to the *real* model
     # --------------------------------------------------------
     # Do this BEFORE wrapping with DistributedDataParallel
-    tml.trace_model_instance(model)
+    traceml.trace_model_instance(model)
 
     # Wrap model with DDP
     if use_cuda:
@@ -258,7 +258,7 @@ def main():
             # ------------------------------------------------
             # TraceML: define ONE training step boundary
             # ------------------------------------------------
-            with tml.trace_step(model.module):
+            with traceml.trace_step(model.module):
 
                 # Load batch to GPU
                 batch = load_batch_to_device(batch, device)

--- a/src/dev/scenarios/bert_memory_creep.py
+++ b/src/dev/scenarios/bert_memory_creep.py
@@ -13,7 +13,7 @@ from transformers import (
     get_linear_schedule_with_warmup,
 )
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 SEED = 42
 MODEL_NAME = "distilbert-base-uncased"
@@ -124,7 +124,7 @@ def main() -> None:
         device = torch.device("cpu")
         amp_dtype = torch.float32
 
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     set_seed(SEED + rank)
 
@@ -138,7 +138,7 @@ def main() -> None:
         output_hidden_states=True,
     ).to(device)
 
-    tml.trace_model_instance(model)
+    traceml.trace_model_instance(model)
 
     if use_cuda:
         model = torch.nn.parallel.DistributedDataParallel(
@@ -177,7 +177,7 @@ def main() -> None:
         running_acc = 0.0
 
         for batch in train_loader:
-            with tml.trace_step(model.module):
+            with traceml.trace_step(model.module):
                 batch = {
                     key: value.to(device, non_blocking=True)
                     for key, value in batch.items()

--- a/src/dev/scenarios/bert_straggler.py
+++ b/src/dev/scenarios/bert_straggler.py
@@ -15,7 +15,7 @@ from transformers import (
     get_linear_schedule_with_warmup,
 )
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 SEED = 42
 MODEL_NAME = "distilbert-base-uncased"
@@ -165,7 +165,7 @@ def main() -> None:
         device = torch.device("cpu")
         amp_dtype = torch.float32
 
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     set_seed(SEED + rank)
 
@@ -178,7 +178,7 @@ def main() -> None:
         num_labels=4,
     ).to(device)
 
-    tml.trace_model_instance(model)
+    traceml.trace_model_instance(model)
 
     if use_cuda:
         model = torch.nn.parallel.DistributedDataParallel(
@@ -217,7 +217,7 @@ def main() -> None:
         for batch in train_loader:
             global_step += 1
 
-            with tml.trace_step(model.module):
+            with traceml.trace_step(model.module):
                 batch = {
                     key: value.to(device, non_blocking=True)
                     for key, value in batch.items()

--- a/src/dev/scenarios/cnn_mnist_deep.py
+++ b/src/dev/scenarios/cnn_mnist_deep.py
@@ -4,7 +4,7 @@ import torch.optim as optim
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 # -------------------------
 # Medium CNN for MNIST
@@ -52,7 +52,7 @@ def optimizer_step(opt):
 
 def main():
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     transform = transforms.Compose(
         [
@@ -73,7 +73,7 @@ def main():
     # Enables per-layer memory + timing hooks.
     # Can add overhead in long training runs.
     # Recommended for short runs, diagnosis, or one-off investigations.
-    tml.trace_model_instance(
+    traceml.trace_model_instance(
         model,
         trace_layer_forward_memory=True,
         trace_layer_backward_memory=True,
@@ -87,7 +87,7 @@ def main():
     print("Starting training...")
     for step, (xb, yb) in enumerate(loader):
 
-        with tml.trace_step(model):
+        with traceml.trace_step(model):
             xb, yb = xb.to(device), yb.to(device)
 
             opt.zero_grad(set_to_none=True)

--- a/src/dev/scenarios/vit_ddp_stress.py
+++ b/src/dev/scenarios/vit_ddp_stress.py
@@ -11,7 +11,7 @@ from torch.utils.data import DataLoader, DistributedSampler
 from torchvision import transforms
 from torchvision.models import vit_b_16
 
-import traceml_ai as tml
+import traceml_ai as traceml
 
 # ============================================================
 # CONFIG
@@ -144,7 +144,7 @@ def main():
 
     dist.init_process_group("nccl")
     set_seed(SEED + rank)
-    tml.init(mode="auto")
+    traceml.init(mode="auto")
 
     # --------------------------------------------------------
     # Data
@@ -188,7 +188,7 @@ def main():
             # ------------------------------------------------
             # TraceML: ONE logical training step
             # ------------------------------------------------
-            with tml.trace_step(model.module):
+            with traceml.trace_step(model.module):
 
                 batch = load_batch_to_device(batch, device)
 

--- a/src/traceml/__init__.py
+++ b/src/traceml/__init__.py
@@ -1,7 +1,7 @@
 """
 Deprecated compatibility package for the former ``traceml`` import path.
 
-Use ``import traceml_ai as tml`` in new code. The ``traceml`` CLI command is
+Use ``import traceml_ai as traceml`` in new code. The ``traceml`` CLI command is
 unchanged.
 """
 
@@ -58,7 +58,7 @@ def _install_alias_finder() -> None:
 
 warnings.warn(
     "The 'traceml' Python import path is deprecated and will be removed in a "
-    "future release. Use 'import traceml_ai as tml' instead.",
+    "future release. Use 'import traceml_ai as traceml' instead.",
     FutureWarning,
     stacklevel=2,
 )

--- a/src/traceml_ai/integrations/ray.py
+++ b/src/traceml_ai/integrations/ray.py
@@ -244,7 +244,7 @@ class _TraceMLWorkerLoop:
     config: TraceMLRayConfig
 
     def __call__(self, train_loop_config: Dict[str, Any]) -> Any:
-        import traceml_ai as tml
+        import traceml_ai as traceml
 
         _apply_ray_train_identity_env()
 
@@ -255,7 +255,7 @@ class _TraceMLWorkerLoop:
         handle: Optional[RuntimeHandle] = None
         try:
             handle = start_runtime_handle(settings, fail_open=True)
-            tml.init(
+            traceml.init(
                 mode=str(self.config.init_mode),
                 patch_dataloader=self.config.patch_dataloader,
                 patch_forward=self.config.patch_forward,

--- a/src/traceml_ai/sdk/decorators_compat.py
+++ b/src/traceml_ai/sdk/decorators_compat.py
@@ -7,9 +7,9 @@ instrumentation.
 
 New code should prefer the explicit path:
 
-    import traceml_ai as tml
-    tml.init(...)
-    with tml.trace_step(...):
+    import traceml_ai as traceml
+    traceml.init(...)
+    with traceml.trace_step(...):
         ...
 
 Backward compatibility

--- a/src/traceml_ai/sdk/instrumentation.py
+++ b/src/traceml_ai/sdk/instrumentation.py
@@ -3,13 +3,13 @@ Core training instrumentation helpers used by TraceML.
 
 This module contains the actual tracing context managers and hook attachment
 logic. It intentionally has no import-time side effects. Patch installation is
-owned by `tml.init(...)` and the legacy decorator compatibility layer.
+owned by `traceml.init(...)` and the legacy decorator compatibility layer.
 
 New path
 --------
-- `import traceml_ai as tml`
-- `tml.init(...)`
-- `tml.trace_step(...)`
+- `import traceml_ai as traceml`
+- `traceml.init(...)`
+- `traceml.trace_step(...)`
 
 Legacy compatibility path
 -------------------------


### PR DESCRIPTION
Docs and developer-experience cleanup.

Refreshes the README, quickstart, integrations docs, FAQ, public API docs, and examples so they all reflect the current recommended usage: import traceml_ai as traceml and traceml.init(mode="auto"). I

t also adds a dedicated distributed training guide, an integrations overview page, a SECURITY.md, a PR template, and better .gitignore coverage for local run artifacts and packaging byproducts.
