### PR TITLE
refactor Lightning callback import for availability check

### DIFF
--- a/src/traceml_ai/integrations/lightning.py
+++ b/src/traceml_ai/integrations/lightning.py
@@ -1,8 +1,6 @@
 import os
 import sys
 
-from lightning.pytorch.callbacks import Callback
-
 from traceml_ai.runtime.state import get_trace_session_state
 from traceml_ai.utils.flush_buffers import flush_step_events
 from traceml_ai.utils.step_memory import StepMemoryTracker
@@ -12,6 +10,13 @@ from traceml_ai.utils.timing import (
     record_event,
     timed_region,
 )
+
+try:
+    from lightning.pytorch.callbacks import Callback
+    IS_LIGHTNING_AVAILABLE = True
+except ImportError:
+    Callback = object
+    IS_LIGHTNING_AVAILABLE = False
 
 TRACEML_DISABLED = os.environ.get("TRACEML_DISABLED") == "1"
 
@@ -47,6 +52,8 @@ class TraceMLCallback(Callback):
     """
 
     def __init__(self):
+        if not IS_LIGHTNING_AVAILABLE:
+            raise ImportError("Install traceml[lightning] to use Lightning integration")
         super().__init__()
         self._traceml_step_ctx = None
         self._forward_ctx = None


### PR DESCRIPTION
## What changed

<!-- Briefly describe the user-visible change. -->
Refactored PyTorch Lightning integration into an optional adapter-style dependency, removing the hard requirement on Lightning from the core TraceML package.



## Why

<!-- What problem does this solve for TraceML users or contributors? -->

## How I tested

<!-- Include exact commands, examples, or environments used. -->

- [ ] Unit tests
- [ ] Integration or smoke test
- [ ] Example training script
- [ ] Docs-only change
- [ ] Not run; reason:

## Runtime impact

<!-- Required for tracing, sampler, transport, aggregator, or reporting changes. -->

- [ ] No training-path runtime impact
- [ ] May affect training-path overhead
- [ ] May affect distributed launch, telemetry, or aggregator behavior
- [ ] Not applicable

Notes:

## Documentation

- [ ] README updated
- [ ] User docs updated
- [ ] Examples updated
- [ ] API docs updated
- [ ] Not needed

## Risk checklist

- [ ] Does not add unnecessary CUDA synchronizations
- [ ] Does not add blocking I/O on the training path
- [ ] Fails safely without crashing user training
- [ ] Keeps new dependencies optional unless discussed
- [ ] Redacts or avoids sensitive training-environment data in examples

## Screenshots or output

<!-- Paste relevant CLI output, final_summary text, viewer screenshot, or compare output. -->
