### PR TITLE
Add Slurm launch guide and sbatch template for multi-node runs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell and Slurm batch scripts must keep LF line endings so they run on
+# Linux clusters (CRLF would break the shebang: "bad interpreter: /bin/bash^M").
+*.sh    text eol=lf
+*.sbatch text eol=lf

--- a/README.md
+++ b/README.md
@@ -156,12 +156,12 @@ changing the final saved artifacts.
 - Single GPU training
 - Single-node multi-GPU DDP / FSDP
 - Multi-node DDP summary reports
+- Multi-node runs on Slurm (sbatch template + guide)
 - Run-to-run comparison from `final_summary.json`
 - Custom PyTorch loops, Hugging Face, PyTorch Lightning, and Ray Train
 
 **On the roadmap:**
 
-- Slurm launch examples
 - Multi-node live CLI / browser dashboard
 - Explicit collective / NCCL timing
 
@@ -177,6 +177,7 @@ changing the final saved artifacts.
 
 - [Quickstart](docs/user_guide/quickstart.md)
 - [Distributed Training](docs/user_guide/distributed-training.md)
+- [Running on Slurm](docs/user_guide/slurm.md)
 - [Use With Your Stack](docs/user_guide/integrations.md)
 - [Compare Runs](docs/user_guide/compare.md)
 - [How to Read Output](docs/user_guide/reading-output.md)

--- a/docs/user_guide/distributed-training.md
+++ b/docs/user_guide/distributed-training.md
@@ -51,3 +51,9 @@ Override that only when needed with `--aggregator-bind-host=<bind-host>`.
 
 `--session-id` remains accepted as a backward-compatible alias for
 `--run-name`.
+
+## Running on Slurm
+
+On a Slurm-managed cluster, derive these flags from the job environment instead
+of setting them by hand. See [Running on Slurm](slurm.md) for the mapping and a
+copy-paste sbatch template.

