### PR TITLE
Fix distributed straggler attribution and improve Lightning/Ray diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,15 @@ checkpoints/
 *.zip
 
 
+# Local private keys / certificates
+
+*.pem
+*.rsa
+*.key
+*.p12
+*.pfx
+
+
 # IDE / Editor
 
 .vscode/

--- a/docs/user_guide/compare.md
+++ b/docs/user_guide/compare.md
@@ -99,9 +99,14 @@ It typically focuses on:
 - step-time diagnosis changes
 - average step time changes
 - wait-time changes
-- step split shifts across dataloader, forward, backward, and optimizer
+- high-level step split shifts across input, H2D, compute, and wait time
 - memory changes when they are meaningful
 - process or system changes when they add useful context
+
+The text report keeps step-time output compact by showing the aggregate compute
+bucket instead of printing forward, backward, and optimizer rows by default.
+The structured compare JSON still includes those compute sub-phases for deeper
+inspection and downstream tooling.
 
 The text report includes a small legend near the top:
 

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -318,6 +318,10 @@ See:
 
 It means one rank is slower in the input path than the typical rank.
 
+In distributed runs, this can still be the primary diagnosis when backward or
+compute skew is also visible, because a slow input rank can push synchronization
+wait into peer ranks.
+
 Common causes:
 
 - uneven data loading
@@ -333,6 +337,10 @@ See:
 ## What does `COMPUTE STRAGGLER` mean?
 
 It means one rank is slower in compute than the typical rank.
+
+If input and compute skew appear together, TraceML first checks whether the
+input excess is large enough to explain the compute skew. If yes, the primary
+diagnosis is `INPUT STRAGGLER`; otherwise the mixed case remains `STRAGGLER`.
 
 Common causes:
 

--- a/docs/user_guide/integrations/lightning.md
+++ b/docs/user_guide/integrations/lightning.md
@@ -244,6 +244,10 @@ Run with:
 traceml run train_lightning.py
 ```
 
+The checked-in `examples/lightning_minimal.py` also accepts small demo flags:
+`--devices`, `--num-nodes`, `--max-steps`, `--delay-rank`, and `--delay-ms`.
+Use the delay flags only when you want to create a deliberate straggler.
+
 ---
 
 ## Gradient accumulation

--- a/docs/user_guide/integrations/ray.md
+++ b/docs/user_guide/integrations/ray.md
@@ -106,8 +106,9 @@ TraceMLRayConfig(
 ```
 
 The ``examples/ray/lightning_text_classifier.py`` demo also includes
-``--input-delay-ms=10`` to make Ray input timing visible and
-``--transfer-dim=131072`` to make Lightning H2D timing visible.
+``--input-delay-ms`` / ``--input-delay-rank`` for input-straggler demos,
+``--delay-ms`` / ``--delay-rank`` for compute-straggler demos, and
+``--transfer-dim`` to make Lightning H2D timing visible.
 ``--transfer-dim`` creates a reusable per-batch CPU tensor; it does not add a
 full dataset-sized tensor.
 

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -545,7 +545,9 @@ The delta row is a helpful clue, not the full diagnosis logic.
 
 ## System metrics
 
-The system panel is context, not the main bottleneck diagnosis.
+The system panel reports machine-level pressure and GPU-utilization symptoms.
+It is still context for the training diagnosis: low or moderate GPU
+utilization says the GPU was not fully busy, but it does not prove why.
 
 It helps answer:
 
@@ -553,7 +555,7 @@ It helps answer:
 - is CPU high?
 - is RAM high?
 - are GPUs hot or close to full memory?
-- is GPU utilization uneven?
+- are GPUs idle, partly utilized, or uneven?
 
 Common fields:
 
@@ -565,6 +567,18 @@ Common fields:
 - GPU headroom
 
 Use this panel to understand machine-level pressure around the training run.
+
+For average GPU utilization, System diagnosis uses these bands:
+
+- below 30%: `LOW_GPU_UTILIZATION`
+- 30% through 70%: `MODERATE_GPU_UTILIZATION`
+- above 70%: no GPU-utilization issue; System can stay `NORMAL` if no pressure
+  rule fires
+
+Use Step Time to explain the likely cause. For example, a System diagnosis of
+`MODERATE_GPU_UTILIZATION` plus a Step Time diagnosis of `INPUT-BOUND` means the
+GPU was only partly utilized and the step breakdown points to input loading as
+the likely reason.
 
 ---
 
@@ -688,6 +702,8 @@ not just a single raw delta
 ### System metrics are context, not the final explanation
 
 Low GPU utilization by itself does not prove an input bottleneck.
+Moderate GPU utilization is the same kind of symptom: it means the GPU was not
+fully busy, not that the GPU was slow.
 
 Always read:
 

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -185,6 +185,9 @@ TraceML uses this idea:
 In simpler words:
 
 - one rank is slower in the input path, enough to matter to the overall run
+- this can remain the primary diagnosis even when compute or backward skew is
+  also visible, if the input excess is large enough to plausibly explain
+  downstream synchronization effects
 
 Common causes:
 
@@ -258,6 +261,11 @@ In the current policy, this is used when:
 - compute straggler score is high
 
 This is a mixed unevenness case.
+
+TraceML keeps this diagnosis when the mixed signal is not clearly explained by
+input skew alone. If input excess is within the configured tolerance of compute
+excess, TraceML reports `INPUT STRAGGLER` instead and keeps the compute signal
+as secondary evidence.
 
 Common causes:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -103,7 +103,8 @@ Ray Data examples wrap `iter_torch_batches(...)` with
 `traceml.wrap_dataloader_fetch(...)` because Ray Data iterators are not PyTorch
 `DataLoader` objects.
 
-Ray + Lightning can use `--input-delay-ms` to make input timing visible and
+Ray + Lightning can use `--input-delay-ms` / `--input-delay-rank` for input
+stragglers, `--delay-ms` / `--delay-rank` for compute stragglers, and
 `--transfer-dim` to make Lightning H2D timing visible.
 
 For explicit manual instrumentation, see:

--- a/examples/lightning_minimal.py
+++ b/examples/lightning_minimal.py
@@ -1,3 +1,6 @@
+import argparse
+import time
+
 import lightning as L
 import torch
 import torch.nn as nn
@@ -30,8 +33,10 @@ class SyntheticClassificationDataset(Dataset):
 
 
 class TinyLightningModel(L.LightningModule):
-    def __init__(self):
+    def __init__(self, *, delay_rank: int = -1, delay_ms: float = 0.0):
         super().__init__()
+        self.delay_rank = int(delay_rank)
+        self.delay_ms = float(delay_ms)
         self.net = nn.Sequential(
             nn.Linear(MODEL_INPUT_DIM, HIDDEN_DIM),
             nn.ReLU(),
@@ -44,6 +49,9 @@ class TinyLightningModel(L.LightningModule):
         return self.net(x)
 
     def training_step(self, batch, batch_idx):
+        if self.delay_ms > 0 and int(self.global_rank) == self.delay_rank:
+            time.sleep(self.delay_ms / 1000.0)
+
         x, y = batch
         logits = self(x)
         loss = self.loss_fn(logits, y)
@@ -58,6 +66,13 @@ class TinyLightningModel(L.LightningModule):
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--devices", type=int, default=1)
+    parser.add_argument("--max-steps", type=int, default=MAX_STEPS)
+    parser.add_argument("--delay-rank", type=int, default=-1)
+    parser.add_argument("--delay-ms", type=float, default=0.0)
+    args = parser.parse_args()
+
     torch.manual_seed(SEED)
     traceml_lightning.init()
 
@@ -70,12 +85,18 @@ def main() -> None:
         pin_memory=torch.cuda.is_available(),
     )
 