--- a/docs/user_guide/slurm.md
+++ b/docs/user_guide/slurm.md
@@ -1,0 +1,232 @@
+# Running on Slurm
+
+This guide shows the recommended way to run TraceML on a Slurm-managed GPU
+cluster, and how to derive TraceML's launch flags from the Slurm environment.
+
+If you are new to multi-node TraceML, read
+[Distributed Training](distributed-training.md) first. This page focuses on the
+Slurm-specific glue.
+
+A ready-to-use template lives in
+[`examples/slurm/`](https://github.com/traceopt-ai/traceml/tree/main/examples/slurm):
+`traceml_ddp.sbatch` (the job) and `launch.sh` (the per-node wrapper).
+
+## Mental model
+
+TraceML's launcher wraps `torchrun` (`torch.distributed.run`) and adds a
+telemetry **aggregator**:
+
+- Run **one `traceml run` per node**. TraceML spawns the per-GPU workers itself
+  (one per GPU), so you do **not** start one task per GPU under Slurm.
+- **Node 0 owns the aggregator.** It is the first host in the allocation and
+  also serves as the `torchrun` rendezvous master. Every other node streams its
+  telemetry to node 0.
+- Use **`--mode=summary`** for multi-node runs. The live `cli` and `dashboard`
+  modes are intended for single-node use.
+
+## Map Slurm variables to TraceML flags
+
+| TraceML flag | Slurm source | Notes |
+|---|---|---|
+| `--nnodes` | `$SLURM_NNODES` | Number of nodes in the allocation. |
+| `--node-rank` | `$SLURM_NODEID` | Per-node rank `0..N-1`. Valid when you run **one task per node**. |
+| `--nproc-per-node` | `$SLURM_GPUS_ON_NODE` | GPUs allocated on this node → one worker per GPU. |
+| `--master-addr` | first host of `$SLURM_JOB_NODELIST` | `scontrol show hostnames "$SLURM_JOB_NODELIST" \| head -n 1`. |
+| `--run-name` | e.g. `ddp-$SLURM_JOB_ID` | Required for multi-node; must match on every node. |
+
+!!! note "Why `SLURM_GPUS_ON_NODE`?"
+    Prefer `SLURM_GPUS_ON_NODE` over `SLURM_GPUS_PER_NODE`. The latter is only
+    set when you request GPUs with `--gpus*` flags and can carry a type prefix
+    (for example `a100:4`), which is not a plain integer. `SLURM_GPUS_ON_NODE`
+    is always an integer count of the GPUs on the node.
+
+    For CPU-only or task-based allocations, use `$SLURM_NTASKS_PER_NODE`
+    instead as the worker count per node.
+
+## Deriving the master address
+
+`--master-addr` (and the aggregator that workers connect to) must be node 0.
+Resolve it from the allocation:
+
+```bash
+export MASTER_ADDR="$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)"
+```
+
+If the hostname is not routable between nodes on your cluster, resolve it to an
+IP address instead:
+
+```bash
+export MASTER_ADDR="$(srun --nodes=1 --ntasks=1 -w "$MASTER_ADDR" hostname --ip-address)"
+```
+
+## The per-node expansion gotcha
+
+TraceML uses **static rendezvous**: each node is told its rank with
+`--node-rank`. There is no automatic rank election, so every node must compute
+its own rank.
+
+`$SLURM_NODEID` is set per node, but it is only expanded correctly if expansion
+happens **on each node**. This does **not** work:
+
+```bash
+# WRONG: the batch shell on node 0 expands $SLURM_NODEID once (to 0) for every
+# task, so all nodes claim rank 0 and the run never rendezvous.
+srun traceml run train.py --node-rank=$SLURM_NODEID ...
+```
+
+Instead, put the command in a small wrapper script that `srun` runs on each
+node, so the variable is expanded per node:
+
+```bash
+# traceml_ddp.sbatch
+srun examples/slurm/launch.sh
+```
+
+```bash
+# launch.sh (runs once per node)
+exec traceml run examples/ddp_minimal.py \
+  --mode=summary \
+  --run-name="${RUN_NAME}" \
+  --nnodes="${SLURM_NNODES}" \
+  --node-rank="${SLURM_NODEID}" \
+  --nproc-per-node="${SLURM_GPUS_ON_NODE}" \
+  --master-addr="${MASTER_ADDR}" \
+  --master-port=29500
+```
+
+`MASTER_ADDR` and `RUN_NAME` are identical on every node, so the sbatch file
+exports them once and Slurm propagates them to the wrapper.
+
+## The network and aggregator model
+
+A multi-node TraceML run uses **two** TCP endpoints, both on node 0:
+
+| Purpose | Default port | Who connects |
+|---|---|---|
+| `torchrun` rendezvous (`--master-port`) | `29500` | All ranks reach node 0 to set up the process group. |
+| TraceML aggregator (`--aggregator-port`) | `29765` | Worker nodes stream telemetry to node 0. |
+
+- Node 0 starts the aggregator and, for multi-node runs, **binds it to
+  `0.0.0.0`** by default so other nodes can connect.
+- Worker nodes connect to the aggregator at `--master-addr:29765` by default
+  (the aggregator's connect host defaults to `--master-addr`).
+
+!!! warning "Firewall"
+    Both ports must be reachable on node 0 from the other nodes: the
+    `torchrun` master port (`29500`) and the TraceML aggregator port
+    (`29765`). On clusters with host firewalls, allow inbound traffic to node 0
+    on both.
+
+### When to use `--aggregator-host`
+
+Set `--aggregator-host` when workers should send telemetry to a **different
+reachable address** than `--master-addr` — for example when node 0 has a
+separate management/data interface or hostname that the other nodes should use
+for telemetry. Pass the same value on every node:
+
+```bash
+traceml run train.py ... --aggregator-host=node0-data.cluster.local
+```
+
+### When to use `--aggregator-bind-host`
+
+Multi-node runs already bind the aggregator to `0.0.0.0`, so you usually do not
+need this. Set `--aggregator-bind-host` only to pin the aggregator to a
+specific interface on node 0 instead of all interfaces:
+
+```bash
+traceml run train.py ... --aggregator-bind-host=10.0.0.5
+```
+
+## Minimal PyTorch DDP command
+
+A single node's launch (what the wrapper runs) looks like this:
+
+```bash
+traceml run examples/ddp_minimal.py \
+  --mode=summary \
+  --run-name=ddp-demo \
+  --nnodes=2 \
+  --node-rank=0 \
+  --nproc-per-node=4 \
+  --master-addr=node0 \
+  --master-port=29500
+```
+
+`examples/ddp_minimal.py` is a runnable DDP script that already calls
+`traceml.init(...)` and `traceml.trace_step(...)`.
+
+## Full template
+
+```bash title="examples/slurm/traceml_ddp.sbatch"
+#!/bin/bash
+#SBATCH --job-name=traceml-ddp
+#SBATCH --nodes=2                 # number of nodes -> --nnodes
+#SBATCH --ntasks-per-node=1       # ONE TraceML launcher per node (it spawns the GPU workers)
+#SBATCH --gres=gpu:4              # all GPUs on each node; some clusters use --gpus-per-node=4 instead
+#SBATCH --cpus-per-task=16        # CPU cores for dataloading; adjust to your node
+#SBATCH --time=00:30:00
+#SBATCH --output=traceml-%j.out
+
+set -euo pipefail
+
+# --- Cluster-specific setup (run BEFORE srun) ---
+# module load cuda/12.x
+# source ~/miniconda3/bin/activate myenv
+# export NCCL_SOCKET_IFNAME=eth0
+# export NCCL_DEBUG=INFO
+
+export MASTER_ADDR="$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)"
+export RUN_NAME="ddp-${SLURM_JOB_ID}"
+
+cd "$SLURM_SUBMIT_DIR"
+srun examples/slurm/launch.sh
+```
+
+Submit it from the repository root:
+
+```bash
+sbatch examples/slurm/traceml_ddp.sbatch
+```
+
+## Where to find results
+
+Node 0's aggregator writes the run report to:
+
+```text
+<logs-dir>/<run-name>/final_summary.json
+<logs-dir>/<run-name>/final_summary.txt
+```
+
+`--logs-dir` defaults to `./logs` relative to the submit directory. Put it on a
+**shared filesystem** (for example your scratch space) so the summary is
+reachable after the job ends. You can compare two runs later with
+[`traceml compare`](compare.md).
+
+## Cluster-specific notes
+
+!!! tip "Adapt these for your cluster"
+    - **Launcher.** This template uses `srun` to start one task per node. Some
+      sites wrap jobs differently (`mpirun`, site launcher scripts); the
+      requirement is just that **one `traceml run` starts per node** and that
+      `$SLURM_NODEID` is expanded per node.
+    - **GPU request.** `--gres=gpu:N` and `--gpus-per-node=N` are both common;
+      use whichever your cluster accepts. Keep `--ntasks-per-node=1` so the
+      single task sees all the node's GPUs.
+    - **Environment.** Run `module load` / `conda activate` in the sbatch file
+      before `srun`. If `traceml` is not found on the worker nodes, also
+      activate the environment inside `launch.sh`.
+    - **Shared filesystem.** `launch.sh`, your training script, and `--logs-dir`
+      should live on storage visible to every node.
+    - **Firewall.** Allow inbound traffic to node 0 on the `torchrun` master
+      port (`29500`) and the aggregator port (`29765`).
+    - **NCCL.** If multi-node NCCL hangs or fails to connect, pin the network
+      interface with `export NCCL_SOCKET_IFNAME=<iface>` and debug with
+      `export NCCL_DEBUG=INFO`.
+    - **Aggregator startup window.** Node 0 must start its aggregator promptly
+      after `srun` launches the tasks. Keep slow setup (`module load`,
+      `conda activate`) **before** the `srun` line so the workers do not give up
+      waiting for the aggregator.
+
+No extra runtime dependency is required beyond Slurm and your existing TraceML
+install.

--- a/examples/README.md
+++ b/examples/README.md
@@ -76,6 +76,16 @@ Single-node DDP:
 traceml run examples/ddp_minimal.py --nproc-per-node=4
 ```
 
+Multi-node on Slurm:
+
+```bash
+sbatch examples/slurm/traceml_ddp.sbatch
+```
+
+See [`examples/slurm/`](slurm/README.md) and the
+[Slurm guide](../docs/user_guide/slurm.md) for the template and the
+network/aggregator model.
+
 Run without TraceML telemetry for a baseline:
 
 ```bash
@@ -155,6 +165,7 @@ That includes things like:
 
 - [Quickstart](../docs/user_guide/quickstart.md)
 - [Distributed Training](../docs/user_guide/distributed-training.md)
+- [Running on Slurm](../docs/user_guide/slurm.md)
 - [Compare Runs](../docs/user_guide/compare.md)
 - [How to Read TraceML Output](../docs/user_guide/reading-output.md)
 - [Use With Your Stack](../docs/user_guide/integrations.md)

--- a/examples/slurm/README.md
+++ b/examples/slurm/README.md
@@ -1,0 +1,59 @@
+# Running TraceML on Slurm
+
+A copy-paste starting point for multi-node, multi-GPU TraceML runs on a
+Slurm-managed GPU cluster.
+
+| File | What it is |
+|---|---|
+| `traceml_ddp.sbatch` | A 2-node sbatch job. Derives TraceML's launch flags from Slurm variables and runs the launcher once per node via `srun`. |
+| `launch.sh` | The per-node wrapper `srun` runs on each node. It expands the per-node Slurm variables and calls `traceml run`. |
+
+The full walkthrough, including the network/aggregator model, lives in the
+[Slurm guide](../../docs/user_guide/slurm.md).
+
+## Submit
+
+From the TraceML repository root (the scripts use paths relative to the submit
+directory):
+
+```bash
+sbatch examples/slurm/traceml_ddp.sbatch
+```
+
+## What it does
+
+- One `traceml run` launches per node (`--ntasks-per-node=1`). TraceML spawns
+  the per-GPU workers itself, like `torchrun`.
+- Node 0 (the first host in the allocation) owns the TraceML aggregator; the
+  other nodes stream telemetry to it.
+- Flags are derived from Slurm:
+
+  | TraceML flag | Source |
+  |---|---|
+  | `--nnodes` | `$SLURM_NNODES` |
+  | `--node-rank` | `$SLURM_NODEID` |
+  | `--nproc-per-node` | `$SLURM_GPUS_ON_NODE` |
+  | `--master-addr` | first host of `$SLURM_JOB_NODELIST` |
+
+## Adapt it
+
+- **More/fewer nodes:** change `#SBATCH --nodes`.
+- **GPUs per node:** change `#SBATCH --gres=gpu:N` (some clusters use
+  `--gpus-per-node=N`). `--nproc-per-node` follows automatically via
+  `$SLURM_GPUS_ON_NODE`.
+- **Your own script:** edit the script path in `launch.sh`.
+- **Environment:** uncomment the `module load` / `conda activate` lines in
+  `traceml_ddp.sbatch`, before the `srun` line.
+
+## Where results land
+
+Node 0 writes the run report to:
+
+```
+<logs-dir>/<run-name>/final_summary.json
+<logs-dir>/<run-name>/final_summary.txt
+```
+
+`--logs-dir` defaults to `./logs` relative to the submit directory. Put it on a
+shared filesystem so the summary is reachable from anywhere. See the
+[Slurm guide](../../docs/user_guide/slurm.md) for details.

--- a/examples/slurm/launch.sh
+++ b/examples/slurm/launch.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Per-node TraceML launcher for Slurm.
+#
+# srun runs this script once on every node in the allocation (because the
+# sbatch template requests one task per node). The Slurm variables below are
+# therefore evaluated *on each node*, which is exactly what TraceML's static
+# rendezvous needs:
+#
+#   SLURM_NODEID       -> --node-rank   (0..N-1, unique per node)
+#   SLURM_NNODES       -> --nnodes
+#   SLURM_GPUS_ON_NODE -> --nproc-per-node (one worker per GPU on this node)
+#
+# MASTER_ADDR and RUN_NAME are identical on every node, so the sbatch template
+# exports them once and Slurm propagates them here.
+#
+# IMPORTANT: do not inline this command as `srun traceml run ... \
+# --node-rank=$SLURM_NODEID` in the sbatch file. There the batch shell would
+# expand $SLURM_NODEID once on the first node (to 0) for every task, so all
+# nodes would claim node rank 0 and the run would never rendezvous. Keeping the
+# command in this wrapper defers expansion to each node.
+
+set -euo pipefail
+
+# Run from the directory the job was submitted from. The paths below are
+# relative to it, so submit this job from the TraceML repository root (or edit
+# the paths to point at your own training script with an absolute path).
+cd "${SLURM_SUBMIT_DIR:-$PWD}"
+
+# Optional: activate your environment here as well. Activating it in the sbatch
+# template usually propagates via Slurm, but some clusters reset the
+# environment per task. Uncomment if `traceml` is not found on the workers.
+# source ~/miniconda3/bin/activate myenv
+
+exec traceml run examples/ddp_minimal.py \
+  --mode=summary \
+  --run-name="${RUN_NAME}" \
+  --nnodes="${SLURM_NNODES}" \
+  --node-rank="${SLURM_NODEID}" \
+  --nproc-per-node="${SLURM_GPUS_ON_NODE}" \
+  --master-addr="${MASTER_ADDR}" \
+  --master-port=29500

--- a/examples/slurm/traceml_ddp.sbatch
+++ b/examples/slurm/traceml_ddp.sbatch
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Minimal 2-node, multi-GPU TraceML run on a Slurm-managed cluster.
+#
+# Submit from the TraceML repository root:
+#
+#     sbatch examples/slurm/traceml_ddp.sbatch
+#
+# It launches one `traceml run` per node (TraceML spawns the per-GPU workers
+# itself, like torchrun). Node 0 owns the TraceML aggregator; the other nodes
+# stream telemetry to it. The final report lands in
+# <logs-dir>/<run-name>/final_summary.json on node 0.
+
+#SBATCH --job-name=traceml-ddp
+#SBATCH --nodes=2                 # number of nodes -> --nnodes
+#SBATCH --ntasks-per-node=1       # ONE TraceML launcher per node (it spawns the GPU workers)
+#SBATCH --gres=gpu:4              # all GPUs on each node; some clusters use --gpus-per-node=4 instead
+#SBATCH --cpus-per-task=16        # CPU cores for dataloading; adjust to your node
+#SBATCH --time=00:30:00
+#SBATCH --output=traceml-%j.out   # combined stdout/stderr; %j = job id
+
+set -euo pipefail
+
+# --- Cluster-specific setup -------------------------------------------------
+# Do all environment setup BEFORE `srun`. Node 0's aggregator must start within
+# ~15s of the workers, so avoid slow activation between srun launching the
+# tasks and TraceML binding the aggregator. Edit these for your cluster.
+#
+# module load cuda/12.x
+# source ~/miniconda3/bin/activate myenv
+#
+# Pin NCCL to the right network interface if multi-node NCCL hangs/fails:
+# export NCCL_SOCKET_IFNAME=eth0
+# export NCCL_DEBUG=INFO
+# ----------------------------------------------------------------------------
+
+# Node 0 = the first host in the allocation. It owns the TraceML aggregator,
+# and torchrun uses it as the rendezvous master.
+export MASTER_ADDR="$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)"
+
+# If the hostname is not routable between nodes, resolve it to an IP instead:
+# export MASTER_ADDR="$(srun --nodes=1 --ntasks=1 -w "$MASTER_ADDR" hostname --ip-address)"
+
+# --run-name is required for multi-node runs so every node writes into the same
+# TraceML run. Tagging it with the job id keeps concurrent jobs from colliding.
+export RUN_NAME="ddp-${SLURM_JOB_ID}"
+
+# Run from the submit directory; launch.sh and the training script paths are
+# relative to it.
+cd "$SLURM_SUBMIT_DIR"
+
+# srun launches launch.sh once per node. The wrapper expands the per-node Slurm
+# variables ($SLURM_NODEID, $SLURM_NNODES, $SLURM_GPUS_ON_NODE) on each node.
+srun examples/slurm/launch.sh

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
   - User Guide:
       - Quickstart: user_guide/quickstart.md
       - Distributed Training: user_guide/distributed-training.md
+      - Slurm (multi-node): user_guide/slurm.md
       - Reading output: user_guide/reading-output.md
       - Integrations:
           - Overview: user_guide/integrations.md


### PR DESCRIPTION
Add a Slurm section and a reusable sbatch template showing the recommended way to run TraceML on Slurm-managed GPU clusters.

- examples/slurm/traceml_ddp.sbatch: 2-node template using traceml run
- examples/slurm/launch.sh: per-node wrapper (defers $SLURM_NODEID expansion to each node)
- docs/user_guide/slurm.md: flag mapping, master-addr derivation, aggregator/network model, and cluster-specific notes
- .gitattributes: force LF on *.sh / *.sbatch so scripts run on Linux
- mkdocs nav + cross-links from README and distributed-training

Closes #133

## What changed

<!-- Briefly describe the user-visible change. -->

## Why

<!-- What problem does this solve for TraceML users or contributors? -->

## How I tested

<!-- Include exact commands, examples, or environments used. -->

- [ ] Unit tests
- [ ] Integration or smoke test
- [ ] Example training script
- [ ] Docs-only change
- [ ] Not run; reason:

## Runtime impact

<!-- Required for tracing, sampler, transport, aggregator, or reporting changes. -->

- [ ] No training-path runtime impact
- [ ] May affect training-path overhead
- [ ] May affect distributed launch, telemetry, or aggregator behavior
- [ ] Not applicable

Notes:

## Documentation

- [ ] README updated
- [ ] User docs updated
- [ ] Examples updated
- [ ] API docs updated
- [ ] Not needed

## Risk checklist

- [ ] Does not add unnecessary CUDA synchronizations
- [ ] Does not add blocking I/O on the training path
- [ ] Fails safely without crashing user training
- [ ] Keeps new dependencies optional unless discussed
- [ ] Redacts or avoids sensitive training-environment data in examples

## Screenshots or output

<!-- Paste relevant CLI output, final_summary text, viewer screenshot, or compare output. -->