-    model = TinyLightningModel()
+    model = TinyLightningModel(
+        delay_rank=args.delay_rank,
+        delay_ms=args.delay_ms,
+    )
+    accelerator = "gpu" if torch.cuda.is_available() else "cpu"
+    strategy = "ddp" if int(args.devices) > 1 else "auto"
 
     trainer = L.Trainer(
-        max_steps=MAX_STEPS,
-        accelerator="auto",
-        devices=1,
+        max_steps=int(args.max_steps),
+        accelerator=accelerator,
+        devices=int(args.devices),
+        strategy=strategy,
         enable_progress_bar=False,
         callbacks=[traceml_lightning.TraceMLCallback()],
         logger=False,

--- a/examples/lightning_minimal.py
+++ b/examples/lightning_minimal.py
@@ -37,6 +37,8 @@ class TinyLightningModel(L.LightningModule):
         super().__init__()
         self.delay_rank = int(delay_rank)
         self.delay_ms = float(delay_ms)
+        self._debug_printed = False
+        self._delay_printed = False
         self.net = nn.Sequential(
             nn.Linear(MODEL_INPUT_DIM, HIDDEN_DIM),
             nn.ReLU(),
@@ -49,7 +51,24 @@ class TinyLightningModel(L.LightningModule):
         return self.net(x)
 
     def training_step(self, batch, batch_idx):
+        if not self._debug_printed:
+            print(
+                "[TraceML Lightning Example] "
+                f"training_step rank={self.global_rank} "
+                f"delay_rank={self.delay_rank} delay_ms={self.delay_ms}",
+                flush=True,
+            )
+            self._debug_printed = True
+
         if self.delay_ms > 0 and int(self.global_rank) == self.delay_rank:
+            if not self._delay_printed:
+                print(
+                    "[TraceML Lightning Example] "
+                    f"applying delay rank={self.global_rank} "
+                    f"batch_idx={batch_idx} delay_ms={self.delay_ms}",
+                    flush=True,
+                )
+                self._delay_printed = True
             time.sleep(self.delay_ms / 1000.0)
 
         x, y = batch
@@ -72,6 +91,12 @@ def main() -> None:
     parser.add_argument("--delay-rank", type=int, default=-1)
     parser.add_argument("--delay-ms", type=float, default=0.0)
     args = parser.parse_args()
+    print(
+        "[TraceML Lightning Example] "
+        f"parsed args devices={args.devices} max_steps={args.max_steps} "
+        f"delay_rank={args.delay_rank} delay_ms={args.delay_ms}",
+        flush=True,
+    )
 
     torch.manual_seed(SEED)
     traceml_lightning.init()
@@ -91,6 +116,12 @@ def main() -> None:
     )
     accelerator = "gpu" if torch.cuda.is_available() else "cpu"
     strategy = "ddp" if int(args.devices) > 1 else "auto"
+    print(
+        "[TraceML Lightning Example] "
+        f"trainer accelerator={accelerator} devices={args.devices} "
+        f"strategy={strategy} cuda_available={torch.cuda.is_available()}",
+        flush=True,
+    )
 
     trainer = L.Trainer(
         max_steps=int(args.max_steps),

--- a/examples/lightning_minimal.py
+++ b/examples/lightning_minimal.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import time
 
 import lightning as L
@@ -16,6 +17,26 @@ NUM_CLASSES = 10
 NUM_SAMPLES = 512
 BATCH_SIZE = 64
 MAX_STEPS = 200
+
+
+def _env_int(name: str, default: int | None = None) -> int | None:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _infer_num_nodes() -> int:
+    traceml_nnodes = _env_int("TRACEML_NNODES")
+    if traceml_nnodes is not None:
+        return max(1, traceml_nnodes)
+
+    world_size = _env_int("WORLD_SIZE", 1) or 1
+    local_world_size = _env_int("LOCAL_WORLD_SIZE", 1) or 1
+    return max(1, world_size // max(1, local_world_size))
 
 
 class SyntheticClassificationDataset(Dataset):
@@ -87,13 +108,27 @@ class TinyLightningModel(L.LightningModule):
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--devices", type=int, default=1)
+    parser.add_argument("--num-nodes", type=int, default=None)
     parser.add_argument("--max-steps", type=int, default=MAX_STEPS)
     parser.add_argument("--delay-rank", type=int, default=-1)
     parser.add_argument("--delay-ms", type=float, default=0.0)
     args = parser.parse_args()
+
+    devices = max(1, int(args.devices))
+    num_nodes = max(
+        1,
+        (
+            int(args.num_nodes)
+            if args.num_nodes is not None
+            else _infer_num_nodes()
+        ),
+    )
+    world_size = devices * num_nodes
+
     print(
         "[TraceML Lightning Example] "
-        f"parsed args devices={args.devices} max_steps={args.max_steps} "
+        f"parsed args devices={devices} num_nodes={num_nodes} "
+        f"max_steps={args.max_steps} "
         f"delay_rank={args.delay_rank} delay_ms={args.delay_ms}",
         flush=True,
     )
@@ -115,18 +150,22 @@ def main() -> None:
         delay_ms=args.delay_ms,
     )
     accelerator = "gpu" if torch.cuda.is_available() else "cpu"
-    strategy = "ddp" if int(args.devices) > 1 else "auto"
+    strategy = "ddp" if world_size > 1 else "auto"
     print(
         "[TraceML Lightning Example] "
-        f"trainer accelerator={accelerator} devices={args.devices} "
-        f"strategy={strategy} cuda_available={torch.cuda.is_available()}",
+        f"trainer accelerator={accelerator} devices={devices} "
+        f"num_nodes={num_nodes} strategy={strategy} "
+        f"env_rank={os.environ.get('RANK', 'unset')} "
+        f"env_world_size={os.environ.get('WORLD_SIZE', 'unset')} "
+        f"cuda_available={torch.cuda.is_available()}",
         flush=True,
     )
 
     trainer = L.Trainer(
         max_steps=int(args.max_steps),
         accelerator=accelerator,
-        devices=int(args.devices),
+        devices=devices,
+        num_nodes=num_nodes,
         strategy=strategy,
         enable_progress_bar=False,
         callbacks=[traceml_lightning.TraceMLCallback()],

--- a/examples/pytorch_minimal.py
+++ b/examples/pytorch_minimal.py
@@ -82,9 +82,6 @@ def main():
 
     print("Done.")
 
-    summary = traceml.final_summary(print_text=True)
-    print(summary is not None)
-
 
 if __name__ == "__main__":
     main()

--- a/examples/ray/lightning_text_classifier.py
+++ b/examples/ray/lightning_text_classifier.py
@@ -127,7 +127,11 @@ def train_loop_per_worker(config: Dict[str, Any]) -> None:
     )
 
     input_delay_s = float(config.get("input_delay_ms", 0.0)) / 1000.0
-    if input_delay_s > 0.0:
+    input_delay_rank = int(config.get("input_delay_rank", -1))
+    rank = int(os.environ.get("RANK", "0"))
+    if input_delay_s > 0.0 and (
+        input_delay_rank < 0 or rank == input_delay_rank
+    ):
         train_loader = _delay_batches(train_loader, input_delay_s)
 
     transfer_dim = int(config.get("transfer_dim", 0))
@@ -205,6 +209,15 @@ def main() -> None:
         help="Optional per-batch delay to make Ray input timing visible.",
     )
     parser.add_argument(
+        "--input-delay-rank",
+        type=int,
+        default=-1,
+        help=(
+            "Global rank to delay for input-straggler demos. "
+            "Default -1 delays all workers."
+        ),
+    )
+    parser.add_argument(
         "--delay-rank",
         type=int,
         default=-1,
@@ -246,6 +259,7 @@ def main() -> None:
             "lr": args.lr,
             "transfer_dim": args.transfer_dim,
             "input_delay_ms": args.input_delay_ms,
+            "input_delay_rank": args.input_delay_rank,
             "delay_rank": args.delay_rank,
             "delay_ms": args.delay_ms,
         },

--- a/examples/ray/lightning_text_classifier.py
+++ b/examples/ray/lightning_text_classifier.py
@@ -108,8 +108,10 @@ def train_loop_per_worker(config: Dict[str, Any]) -> None:
             logits = self(batch["input_ids"].long())
             loss = F.cross_entropy(logits, batch["labels"].long())
             acc = (logits.argmax(dim=-1) == batch["labels"]).float().mean()
-            self.log("train_loss", loss, prog_bar=True, sync_dist=True)
-            self.log("train_acc", acc, prog_bar=True, sync_dist=True)
+            # Keep metric logging local so straggler demos synchronize first in
+            # DDP backward instead of in Lightning's distributed metric reduce.
+            self.log("train_loss", loss, prog_bar=True, sync_dist=False)
+            self.log("train_acc", acc, prog_bar=True, sync_dist=False)
             return loss
 
         def configure_optimizers(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "traceml-ai"
-version = "0.3.0"
+version = "0.3.1"
 
 description = "TraceML: Lightweight runtime bottleneck diagnostics for PyTorch training."
 authors = [{ name = "OptAI UG (haftungsbeschränkt)", email = "support@traceopt.ai" }]

--- a/src/traceml_ai/__init__.py
+++ b/src/traceml_ai/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = [
     "__version__",

--- a/src/traceml_ai/aggregator/sqlite_writer.py
+++ b/src/traceml_ai/aggregator/sqlite_writer.py
@@ -30,6 +30,10 @@ from traceml_ai.reporting.config import (
     DEFAULT_SUMMARY_WINDOW_ROWS,
     summary_retention_rows_for_window,
 )
+from traceml_ai.telemetry.envelope import (
+    TelemetryEnvelope,
+    normalize_telemetry_envelope,
+)
 from traceml_ai.utils.msgpack_codec import Encoder as MsgpackEncoder
 
 _PROJECTION_WRITERS = [
@@ -241,29 +245,14 @@ class SQLiteWriterSimple:
         return items
 
     def _extract_rank_sampler(
-        self, msg: Dict[str, Any]
+        self, envelope: TelemetryEnvelope
     ) -> tuple[Optional[int], Optional[str]]:
-        """Extract best-effort ``rank`` and ``sampler`` metadata from a message."""
-        rank_val = msg.get("global_rank", msg.get("rank", None))
-        sampler_val = msg.get("sampler", None)
+        """Extract best-effort ``rank`` and ``sampler`` from envelope metadata."""
+        return envelope.meta.rank, envelope.meta.sampler
 
-        rank: Optional[int]
-        try:
-            rank = int(rank_val) if rank_val is not None else None
-        except Exception:
-            rank = None
-
-        sampler: Optional[str]
-        try:
-            sampler = str(sampler_val) if sampler_val is not None else None
-        except Exception:
-            sampler = None
-
-        return rank, sampler
-
-    def _iter_payload_dicts(self, msg: Any) -> Iterator[Dict[str, Any]]:
+    def _iter_envelopes(self, msg: Any) -> Iterator[TelemetryEnvelope]:
         """
-        Yield payload dicts from a single message or batch.
+        Yield normalized telemetry envelopes from a single message or batch.
 
         Accepted forms:
         - dict
@@ -274,10 +263,13 @@ class SQLiteWriterSimple:
 
         if isinstance(msg, list):
             for item in msg:
-                if isinstance(item, dict):
-                    yield item
+                envelope = normalize_telemetry_envelope(item)
+                if envelope is not None:
+                    yield envelope
         elif isinstance(msg, dict):
-            yield msg
+            envelope = normalize_telemetry_envelope(msg)
+            if envelope is not None:
+                yield envelope
 
     def _collect_flush_rows(
         self,
@@ -298,11 +290,11 @@ class SQLiteWriterSimple:
         }
 
         for item in items:
-            for payload_dict in self._iter_payload_dicts(item):
+            for envelope in self._iter_envelopes(item):
                 try:
                     recv_ts_ns = time.time_ns()
-                    rank, sampler = self._extract_rank_sampler(payload_dict)
-                    payload = self._encoder.encode(payload_dict)
+                    rank, sampler = self._extract_rank_sampler(envelope)
+                    payload = self._encoder.encode(envelope.to_dict())
                     raw_rows.append((recv_ts_ns, rank, sampler, payload))
 
                     for writer in _PROJECTION_WRITERS:
@@ -310,7 +302,7 @@ class SQLiteWriterSimple:
                             continue
 
                         rows_by_table = writer.build_rows(
-                            payload_dict=payload_dict,
+                            envelope=envelope,
                             recv_ts_ns=recv_ts_ns,
                         )
                         for table_name, rows in rows_by_table.items():

--- a/src/traceml_ai/aggregator/sqlite_writers/process.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/process.py
@@ -13,7 +13,7 @@ table while preserving the original sampler payload in `raw_messages`.
 Design
 ------
 - Keeps sampler-specific SQL logic out of the core SQLite writer
-- Accepts already-decoded payload dicts from the main writer
+- Accepts canonical telemetry envelopes from the main writer
 - Produces one query-friendly table:
     1) process_samples
        One row per sampled process snapshot, keyed by global rank and sample
@@ -34,37 +34,11 @@ This projection stores raw values wherever possible.
 
 Expected payload shape
 ----------------------
-Envelope:
+Canonical telemetry envelope:
 {
-    "rank": int,          # legacy alias for global_rank
-    "global_rank": int,
-    "local_rank": int,
-    "world_size": int,
-    "local_world_size": int,
-    "node_rank": int,
-    "hostname": str,
-    "sampler": "ProcessSampler",
-    "timestamp": float,
-    "tables": {
-        "<table_name>": [
-            {
-                "seq": int,
-                "timestamp": float,
-                "cpu_percent": float,
-                "cpu_logical_core_count": int,
-                "ram_used": float,   # bytes
-                "ram_total": float,  # bytes
-                "gpu_available": bool,
-                "gpu_count": int,
-                "gpu": {
-                    "device_index": int,
-                    "mem_used": float,      # bytes
-                    "mem_reserved": float,  # bytes
-                    "mem_total": float      # bytes
-                } | None
-            },
-            ...
-        ]
+    "meta": {"sampler": "ProcessSampler", ...},
+    "body": {
+        "tables": {"<table_name>": [ProcessSample.to_wire(), ...]}
     }
 }
 """
@@ -74,6 +48,8 @@ from __future__ import annotations
 import sqlite3
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
+
+from traceml_ai.telemetry.envelope import TelemetryEnvelope, TelemetryMeta
 
 SAMPLER_NAME = "ProcessSampler"
 RETENTION_TABLES = ("process_samples",)
@@ -110,7 +86,7 @@ class ProcessPayloadIdentity:
     hostname: Optional[str]
 
 
-def _payload_identity(payload_dict: Dict[str, Any]) -> ProcessPayloadIdentity:
+def _payload_identity(meta: TelemetryMeta) -> ProcessPayloadIdentity:
     """
     Return storage identity for one ProcessSampler payload.
 
@@ -118,18 +94,18 @@ def _payload_identity(payload_dict: Dict[str, Any]) -> ProcessPayloadIdentity:
     written as the same value to keep existing process summaries working while
     the reporting layer is migrated separately.
     """
-    global_rank = _optional_int(payload_dict.get("global_rank"))
-    legacy_rank = _optional_int(payload_dict.get("rank"))
+    global_rank = _optional_int(meta.global_rank)
+    legacy_rank = _optional_int(meta.rank)
     rank = global_rank if global_rank is not None else legacy_rank
 
     return ProcessPayloadIdentity(
         rank=rank,
         global_rank=global_rank,
-        local_rank=_optional_int(payload_dict.get("local_rank")),
-        world_size=_optional_int(payload_dict.get("world_size")),
-        local_world_size=_optional_int(payload_dict.get("local_world_size")),
-        node_rank=_optional_int(payload_dict.get("node_rank")),
-        hostname=_optional_str(payload_dict.get("hostname")),
+        local_rank=_optional_int(meta.local_rank),
+        world_size=_optional_int(meta.world_size),
+        local_world_size=_optional_int(meta.local_world_size),
+        node_rank=_optional_int(meta.node_rank),
+        hostname=_optional_str(meta.hostname),
     )
 
 
@@ -242,7 +218,7 @@ def init_schema(conn: sqlite3.Connection) -> None:
 
 
 def build_rows(
-    payload_dict: Dict[str, Any],
+    envelope: TelemetryEnvelope,
     recv_ts_ns: int,
 ) -> Dict[str, list[tuple]]:
     """
@@ -250,8 +226,8 @@ def build_rows(
 
     Parameters
     ----------
-    payload_dict:
-        Decoded sampler payload dict from the main SQLite writer.
+    envelope:
+        Canonical telemetry envelope from the main SQLite writer.
     recv_ts_ns:
         Receive timestamp assigned by the main writer for this payload.
 
@@ -272,13 +248,13 @@ def build_rows(
         "process_samples": [],
     }
 
-    sampler = payload_dict.get("sampler")
-    if not accepts_sampler(str(sampler) if sampler is not None else None):
+    sampler = envelope.meta.sampler
+    if not accepts_sampler(sampler):
         return out
 
-    identity = _payload_identity(payload_dict)
+    identity = _payload_identity(envelope.meta)
 
-    tables = payload_dict.get("tables")
+    tables = envelope.tables
     if not isinstance(tables, dict):
         return out
 

--- a/src/traceml_ai/aggregator/sqlite_writers/stdout_stderr.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/stdout_stderr.py
@@ -8,7 +8,7 @@ query-friendly SQLite table while preserving the original sampler payload in
 Design
 ------
 - Keeps sampler-specific SQL logic out of the core SQLite writer
-- Accepts already-decoded payload dicts from the main writer
+- Accepts canonical telemetry envelopes from the main writer
 - Produces one append-only table:
     1) stdout_stderr_samples
        One row per captured output line
@@ -23,16 +23,11 @@ Stdout/stderr is intentionally stored as a very simple append-only stream:
 
 Expected payload shape
 ----------------------
-Envelope:
+Canonical telemetry envelope:
 {
-    "rank": int,
-    "sampler": "Stdout/Stderr",
-    "timestamp": float,
-    "tables": {
-        "stdout_stderr": [
-            {"line": "..."},
-            ...
-        ]
+    "meta": {"sampler": "Stdout/Stderr", ...},
+    "body": {
+        "tables": {"stdout_stderr": [{"line": "..."}, ...]}
     }
 }
 """
@@ -40,7 +35,9 @@ Envelope:
 from __future__ import annotations
 
 import sqlite3
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
+
+from traceml_ai.telemetry.envelope import TelemetryEnvelope
 
 SAMPLER_NAME = "Stdout/Stderr"
 
@@ -82,7 +79,7 @@ def init_schema(conn: sqlite3.Connection) -> None:
 
 
 def build_rows(
-    payload_dict: Dict[str, Any],
+    envelope: TelemetryEnvelope,
     recv_ts_ns: int,
 ) -> Dict[str, list[tuple]]:
     """
@@ -90,8 +87,8 @@ def build_rows(
 
     Parameters
     ----------
-    payload_dict:
-        Decoded sampler payload dict from the main SQLite writer.
+    envelope:
+        Canonical telemetry envelope from the main SQLite writer.
     recv_ts_ns:
         Receive timestamp assigned by the main writer for this payload.
 
@@ -111,20 +108,16 @@ def build_rows(
         "stdout_stderr_samples": [],
     }
 
-    sampler = payload_dict.get("sampler")
-    if not accepts_sampler(str(sampler) if sampler is not None else None):
+    sampler = envelope.meta.sampler
+    if not accepts_sampler(sampler):
         return out
 
-    rank_raw = payload_dict.get("rank")
-    try:
-        rank = int(rank_raw) if rank_raw is not None else None
-    except Exception:
-        rank = None
+    rank = envelope.meta.rank
 
-    ts_raw = payload_dict.get("timestamp")
+    ts_raw = envelope.meta.timestamp
     sample_ts_s = float(ts_raw) if isinstance(ts_raw, (int, float)) else None
 
-    tables = payload_dict.get("tables")
+    tables = envelope.tables
     if not isinstance(tables, dict):
         return out
 

--- a/src/traceml_ai/aggregator/sqlite_writers/step_memory.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/step_memory.py
@@ -13,7 +13,7 @@ SQLite table while preserving the original sampler payload in `raw_messages`.
 Design
 ------
 - Keeps sampler-specific SQL logic out of the core SQLite writer.
-- Accepts already-decoded payload dicts from the main writer.
+- Accepts canonical telemetry envelopes from the main writer.
 - Produces one query-friendly table:
     1) step_memory_samples
        One row per (global rank, step memory event) with stable runtime
@@ -21,29 +21,11 @@ Design
 
 Expected payload shape
 ----------------------
-Envelope:
+Canonical telemetry envelope:
 {
-    "rank": int,          # legacy alias for global_rank
-    "global_rank": int,
-    "local_rank": int,
-    "world_size": int,
-    "local_world_size": int,
-    "node_rank": int,
-    "hostname": str,
-    "sampler": "StepMemorySampler",
-    "timestamp": float,
-    "tables": {
-        "<table_name>": [
-            {
-                "seq": int,
-                "ts": float,
-                "device": str | null,
-                "step": int | null,
-                "peak_alloc": float | null,   # bytes
-                "peak_resv": float | null     # bytes
-            },
-            ...
-        ]
+    "meta": {"sampler": "StepMemorySampler", ...},
+    "body": {
+        "tables": {"<table_name>": [StepMemorySample.to_wire(), ...]}
     }
 }
 """
@@ -53,6 +35,8 @@ from __future__ import annotations
 import sqlite3
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
+
+from traceml_ai.telemetry.envelope import TelemetryEnvelope, TelemetryMeta
 
 SAMPLER_NAME = "StepMemorySampler"
 RETENTION_TABLES = ("step_memory_samples",)
@@ -89,22 +73,20 @@ class StepMemoryPayloadIdentity:
     hostname: Optional[str]
 
 
-def _payload_identity(
-    payload_dict: Dict[str, Any]
-) -> StepMemoryPayloadIdentity:
+def _payload_identity(meta: TelemetryMeta) -> StepMemoryPayloadIdentity:
     """Return storage identity for one StepMemorySampler payload."""
-    global_rank = _optional_int(payload_dict.get("global_rank"))
-    legacy_rank = _optional_int(payload_dict.get("rank"))
+    global_rank = _optional_int(meta.global_rank)
+    legacy_rank = _optional_int(meta.rank)
     rank = global_rank if global_rank is not None else legacy_rank
 
     return StepMemoryPayloadIdentity(
         rank=rank,
         global_rank=global_rank,
-        local_rank=_optional_int(payload_dict.get("local_rank")),
-        world_size=_optional_int(payload_dict.get("world_size")),
-        local_world_size=_optional_int(payload_dict.get("local_world_size")),
-        node_rank=_optional_int(payload_dict.get("node_rank")),
-        hostname=_optional_str(payload_dict.get("hostname")),
+        local_rank=_optional_int(meta.local_rank),
+        world_size=_optional_int(meta.world_size),
+        local_world_size=_optional_int(meta.local_world_size),
+        node_rank=_optional_int(meta.node_rank),
+        hostname=_optional_str(meta.hostname),
     )
 
 
@@ -217,7 +199,7 @@ def init_schema(conn: sqlite3.Connection) -> None:
 
 
 def build_rows(
-    payload_dict: Dict[str, Any],
+    envelope: TelemetryEnvelope,
     recv_ts_ns: int,
 ) -> Dict[str, list[tuple]]:
     """
@@ -232,13 +214,13 @@ def build_rows(
         "step_memory_samples": [],
     }
 
-    sampler = payload_dict.get("sampler")
-    if not accepts_sampler(str(sampler) if sampler is not None else None):
+    sampler = envelope.meta.sampler
+    if not accepts_sampler(sampler):
         return out
 
-    identity = _payload_identity(payload_dict)
+    identity = _payload_identity(envelope.meta)
 
-    tables = payload_dict.get("tables")
+    tables = envelope.tables
     if not isinstance(tables, dict):
         return out
 

--- a/src/traceml_ai/aggregator/sqlite_writers/step_memory.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/step_memory.py
@@ -37,7 +37,6 @@ Envelope:
             {
                 "seq": int,
                 "ts": float,
-                "model_id": int | null,
                 "device": str | null,
                 "step": int | null,
                 "peak_alloc": float | null,   # bytes
@@ -148,7 +147,6 @@ def init_schema(conn: sqlite3.Connection) -> None:
             hostname             TEXT,
             sample_ts_s          REAL,
             seq                  INTEGER,
-            model_id             INTEGER,
             device               TEXT,
             step                 INTEGER,
             peak_alloc_bytes     REAL,
@@ -254,7 +252,6 @@ def build_rows(
 
             seq_raw = row.get("seq")
             ts_raw = row.get("ts")
-            model_id_raw = row.get("model_id")
             device_raw = row.get("device")
             step_raw = row.get("step")
             peak_alloc_raw = row.get("peak_alloc")
@@ -263,9 +260,6 @@ def build_rows(
             seq = int(seq_raw) if isinstance(seq_raw, int) else None
             sample_ts_s = (
                 float(ts_raw) if isinstance(ts_raw, (int, float)) else None
-            )
-            model_id = (
-                int(model_id_raw) if isinstance(model_id_raw, int) else None
             )
             device = str(device_raw) if isinstance(device_raw, str) else None
             step = int(step_raw) if isinstance(step_raw, int) else None
@@ -292,7 +286,6 @@ def build_rows(
                     identity.hostname,
                     sample_ts_s,
                     seq,
-                    model_id,
                     device,
                     step,
                     peak_alloc_bytes,
@@ -324,13 +317,12 @@ def insert_rows(
                 hostname,
                 sample_ts_s,
                 seq,
-                model_id,
                 device,
                 step,
                 peak_alloc_bytes,
                 peak_reserved_bytes
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
             """,
             rows,
         )

--- a/src/traceml_ai/aggregator/sqlite_writers/step_time.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/step_time.py
@@ -13,7 +13,7 @@ SQLite table while preserving the original sampler payload in `raw_messages`.
 Design
 ------
 - Keeps sampler-specific SQL logic out of the core SQLite writer
-- Accepts already-decoded payload dicts from the main writer
+- Accepts canonical telemetry envelopes from the main writer
 - Produces one query-friendly table:
     1) step_time_samples
        One row per (global rank, step) with stable metadata columns plus a
@@ -34,36 +34,11 @@ and stores the dynamic event map as JSON text in `events_json`.
 
 Expected payload shape
 ----------------------
-Envelope:
+Canonical telemetry envelope:
 {
-    "rank": int,          # legacy alias for global_rank
-    "global_rank": int,
-    "local_rank": int,
-    "world_size": int,
-    "local_world_size": int,
-    "node_rank": int,
-    "hostname": str,
-    "pid": int,
-    "sampler": "StepTimeSampler",
-    "timestamp": float,
-    "tables": {
-        "<table_name>": [
-            {
-                "seq": int,
-                "timestamp": float,
-                "step": int,
-                "events": {
-                    "<event_name>": {
-                        "<device>": {
-                            "is_gpu": bool,
-                            "duration_ms": float,
-                            "n_calls": int
-                        }
-                    }
-                }
-            },
-            ...
-        ]
+    "meta": {"sampler": "StepTimeSampler", ...},
+    "body": {
+        "tables": {"<table_name>": [StepTimeEventSample.to_wire(), ...]}
     }
 }
 """
@@ -74,6 +49,8 @@ import json
 import sqlite3
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
+
+from traceml_ai.telemetry.envelope import TelemetryEnvelope, TelemetryMeta
 
 SAMPLER_NAME = "StepTimeSampler"
 RETENTION_TABLES = ("step_time_samples",)
@@ -110,7 +87,7 @@ class StepTimePayloadIdentity:
     hostname: Optional[str]
 
 
-def _payload_identity(payload_dict: Dict[str, Any]) -> StepTimePayloadIdentity:
+def _payload_identity(meta: TelemetryMeta) -> StepTimePayloadIdentity:
     """
     Return storage identity for one StepTimeSampler payload.
 
@@ -118,18 +95,18 @@ def _payload_identity(payload_dict: Dict[str, Any]) -> StepTimePayloadIdentity:
     written as the same value so current live renderers keep working until they
     move to explicit identity fields.
     """
-    global_rank = _optional_int(payload_dict.get("global_rank"))
-    legacy_rank = _optional_int(payload_dict.get("rank"))
+    global_rank = _optional_int(meta.global_rank)
+    legacy_rank = _optional_int(meta.rank)
     rank = global_rank if global_rank is not None else legacy_rank
 
     return StepTimePayloadIdentity(
         rank=rank,
         global_rank=global_rank,
-        local_rank=_optional_int(payload_dict.get("local_rank")),
-        world_size=_optional_int(payload_dict.get("world_size")),
-        local_world_size=_optional_int(payload_dict.get("local_world_size")),
-        node_rank=_optional_int(payload_dict.get("node_rank")),
-        hostname=_optional_str(payload_dict.get("hostname")),
+        local_rank=_optional_int(meta.local_rank),
+        world_size=_optional_int(meta.world_size),
+        local_world_size=_optional_int(meta.local_world_size),
+        node_rank=_optional_int(meta.node_rank),
+        hostname=_optional_str(meta.hostname),
     )
 
 
@@ -307,7 +284,7 @@ def _normalize_events(events_raw: Any) -> Dict[str, Dict[str, Dict[str, Any]]]:
 
 
 def build_rows(
-    payload_dict: Dict[str, Any],
+    envelope: TelemetryEnvelope,
     recv_ts_ns: int,
 ) -> Dict[str, list[tuple]]:
     """
@@ -315,8 +292,8 @@ def build_rows(
 
     Parameters
     ----------
-    payload_dict:
-        Decoded sampler payload dict from the main SQLite writer.
+    envelope:
+        Canonical telemetry envelope from the main SQLite writer.
     recv_ts_ns:
         Receive timestamp assigned by the main writer for this payload.
 
@@ -337,13 +314,13 @@ def build_rows(
         "step_time_samples": [],
     }
 
-    sampler = payload_dict.get("sampler")
-    if not accepts_sampler(str(sampler) if sampler is not None else None):
+    sampler = envelope.meta.sampler
+    if not accepts_sampler(sampler):
         return out
 
-    identity = _payload_identity(payload_dict)
+    identity = _payload_identity(envelope.meta)
 
-    tables = payload_dict.get("tables")
+    tables = envelope.tables
     if not isinstance(tables, dict):
         return out
 

--- a/src/traceml_ai/aggregator/sqlite_writers/step_time.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/step_time.py
@@ -25,7 +25,7 @@ Step-time event names are not stable enough to justify fixed SQL columns.
 Therefore, the SQL schema keeps only stable fields in first-class columns:
 - rank, retained as a legacy alias for global_rank while live paths migrate
 - global_rank, local_rank, world_size, local_world_size, node_rank
-- hostname, runtime_pid
+- hostname
 - step
 - sample_ts_s
 - seq
@@ -108,7 +108,6 @@ class StepTimePayloadIdentity:
     local_world_size: Optional[int]
     node_rank: Optional[int]
     hostname: Optional[str]
-    runtime_pid: Optional[int]
 
 
 def _payload_identity(payload_dict: Dict[str, Any]) -> StepTimePayloadIdentity:
@@ -131,7 +130,6 @@ def _payload_identity(payload_dict: Dict[str, Any]) -> StepTimePayloadIdentity:
         local_world_size=_optional_int(payload_dict.get("local_world_size")),
         node_rank=_optional_int(payload_dict.get("node_rank")),
         hostname=_optional_str(payload_dict.get("hostname")),
-        runtime_pid=_optional_int(payload_dict.get("pid")),
     )
 
 
@@ -179,7 +177,6 @@ def init_schema(conn: sqlite3.Connection) -> None:
             local_world_size   INTEGER,
             node_rank          INTEGER,
             hostname           TEXT,
-            runtime_pid        INTEGER,
             sample_ts_s        REAL,
             seq                INTEGER,
             step               INTEGER,
@@ -222,12 +219,6 @@ def init_schema(conn: sqlite3.Connection) -> None:
         table="step_time_samples",
         column="hostname",
         definition="TEXT",
-    )
-    _ensure_column(
-        conn,
-        table="step_time_samples",
-        column="runtime_pid",
-        definition="INTEGER",
     )
     conn.execute(
         """
@@ -392,7 +383,6 @@ def build_rows(
                     identity.local_world_size,
                     identity.node_rank,
                     identity.hostname,
-                    identity.runtime_pid,
                     sample_ts_s,
                     seq,
                     step,
@@ -429,13 +419,12 @@ def insert_rows(
                 local_world_size,
                 node_rank,
                 hostname,
-                runtime_pid,
                 sample_ts_s,
                 seq,
                 step,
                 events_json
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
             """,
             rows,
         )

--- a/src/traceml_ai/aggregator/sqlite_writers/system.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/system.py
@@ -27,33 +27,11 @@ This projection stores raw values wherever possible.
 
 Expected payload shape
 ----------------------
-Envelope:
+Canonical telemetry envelope:
 {
-    "global_rank": int,  # process that emitted this node-level sample
-    "local_rank": int,
-    "world_size": int,
-    "local_world_size": int,
-    "node_rank": int,    # canonical System grouping identity
-    "hostname": str,
-    "sampler": "SystemSampler",
-    "timestamp": float,
-    "tables": {
-        "<table_name>": [
-            {
-                "seq": int,
-                "ts": float,
-                "cpu": float,
-                "ram_used": float,   # bytes
-                "ram_total": float,  # bytes
-                "gpu_available": bool,
-                "gpu_count": int,
-                "gpus": [
-                    [util, mem_used, mem_total, temperature, power_usage, power_limit],
-                    ...
-                ]
-            },
-            ...
-        ]
+    "meta": {"sampler": "SystemSampler", ...},
+    "body": {
+        "tables": {"<table_name>": [SystemSample.to_wire(), ...]}
     }
 }
 """
@@ -63,6 +41,8 @@ from __future__ import annotations
 import sqlite3
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
+
+from traceml_ai.telemetry.envelope import TelemetryEnvelope, TelemetryMeta
 
 SAMPLER_NAME = "SystemSampler"
 RETENTION_TABLES = ("system_samples",)
@@ -98,24 +78,20 @@ class SystemPayloadIdentity:
     hostname: Optional[str]
 
 
-def _payload_identity(
-    payload_dict: Dict[str, Any],
-) -> SystemPayloadIdentity:
+def _payload_identity(meta: TelemetryMeta) -> SystemPayloadIdentity:
     """
     Return storage identity for one payload.
 
     System projection tables store explicit distributed identity fields only.
     The legacy generic ``rank`` field is intentionally ignored.
     """
-    global_rank = _optional_int(payload_dict.get("global_rank"))
-
     return SystemPayloadIdentity(
-        global_rank=global_rank,
-        local_rank=_optional_int(payload_dict.get("local_rank")),
-        world_size=_optional_int(payload_dict.get("world_size")),
-        local_world_size=_optional_int(payload_dict.get("local_world_size")),
-        node_rank=_optional_int(payload_dict.get("node_rank")),
-        hostname=_optional_str(payload_dict.get("hostname")),
+        global_rank=_optional_int(meta.global_rank),
+        local_rank=_optional_int(meta.local_rank),
+        world_size=_optional_int(meta.world_size),
+        local_world_size=_optional_int(meta.local_world_size),
+        node_rank=_optional_int(meta.node_rank),
+        hostname=_optional_str(meta.hostname),
     )
 
 
@@ -285,7 +261,7 @@ def init_schema(conn: sqlite3.Connection) -> None:
 
 
 def build_rows(
-    payload_dict: Dict[str, Any],
+    envelope: TelemetryEnvelope,
     recv_ts_ns: int,
 ) -> Dict[str, list[tuple]]:
     """
@@ -293,8 +269,8 @@ def build_rows(
 
     Parameters
     ----------
-    payload_dict:
-        Decoded sampler payload dict from the main SQLite writer.
+    envelope:
+        Canonical telemetry envelope from the main SQLite writer.
     recv_ts_ns:
         Receive timestamp assigned by the main writer for this payload.
 
@@ -317,13 +293,13 @@ def build_rows(
         "system_gpu_samples": [],
     }
 
-    sampler = payload_dict.get("sampler")
-    if not accepts_sampler(str(sampler) if sampler is not None else None):
+    sampler = envelope.meta.sampler
+    if not accepts_sampler(sampler):
         return out
 
-    identity = _payload_identity(payload_dict)
+    identity = _payload_identity(envelope.meta)
 
-    tables = payload_dict.get("tables")
+    tables = envelope.tables
     if not isinstance(tables, dict):
         return out
 

--- a/src/traceml_ai/aggregator/sqlite_writers/system.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/system.py
@@ -147,12 +147,12 @@ def init_schema(conn: sqlite3.Connection) -> None:
     Tables
     ------
     system_samples
-        One row per sampled system snapshot. Includes host fields plus
-        aggregated GPU statistics for the snapshot.
+        One row per sampled system snapshot. Includes node-level raw fields.
 
     system_gpu_samples
-        One row per GPU within a sampled system snapshot. Useful for detailed
-        per-GPU analysis and future imbalance/hotspot queries.
+        One row per GPU within a sampled system snapshot. Summary and live
+        views derive GPU rollups from this table instead of storing duplicate
+        per-snapshot aggregates in `system_samples`.
     """
     conn.execute(
         """
@@ -171,15 +171,7 @@ def init_schema(conn: sqlite3.Connection) -> None:
             ram_used_bytes         REAL,
             ram_total_bytes        REAL,
             gpu_available          INTEGER,
-            gpu_count              INTEGER,
-            gpu_util_avg           REAL,
-            gpu_util_peak          REAL,
-            gpu_mem_used_avg_bytes REAL,
-            gpu_mem_used_peak_bytes REAL,
-            gpu_temp_avg_c         REAL,
-            gpu_temp_peak_c        REAL,
-            gpu_power_avg_w        REAL,
-            gpu_power_peak_w       REAL
+            gpu_count              INTEGER
         );
         """
     )
@@ -378,11 +370,6 @@ def build_rows(
                 int(gpu_count_raw) if isinstance(gpu_count_raw, int) else None
             )
 
-            utils: list[float] = []
-            mem_useds_bytes: list[float] = []
-            temps_c: list[float] = []
-            powers_w: list[float] = []
-
             if isinstance(gpus_raw, list):
                 for gpu_idx, g in enumerate(gpus_raw):
                     if not (isinstance(g, list) and len(g) >= 6):
@@ -426,15 +413,6 @@ def build_rows(
                         else None
                     )
 
-                    if util is not None:
-                        utils.append(util)
-                    if mem_used_bytes is not None:
-                        mem_useds_bytes.append(mem_used_bytes)
-                    if temp_c is not None:
-                        temps_c.append(temp_c)
-                    if power_w is not None:
-                        powers_w.append(power_w)
-
                     out["system_gpu_samples"].append(
                         (
                             recv_ts_ns,
@@ -456,23 +434,6 @@ def build_rows(
                         )
                     )
 
-            gpu_util_avg = sum(utils) / len(utils) if utils else None
-            gpu_util_peak = max(utils) if utils else None
-            gpu_mem_used_avg_bytes = (
-                sum(mem_useds_bytes) / len(mem_useds_bytes)
-                if mem_useds_bytes
-                else None
-            )
-            gpu_mem_used_peak_bytes = (
-                max(mem_useds_bytes) if mem_useds_bytes else None
-            )
-            gpu_temp_avg_c = sum(temps_c) / len(temps_c) if temps_c else None
-            gpu_temp_peak_c = max(temps_c) if temps_c else None
-            gpu_power_avg_w = (
-                sum(powers_w) / len(powers_w) if powers_w else None
-            )
-            gpu_power_peak_w = max(powers_w) if powers_w else None
-
             out["system_samples"].append(
                 (
                     recv_ts_ns,
@@ -489,14 +450,6 @@ def build_rows(
                     ram_total_bytes,
                     gpu_available,
                     gpu_count,
-                    gpu_util_avg,
-                    gpu_util_peak,
-                    gpu_mem_used_avg_bytes,
-                    gpu_mem_used_peak_bytes,
-                    gpu_temp_avg_c,
-                    gpu_temp_peak_c,
-                    gpu_power_avg_w,
-                    gpu_power_peak_w,
                 )
             )
 
@@ -534,17 +487,9 @@ def insert_rows(
                 ram_used_bytes,
                 ram_total_bytes,
                 gpu_available,
-                gpu_count,
-                gpu_util_avg,
-                gpu_util_peak,
-                gpu_mem_used_avg_bytes,
-                gpu_mem_used_peak_bytes,
-                gpu_temp_avg_c,
-                gpu_temp_peak_c,
-                gpu_power_avg_w,
-                gpu_power_peak_w
+                gpu_count
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
             """,
             system_rows,
         )

--- a/src/traceml_ai/aggregator/trace_aggregator.py
+++ b/src/traceml_ai/aggregator/trace_aggregator.py
@@ -22,6 +22,7 @@ from traceml_ai.aggregator.summary_service import FinalSummaryService
 from traceml_ai.database.remote_database_store import RemoteDBStore
 from traceml_ai.reporting.final import generate_summary
 from traceml_ai.runtime.settings import AggregatorEndpoint, TraceMLSettings
+from traceml_ai.telemetry.envelope import normalize_telemetry_envelope
 from traceml_ai.transport.tcp_transport import TCPConfig, TCPServer
 
 DASHBOARD_EXTRA_INSTALL_HINT = (
@@ -272,17 +273,11 @@ class TraceMLAggregator:
         Returns ``None`` when the payload is malformed or does not follow the
         expected envelope shape.
         """
-        if not isinstance(msg, dict):
+        envelope = normalize_telemetry_envelope(msg)
+        if envelope is None:
             return None
 
-        sampler = msg.get("sampler")
-        if sampler is None:
-            return None
-
-        try:
-            return str(sampler)
-        except Exception:
-            return None
+        return envelope.meta.sampler
 
     def _filter_remote_store_message(self, msg: Any) -> Any:
         """

--- a/src/traceml_ai/core/telemetry.py
+++ b/src/traceml_ai/core/telemetry.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import sqlite3
 from typing import Any, Dict, Generic, Mapping, Optional, Protocol, TypeVar
 
+from traceml_ai.telemetry.envelope import TelemetryEnvelope
+
 MetricResultT = TypeVar("MetricResultT")
 TelemetryPayload = Mapping[str, Any]
 
@@ -34,10 +36,10 @@ class ProjectionWriter(Protocol):
 
     def build_rows(
         self,
-        payload_dict: Dict[str, Any],
+        envelope: TelemetryEnvelope,
         recv_ts_ns: int,
     ) -> Dict[str, list[tuple]]:
-        """Build table-keyed SQLite rows from one decoded payload."""
+        """Build table-keyed SQLite rows from one canonical envelope."""
 
     def insert_rows(
         self,

--- a/src/traceml_ai/database/database_sender.py
+++ b/src/traceml_ai/database/database_sender.py
@@ -11,6 +11,7 @@ from typing import Any, Optional, Protocol
 
 from traceml_ai.loggers.error_log import get_error_logger
 from traceml_ai.runtime.sender import SenderIdentity
+from traceml_ai.telemetry.envelope import build_telemetry_envelope
 
 
 class AppendOnlyDatabase(Protocol):
@@ -48,21 +49,24 @@ class DBIncrementalSender:
 
     Payload contract
     ----------------
-    This class returns a single payload dict from `collect_payload()`:
+    This class returns one canonical telemetry envelope from
+    `collect_payload()`:
 
     {
-        "rank": <int>,          # globally unique runtime rank
-        "global_rank": <int>,
-        "local_rank": <int>,
-        "world_size": <int>,
-        "local_world_size": <int>,
-        "node_rank": <int>,
-        "hostname": <str>,
-        "pid": <int>,
-        "sampler": <str>,
-        "timestamp": <float>,
-        "tables": {
-            table_name: [row, row, ...]
+        "meta": {
+            "rank": <int>,
+            "global_rank": <int>,
+            "local_rank": <int>,
+            "world_size": <int>,
+            "local_world_size": <int>,
+            "node_rank": <int>,
+            "hostname": <str>,
+            "pid": <int>,
+            "sampler": <str>,
+            "timestamp": <float>
+        },
+        "body": {
+            "tables": {table_name: [row, row, ...]}
         }
     }
 
@@ -162,12 +166,12 @@ class DBIncrementalSender:
             return None
         identity = self._payload_identity()
 
-        return {
-            **identity.to_payload_fields(),
-            "sampler": self.sampler_name,
-            "timestamp": time.time(),
-            "tables": tables_payload,
-        }
+        return build_telemetry_envelope(
+            identity=identity,
+            sampler_name=self.sampler_name,
+            tables=tables_payload,
+            timestamp=time.time(),
+        )
 
     def flush(self) -> None:
         """

--- a/src/traceml_ai/database/remote_database_store.py
+++ b/src/traceml_ai/database/remote_database_store.py
@@ -2,6 +2,7 @@ import time
 from typing import Dict, Optional
 
 from traceml_ai.loggers.error_log import get_error_logger
+from traceml_ai.telemetry.envelope import normalize_telemetry_envelope
 
 from .database import Database
 
@@ -45,8 +46,8 @@ class RemoteDBStore:
             A ``list`` of individual payload dicts.  Each item is ingested
             independently, exactly as if it had been sent in a separate message.
 
-        **Single format** (legacy — from ``TCPClient.send()``):
-            A single ``dict`` with keys ``rank``, ``sampler``, ``tables``.
+        **Single format**:
+            A canonical telemetry envelope with ``meta`` and ``body.tables``.
 
         Both formats are fully supported.  The type check on ``message`` is the
         only branching point; all ingestion logic lives in :meth:`_ingest_one`.
@@ -63,17 +64,13 @@ class RemoteDBStore:
 
     def _ingest_one(self, message: dict) -> None:
         """
-        Ingest a single telemetry payload dict into the store.
+        Ingest a single telemetry envelope into the store.
 
         Expected payload format
         -----------------------
             {
-              "rank": int,
-              "sampler": str,
-              "tables": {
-                  "table_name": [ {row...}, {row...}, ... ],
-                  ...
-              }
+              "meta": {"rank": int, "sampler": str, ...},
+              "body": {"tables": {"table_name": [{row...}, ...]}}
             }
 
         Behavior
@@ -86,8 +83,12 @@ class RemoteDBStore:
         if message is None:
             return
 
-        rank = message.get("rank")
-        sampler_name = message.get("sampler")
+        envelope = normalize_telemetry_envelope(message)
+        if envelope is None:
+            return
+
+        rank = envelope.meta.rank
+        sampler_name = envelope.meta.sampler
 
         try:
             rank = int(rank)
@@ -95,7 +96,7 @@ class RemoteDBStore:
             self.logger.warning(f"Invalid rank in message: {rank}")
             return
 
-        tables = message.get("tables", {})
+        tables = envelope.tables
 
         # Track last time we received telemetry from this rank
         self._last_seen[rank] = time.time()

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -13,7 +13,7 @@ complete root-cause proof.
 
 ## System
 
-Host/node pressure.
+Host/node pressure and GPU-utilization symptoms.
 
 - `NO_DATA`: no system telemetry.
 - `NORMAL`: no CPU, RAM, or available GPU pressure.
@@ -23,8 +23,16 @@ Host/node pressure.
 - `HIGH_GPU_POWER`: elevated GPU power use.
 - `HIGH_HOST_MEMORY`: elevated host RAM use.
 - `HIGH_CPU`: elevated host CPU use.
-- `LOW_GPU_UTILIZATION`: GPU utilization is low while host-side signals suggest
-  the GPU may be underfed.
+- `LOW_GPU_UTILIZATION`: average GPU utilization is below 30%. The GPU was
+  mostly idle.
+- `MODERATE_GPU_UTILIZATION`: average GPU utilization is between 30% and 70%,
+  inclusive. The GPU was only partly utilized.
+
+`LOW_GPU_UTILIZATION` and `MODERATE_GPU_UTILIZATION` are observed System
+symptoms, not root-cause proof. Use Step Time to identify whether the likely
+cause is input loading, compute balance, waits, synchronization, or other
+training behavior. Average GPU utilization above 70% does not emit a
+GPU-utilization issue and can remain `NORMAL` when no pressure rules fire.
 
 ## Process
 

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -75,6 +75,12 @@ wait_ms = traced_step_ms - known_step_ms
 total_step_ms = dataloader_ms + traced_step_ms
 ```
 
+When input and compute straggler signals appear together, step-time diagnosis
+attributes the primary cause to `INPUT_STRAGGLER` if dataloader excess is within
+the configured tolerance of compute excess. Otherwise the primary diagnosis
+stays `STRAGGLER`, with both input and compute findings preserved as secondary
+issues.
+
 It can include validation, checkpointing, logging, framework orchestration, CPU
 stalls, unobserved transfer stalls, or other work inside the timed step but
 outside the traced H2D and compute phases. It is not direct NCCL, all-reduce,

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -6,7 +6,8 @@ also copies that same item to `diagnosis`.
 
 Use `kind` as the stable internal key for logic and comparisons. Use `status`
 as the user-facing display label. In many cases they are similar, but they are
-not required to match.
+not required to match; System statuses intentionally use compact labels such as
+`HIGH GPU MEM` and `MODERATE GPU UTIL`.
 
 Diagnoses are conservative. They identify likely bottleneck categories, not a
 complete root-cause proof.

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -156,6 +156,13 @@ def _pct(value: float) -> str:
     return f"{non_negative_finite(value) * 100.0:.1f}%"
 
 
+def _ms(value: float) -> str:
+    """
+    Format a millisecond value for compact diagnosis notes.
+    """
+    return f"{non_negative_finite(value):.1f}ms"
+
+
 def _rank_str(rank: Optional[int]) -> str:
     """
     Format a rank identifier for UI text.
@@ -188,6 +195,53 @@ def _issue_by_kind(
         if issue.kind == kind:
             return issue
     return None
+
+
+def _input_explains_compute_skew(
+    *,
+    dataloader_excess_ms: float,
+    compute_excess_ms: float,
+    thresholds: DiagnosisThresholds,
+) -> bool:
+    """
+    Return whether input excess can plausibly explain compute skew.
+
+    In distributed training, a slow input rank can surface as extra
+    backward/compute time on peer ranks because synchronization shifts where
+    waiting is observed. Treat input as primary when its absolute excess is
+    close enough to the compute excess, using a policy-controlled tolerance.
+    """
+    tolerance = max(
+        1.0,
+        non_negative_finite(
+            thresholds.input_straggler_compute_excess_tolerance
+        ),
+    )
+    compute_excess = non_negative_finite(compute_excess_ms)
+    if compute_excess <= 0.0:
+        return non_negative_finite(dataloader_excess_ms) > 0.0
+    return non_negative_finite(dataloader_excess_ms) >= (
+        compute_excess / tolerance
+    )
+
+
+def _input_explained_compute_note(
+    *,
+    dataloader_excess_ms: float,
+    compute_excess_ms: float,
+    thresholds: DiagnosisThresholds,
+) -> str:
+    tolerance = max(
+        1.0,
+        non_negative_finite(
+            thresholds.input_straggler_compute_excess_tolerance
+        ),
+    )
+    return (
+        f"Input excess {_ms(dataloader_excess_ms)} can explain compute excess "
+        f"{_ms(compute_excess_ms)} within {tolerance:.1f}x tolerance; "
+        "compute skew may be downstream synchronization."
+    )
 
 
 def _top_rank_entries(
@@ -383,8 +437,21 @@ def build_step_diagnosis_result(
 
     input_issue = _issue_by_kind(issue_list, "INPUT_STRAGGLER")
     compute_issue = _issue_by_kind(issue_list, "COMPUTE_STRAGGLER")
+    input_explains_compute = False
+    input_explained_note: Optional[str] = None
 
     if input_issue is not None and compute_issue is not None:
+        input_explains_compute = _input_explains_compute_skew(
+            dataloader_excess_ms=context.dataloader_excess_ms,
+            compute_excess_ms=context.compute_excess_ms,
+            thresholds=thresholds,
+        )
+        if input_explains_compute:
+            input_explained_note = _input_explained_compute_note(
+                dataloader_excess_ms=context.dataloader_excess_ms,
+                compute_excess_ms=context.compute_excess_ms,
+                thresholds=thresholds,
+            )
         combined_rank = (
             context.dataloader_worst_rank
             if context.input_straggler_score >= context.compute_straggler_score
@@ -429,40 +496,81 @@ def build_step_diagnosis_result(
                 evidence={
                     "input_score": context.input_straggler_score,
                     "compute_score": context.compute_straggler_score,
+                    "dataloader_excess_ms": context.dataloader_excess_ms,
+                    "compute_excess_ms": context.compute_excess_ms,
+                    "input_straggler_compute_excess_tolerance": (
+                        thresholds.input_straggler_compute_excess_tolerance
+                    ),
                 },
             )
         )
+        if input_explains_compute:
+            issue_list = [
+                (
+                    replace(
+                        issue,
+                        evidence={
+                            **issue.evidence,
+                            "dataloader_excess_ms": context.dataloader_excess_ms,
+                            "compute_excess_ms": context.compute_excess_ms,
+                            "input_straggler_compute_excess_tolerance": (
+                                thresholds.input_straggler_compute_excess_tolerance
+                            ),
+                            "downstream_synchronization_note": (
+                                input_explained_note
+                            ),
+                        },
+                    )
+                    if issue is input_issue
+                    else issue
+                )
+                for issue in issue_list
+            ]
+            input_issue = _issue_by_kind(issue_list, "INPUT_STRAGGLER")
 
     issues = sort_issues(issue_list)
     primary_issue = _select_primary_issue(issues)
 
     if input_issue is not None and compute_issue is not None:
-        dominant_rank = (
-            context.dataloader_worst_rank
-            if context.input_straggler_score >= context.compute_straggler_score
-            else context.compute_worst_rank
-        )
-        primary = _mk_diag(
-            kind="STRAGGLER",
-            severity=_severity(
-                max(
-                    context.input_straggler_score,
-                    context.compute_straggler_score,
-                ),
-                max(
-                    thresholds.input_straggler_score_crit,
-                    thresholds.compute_straggler_score_crit,
-                ),
+        mixed_severity = _severity(
+            max(
+                context.input_straggler_score,
+                context.compute_straggler_score,
             ),
-            reason="Both input and compute are uneven across ranks.",
-            action="Inspect the slowest rank and both dominant phases.",
-            steps_used=context.steps_used,
-            worst_rank=dominant_rank,
-            note=(
-                f"Input score {_pct(context.input_straggler_score)}, "
-                f"compute score {_pct(context.compute_straggler_score)}."
+            max(
+                thresholds.input_straggler_score_crit,
+                thresholds.compute_straggler_score_crit,
             ),
         )
+        if input_explains_compute:
+            primary = _mk_diag(
+                kind="INPUT_STRAGGLER",
+                severity=mixed_severity,
+                reason=input_issue.summary,
+                action=input_issue.action,
+                steps_used=context.steps_used,
+                worst_rank=context.dataloader_worst_rank,
+                note=input_explained_note,
+            )
+        else:
+            dominant_rank = (
+                context.dataloader_worst_rank
+                if context.input_straggler_score
+                >= context.compute_straggler_score
+                else context.compute_worst_rank
+            )
+            primary = _mk_diag(
+                kind="STRAGGLER",
+                severity=mixed_severity,
+                reason="Both input and compute are uneven across ranks.",
+                action="Inspect the slowest rank and both dominant phases.",
+                steps_used=context.steps_used,
+                worst_rank=dominant_rank,
+                note=(
+                    f"Input score {_pct(context.input_straggler_score)}, "
+                    f"compute score {_pct(context.compute_straggler_score)}."
+                ),
+            )
     elif input_issue is not None:
         primary = _mk_diag(
             kind="INPUT_STRAGGLER",

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -64,6 +64,8 @@ class StepTimeAnalysisContext:
     wait_total: float
     compute_total: float
     typical_step_total: float
+    dataloader_excess_ms: float
+    compute_excess_ms: float
     compute_phase_excess_total: float
 
     dataloader_share: float
@@ -513,6 +515,7 @@ def build_step_time_context(
         optimizer=optimizer_metric,
         wait=wait_metric,
     )
+    dataloader_excess_value = metric_excess(dataloader_metric)
     compute_excess_value = compute_phase_excess_total(
         forward=forward_metric,
         backward=backward_metric,
@@ -608,6 +611,8 @@ def build_step_time_context(
         wait_total=wait_total,
         compute_total=compute_total_value,
         typical_step_total=typical_step_value,
+        dataloader_excess_ms=dataloader_excess_value,
+        compute_excess_ms=compute_excess_value,
         compute_phase_excess_total=compute_excess_value,
         dataloader_share=share(dataloader_total, step_total),
         wait_share=share(wait_total, step_total),

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -19,6 +19,7 @@ class DiagnosisThresholds:
 
     compute_straggler_score_warn: float = 0.10
     compute_straggler_score_crit: float = 0.20
+    input_straggler_compute_excess_tolerance: float = 1.5
 
     input_share_warn: float = 0.25
     input_share_crit: float = 0.35

--- a/src/traceml_ai/diagnostics/system/__init__.py
+++ b/src/traceml_ai/diagnostics/system/__init__.py
@@ -13,10 +13,15 @@ payloads rather than live runtime UI changes.
 """
 
 from .api import SystemDiagnosis, diagnose_system
-from .policy import DEFAULT_SYSTEM_POLICY, SystemDiagnosisPolicy
+from .policy import (
+    DEFAULT_SYSTEM_POLICY,
+    GPUUtilizationBands,
+    SystemDiagnosisPolicy,
+)
 
 __all__ = [
     "DEFAULT_SYSTEM_POLICY",
+    "GPUUtilizationBands",
     "SystemDiagnosisPolicy",
     "SystemDiagnosis",
     "diagnose_system",

--- a/src/traceml_ai/diagnostics/system/policy.py
+++ b/src/traceml_ai/diagnostics/system/policy.py
@@ -3,8 +3,43 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import isfinite
+from typing import Literal, Optional
 
 from traceml_ai.diagnostics.bands import BandThresholds
+
+GPUUtilizationBand = Literal["low", "moderate", "healthy"]
+
+
+@dataclass(frozen=True)
+class GPUUtilizationBands:
+    """
+    Average GPU utilization bands for System diagnosis.
+
+    The public diagnosis bands are intentionally explicit:
+    - x < 30.0: low utilization
+    - 30.0 <= x <= 70.0: moderate utilization
+    - x > 70.0: healthy utilization, so no GPU-utilization issue is emitted
+    """
+
+    low_below: float = 30.0
+    moderate_at_or_below: float = 70.0
+
+    def classify(self, value: Optional[float]) -> Optional[GPUUtilizationBand]:
+        if value is None:
+            return None
+        try:
+            numeric = float(value)
+        except Exception:
+            return None
+        if not isfinite(numeric):
+            return None
+
+        if numeric < float(self.low_below):
+            return "low"
+        if numeric <= float(self.moderate_at_or_below):
+            return "moderate"
+        return "healthy"
 
 
 @dataclass(frozen=True)
@@ -13,7 +48,7 @@ class SystemDiagnosisPolicy:
 
     cpu_avg_percent: BandThresholds
     ram_peak_percent: BandThresholds
-    gpu_util_avg_percent: BandThresholds
+    gpu_util_avg_percent: GPUUtilizationBands
     gpu_memory_peak_percent: BandThresholds
     gpu_temp_peak_c: BandThresholds
     gpu_power_avg_limit_percent: BandThresholds
@@ -22,7 +57,7 @@ class SystemDiagnosisPolicy:
 DEFAULT_SYSTEM_POLICY = SystemDiagnosisPolicy(
     cpu_avg_percent=BandThresholds(low_below=30.0, high_at=80.0),
     ram_peak_percent=BandThresholds(low_below=30.0, high_at=80.0),
-    gpu_util_avg_percent=BandThresholds(low_below=30.0, high_at=80.0),
+    gpu_util_avg_percent=GPUUtilizationBands(),
     gpu_memory_peak_percent=BandThresholds(
         low_below=30.0,
         high_at=80.0,
@@ -38,5 +73,7 @@ DEFAULT_SYSTEM_POLICY = SystemDiagnosisPolicy(
 
 __all__ = [
     "DEFAULT_SYSTEM_POLICY",
+    "GPUUtilizationBand",
+    "GPUUtilizationBands",
     "SystemDiagnosisPolicy",
 ]

--- a/src/traceml_ai/diagnostics/system/policy.py
+++ b/src/traceml_ai/diagnostics/system/policy.py
@@ -48,7 +48,7 @@ class SystemDiagnosisPolicy:
 
     cpu_avg_percent: BandThresholds
     ram_peak_percent: BandThresholds
-    gpu_util_avg_percent: GPUUtilizationBands
+    gpu_utilization: GPUUtilizationBands
     gpu_memory_peak_percent: BandThresholds
     gpu_temp_peak_c: BandThresholds
     gpu_power_avg_limit_percent: BandThresholds
@@ -57,7 +57,7 @@ class SystemDiagnosisPolicy:
 DEFAULT_SYSTEM_POLICY = SystemDiagnosisPolicy(
     cpu_avg_percent=BandThresholds(low_below=30.0, high_at=80.0),
     ram_peak_percent=BandThresholds(low_below=30.0, high_at=80.0),
-    gpu_util_avg_percent=GPUUtilizationBands(),
+    gpu_utilization=GPUUtilizationBands(),
     gpu_memory_peak_percent=BandThresholds(
         low_below=30.0,
         high_at=80.0,

--- a/src/traceml_ai/diagnostics/system/rules.py
+++ b/src/traceml_ai/diagnostics/system/rules.py
@@ -231,32 +231,56 @@ class HighCPURule(_BaseSystemRule):
 
 
 @dataclass(frozen=True)
-class LowGPUUtilizationRule(_BaseSystemRule):
-    name: str = "low_gpu_utilization"
+class GPUUtilizationRule(_BaseSystemRule):
+    name: str = "gpu_utilization"
 
     def evaluate(
         self, context: SystemSummarySignals
     ) -> Optional[DiagnosticIssue]:
         pct = context.gpu_util_avg_percent
-        if self.policy.gpu_util_avg_percent.classify(pct) != "low":
+        band = self.policy.gpu_util_avg_percent.classify(pct)
+        if band not in {"low", "moderate"}:
             return None
 
+        pct_value = float(pct)
         gpu_idx = context.lowest_util_gpu_idx
+        if band == "low":
+            kind = "LOW_GPU_UTILIZATION"
+            status = "LOW GPU UTILIZATION"
+            summary = (
+                f"GPU utilization was low, averaging {_fmt_pct(pct_value)}."
+            )
+        else:
+            kind = "MODERATE_GPU_UTILIZATION"
+            status = "MODERATE GPU UTILIZATION"
+            summary = (
+                "GPU utilization was moderate, averaging "
+                f"{_fmt_pct(pct_value)}."
+            )
+
         return self._issue(
-            kind="LOW_GPU_UTILIZATION",
-            status="LOW GPU UTILIZATION",
+            kind=kind,
+            status=status,
             severity="info",
-            summary=f"GPU utilization was low, averaging {_fmt_pct(pct)}.",
-            action="Use step-time diagnostics to check host or input stalls.",
+            summary=summary,
+            action=(
+                "Use training diagnostics to identify why the GPU was not "
+                "fully utilized."
+            ),
             metric="gpu_util_avg_percent",
             phase="gpu_utilization",
-            score=100.0 - float(pct),
-            ranks=(() if gpu_idx is None else (gpu_idx,)),
+            score=max(0.0, 100.0 - pct_value),
+            ranks=(),
             evidence={
-                "gpu_util_avg_percent": pct,
+                "gpu_util_avg_percent": pct_value,
+                "gpu_utilization_band": band,
                 "lowest_util_gpu_idx": gpu_idx,
             },
         )
+
+
+# Keep the old import name stable; the rule now covers low and moderate bands.
+LowGPUUtilizationRule = GPUUtilizationRule
 
 
 DEFAULT_SYSTEM_RULES = (
@@ -266,7 +290,7 @@ DEFAULT_SYSTEM_RULES = (
     HighGPUPowerRule(),
     HighHostMemoryRule(),
     HighCPURule(),
-    LowGPUUtilizationRule(),
+    GPUUtilizationRule(),
 )
 
 
@@ -278,6 +302,7 @@ SYSTEM_ISSUE_PRIORITY = {
     "HIGH_HOST_MEMORY": 4,
     "HIGH_CPU": 5,
     "LOW_GPU_UTILIZATION": 6,
+    "MODERATE_GPU_UTILIZATION": 7,
 }
 
 
@@ -312,6 +337,7 @@ def run_system_rules(
 
 __all__ = [
     "DEFAULT_SYSTEM_RULES",
+    "GPUUtilizationRule",
     "HighCPURule",
     "HighGPUMemoryRule",
     "HighGPUPowerRule",

--- a/src/traceml_ai/diagnostics/system/rules.py
+++ b/src/traceml_ai/diagnostics/system/rules.py
@@ -65,7 +65,7 @@ class VeryHighGPUMemoryRule(_BaseSystemRule):
         gpu_idx = context.highest_mem_pressure_gpu_idx
         return self._issue(
             kind="VERY_HIGH_GPU_MEMORY",
-            status="VERY HIGH GPU MEMORY",
+            status="VERY HIGH GPU MEM",
             severity="crit",
             summary=(
                 "GPU memory was very high, peaking at "
@@ -97,7 +97,7 @@ class HighGPUMemoryRule(_BaseSystemRule):
         gpu_idx = context.highest_mem_pressure_gpu_idx
         return self._issue(
             kind="HIGH_GPU_MEMORY",
-            status="HIGH GPU MEMORY",
+            status="HIGH GPU MEM",
             severity="warn",
             summary=(
                 "GPU memory was high, peaking at "
@@ -129,7 +129,7 @@ class HighGPUTemperatureRule(_BaseSystemRule):
         gpu_idx = context.highest_temp_gpu_idx
         return self._issue(
             kind="HIGH_GPU_TEMPERATURE",
-            status="HIGH GPU TEMPERATURE",
+            status="HIGH GPU TEMP",
             severity="crit",
             summary=(
                 "GPU temperature was high, peaking at "
@@ -161,7 +161,7 @@ class HighGPUPowerRule(_BaseSystemRule):
         gpu_idx = context.highest_power_gpu_idx
         return self._issue(
             kind="HIGH_GPU_POWER",
-            status="HIGH GPU POWER",
+            status="HIGH GPU PWR",
             severity="warn",
             summary=(
                 "GPU power was high, averaging "
@@ -192,7 +192,7 @@ class HighHostMemoryRule(_BaseSystemRule):
 
         return self._issue(
             kind="HIGH_HOST_MEMORY",
-            status="HIGH HOST MEMORY",
+            status="HIGH RAM",
             severity="warn",
             summary=(
                 "Host RAM usage was high, peaking at "
@@ -238,7 +238,7 @@ class GPUUtilizationRule(_BaseSystemRule):
         self, context: SystemSummarySignals
     ) -> Optional[DiagnosticIssue]:
         pct = context.gpu_util_avg_percent
-        band = self.policy.gpu_util_avg_percent.classify(pct)
+        band = self.policy.gpu_utilization.classify(pct)
         if band not in {"low", "moderate"}:
             return None
 
@@ -246,13 +246,13 @@ class GPUUtilizationRule(_BaseSystemRule):
         gpu_idx = context.lowest_util_gpu_idx
         if band == "low":
             kind = "LOW_GPU_UTILIZATION"
-            status = "LOW GPU UTILIZATION"
+            status = "LOW GPU UTIL"
             summary = (
                 f"GPU utilization was low, averaging {_fmt_pct(pct_value)}."
             )
         else:
             kind = "MODERATE_GPU_UTILIZATION"
-            status = "MODERATE GPU UTILIZATION"
+            status = "MODERATE GPU UTIL"
             summary = (
                 "GPU utilization was moderate, averaging "
                 f"{_fmt_pct(pct_value)}."

--- a/src/traceml_ai/integrations/lightning.py
+++ b/src/traceml_ai/integrations/lightning.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import sys
 
@@ -23,16 +24,18 @@ except ImportError:
     IS_LIGHTNING_AVAILABLE = False
 
 TRACEML_DISABLED = os.environ.get("TRACEML_DISABLED") == "1"
+_MISSING = object()
 
 
 def init():
     """
     Initialize TraceML for PyTorch Lightning runs.
 
-    Lightning owns forward/backward/optimizer timing through TraceMLCallback.
-    The integration init enables DataLoader fetch timing plus the H2D Tensor.to
-    patch. The callback turns H2D timing on only around Lightning's batch
-    transfer hooks, so forward/backward timing stays callback-owned.
+    Lightning owns the training loop, so TraceMLCallback owns step boundaries,
+    flushing, and framework hook integration. The integration init enables
+    DataLoader fetch timing plus the H2D Tensor.to patch. The callback turns H2D
+    timing on only around Lightning's batch transfer hooks and wraps
+    LightningModule.forward directly for model-forward timing.
     """
     import traceml_ai as traceml
 
@@ -97,11 +100,14 @@ class TraceMLCallback(Callback):
             )
         super().__init__()
         self._traceml_step_ctx = None
-        self._forward_ctx = None
         self._backward_ctx = None
         self._optimizer_ctx = None
         self._batch_to_device_strategy = None
         self._original_batch_to_device = None
+        self._forward_module = None
+        self._original_forward = None
+        self._original_forward_attr = _MISSING
+        self._wrapped_forward = None
 
         self._mem_tracker = None
         self._opt_step_occurred = False
@@ -117,6 +123,44 @@ class TraceMLCallback(Callback):
         setattr(self, ctx_attr, None)
 
     def setup(self, trainer, pl_module, stage=None):
+        self._wrap_forward(trainer, pl_module)
+        self._wrap_batch_to_device(trainer, pl_module)
+
+    def _wrap_forward(self, trainer, pl_module) -> None:
+        if self._original_forward is not None:
+            return
+
+        original_forward = getattr(pl_module, "forward", None)
+        if not callable(original_forward):
+            return
+        original_forward_attr = getattr(pl_module, "__dict__", {}).get(
+            "forward", _MISSING
+        )
+
+        @functools.wraps(original_forward)
+        def wrapped_forward(*args, **kwargs):
+            if TRACEML_DISABLED or not getattr(trainer, "training", False):
+                return original_forward(*args, **kwargs)
+
+            with timed_region(
+                "_traceml_internal:forward_time",
+                scope=TimeScope.STEP,
+                use_gpu=True,
+            ):
+                return original_forward(*args, **kwargs)
+
+        try:
+            pl_module.forward = wrapped_forward
+        except Exception as e:
+            _log_lightning_error("forward wrap failed", e)
+            return
+
+        self._forward_module = pl_module
+        self._original_forward = original_forward
+        self._original_forward_attr = original_forward_attr
+        self._wrapped_forward = wrapped_forward
+
+    def _wrap_batch_to_device(self, trainer, pl_module) -> None:
         if self._original_batch_to_device is not None:
             return
 
@@ -146,6 +190,33 @@ class TraceMLCallback(Callback):
         self._original_batch_to_device = original
 
     def teardown(self, trainer, pl_module, stage=None):
+        self._restore_forward()
+        self._restore_batch_to_device()
+
+    def _restore_forward(self) -> None:
+        module = self._forward_module
+        original = self._original_forward
+        if module is None or original is None:
+            return
+
+        try:
+            current_forward_attr = getattr(module, "__dict__", {}).get(
+                "forward", _MISSING
+            )
+            if current_forward_attr is self._wrapped_forward:
+                if self._original_forward_attr is _MISSING:
+                    delattr(module, "forward")
+                else:
+                    module.forward = self._original_forward_attr
+        except Exception as e:
+            _log_lightning_error("forward restore failed", e)
+        finally:
+            self._forward_module = None
+            self._original_forward = None
+            self._original_forward_attr = _MISSING
+            self._wrapped_forward = None
+
+    def _restore_batch_to_device(self) -> None:
         strategy = self._batch_to_device_strategy
         original = self._original_batch_to_device
         if strategy is None or original is None:
@@ -180,18 +251,9 @@ class TraceMLCallback(Callback):
             _log_lightning_error("memory reset failed", e)
             self._mem_tracker = None
 
-        # Start timing the forward pass (ends in on_before_backward)
-        self._forward_ctx = timed_region(
-            "_traceml_internal:forward_time", scope="step"
-        )
-        self._forward_ctx.__enter__()
-
     def on_before_backward(self, trainer, pl_module, loss):
         if TRACEML_DISABLED:
             return
-        # End forward timing
-        self._close_context("_forward_ctx")
-
         # Start backward timing
         self._backward_ctx = timed_region(
             "_traceml_internal:backward_time", scope="step"
@@ -228,7 +290,6 @@ class TraceMLCallback(Callback):
             return
         # Safety: end any active context managers (edge cases)
         for ctx_attr in (
-            "_forward_ctx",
             "_backward_ctx",
             "_optimizer_ctx",
             "_traceml_step_ctx",

--- a/src/traceml_ai/reporting/compare/formatters.py
+++ b/src/traceml_ai/reporting/compare/formatters.py
@@ -21,6 +21,44 @@ from traceml_ai.utils.formatting import fmt_mem_new
 COMPARE_WIDTH = 88
 COMPARE_INNER_WIDTH = COMPARE_WIDTH - 4
 
+TEXT_METRIC_ORDER_BY_SECTION: Dict[str, tuple[str, ...]] = {
+    "step_time": (
+        "total_step_ms",
+        "input_ms",
+        "h2d_ms",
+        "compute_ms",
+        "wait_ms",
+    ),
+    "step_memory": (
+        "peak_reserved_bytes",
+        "memory_skew_pct",
+    ),
+    "process": (
+        "cpu_avg_percent",
+        "rss_avg_gb",
+    ),
+    "system": (
+        "cpu_avg_percent",
+        "ram_avg_gb",
+        "gpu_util_avg_percent",
+        "gpu_memory_avg_percent",
+    ),
+}
+
+DIAGNOSIS_LABEL_BY_SECTION: Dict[str, str] = {
+    "step_time": "Step time diagnosis",
+    "step_memory": "Step memory diagnosis",
+    "process": "Process diagnosis",
+    "system": "System diagnosis",
+}
+
+SECTION_TITLE_BY_SECTION: Dict[str, str] = {
+    "step_time": "Step Time",
+    "step_memory": "Step Memory",
+    "process": "Process",
+    "system": "System",
+}
+
 
 def _as_float(value: Any) -> Optional[float]:
     try:
@@ -109,41 +147,14 @@ def _rows_for_section(
     section_name: str,
     section: Dict[str, Any],
 ) -> list[tuple[str, str, str, str]]:
-    metric_order = {
-        "step_time": (
-            "total_step_ms",
-            "input_ms",
-            "h2d_ms",
-            "compute_ms",
-            "wait_ms",
-            "forward_ms",
-            "backward_ms",
-            "optimizer_ms",
-        ),
-        "step_memory": (
-            "peak_reserved_bytes",
-            "memory_skew_pct",
-        ),
-        "process": (
-            "cpu_avg_percent",
-            "rss_avg_gb",
-        ),
-        "system": (
-            "cpu_avg_percent",
-            "ram_avg_gb",
-            "gpu_util_avg_percent",
-            "gpu_memory_avg_percent",
-        ),
-    }
-    diagnosis_labels = {
-        "step_time": "Step time diagnosis",
-        "step_memory": "Step memory diagnosis",
-        "process": "Process diagnosis",
-        "system": "System diagnosis",
-    }
-    rows = [_diagnosis_row(diagnosis_labels[section_name], section)]
+    rows = [
+        _diagnosis_row(
+            DIAGNOSIS_LABEL_BY_SECTION.get(section_name, "Diagnosis"),
+            section,
+        )
+    ]
     metrics = section.get("metrics", {})
-    for key in metric_order[section_name]:
+    for key in TEXT_METRIC_ORDER_BY_SECTION.get(section_name, ()):
         metric = metrics.get(key)
         if isinstance(metric, dict) and _has_signal(metric):
             rows.append(_metric_row(metric))
@@ -151,12 +162,10 @@ def _rows_for_section(
 
 
 def _section_title(section_name: str) -> str:
-    return {
-        "step_time": "Step Time",
-        "step_memory": "Step Memory",
-        "process": "Process",
-        "system": "System",
-    }[section_name]
+    return SECTION_TITLE_BY_SECTION.get(
+        section_name,
+        section_name.replace("_", " ").title(),
+    )
 
 
 def _format_table_rows(rows: Iterable[tuple[str, str, str, str]]) -> list[str]:

--- a/src/traceml_ai/reporting/compare/formatters.py
+++ b/src/traceml_ai/reporting/compare/formatters.py
@@ -170,7 +170,7 @@ def _section_title(section_name: str) -> str:
 
 def _format_table_rows(rows: Iterable[tuple[str, str, str, str]]) -> list[str]:
     rows = list(rows)
-    widths = [30, 16, 16, 17]
+    widths = [28, 17, 17, 17]
     out = [
         f"{'Metric':<{widths[0]}} "
         f"{'A':<{widths[1]}} "

--- a/src/traceml_ai/reporting/sections/system/loader.py
+++ b/src/traceml_ai/reporting/sections/system/loader.py
@@ -51,6 +51,12 @@ class _SampleRow:
     ram_total_bytes: Optional[float]
     gpu_available: Optional[bool]
     gpu_count: Optional[int]
+
+
+@dataclass(frozen=True)
+class _SampleGpuRollup:
+    """Per-system-sample GPU rollup derived from raw GPU rows."""
+
     gpu_util_avg: Optional[float]
     gpu_util_peak: Optional[float]
     gpu_mem_used_avg_bytes: Optional[float]
@@ -75,6 +81,13 @@ class _GpuRow:
     power_limit_w: Optional[float]
 
 
+_SampleKey = tuple[Optional[int], Optional[int], Optional[int]]
+
+
+def _sample_key(row: _SampleRow | _GpuRow) -> _SampleKey:
+    return (row.global_rank, row.node_rank, row.seq)
+
+
 def _node_label(row: _SampleRow) -> str:
     if row.node_rank is not None:
         return str(int(row.node_rank))
@@ -94,7 +107,44 @@ def _node_identity(rows: list[_SampleRow]) -> SystemNodeIdentity:
     )
 
 
-def _aggregate_samples(rows: list[_SampleRow]) -> SystemSummaryAgg:
+def _aggregate_sample_gpu_rows(rows: list[_GpuRow]) -> _SampleGpuRollup:
+    return _SampleGpuRollup(
+        gpu_util_avg=average_optional(row.util for row in rows),
+        gpu_util_peak=max_optional(row.util for row in rows),
+        gpu_mem_used_avg_bytes=average_optional(
+            row.mem_used_bytes for row in rows
+        ),
+        gpu_mem_used_peak_bytes=max_optional(
+            row.mem_used_bytes for row in rows
+        ),
+        gpu_temp_avg_c=average_optional(row.temperature_c for row in rows),
+        gpu_temp_peak_c=max_optional(row.temperature_c for row in rows),
+        gpu_power_avg_w=average_optional(row.power_usage_w for row in rows),
+        gpu_power_peak_w=max_optional(row.power_usage_w for row in rows),
+    )
+
+
+def _gpu_rollups_by_sample(
+    rows: list[_GpuRow],
+) -> Dict[_SampleKey, _SampleGpuRollup]:
+    grouped: Dict[_SampleKey, list[_GpuRow]] = {}
+    for row in rows:
+        grouped.setdefault(_sample_key(row), []).append(row)
+    return {
+        key: _aggregate_sample_gpu_rows(gpu_rows)
+        for key, gpu_rows in grouped.items()
+    }
+
+
+def _aggregate_samples(
+    rows: list[_SampleRow],
+    gpu_rollups_by_key: Dict[_SampleKey, _SampleGpuRollup],
+) -> SystemSummaryAgg:
+    gpu_rollups = [
+        gpu_rollups_by_key[_sample_key(row)]
+        for row in rows
+        if _sample_key(row) in gpu_rollups_by_key
+    ]
     return SystemSummaryAgg(
         first_ts=min_timestamp(row.sample_ts_s for row in rows),
         last_ts=max_optional(row.sample_ts_s for row in rows),
@@ -109,19 +159,29 @@ def _aggregate_samples(rows: list[_SampleRow]) -> SystemSummaryAgg:
         ),
         gpu_count=max_int_optional(row.gpu_count for row in rows),
         gpu_util_avg_percent=average_optional(
-            row.gpu_util_avg for row in rows
+            rollup.gpu_util_avg for rollup in gpu_rollups
         ),
-        gpu_util_peak_percent=max_optional(row.gpu_util_peak for row in rows),
+        gpu_util_peak_percent=max_optional(
+            rollup.gpu_util_peak for rollup in gpu_rollups
+        ),
         gpu_mem_avg_bytes=average_optional(
-            row.gpu_mem_used_avg_bytes for row in rows
+            rollup.gpu_mem_used_avg_bytes for rollup in gpu_rollups
         ),
         gpu_mem_peak_bytes=max_optional(
-            row.gpu_mem_used_peak_bytes for row in rows
+            rollup.gpu_mem_used_peak_bytes for rollup in gpu_rollups
         ),
-        gpu_temp_avg_c=average_optional(row.gpu_temp_avg_c for row in rows),
-        gpu_temp_peak_c=max_optional(row.gpu_temp_peak_c for row in rows),
-        gpu_power_avg_w=average_optional(row.gpu_power_avg_w for row in rows),
-        gpu_power_peak_w=max_optional(row.gpu_power_peak_w for row in rows),
+        gpu_temp_avg_c=average_optional(
+            rollup.gpu_temp_avg_c for rollup in gpu_rollups
+        ),
+        gpu_temp_peak_c=max_optional(
+            rollup.gpu_temp_peak_c for rollup in gpu_rollups
+        ),
+        gpu_power_avg_w=average_optional(
+            rollup.gpu_power_avg_w for rollup in gpu_rollups
+        ),
+        gpu_power_peak_w=max_optional(
+            rollup.gpu_power_peak_w for rollup in gpu_rollups
+        ),
     )
 
 
@@ -211,10 +271,7 @@ def _sample_rows(
         + """
         SELECT global_rank, local_rank, world_size, local_world_size,
                node_rank, hostname, sample_ts_s, seq, cpu_percent,
-               ram_used_bytes, ram_total_bytes, gpu_available, gpu_count,
-               gpu_util_avg, gpu_util_peak, gpu_mem_used_avg_bytes,
-               gpu_mem_used_peak_bytes, gpu_temp_avg_c, gpu_temp_peak_c,
-               gpu_power_avg_w, gpu_power_peak_w
+               ram_used_bytes, ram_total_bytes, gpu_available, gpu_count
         FROM recent_system_samples
         ORDER BY COALESCE(node_rank, global_rank, 0) ASC, id ASC;
         """,
@@ -235,14 +292,6 @@ def _sample_rows(
             ram_total_bytes=row[10],
             gpu_available=bool(row[11]) if row[11] is not None else None,
             gpu_count=row[12],
-            gpu_util_avg=row[13],
-            gpu_util_peak=row[14],
-            gpu_mem_used_avg_bytes=row[15],
-            gpu_mem_used_peak_bytes=row[16],
-            gpu_temp_avg_c=row[17],
-            gpu_temp_peak_c=row[18],
-            gpu_power_avg_w=row[19],
-            gpu_power_peak_w=row[20],
         )
         for row in rows
     ]
@@ -317,15 +366,12 @@ def _load_cluster_summary(
         max_system_rows=max_system_rows,
     )
 
-    # Index GPU rows by the sample identity they were emitted with.
-    gpu_by_key: Dict[
-        tuple[Optional[int], Optional[int], Optional[int]],
-        list[_GpuRow],
-    ] = {}
-
+    # GPU summary fields are derived from raw GPU rows at read time so the
+    # storage projection does not duplicate per-sample aggregates.
+    gpu_by_key: Dict[_SampleKey, list[_GpuRow]] = {}
     for row in gpus:
-        key = (row.global_rank, row.node_rank, row.seq)
-        gpu_by_key.setdefault(key, []).append(row)
+        gpu_by_key.setdefault(_sample_key(row), []).append(row)
+    gpu_rollups_by_key = _gpu_rollups_by_sample(gpus)
 
     # Group system samples by node so each node gets its own rollup.
     sample_groups: Dict[str, list[_SampleRow]] = {}
@@ -338,22 +384,17 @@ def _load_cluster_summary(
         # Collect GPU rows that match this node's retained system samples.
         node_gpu_rows: list[_GpuRow] = []
         for row in node_rows:
-            node_gpu_rows.extend(
-                gpu_by_key.get(
-                    (row.global_rank, row.node_rank, row.seq),
-                    [],
-                )
-            )
+            node_gpu_rows.extend(gpu_by_key.get(_sample_key(row), []))
         # Store the final per-node identity, system rollup, and GPU rollup.
         nodes[label] = SystemNodeSummary(
             identity=_node_identity(node_rows),
-            aggregate=_aggregate_samples(node_rows),
+            aggregate=_aggregate_samples(node_rows, gpu_rollups_by_key),
             per_gpu=_aggregate_gpu(node_gpu_rows),
         )
 
     # Return the cluster-level rollup plus the per-node summaries.
     return SystemClusterSummary(
-        aggregate=_aggregate_samples(samples),
+        aggregate=_aggregate_samples(samples, gpu_rollups_by_key),
         nodes=nodes,
         expected_nodes=_expected_nodes(samples),
     )

--- a/src/traceml_ai/reporting/sections/system/model.py
+++ b/src/traceml_ai/reporting/sections/system/model.py
@@ -50,12 +50,14 @@ def percent(
 @dataclass
 class SystemSummaryAgg:
     """
-    Aggregated system metrics loaded from `system_samples`.
+    Aggregated system metrics loaded from system projection tables.
 
     Notes
     -----
     - Memory values remain in raw bytes while aggregating and are converted
       only at formatting / serialization time.
+    - Node-level CPU/RAM fields come from `system_samples`; GPU rollups are
+      derived from raw `system_gpu_samples` rows.
     - GPU fields are optional because CPU-only runs are fully supported.
     """
 

--- a/src/traceml_ai/runtime/executor.py
+++ b/src/traceml_ai/runtime/executor.py
@@ -236,13 +236,14 @@ def extract_script_args() -> list[str]:
         traceml run train.py --args --epochs 10 --lr 1e-3
 
     Everything after '--' is forwarded to the target script.
-    If '--' is absent, no extra script arguments are forwarded.
+    If torchrun strips the separator before this executor sees argv, all
+    remaining executor argv entries are user script arguments.
     """
     try:
         separator_index = sys.argv.index("--")
         return sys.argv[separator_index + 1 :]
     except ValueError:
-        return []
+        return sys.argv[1:]
 
 
 def build_runtime_settings(cfg: Dict[str, Any]) -> TraceMLSettings:

--- a/src/traceml_ai/telemetry/__init__.py
+++ b/src/traceml_ai/telemetry/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared telemetry transport contracts."""
+
+from traceml_ai.telemetry.envelope import (
+    TelemetryEnvelope,
+    TelemetryMeta,
+    build_telemetry_envelope,
+    normalize_telemetry_envelope,
+)
+
+__all__ = [
+    "TelemetryEnvelope",
+    "TelemetryMeta",
+    "build_telemetry_envelope",
+    "normalize_telemetry_envelope",
+]

--- a/src/traceml_ai/telemetry/envelope.py
+++ b/src/traceml_ai/telemetry/envelope.py
@@ -1,0 +1,166 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical telemetry envelope shared by runtime and aggregator code."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+def _optional_int(value: Any) -> Optional[int]:
+    try:
+        return int(value) if value is not None else None
+    except Exception:
+        return None
+
+
+def _optional_float(value: Any) -> Optional[float]:
+    try:
+        return float(value) if value is not None else None
+    except Exception:
+        return None
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    try:
+        return str(value)
+    except Exception:
+        return None
+
+
+@dataclass(frozen=True)
+class TelemetryMeta:
+    """Stable metadata carried once per sampler payload."""
+
+    rank: Optional[int]
+    global_rank: Optional[int]
+    local_rank: Optional[int]
+    world_size: Optional[int]
+    local_world_size: Optional[int]
+    node_rank: Optional[int]
+    hostname: Optional[str]
+    pid: Optional[int]
+    sampler: Optional[str]
+    timestamp: Optional[float]
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "TelemetryMeta":
+        """Create metadata from a transport mapping using best-effort coercion."""
+        global_rank = _optional_int(data.get("global_rank"))
+        rank = global_rank
+        if rank is None:
+            rank = _optional_int(data.get("rank"))
+
+        return cls(
+            rank=rank,
+            global_rank=global_rank,
+            local_rank=_optional_int(data.get("local_rank")),
+            world_size=_optional_int(data.get("world_size")),
+            local_world_size=_optional_int(data.get("local_world_size")),
+            node_rank=_optional_int(data.get("node_rank")),
+            hostname=_optional_str(data.get("hostname")),
+            pid=_optional_int(data.get("pid")),
+            sampler=_optional_str(data.get("sampler")),
+            timestamp=_optional_float(data.get("timestamp")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a MessagePack/JSON-friendly metadata dictionary."""
+        return {
+            "rank": self.rank,
+            "global_rank": self.global_rank,
+            "local_rank": self.local_rank,
+            "world_size": self.world_size,
+            "local_world_size": self.local_world_size,
+            "node_rank": self.node_rank,
+            "hostname": self.hostname,
+            "pid": self.pid,
+            "sampler": self.sampler,
+            "timestamp": self.timestamp,
+        }
+
+
+@dataclass(frozen=True)
+class TelemetryEnvelope:
+    """
+    Canonical sampler payload.
+
+    `meta` contains fields shared by every row in the payload. `body.tables`
+    contains the sampler-owned append-only rows grouped by table name.
+    """
+
+    meta: TelemetryMeta
+    body: Mapping[str, Any]
+
+    @property
+    def tables(self) -> Mapping[str, Any]:
+        """Return the body table mapping, or an empty mapping if malformed."""
+        tables = (
+            self.body.get("tables") if isinstance(self.body, Mapping) else None
+        )
+        return tables if isinstance(tables, Mapping) else {}
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical wire dictionary."""
+        return {
+            "meta": self.meta.to_dict(),
+            "body": {"tables": dict(self.tables)},
+        }
+
+
+def build_telemetry_envelope(
+    *,
+    identity: Any,
+    sampler_name: str,
+    tables: Mapping[str, Any],
+    timestamp: Optional[float] = None,
+) -> dict[str, Any]:
+    """Build the canonical wire payload emitted by runtime sampler senders."""
+    fields = dict(identity.to_payload_fields())
+    fields["sampler"] = str(sampler_name)
+    fields["timestamp"] = (
+        time.time() if timestamp is None else float(timestamp)
+    )
+    return TelemetryEnvelope(
+        meta=TelemetryMeta.from_mapping(fields),
+        body={"tables": dict(tables)},
+    ).to_dict()
+
+
+def normalize_telemetry_envelope(raw: Any) -> Optional[TelemetryEnvelope]:
+    """
+    Normalize one decoded telemetry payload.
+
+    The canonical shape is `{"meta": {...}, "body": {"tables": {...}}}`.
+    A temporary flat-envelope fallback remains for direct tests or external
+    clients that still send the old shape during the transport migration.
+    TODO: remove flat-envelope normalization after all direct callers emit
+    canonical envelopes.
+    """
+    if not isinstance(raw, Mapping):
+        return None
+
+    meta_raw = raw.get("meta")
+    body_raw = raw.get("body")
+    if isinstance(meta_raw, Mapping) and isinstance(body_raw, Mapping):
+        return TelemetryEnvelope(
+            meta=TelemetryMeta.from_mapping(meta_raw),
+            body=body_raw,
+        )
+
+    tables = raw.get("tables")
+    if isinstance(tables, Mapping):
+        return TelemetryEnvelope(
+            meta=TelemetryMeta.from_mapping(raw),
+            body={"tables": tables},
+        )
+
+    return None

--- a/tests/diagnostics/test_common.py
+++ b/tests/diagnostics/test_common.py
@@ -77,7 +77,7 @@ def test_diagnostic_result_moves_matching_primary_issue_to_front() -> None:
     )
     secondary_issue = DiagnosticIssue(
         kind="LOW_GPU_UTILIZATION",
-        status="LOW GPU UTILIZATION",
+        status="LOW GPU UTIL",
         severity="info",
         summary="GPU utilization is low.",
         action="Inspect timing.",
@@ -105,7 +105,7 @@ def test_diagnosis_to_issue_preserves_structured_evidence() -> None:
 def test_ensure_primary_issue_prepends_primary_when_missing() -> None:
     secondary_issue = DiagnosticIssue(
         kind="LOW_GPU_UTILIZATION",
-        status="LOW GPU UTILIZATION",
+        status="LOW GPU UTIL",
         severity="info",
         summary="GPU utilization is low.",
         action="Inspect timing.",

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -274,10 +274,37 @@ def test_compute_straggler_uses_typical_step_and_phase_blame() -> None:
     assert issue.ranks == (2,)
     assert ctx.typical_step_total == pytest.approx(167.3)
     assert ctx.compute_phase_excess_total == pytest.approx(24.0)
+    assert ctx.compute_excess_ms == pytest.approx(24.0)
+    assert ctx.dataloader_excess_ms == pytest.approx(0.0)
     assert issue.score == pytest.approx(24.0 / 167.3)
 
 
-def test_step_time_primary_selection_combines_stragglers() -> None:
+def test_step_time_primary_selection_input_explains_mixed_straggler() -> None:
+    result = build_step_diagnosis_result(
+        [
+            _time_metric("step_time", median=240.0, worst=330.0),
+            _time_metric(
+                "dataloader_fetch", median=10.0, worst=110.0, skew=0.2
+            ),
+            _time_metric("forward", median=40.0, worst=90.0, skew=0.2),
+            _time_metric("backward", median=130.0, worst=160.0, skew=0.15),
+            _time_metric("optimizer_step", median=20.0, worst=20.0),
+            _time_metric("wait_proxy", median=40.0, worst=40.0),
+        ]
+    )
+
+    assert result.primary.kind == "INPUT_STRAGGLER"
+    assert result.primary.worst_rank == 1
+    assert result.primary.note is not None
+    assert "downstream synchronization" in result.primary.note
+    assert {issue.kind for issue in result.issues} >= {
+        "INPUT_STRAGGLER",
+        "COMPUTE_STRAGGLER",
+        "STRAGGLER",
+    }
+
+
+def test_step_time_primary_selection_keeps_unexplained_mixed() -> None:
     result = build_step_diagnosis_result(
         [
             _time_metric("step_time", median=240.0, worst=330.0),
@@ -307,6 +334,10 @@ def test_step_time_live_and_summary_policies_are_explicit() -> None:
     assert (
         SUMMARY_STEP_TIME_POLICY.thresholds.wait_share_warn
         > LIVE_STEP_TIME_POLICY.thresholds.wait_share_warn
+    )
+    assert (
+        SUMMARY_STEP_TIME_POLICY.thresholds.input_straggler_compute_excess_tolerance
+        == pytest.approx(1.5)
     )
     assert (
         SUMMARY_STEP_TIME_POLICY.min_steps_for_diag

--- a/tests/diagnostics/test_system.py
+++ b/tests/diagnostics/test_system.py
@@ -238,10 +238,10 @@ def test_system_primary_diagnosis_for_each_issue(
 @pytest.mark.parametrize(
     ("gpu_util", "expected_kind", "expected_status"),
     [
-        (29.999, "LOW_GPU_UTILIZATION", "LOW GPU UTILIZATION"),
-        (30.0, "MODERATE_GPU_UTILIZATION", "MODERATE GPU UTILIZATION"),
-        (37.8, "MODERATE_GPU_UTILIZATION", "MODERATE GPU UTILIZATION"),
-        (70.0, "MODERATE_GPU_UTILIZATION", "MODERATE GPU UTILIZATION"),
+        (29.999, "LOW_GPU_UTILIZATION", "LOW GPU UTIL"),
+        (30.0, "MODERATE_GPU_UTILIZATION", "MODERATE GPU UTIL"),
+        (37.8, "MODERATE_GPU_UTILIZATION", "MODERATE GPU UTIL"),
+        (70.0, "MODERATE_GPU_UTILIZATION", "MODERATE GPU UTIL"),
         (70.001, "NORMAL", "NORMAL"),
         (None, "NORMAL", "NORMAL"),
     ],

--- a/tests/diagnostics/test_system.py
+++ b/tests/diagnostics/test_system.py
@@ -16,6 +16,7 @@ from traceml_ai.diagnostics.system.context import (
     build_system_summary_signals,
 )
 from traceml_ai.diagnostics.system.rules import (
+    GPUUtilizationRule,
     HighCPURule,
     HighGPUMemoryRule,
     HighGPUPowerRule,
@@ -28,7 +29,7 @@ from traceml_ai.diagnostics.system.rules import (
 
 def _per_gpu(
     *,
-    util: float = 70.0,
+    util: float | None = 80.0,
     mem_peak: float = 200.0,
     mem_total: float = 1000.0,
     temp_peak: float | None = None,
@@ -60,7 +61,7 @@ def _node_input(**overrides) -> SystemNodeDiagnosisInput:
         ram_total_bytes=1000.0,
         gpu_available=True,
         gpu_count=1,
-        gpu_util_avg_percent=70.0,
+        gpu_util_avg_percent=80.0,
         gpu_util_peak_percent=90.0,
         gpu_mem_avg_bytes=100.0,
         gpu_mem_peak_bytes=200.0,
@@ -103,16 +104,28 @@ def _signals(**overrides):
     return build_system_summary_signals(_node_input(**overrides))
 
 
+def test_low_gpu_utilization_rule_alias_keeps_legacy_import() -> None:
+    assert LowGPUUtilizationRule is GPUUtilizationRule
+
+
 @pytest.mark.parametrize(
     ("rule", "overrides", "expected_kind"),
     [
         (
-            LowGPUUtilizationRule(),
+            GPUUtilizationRule(),
             {
                 "gpu_util_avg_percent": 10.0,
                 "per_gpu": _per_gpu(util=10.0),
             },
             "LOW_GPU_UTILIZATION",
+        ),
+        (
+            GPUUtilizationRule(),
+            {
+                "gpu_util_avg_percent": 37.8,
+                "per_gpu": _per_gpu(util=37.8),
+            },
+            "MODERATE_GPU_UTILIZATION",
         ),
         (
             HighCPURule(),
@@ -163,7 +176,7 @@ def test_system_rules_trigger_one_condition(
 @pytest.mark.parametrize(
     ("rule", "overrides"),
     [
-        (LowGPUUtilizationRule(), {"gpu_util_avg_percent": 60.0}),
+        (GPUUtilizationRule(), {"gpu_util_avg_percent": 70.001}),
         (HighCPURule(), {"cpu_avg_percent": 50.0}),
         (HighHostMemoryRule(), {"ram_peak_bytes": 500.0}),
         (HighGPUMemoryRule(), {"per_gpu": _per_gpu(mem_peak=500.0)}),
@@ -204,6 +217,13 @@ def test_system_rules_do_not_trigger_normal_condition(rule, overrides) -> None:
             },
             "LOW_GPU_UTILIZATION",
         ),
+        (
+            {
+                "gpu_util_avg_percent": 37.8,
+                "per_gpu": _per_gpu(util=37.8),
+            },
+            "MODERATE_GPU_UTILIZATION",
+        ),
     ],
 )
 def test_system_primary_diagnosis_for_each_issue(
@@ -213,6 +233,33 @@ def test_system_primary_diagnosis_for_each_issue(
     result = _diagnose(**overrides)
 
     assert result.primary.kind == expected_primary
+
+
+@pytest.mark.parametrize(
+    ("gpu_util", "expected_kind", "expected_status"),
+    [
+        (29.999, "LOW_GPU_UTILIZATION", "LOW GPU UTILIZATION"),
+        (30.0, "MODERATE_GPU_UTILIZATION", "MODERATE GPU UTILIZATION"),
+        (37.8, "MODERATE_GPU_UTILIZATION", "MODERATE GPU UTILIZATION"),
+        (70.0, "MODERATE_GPU_UTILIZATION", "MODERATE GPU UTILIZATION"),
+        (70.001, "NORMAL", "NORMAL"),
+        (None, "NORMAL", "NORMAL"),
+    ],
+)
+def test_system_gpu_utilization_boundaries(
+    gpu_util,
+    expected_kind,
+    expected_status,
+) -> None:
+    result = _diagnose(
+        gpu_util_avg_percent=gpu_util,
+        gpu_util_peak_percent=gpu_util,
+        per_gpu=_per_gpu(util=gpu_util),
+    )
+
+    assert result.primary.kind == expected_kind
+    assert result.primary.status == expected_status
+    assert result.issues[0].kind == expected_kind
 
 
 def test_system_primary_priority_when_everything_triggers() -> None:
@@ -238,6 +285,20 @@ def test_system_primary_priority_when_everything_triggers() -> None:
         "HIGH_HOST_MEMORY",
         "HIGH_CPU",
         "LOW_GPU_UTILIZATION",
+    ]
+
+
+def test_system_pressure_issues_rank_before_utilization_symptoms() -> None:
+    result = _diagnose(
+        cpu_avg_percent=95.0,
+        gpu_util_avg_percent=37.8,
+        per_gpu=_per_gpu(util=37.8),
+    )
+
+    assert result.primary.kind == "HIGH_CPU"
+    assert [issue.kind for issue in result.issues] == [
+        "HIGH_CPU",
+        "MODERATE_GPU_UTILIZATION",
     ]
 
 

--- a/tests/reporting/compare/test_compare.py
+++ b/tests/reporting/compare/test_compare.py
@@ -441,6 +441,32 @@ def test_compare_payload_has_section_based_json_and_table_text() -> None:
     assert "+2.70 GB (+43.5%)" in text
 
 
+def test_compare_shows_system_gpu_utilization_diagnosis_change() -> None:
+    lhs = _payload_with_sections()
+    rhs = _payload_with_sections()
+    lhs["system"]["diagnosis"] = {"status": "NORMAL"}
+    rhs["system"]["diagnosis"] = {"status": "MODERATE GPU UTILIZATION"}
+    lhs["system"]["global"]["average"]["gpu_util_percent"] = 86.9
+    rhs["system"]["global"]["average"]["gpu_util_percent"] = 37.8
+
+    compare_payload = _build_compare(lhs, rhs)
+    system = compare_payload["sections"]["system"]
+    text = build_compare_text(compare_payload)
+
+    assert system["diagnosis"] == {
+        "lhs": "NORMAL",
+        "rhs": "MODERATE GPU UTILIZATION",
+        "changed": True,
+    }
+    assert (
+        round(system["metrics"]["gpu_util_avg_percent"]["delta"], 1) == -49.1
+    )
+    assert "System diagnosis" in text
+    assert "MODERATE GPU UTILIZATION" in text
+    assert "GPU util avg" in text
+    assert "-49.1 pp" in text
+
+
 def test_compare_verdict_uses_priority_for_mixed_primary_signals() -> None:
     lhs = _payload_with_sections(
         step_time=_step_time_section(total_step_ms=700.0),

--- a/tests/reporting/compare/test_compare.py
+++ b/tests/reporting/compare/test_compare.py
@@ -39,6 +39,7 @@ def _step_time_section(
     reason: str = "No clear timing issue.",
     action: str = "Keep monitoring.",
     total_step_ms: float = 300.0,
+    h2d_ms: Optional[float] = None,
     wait_ms: Optional[float] = None,
     split_ms: Optional[dict] = None,
 ) -> dict:
@@ -50,27 +51,34 @@ def _step_time_section(
     }
     compute_ms = splits["forward"] + splits["backward"] + splits["optimizer"]
     resolved_wait_ms = (
-        max(0.0, total_step_ms - splits["dataloader"] - compute_ms)
+        max(
+            0.0,
+            total_step_ms
+            - splits["dataloader"]
+            - float(h2d_ms or 0.0)
+            - compute_ms,
+        )
         if wait_ms is None
         else wait_ms
     )
+    average = {
+        "total_step_ms": total_step_ms,
+        "dataloader_ms": splits["dataloader"],
+        "compute_ms": compute_ms,
+        "wait_ms": resolved_wait_ms,
+        "forward_ms": splits["forward"],
+        "backward_ms": splits["backward"],
+        "optimizer_ms": splits["optimizer"],
+    }
+    if h2d_ms is not None:
+        average["h2d_ms"] = h2d_ms
     return {
         "diagnosis": {
             "status": status,
             "reason": reason,
             "action": action,
         },
-        "global": {
-            "average": {
-                "total_step_ms": total_step_ms,
-                "dataloader_ms": splits["dataloader"],
-                "compute_ms": compute_ms,
-                "wait_ms": resolved_wait_ms,
-                "forward_ms": splits["forward"],
-                "backward_ms": splits["backward"],
-                "optimizer_ms": splits["optimizer"],
-            }
-        },
+        "global": {"average": average},
     }
 
 
@@ -366,6 +374,7 @@ def test_compare_payload_has_section_based_json_and_table_text() -> None:
         step_time=_step_time_section(
             status="COMPUTE-BOUND",
             total_step_ms=621.1,
+            h2d_ms=2.0,
             split_ms={
                 "dataloader": 1.3,
                 "forward": 228.4,
@@ -383,6 +392,7 @@ def test_compare_payload_has_section_based_json_and_table_text() -> None:
         step_time=_step_time_section(
             status="COMPUTE-BOUND",
             total_step_ms=735.2,
+            h2d_ms=2.4,
             split_ms={
                 "dataloader": 1.9,
                 "forward": 300.0,
@@ -407,19 +417,23 @@ def test_compare_payload_has_section_based_json_and_table_text() -> None:
         "process",
         "system",
     }
-    assert (
-        compare_payload["sections"]["step_time"]["metrics"]["total_step_ms"][
-            "pct_change"
-        ]
-        == compare_payload["sections"]["step_time"]["metrics"][
-            "total_step_ms"
-        ]["pct_change"]
-    )
+    step_time_metrics = compare_payload["sections"]["step_time"]["metrics"]
+    assert step_time_metrics["total_step_ms"]["pct_change"] is not None
+    assert "forward_ms" in step_time_metrics
+    assert "backward_ms" in step_time_metrics
+    assert "optimizer_ms" in step_time_metrics
     assert compare_payload["verdict"]["status"] == "REGRESSION"
     assert compare_payload["verdict"]["primary_domain"] == "step_time"
     assert "Metric" in text
     assert "Step time diagnosis" in text
     assert "Total step" in text
+    assert "Input" in text
+    assert "H2D" in text
+    assert "Compute" in text
+    assert "Wait" in text
+    assert "Forward" not in text
+    assert "Backward" not in text
+    assert "Optimizer" not in text
     assert "621.1 ms" in text
     assert "735.2 ms" in text
     assert "+114.1 ms (+18.4%)" in text

--- a/tests/reporting/compare/test_compare.py
+++ b/tests/reporting/compare/test_compare.py
@@ -445,7 +445,7 @@ def test_compare_shows_system_gpu_utilization_diagnosis_change() -> None:
     lhs = _payload_with_sections()
     rhs = _payload_with_sections()
     lhs["system"]["diagnosis"] = {"status": "NORMAL"}
-    rhs["system"]["diagnosis"] = {"status": "MODERATE GPU UTILIZATION"}
+    rhs["system"]["diagnosis"] = {"status": "MODERATE GPU UTIL"}
     lhs["system"]["global"]["average"]["gpu_util_percent"] = 86.9
     rhs["system"]["global"]["average"]["gpu_util_percent"] = 37.8
 
@@ -455,14 +455,14 @@ def test_compare_shows_system_gpu_utilization_diagnosis_change() -> None:
 
     assert system["diagnosis"] == {
         "lhs": "NORMAL",
-        "rhs": "MODERATE GPU UTILIZATION",
+        "rhs": "MODERATE GPU UTIL",
         "changed": True,
     }
     assert (
         round(system["metrics"]["gpu_util_avg_percent"]["delta"], 1) == -49.1
     )
     assert "System diagnosis" in text
-    assert "MODERATE GPU UTILIZATION" in text
+    assert "MODERATE GPU UTIL" in text
     assert "GPU util avg" in text
     assert "-49.1 pp" in text
 

--- a/tests/reporting/summary/test_fixtures.py
+++ b/tests/reporting/summary/test_fixtures.py
@@ -294,17 +294,9 @@ def _insert_system_sample(
             ram_used_bytes,
             ram_total_bytes,
             gpu_available,
-            gpu_count,
-            gpu_util_avg,
-            gpu_util_peak,
-            gpu_mem_used_avg_bytes,
-            gpu_mem_used_peak_bytes,
-            gpu_temp_avg_c,
-            gpu_temp_peak_c,
-            gpu_power_avg_w,
-            gpu_power_peak_w
+            gpu_count
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
         """,
         (
             row_id,
@@ -321,14 +313,6 @@ def _insert_system_sample(
             16_000.0,
             int(gpu_available),
             gpu_count,
-            gpu_util,
-            gpu_util,
-            2_000.0 if gpu_available else None,
-            2_500.0 if gpu_available else None,
-            None,
-            None,
-            None,
-            None,
         ),
     )
     if gpu_available and gpu_count > 0:

--- a/tests/reporting/summary/test_fixtures.py
+++ b/tests/reporting/summary/test_fixtures.py
@@ -472,13 +472,12 @@ def _insert_step_time_sample(
             local_world_size,
             node_rank,
             hostname,
-            runtime_pid,
             sample_ts_s,
             seq,
             step,
             events_json
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
         """,
         (
             row_id,
@@ -489,7 +488,6 @@ def _insert_step_time_sample(
             1,
             rank,
             f"worker-{rank}",
-            10_000 + rank,
             float(step),
             row_id,
             step,
@@ -529,13 +527,12 @@ def _insert_step_memory_sample(
             hostname,
             sample_ts_s,
             seq,
-            model_id,
             device,
             step,
             peak_alloc_bytes,
             peak_reserved_bytes
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
         """,
         (
             row_id,
@@ -548,7 +545,6 @@ def _insert_step_memory_sample(
             f"worker-{rank}",
             float(step),
             row_id,
-            1,
             device,
             step,
             alloc,

--- a/tests/reporting/summary/test_step_memory.py
+++ b/tests/reporting/summary/test_step_memory.py
@@ -33,7 +33,6 @@ def _create_step_memory_db(path: str) -> None:
                 hostname             TEXT,
                 sample_ts_s          REAL,
                 seq                  INTEGER,
-                model_id             INTEGER,
                 device               TEXT,
                 step                 INTEGER,
                 peak_alloc_bytes     REAL,
@@ -53,7 +52,6 @@ def _create_step_memory_db(path: str) -> None:
                 "worker-0",
                 1.0,
                 1,
-                10,
                 "cuda:0",
                 1,
                 100.0,
@@ -70,7 +68,6 @@ def _create_step_memory_db(path: str) -> None:
                 "worker-0",
                 2.0,
                 2,
-                10,
                 "cuda:0",
                 2,
                 110.0,
@@ -87,7 +84,6 @@ def _create_step_memory_db(path: str) -> None:
                 "worker-0",
                 3.0,
                 3,
-                10,
                 "cuda:0",
                 3,
                 120.0,
@@ -107,13 +103,12 @@ def _create_step_memory_db(path: str) -> None:
                 hostname,
                 sample_ts_s,
                 seq,
-                model_id,
                 device,
                 step,
                 peak_alloc_bytes,
                 peak_reserved_bytes
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
             """,
             rows,
         )
@@ -224,7 +219,6 @@ def test_step_memory_loader_uses_latest_common_steps_per_global_rank(tmp_path):
                 "worker-0",
                 2.0,
                 1,
-                10,
                 "cuda:0",
                 2,
                 210.0,
@@ -241,7 +235,6 @@ def test_step_memory_loader_uses_latest_common_steps_per_global_rank(tmp_path):
                 "worker-0",
                 3.0,
                 2,
-                10,
                 "cuda:0",
                 3,
                 220.0,
@@ -258,7 +251,6 @@ def test_step_memory_loader_uses_latest_common_steps_per_global_rank(tmp_path):
                 "worker-0",
                 4.0,
                 3,
-                10,
                 "cuda:0",
                 4,
                 230.0,
@@ -278,13 +270,12 @@ def test_step_memory_loader_uses_latest_common_steps_per_global_rank(tmp_path):
                 hostname,
                 sample_ts_s,
                 seq,
-                model_id,
                 device,
                 step,
                 peak_alloc_bytes,
                 peak_reserved_bytes
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
             """,
             rows,
         )

--- a/tests/reporting/summary/test_step_time.py
+++ b/tests/reporting/summary/test_step_time.py
@@ -32,7 +32,6 @@ def _create_step_time_db(path: str) -> None:
                 local_world_size   INTEGER,
                 node_rank          INTEGER,
                 hostname           TEXT,
-                runtime_pid        INTEGER,
                 sample_ts_s        REAL,
                 seq                INTEGER,
                 step               INTEGER,
@@ -87,7 +86,6 @@ def _create_step_time_db(path: str) -> None:
                 1,
                 0,
                 "worker-0",
-                10_000,
                 1.0,
                 1,
                 1,
@@ -102,7 +100,6 @@ def _create_step_time_db(path: str) -> None:
                 1,
                 0,
                 "worker-0",
-                10_000,
                 2.0,
                 2,
                 2,
@@ -120,13 +117,12 @@ def _create_step_time_db(path: str) -> None:
                 local_world_size,
                 node_rank,
                 hostname,
-                runtime_pid,
                 sample_ts_s,
                 seq,
                 step,
                 events_json
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
             """,
             rows,
         )

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -252,7 +252,7 @@ def test_step_time_compute_straggler_card_shows_rank_evidence() -> None:
     _assert_compact_card(payload["card"])
 
 
-def test_step_time_combined_straggler_priority_keeps_all_rank_issues() -> None:
+def test_step_time_mixed_straggler_can_be_attributed_to_input() -> None:
     payload = _summary(
         {
             0: _rank(
@@ -269,14 +269,41 @@ def test_step_time_combined_straggler_priority_keeps_all_rank_issues() -> None:
     )
 
     assert payload["diagnosis"] == payload["issues"][0]
-    assert payload["diagnosis"] == payload["issues"][0]
-    assert payload["diagnosis"]["status"] == "STRAGGLER"
+    assert payload["diagnosis"]["status"] == "INPUT STRAGGLER"
+    assert (
+        "downstream synchronization"
+        in payload["diagnosis"]["evidence"]["downstream_synchronization_note"]
+    )
     assert {issue["kind"] for issue in payload["issues"]} >= {
         "STRAGGLER",
         "INPUT_STRAGGLER",
         "COMPUTE_STRAGGLER",
     }
     assert "issues" not in payload["groups"]["rows"]["1"]
+    assert (
+        "- Why: r1 input was slower than median global rank" in payload["card"]
+    )
+    _assert_compact_card(payload["card"])
+
+
+def test_step_time_unexplained_mixed_straggler_stays_straggler() -> None:
+    payload = _summary(
+        {
+            0: _rank(
+                dataloader=10.0,
+                forward=40.0,
+                backward=130.0,
+            ),
+            1: _rank(
+                dataloader=90.0,
+                forward=160.0,
+                backward=260.0,
+            ),
+        }
+    )
+
+    assert payload["diagnosis"] == payload["issues"][0]
+    assert payload["diagnosis"]["status"] == "STRAGGLER"
     assert {issue["kind"] for issue in payload["issues"]} >= {
         "STRAGGLER",
         "INPUT_STRAGGLER",
@@ -296,10 +323,10 @@ def test_step_time_priority_prefers_straggler_over_wait_heavy() -> None:
                 step_cpu=350.0,
             ),
             1: _rank(
-                dataloader=100.0,
-                forward=100.0,
-                backward=170.0,
-                step_cpu=350.0,
+                dataloader=110.0,
+                forward=180.0,
+                backward=270.0,
+                step_cpu=500.0,
             ),
         }
     )

--- a/tests/reporting/summary/test_system_process.py
+++ b/tests/reporting/summary/test_system_process.py
@@ -37,15 +37,7 @@ def _create_system_tables(conn: sqlite3.Connection) -> None:
             ram_used_bytes REAL,
             ram_total_bytes REAL,
             gpu_available INTEGER,
-            gpu_count INTEGER,
-            gpu_util_avg REAL,
-            gpu_util_peak REAL,
-            gpu_mem_used_avg_bytes REAL,
-            gpu_mem_used_peak_bytes REAL,
-            gpu_temp_avg_c REAL,
-            gpu_temp_peak_c REAL,
-            gpu_power_avg_w REAL,
-            gpu_power_peak_w REAL
+            gpu_count INTEGER
         )
         """
     )
@@ -74,8 +66,7 @@ def _create_system_tables(conn: sqlite3.Connection) -> None:
         """
         INSERT INTO system_samples VALUES (
             1, 0, 0, 1, 1, 0, 'worker-0', 1, 10.0,
-            40.0, 8.0, 16.0, 1, 1,
-            55.0, 70.0, 4.0, 5.0, 60.0, 68.0, 100.0, 120.0
+            40.0, 8.0, 16.0, 1, 2
         )
         """
     )
@@ -84,6 +75,14 @@ def _create_system_tables(conn: sqlite3.Connection) -> None:
         INSERT INTO system_gpu_samples VALUES (
             1, 0, 0, 1, 1, 0, 'worker-0', 10.0, 1, 0,
             70.0, 5.0, 10.0, 68.0, 120.0
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO system_gpu_samples VALUES (
+            10, 0, 0, 1, 1, 0, 'worker-0', 10.0, 1, 1,
+            40.0, 5.0, 10.0, 52.0, 80.0
         )
         """
     )
@@ -187,8 +186,7 @@ def test_system_section_reports_scoped_multinode_primary_issue(tmp_path):
             """
             INSERT INTO system_samples VALUES (
                 2, 1, 0, 2, 1, 1, 'worker-1', 2, 11.0,
-                41.0, 8.0, 16.0, 1, 1,
-                45.0, 80.0, 4.0, 5.0, 90.0, 95.0, 100.0, 120.0
+                41.0, 8.0, 16.0, 1, 1
             )
             """
         )
@@ -231,8 +229,7 @@ def test_system_loader_uses_latest_bounded_window(tmp_path):
             """
             INSERT INTO system_samples VALUES (
                 2, 0, 0, 1, 1, 0, 'worker-0', 2, 20.0,
-                90.0, 12.0, 16.0, 1, 1,
-                80.0, 85.0, 7.0, 8.0, 62.0, 70.0, 110.0, 130.0
+                90.0, 12.0, 16.0, 1, 1
             )
             """
         )
@@ -271,8 +268,7 @@ def test_system_loader_uses_latest_bounded_window_per_node(tmp_path):
                     """
                     INSERT INTO system_samples VALUES (
                         ?, ?, 0, 2, 1, ?, ?, ?, ?,
-                        ?, 8.0, 16.0, 1, 1,
-                        ?, ?, 4.0, 5.0, 60.0, 68.0, 100.0, 120.0
+                        ?, 8.0, 16.0, 1, 1
                     )
                     """,
                     (
@@ -283,8 +279,6 @@ def test_system_loader_uses_latest_bounded_window_per_node(tmp_path):
                         seq,
                         10.0 + seq,
                         10.0 * row_id,
-                        50.0 + row_id,
-                        60.0 + row_id,
                     ),
                 )
                 conn.execute(

--- a/tests/reporting/summary/test_system_process.py
+++ b/tests/reporting/summary/test_system_process.py
@@ -151,7 +151,13 @@ def test_system_section_loader_and_builder_use_sqlite_fixture(tmp_path):
     assert result.section == "system"
     assert result.payload["metadata"]["samples"] == 1
     assert "TraceML System Summary" in result.text
-    assert "- Diagnosis: NORMAL" in result.text
+    assert "- Diagnosis: MODERATE GPU UTILIZATION" in result.text
+    assert result.payload["diagnosis"]["kind"] == "MODERATE_GPU_UTILIZATION"
+    assert result.payload["diagnosis"] == result.payload["issues"][0]
+    assert result.payload["diagnosis"]["summary"].startswith(
+        "GPU utilization was moderate, averaging 55.0%"
+    )
+    assert result.payload["diagnosis"]["evidence"]["lowest_util_gpu_idx"] == 1
     assert (
         "- Stats: CPU 40% | RAM 50% | GPU util 55% | "
         "GPU memory 50% | GPU temp 68.0C"

--- a/tests/reporting/summary/test_system_process.py
+++ b/tests/reporting/summary/test_system_process.py
@@ -151,7 +151,7 @@ def test_system_section_loader_and_builder_use_sqlite_fixture(tmp_path):
     assert result.section == "system"
     assert result.payload["metadata"]["samples"] == 1
     assert "TraceML System Summary" in result.text
-    assert "- Diagnosis: MODERATE GPU UTILIZATION" in result.text
+    assert "- Diagnosis: MODERATE GPU UTIL" in result.text
     assert result.payload["diagnosis"]["kind"] == "MODERATE_GPU_UTILIZATION"
     assert result.payload["diagnosis"] == result.payload["issues"][0]
     assert result.payload["diagnosis"]["summary"].startswith(

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -30,7 +30,29 @@ sys.modules.setdefault(
     ),
 )
 
-from traceml_ai.runtime.executor import run_user_script
+from traceml_ai.runtime.executor import extract_script_args, run_user_script
+
+
+def test_extract_script_args_uses_separator_when_present(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["executor.py", "--", "--epochs", "2"],
+    )
+
+    assert extract_script_args() == ["--epochs", "2"]
+
+
+def test_extract_script_args_keeps_args_when_torchrun_strips_separator(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["executor.py", "--epochs", "2"],
+    )
+
+    assert extract_script_args() == ["--epochs", "2"]
 
 
 def test_run_user_script_adds_script_dir_to_sys_path(tmp_path, monkeypatch):

--- a/tests/runtime/test_telemetry_publisher.py
+++ b/tests/runtime/test_telemetry_publisher.py
@@ -103,6 +103,24 @@ class _FakeSampler:
         self.db = _FakeDB(writer) if writer is not None else None
 
 
+def _payload(sampler: str) -> dict:
+    return {
+        "meta": {
+            "rank": 0,
+            "global_rank": 0,
+            "local_rank": 0,
+            "world_size": 1,
+            "local_world_size": 1,
+            "node_rank": 0,
+            "hostname": "",
+            "pid": 0,
+            "sampler": sampler,
+            "timestamp": 1.0,
+        },
+        "body": {"tables": {"rows": [{"v": 1}]}},
+    }
+
+
 def test_publisher_attaches_senders_to_tcp_client_and_rank() -> None:
     tcp_client = _FakeTCPClient()
     sender = _FakeSender(payload={"rows": [1]})
@@ -146,7 +164,7 @@ def test_publisher_flushes_collects_and_sends_one_batch() -> None:
     writer = _FakeWriter()
     sampler_a = _FakeSampler(
         "SamplerA",
-        sender=_FakeSender(payload={"sampler": "a"}),
+        sender=_FakeSender(payload=_payload("a")),
         writer=writer,
     )
     sampler_b = _FakeSampler(
@@ -162,7 +180,7 @@ def test_publisher_flushes_collects_and_sends_one_batch() -> None:
     publisher.publish([sampler_a, sampler_b])
 
     assert writer.flush_count == 1
-    assert tcp_client.sent_batches == [[{"sampler": "a"}]]
+    assert tcp_client.sent_batches == [[_payload("a")]]
 
 
 def test_publisher_collects_empty_mapping_payloads() -> None:
@@ -204,12 +222,12 @@ def test_publisher_logs_failures_and_continues() -> None:
     logger = _FakeLogger()
     good_sampler = _FakeSampler(
         "GoodSampler",
-        sender=_FakeSender(payload={"sampler": "good"}),
+        sender=_FakeSender(payload=_payload("good")),
         writer=_FakeWriter(),
     )
     bad_flush_sampler = _FakeSampler(
         "BadFlushSampler",
-        sender=_FakeSender(payload={"sampler": "bad_flush"}),
+        sender=_FakeSender(payload=_payload("bad_flush")),
         writer=_FakeWriter(fail_flush=True),
     )
     bad_collect_sampler = _FakeSampler(

--- a/tests/telemetry/test_sender_sequence.py
+++ b/tests/telemetry/test_sender_sequence.py
@@ -87,6 +87,11 @@ class TestDBIncrementalSender:
         )
         return sender, mock_transport
 
+    def _tables(self, payload):
+        assert set(payload) == {"meta", "body"}
+        assert set(payload["body"]) == {"tables"}
+        return payload["body"]["tables"]
+
     def test_skip_when_no_new_rows(self):
         db = Database(sampler_name="test")
         db.add_record("t1", {"v": 1})
@@ -111,7 +116,7 @@ class TestDBIncrementalSender:
         sender.flush()
 
         payload = transport.send.call_args[0][0]
-        rows_sent = payload["tables"]["t1"]
+        rows_sent = self._tables(payload)["t1"]
         assert len(rows_sent) == 3
 
         # Add 2 more, flush again
@@ -121,7 +126,7 @@ class TestDBIncrementalSender:
         sender.flush()
 
         payload = transport.send.call_args[0][0]
-        rows_sent = payload["tables"]["t1"]
+        rows_sent = self._tables(payload)["t1"]
         assert len(rows_sent) == 2
         assert rows_sent[0]["step"] == 3
         assert rows_sent[1]["step"] == 4
@@ -143,7 +148,7 @@ class TestDBIncrementalSender:
         sender.flush()
 
         payload = transport.send.call_args[0][0]
-        rows_sent = payload["tables"]["t1"]
+        rows_sent = self._tables(payload)["t1"]
         # new_count=5, len(deque)=3 → sends all 3 available
         assert len(rows_sent) == 3
         assert rows_sent[0]["i"] == 5
@@ -159,7 +164,7 @@ class TestDBIncrementalSender:
         sender.flush()
 
         payload = transport.send.call_args[0][0]
-        rows_sent = payload["tables"]["t1"]
+        rows_sent = self._tables(payload)["t1"]
         assert len(rows_sent) == 1
         assert rows_sent[0]["step"] == 4  # latest
 
@@ -172,8 +177,9 @@ class TestDBIncrementalSender:
         sender.flush()
 
         payload = transport.send.call_args[0][0]
-        assert "t1" in payload["tables"]
-        assert "t2" in payload["tables"]
+        tables = self._tables(payload)
+        assert "t1" in tables
+        assert "t2" in tables
 
         # Add only to t2
         transport.send.reset_mock()
@@ -181,9 +187,10 @@ class TestDBIncrementalSender:
         sender.flush()
 
         payload = transport.send.call_args[0][0]
-        assert "t1" not in payload["tables"]
-        assert "t2" in payload["tables"]
-        assert len(payload["tables"]["t2"]) == 1
+        tables = self._tables(payload)
+        assert "t1" not in tables
+        assert "t2" in tables
+        assert len(tables["t2"]) == 1
 
     def test_payload_rank_uses_attached_runtime_rank(self):
         db = Database(sampler_name="test")
@@ -194,14 +201,17 @@ class TestDBIncrementalSender:
         sender.flush()
 
         payload = transport.send.call_args[0][0]
-        assert payload["rank"] == 5
-        assert payload["global_rank"] == 5
-        assert payload["local_rank"] == 1
-        assert payload["world_size"] == 1
-        assert payload["local_world_size"] == 1
-        assert payload["node_rank"] == 0
-        assert payload["hostname"] == ""
-        assert payload["pid"] == 0
+        assert set(payload) == {"meta", "body"}
+        assert payload["meta"]["rank"] == 5
+        assert payload["meta"]["global_rank"] == 5
+        assert payload["meta"]["local_rank"] == 1
+        assert payload["meta"]["world_size"] == 1
+        assert payload["meta"]["local_world_size"] == 1
+        assert payload["meta"]["node_rank"] == 0
+        assert payload["meta"]["hostname"] == ""
+        assert payload["meta"]["pid"] == 0
+        assert payload["meta"]["sampler"] == "test_sampler"
+        assert isinstance(payload["meta"]["timestamp"], float)
 
 
 # DatabaseWriter tests

--- a/tests/telemetry/test_system_projection_identity.py
+++ b/tests/telemetry/test_system_projection_identity.py
@@ -8,7 +8,13 @@ from __future__ import annotations
 
 import sqlite3
 
+from traceml_ai.aggregator.sqlite_writer import (
+    SQLiteWriterConfig,
+    SQLiteWriterSimple,
+)
 from traceml_ai.aggregator.sqlite_writers import system as system_projection
+from traceml_ai.telemetry.envelope import normalize_telemetry_envelope
+from traceml_ai.utils.msgpack_codec import Decoder as MsgpackDecoder
 
 
 def _system_payload() -> dict:
@@ -42,7 +48,9 @@ def test_system_projection_stores_global_and_local_rank_identity() -> None:
     conn = sqlite3.connect(":memory:")
     system_projection.init_schema(conn)
 
-    rows = system_projection.build_rows(_system_payload(), recv_ts_ns=999)
+    envelope = normalize_telemetry_envelope(_system_payload())
+    assert envelope is not None
+    rows = system_projection.build_rows(envelope, recv_ts_ns=999)
     system_projection.insert_rows(conn, rows)
 
     sample = conn.execute(
@@ -62,3 +70,30 @@ def test_system_projection_stores_global_and_local_rank_identity() -> None:
 
     assert sample == (5, 1, 8, 4, 1, "worker-1", 7)
     assert gpu_sample == (5, 1, 8, 4, 1, "worker-1", 0)
+
+
+def test_sqlite_writer_persists_canonical_raw_envelope(tmp_path) -> None:
+    db_path = tmp_path / "telemetry.db"
+    writer = SQLiteWriterSimple(SQLiteWriterConfig(path=str(db_path)))
+
+    conn = sqlite3.connect(db_path)
+    try:
+        writer._init_schema(conn)
+        system_projection.init_schema(conn)
+
+        raw_rows, projection_rows = writer._collect_flush_rows(
+            [_system_payload()]
+        )
+        writer._write_flush_rows(conn, raw_rows, projection_rows)
+
+        payload_mp = conn.execute(
+            "SELECT payload_mp FROM raw_messages;"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    payload = MsgpackDecoder().decode(payload_mp)
+    assert set(payload) == {"meta", "body"}
+    assert payload["meta"]["sampler"] == "SystemSampler"
+    assert payload["meta"]["global_rank"] == 5
+    assert payload["body"]["tables"]["SystemTable"][0]["seq"] == 7


### PR DESCRIPTION
## What changed

TraceML now classifies mixed input+compute skew more accurately in distributed runs. When input delay plausibly explains downstream compute/backward skew, the primary diagnosis is now `INPUT STRAGGLER` instead of generic `STRAGGLER`, while secondary issues remain available in JSON.

This branch also improves Lightning/Ray examples and instrumentation:

- Fixes Lightning forward timing by wrapping `LightningModule.forward`.
- Keeps Lightning H2D timing scoped to batch transfer hooks.
- Adds practical Lightning and Ray Lightning demo controls for input and compute
  straggler testing.
- Cleans telemetry envelope handling between runtime senders and the aggregator.
- Improves system diagnosis and compare output formatting.
- Updates user docs for the new straggler attribution behavior.

## Why

Distributed training can make a slow input rank appear as compute/backward skew
on a peer rank because synchronization shifts where waiting is observed. TraceML
was previously labeling these mixed cases as generic `STRAGGLER`, which made the
root cause less clear.

This change gives users a more actionable diagnosis for common DDP/Ray/Lightning
runs: if input excess is large enough to explain compute skew, TraceML points at
the input path first while preserving compute evidence for deeper inspection.

## How I tested

- [x] Unit tests
- [x] Integration or smoke test
- [x] Example training script
- [x] Docs-only change
- [ ] Not run; reason:

Commands run:

```bash
python -m pytest tests/diagnostics/test_step_time.py tests/reporting/summary/test_step_time_card.py -q
```

Result:

```text
16 passed
```

Additional validation:

- Ran Lightning locally with synthetic delay to verify delay is no longer
  counted as forward compute.
- Ran Ray Lightning on two EC2 nodes with two Ray workers to validate distributed
  input and compute straggler behavior.
- Verified a mixed input+compute Ray Lightning run now reports:

```text
Step Time
- Diagnosis: INPUT STRAGGLER
- Stats: median/worst | total 298.9/316.9ms | input 130.7/257.4ms |
  H2D 0.1/0.2ms | compute 143.2/263.1ms | wait 24.9/49.8ms
- Why: r0 input was slower than median global rank (257.4/130.7ms).
```

## Runtime impact

- [ ] No training-path runtime impact
- [x] May affect training-path overhead
- [x] May affect distributed launch, telemetry, or aggregator behavior
- [ ] Not applicable

Notes:

- Lightning instrumentation now wraps `LightningModule.forward` to measure
  forward timing correctly.
- The new diagnosis rule is summary/reporting logic and does not add training
  synchronization.
- Telemetry envelope/database cleanup affects runtime-to-aggregator payload
  handling.

## Documentation

- [ ] README updated
- [x] User docs updated
- [x] Examples updated
- [x] API docs updated
- [ ] Not needed

## Risk checklist

- [x] Does not add unnecessary CUDA synchronizations
- [x] Does not add blocking I/O on the training path
- [x] Fails safely without crashing user training
- [x] Keeps new dependencies optional unless discussed
- [x] Redacts or avoids sensitive training-environment data in examples

## Screenshots or output

Relevant final summary output from a two-node Ray Lightning run:

```text
+----------------------------------------------------------------------------+
|  TraceML Run Summary | duration 6032.0s                                    |
+----------------------------------------------------------------------------+
|                                                                            |
|  Step Time                                                                 |
|  - Diagnosis: INPUT STRAGGLER                                              |
|  - Scope: compared over last 612 aligned steps across 2 global ranks       |
|  - Stats: median/worst | total 298.9/316.9ms | input 130.7/257.4ms | H2D   |
|  0.1/0.2ms | compute 143.2/263.1ms | wait 24.9/49.8ms                      |
|  - Ranks: median/worst | total r0/r1 | input r1/r0 | H2D r0/r0 | compute   |
|  r1/r1 | wait r0/r1                                                        |
|  - Why: r0 input was slower than median global rank (257.4/130.7ms).       |
+----------------------------------------------------------------------------+
```