### PR TITLE
Step-limited tracing and stable final summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,21 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.gitignore'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.gitignore'
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -13,42 +25,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pre-commit
-
       - name: Run pre-commit
         env:
           SKIP: no-commit-to-branch
-        run: |
-          pre-commit run --all-files --show-diff-on-failure
+        run: pre-commit run --all-files --show-diff-on-failure
 
   test-core:
     name: Core Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        # PRs only run on 3.10. Main branch and manual dispatches run on all versions.
+        python-version: >-
+          ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') &&
+              fromJSON('["3.10", "3.11", "3.12", "3.13"]') ||
+              fromJSON('["3.10"]') }}
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .
           pip install pytest
-
       - name: Run core tests
         run: |
           pytest \
@@ -65,18 +74,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: "pip"
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[torch]"
           pip install pytest
-
       - name: Run integration tests
         run: |
           pytest \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,10 +3,9 @@ name: CodeQL
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  # Removed pull_request to stop clones on everyday feature branches
   schedule:
-    - cron: "24 3 * * 1"
+    - cron: "24 3 * * 1" # Runs automatically every single Monday at 3:24 AM UTC
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,16 @@ name: Docs
 on:
   push:
     branches: [main]
+    paths:
+      - 'docs/**'
+      - '*.md'
+      - 'mkdocs.yml'
+      - 'pyproject.toml'
   pull_request:
     branches: [main]
+    paths:
+      - 'mkdocs.yml'
+      - 'pyproject.toml' # Skips PR builds entirely for pure .md text files!
 
 concurrency:
   group: docs-${{ github.ref }}
@@ -19,13 +27,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: pip
           cache-dependency-path: pyproject.toml
-      - run: pip install -e ".[docs,torch,lightning,hf]"
-      - run: mkdocs build --strict
+
+      - name: Install dependencies
+        run: pip install -e ".[docs,torch,lightning,hf]"
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
       - uses: actions/upload-pages-artifact@v3
         with:
           path: site

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -72,6 +72,19 @@ The preferred public API is the top-level `traceml.*` from `import traceml_ai as
 
 ---
 
+## Can I trace only a small number of steps?
+
+Yes. Use `--trace-max-steps` with `traceml run`:
+
+```bash
+traceml run train.py --trace-max-steps 100 --args --epochs 5
+```
+
+TraceML records and flushes the first N TraceML steps, then stops recording
+telemetry while your training job continues normally.
+
+---
+
 ## Should I use `traceml.trace_step()` or `trace_step()`?
 
 Prefer:

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -296,6 +296,8 @@ recommended low-noise path is:
 3. log the returned flat dict into W&B or MLflow
 
 Use `traceml.final_summary()` if you need the full structured JSON payload.
+Both APIs reuse the same canonical `final_summary.json` once it has been
+generated.
 
 See:
 

--- a/docs/user_guide/integrations/ray.md
+++ b/docs/user_guide/integrations/ray.md
@@ -89,6 +89,32 @@ When using Ray Data, wrap the ``iter_torch_batches(...)`` iterator with
 ``traceml.wrap_dataloader_fetch(...)``. Ray Data is not a PyTorch
 ``DataLoader``, so the PyTorch DataLoader patch cannot see those fetches.
 
+## Example scripts
+
+Use ``--ray-address=auto`` when you already have a Ray cluster running, or omit
+it for a local Ray run.
+
+Minimal Ray Train example:
+
+```bash
+python examples/ray/torchtrainer_minimal.py \
+  --ray-address=auto \
+  --num-workers=2 \
+  --steps=100 \
+  --use-gpu
+```
+
+To make input timing visible in the minimal example:
+
+```bash
+python examples/ray/torchtrainer_minimal.py \
+  --ray-address=auto \
+  --num-workers=2 \
+  --steps=100 \
+  --use-gpu \
+  --input-delay-ms=100
+```
+
 ## Ray + Lightning
 
 When combining Ray Train and PyTorch Lightning, add ``TraceMLCallback()`` to the
@@ -111,6 +137,42 @@ The ``examples/ray/lightning_text_classifier.py`` demo also includes
 ``--transfer-dim`` to make Lightning H2D timing visible.
 ``--transfer-dim`` creates a reusable per-batch CPU tensor; it does not add a
 full dataset-sized tensor.
+
+Baseline Ray + Lightning run:
+
+```bash
+python examples/ray/lightning_text_classifier.py \
+  --ray-address=auto \
+  --num-workers=2 \
+  --max-steps=100 \
+  --use-gpu
+```
+
+Input-straggler demo:
+
+```bash
+python examples/ray/lightning_text_classifier.py \
+  --ray-address=auto \
+  --num-workers=2 \
+  --max-steps=100 \
+  --use-gpu \
+  --input-delay-rank=0 \
+  --input-delay-ms=200
+```
+
+Compute-straggler demo:
+
+```bash
+python examples/ray/lightning_text_classifier.py \
+  --ray-address=auto \
+  --num-workers=2 \
+  --max-steps=100 \
+  --use-gpu \
+  --delay-rank=0 \
+  --delay-ms=200
+```
+
+For CPU-only runs, remove ``--use-gpu``.
 
 ## Network Model
 

--- a/docs/user_guide/integrations/wandb-mlflow.md
+++ b/docs/user_guide/integrations/wandb-mlflow.md
@@ -142,8 +142,9 @@ This lets W&B stay your experiment system of record while TraceML contributes a
 clean bottleneck diagnosis at the end of the run.
 
 `traceml.summary()` returns a flat dict of diagnosis statuses and global
-average metrics. If you also store `final_summary.json` as a run artifact, you
-can reuse it later with `traceml compare`.
+average metrics. It is derived from the canonical `final_summary.json` artifact,
+which TraceML generates once per run and reuses on later calls. Keep that JSON
+as a run artifact when you want to use `traceml compare`.
 
 ---
 

--- a/docs/user_guide/public-api.md
+++ b/docs/user_guide/public-api.md
@@ -83,7 +83,8 @@ See `traceml --help` for the full set of options.
 ### `traceml.summary()`
 
 Returns a compact flat dict for experiment trackers such as W&B, MLflow, or
-internal dashboards.
+internal dashboards. Call it near the end of training; it reuses the canonical
+`final_summary.json` if one already exists.
 
 ```python
 summary = traceml.summary(print_text=True)
@@ -95,3 +96,5 @@ if summary is not None:
 
 Returns the full `final_summary.json` payload. Use this when you need the
 complete structured report or want to store the artifact for `traceml compare`.
+TraceML generates this canonical artifact once per run and reuses it on later
+calls.

--- a/examples/pytorch_minimal.py
+++ b/examples/pytorch_minimal.py
@@ -80,6 +80,8 @@ def main():
 
                 time.sleep(PAUSE_BETWEEN_STEPS)
 
+    summary = traceml.summary(print_text=True)
+    print(summary)
     print("Done.")
 
 

--- a/src/traceml_ai/aggregator/summary_service.py
+++ b/src/traceml_ai/aggregator/summary_service.py
@@ -35,12 +35,14 @@ class FinalSummaryService:
         session_root: Path,
         db_path: str,
         flush_history: Callable[[float], bool],
+        settle_telemetry: Optional[Callable[[float], bool]] = None,
         summary_window_rows: int = DEFAULT_SUMMARY_WINDOW_ROWS,
     ) -> None:
         self._logger = logger
         self._session_root = Path(session_root).resolve()
         self._db_path = str(db_path)
         self._flush_history = flush_history
+        self._settle_telemetry = settle_telemetry
         self._summary_window_rows = int(summary_window_rows)
         self._last_request_id: Optional[str] = None
 
@@ -66,10 +68,15 @@ class FinalSummaryService:
         response_path = get_final_summary_response_path(self._session_root)
 
         try:
-            flushed = self._flush_history(5.0)
-            if not flushed:
+            if self._summary_exists():
+                self._write_ok_response(response_path, request_id=request_id)
+                self._last_request_id = request_id
+                return
+
+            settled = self._settle_before_generation(5.0)
+            if not settled:
                 raise RuntimeError(
-                    "Timed out while waiting for SQLite history to flush."
+                    "Timed out while waiting for TraceML telemetry to settle."
                 )
 
             generate_summary(
@@ -79,19 +86,7 @@ class FinalSummaryService:
                 summary_window_rows=self._summary_window_rows,
             )
 
-            response = FinalSummaryResponse(
-                request_id=request_id,
-                status="ok",
-                completed_at=utc_now_iso(),
-                summary_json_path=str(
-                    get_final_summary_json_path(self._session_root)
-                ),
-                summary_txt_path=str(
-                    get_final_summary_txt_path(self._session_root)
-                ),
-                error=None,
-            )
-            write_json_atomic(response_path, response_to_json(response))
+            self._write_ok_response(response_path, request_id=request_id)
             self._last_request_id = request_id
 
         except Exception as exc:
@@ -112,3 +107,34 @@ class FinalSummaryService:
             )
             write_json_atomic(response_path, response_to_json(response))
             self._last_request_id = request_id
+
+    def _summary_exists(self) -> bool:
+        """Return True when the canonical JSON artifact already exists."""
+        return get_final_summary_json_path(self._session_root).is_file()
+
+    def _settle_before_generation(self, timeout_sec: float) -> bool:
+        """Best-effort telemetry settle before first summary generation."""
+        if self._settle_telemetry is not None:
+            return bool(self._settle_telemetry(float(timeout_sec)))
+        return bool(self._flush_history(float(timeout_sec)))
+
+    def _write_ok_response(
+        self,
+        response_path: Path,
+        *,
+        request_id: str,
+    ) -> None:
+        """Publish an OK response pointing at canonical summary artifacts."""
+        response = FinalSummaryResponse(
+            request_id=request_id,
+            status="ok",
+            completed_at=utc_now_iso(),
+            summary_json_path=str(
+                get_final_summary_json_path(self._session_root)
+            ),
+            summary_txt_path=str(
+                get_final_summary_txt_path(self._session_root)
+            ),
+            error=None,
+        )
+        write_json_atomic(response_path, response_to_json(response))

--- a/src/traceml_ai/aggregator/trace_aggregator.py
+++ b/src/traceml_ai/aggregator/trace_aggregator.py
@@ -22,6 +22,7 @@ from traceml_ai.aggregator.summary_service import FinalSummaryService
 from traceml_ai.database.remote_database_store import RemoteDBStore
 from traceml_ai.reporting.final import generate_summary
 from traceml_ai.runtime.settings import AggregatorEndpoint, TraceMLSettings
+from traceml_ai.sdk.protocol import get_final_summary_json_path
 from traceml_ai.telemetry.envelope import normalize_telemetry_envelope
 from traceml_ai.transport.tcp_transport import TCPConfig, TCPServer
 
@@ -130,6 +131,7 @@ class TraceMLAggregator:
             session_root=session_root,
             db_path=str(db_path),
             flush_history=self._sqlite_writer.flush_now,
+            settle_telemetry=self._settle_telemetry,
             summary_window_rows=int(settings.summary_window_rows),
         )
 
@@ -220,16 +222,20 @@ class TraceMLAggregator:
             self._sqlite_writer.stop,
         )
 
-        if self._settings.history_enabled and self._settings.db_path:
+        session_root = Path(str(self._settings.logs_dir)).resolve() / str(
+            self._settings.session_id or "default"
+        )
+        if (
+            self._settings.history_enabled
+            and self._settings.db_path
+            and not get_final_summary_json_path(session_root).is_file()
+        ):
             _safe(
                 self._logger,
                 "Final summary failed",
                 lambda: generate_summary(
                     str(self._settings.db_path),
-                    session_root=str(
-                        Path(str(self._settings.logs_dir)).resolve()
-                        / str(self._settings.session_id or "default")
-                    ),
+                    session_root=str(session_root),
                     print_to_stdout=True,
                     summary_window_rows=int(
                         self._settings.summary_window_rows
@@ -265,6 +271,28 @@ class TraceMLAggregator:
                 self._sqlite_writer.ingest(msg)
             except Exception:
                 self._logger.exception("[TraceML] SQLiteWriter.ingest failed")
+
+    def _settle_telemetry(self, timeout_sec: float) -> bool:
+        """
+        Best-effort drain of in-flight telemetry before first final summary.
+
+        This waits until TCP input is quiet for a short window or until the
+        timeout expires, then flushes SQLite history.
+        """
+        deadline = time.monotonic() + float(timeout_sec)
+        quiet_sec = min(0.5, max(0.0, float(timeout_sec)))
+
+        while time.monotonic() < deadline:
+            self._drain_tcp()
+            remaining = max(0.0, deadline - time.monotonic())
+            if not self._tcp_server.wait_for_data(
+                timeout=min(quiet_sec, remaining)
+            ):
+                self._drain_tcp()
+                return bool(self._sqlite_writer.flush_now(remaining))
+
+        self._drain_tcp()
+        return bool(self._sqlite_writer.flush_now(0.0))
 
     def _message_sampler_name(self, msg: Any) -> Optional[str]:
         """

--- a/src/traceml_ai/instrumentation/hooks/layer_backward_memory_hooks.py
+++ b/src/traceml_ai/instrumentation/hooks/layer_backward_memory_hooks.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Tuple
 import torch
 import torch.nn as nn
 
+from traceml_ai.runtime.state import should_record_trace_events
 from traceml_ai.utils.shared_utils import get_hookable_modules
 
 # Shared queue for gradient events
@@ -134,6 +135,9 @@ class LayerBackwardModuleHook:
         self.layer_name = layer_name
 
     def __call__(self, module: nn.Module, grad_input: Any, grad_output: Any):
+        if not should_record_trace_events():
+            return
+
         try:
             total_bytes = _accumulate_tensor_bytes(grad_output)
 
@@ -163,6 +167,9 @@ def flush_layer_backward_memory_buffers(model: nn.Module, step: int) -> None:
     step : int
         Current training step.
     """
+    if not should_record_trace_events():
+        return
+
     model_id = id(model)
     buf = _layer_backward_memory_buffer.pop(model_id, None)
 

--- a/src/traceml_ai/instrumentation/hooks/layer_backward_time_hooks.py
+++ b/src/traceml_ai/instrumentation/hooks/layer_backward_time_hooks.py
@@ -29,6 +29,7 @@ from typing import Dict, List, Optional
 import torch
 import torch.nn as nn
 
+from traceml_ai.runtime.state import should_record_trace_events
 from traceml_ai.utils.cuda_event_pool import get_cuda_event, return_cuda_event
 from traceml_ai.utils.shared_utils import (
     get_hookable_modules,
@@ -133,6 +134,9 @@ class LayerBackwardTimePreHook:
         self.on_gpu = on_gpu
 
     def __call__(self, module, grad_output):
+        if not should_record_trace_events():
+            return
+
         try:
             cpu_start = time.perf_counter()
             gpu_start = None
@@ -172,6 +176,9 @@ class LayerBackwardTimePostHook:
         self.on_gpu = on_gpu
 
     def __call__(self, module, grad_input, grad_output):
+        if not should_record_trace_events():
+            return
+
         try:
             cpu_end = time.perf_counter()
 
@@ -218,6 +225,9 @@ def flush_layer_backward_time_buffers(model: nn.Module, step: int) -> None:
     Flush all backward timing events for `model` at a step boundary.
     Emits a single LayerBackwardTimeStepEvent into the shared queue.
     """
+    if not should_record_trace_events():
+        return
+
     model_id = id(model)
     layers = _layer_backward_time_event_buffer.pop(model_id, None)
     if not layers:

--- a/src/traceml_ai/instrumentation/hooks/layer_forward_memory_hooks.py
+++ b/src/traceml_ai/instrumentation/hooks/layer_forward_memory_hooks.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Tuple
 import torch
 import torch.nn as nn
 
+from traceml_ai.runtime.state import should_record_trace_events
 from traceml_ai.utils.shared_utils import get_hookable_modules
 
 # Shared queue for forward events
@@ -95,6 +96,9 @@ class LayerForwardMemoryHook:
         self.layer_name = layer_name
 
     def __call__(self, module: nn.Module, inputs: Any, output: Any):
+        if not should_record_trace_events():
+            return
+
         try:
             total_bytes = 0.0
 
@@ -139,6 +143,9 @@ def flush_layer_forward_memory_buffers(model: nn.Module, step: int) -> None:
     step : int
         Current training step.
     """
+    if not should_record_trace_events():
+        return
+
     model_id = id(model)
     buf = _layer_forward_memory_buffer.pop(model_id, None)
     if not buf:

--- a/src/traceml_ai/instrumentation/hooks/layer_forward_time_hooks.py
+++ b/src/traceml_ai/instrumentation/hooks/layer_forward_time_hooks.py
@@ -29,6 +29,7 @@ from typing import Dict, List, Optional
 import torch
 import torch.nn as nn
 
+from traceml_ai.runtime.state import should_record_trace_events
 from traceml_ai.utils.cuda_event_pool import get_cuda_event, return_cuda_event
 from traceml_ai.utils.shared_utils import (
     get_hookable_modules,
@@ -143,6 +144,9 @@ class LayerForwardTimePreHook:
         ).setdefault(self.layer_name, deque())
 
     def __call__(self, module, inputs):
+        if not should_record_trace_events():
+            return
+
         try:
             cpu_start = time.perf_counter()
             gpu_start = None
@@ -179,6 +183,9 @@ class LayerForwardTimePostHook:
         ).setdefault(self.layer_name, deque())
 
     def __call__(self, module, inputs, output):
+        if not should_record_trace_events():
+            return
+
         try:
             cpu_end = time.perf_counter()
 
@@ -220,6 +227,9 @@ def flush_layer_forward_time_buffers(model: nn.Module, step: int) -> None:
     Flush all forward timing events for `model` at a step boundary.
     Emits a single LayerForwardTimeStepEvent into the shared queue.
     """
+    if not should_record_trace_events():
+        return
+
     model_id = id(model)
     layers = _layer_forward_time_event_buffer.pop(model_id, None)
     if not layers:

--- a/src/traceml_ai/instrumentation/hooks/model_forward_memory_hooks.py
+++ b/src/traceml_ai/instrumentation/hooks/model_forward_memory_hooks.py
@@ -6,6 +6,8 @@ from typing import Dict, Optional
 import torch
 import torch.nn as nn
 
+from traceml_ai.runtime.state import should_record_trace_events
+
 # Shared queue for model forward peak memory events
 model_forward_memory_queue: Queue = Queue(maxsize=128)
 
@@ -42,6 +44,9 @@ class ModelForwardMemoryPreHook:
         self.device = device
 
     def __call__(self, module: nn.Module, inputs):
+        if not should_record_trace_events():
+            return
+
         try:
             if self.device.type == "cuda":
                 torch.cuda.reset_peak_memory_stats(self.device)
@@ -61,6 +66,9 @@ class ModelForwardMemoryPostHook:
         self.device = device
 
     def __call__(self, module: nn.Module, inputs, output):
+        if not should_record_trace_events():
+            return
+
         try:
             if self.device.type != "cuda":
                 return
@@ -82,6 +90,9 @@ class ModelForwardMemoryPostHook:
 
 
 def flush_model_forward_memory_buffers(model: nn.Module, step: int) -> None:
+    if not should_record_trace_events():
+        return
+
     model_id = id(model)
     evt: Optional[ModelForwardMemoryEvent] = _model_forward_memory_buffer.pop(
         model_id, None

--- a/src/traceml_ai/instrumentation/patches/backward_auto_timer_patch.py
+++ b/src/traceml_ai/instrumentation/patches/backward_auto_timer_patch.py
@@ -75,14 +75,26 @@ def patch_backward() -> None:
 class backward_auto_timer:
     """
     Enables backward timing during its scope.
+
+    The previous thread-local state is restored on exit so nested tracing
+    contexts preserve the outer context's timing state.
+
     Assumes patch_backward() has been called once at startup/runtime init.
     """
 
+    def __init__(self):
+        self._prev_enabled = False
+        self._prev_depth = 0
+
     def __enter__(self):
+        self._prev_enabled = _enabled()
+        self._prev_depth = _depth()
+
         _BACKWARD_TLS._traceml_backward_enabled = True
+        _BACKWARD_TLS._traceml_backward_depth = 0
         return self
 
     def __exit__(self, exc_type, exc, tb):
-        _BACKWARD_TLS._traceml_backward_enabled = False
-        _BACKWARD_TLS._traceml_backward_depth = 0
+        _BACKWARD_TLS._traceml_backward_enabled = self._prev_enabled
+        _BACKWARD_TLS._traceml_backward_depth = self._prev_depth
         return False

--- a/src/traceml_ai/integrations/lightning.py
+++ b/src/traceml_ai/integrations/lightning.py
@@ -5,7 +5,10 @@ import sys
 from traceml_ai.instrumentation.patches.h2d_auto_timer_patch import (
     h2d_auto_timer,
 )
-from traceml_ai.runtime.state import get_trace_session_state
+from traceml_ai.runtime.state import (
+    get_trace_session_state,
+    mark_trace_step_flushed,
+)
 from traceml_ai.utils.flush_buffers import flush_step_events
 from traceml_ai.utils.step_memory import StepMemoryTracker
 from traceml_ai.utils.timing import (
@@ -331,6 +334,11 @@ class TraceMLCallback(Callback):
             flush_step_events(pl_module, trace_state.step)
         except Exception as e:
             _log_lightning_error("flush failed", e)
+
+        try:
+            mark_trace_step_flushed(trace_state.step)
+        except Exception as e:
+            _log_lightning_error("recording state update failed", e)
 
 
 __all__ = ["TraceMLCallback", "init"]

--- a/src/traceml_ai/launcher/cli.py
+++ b/src/traceml_ai/launcher/cli.py
@@ -104,6 +104,15 @@ def _add_launch_args(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
+        "--trace-max-steps",
+        type=int,
+        default=None,
+        help=(
+            "Record TraceML telemetry for only the first N TraceML steps. "
+            "Training continues after recording stops."
+        ),
+    )
+    parser.add_argument(
         "--nproc-per-node",
         type=int,
         default=1,

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -94,6 +94,11 @@ def validate_launch_args(args: argparse.Namespace) -> None:
         raise SystemExit(
             "[TraceML] ERROR: --summary-window-rows must be greater than 0."
         )
+    trace_max_steps = getattr(args, "trace_max_steps", None)
+    if trace_max_steps is not None and int(trace_max_steps) <= 0:
+        raise SystemExit(
+            "[TraceML] ERROR: --trace-max-steps must be greater than 0."
+        )
     try:
         launch_cfg = DistributedLaunchConfig.from_args(args)
         RunIdentity.from_args(
@@ -137,6 +142,10 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
     env["TRACEML_REMOTE_MAX_ROWS"] = str(args.remote_max_rows)
     env["TRACEML_SUMMARY_WINDOW_ROWS"] = str(
         int(getattr(args, "summary_window_rows", DEFAULT_SUMMARY_WINDOW_ROWS))
+    )
+    trace_max_steps = getattr(args, "trace_max_steps", None)
+    env["TRACEML_TRACE_MAX_STEPS"] = (
+        "" if trace_max_steps is None else str(int(trace_max_steps))
     )
     env["TRACEML_NNODES"] = str(torchrun_cfg.nnodes)
     env["TRACEML_NPROC_PER_NODE"] = str(torchrun_cfg.nproc_per_node)

--- a/src/traceml_ai/runtime/__init__.py
+++ b/src/traceml_ai/runtime/__init__.py
@@ -1,11 +1,25 @@
 from traceml_ai.runtime.state import (
+    TraceMLRecordingState,
+    TraceMLRecordingStatus,
     TraceSessionState,
+    configure_trace_recording,
+    get_trace_recording_state,
     get_trace_session_state,
+    mark_trace_recording_drained,
+    mark_trace_step_flushed,
     reset_trace_session_state,
+    should_record_trace_events,
 )
 
 __all__ = [
+    "TraceMLRecordingState",
+    "TraceMLRecordingStatus",
     "TraceSessionState",
+    "configure_trace_recording",
+    "get_trace_recording_state",
     "get_trace_session_state",
+    "mark_trace_recording_drained",
+    "mark_trace_step_flushed",
     "reset_trace_session_state",
+    "should_record_trace_events",
 ]

--- a/src/traceml_ai/runtime/executor.py
+++ b/src/traceml_ai/runtime/executor.py
@@ -47,6 +47,16 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _parse_optional_positive_int(value: Optional[str]) -> Optional[int]:
+    """Parse an optional positive integer from an environment variable."""
+    if value is None or str(value).strip() == "":
+        return None
+    parsed = int(value)
+    if parsed <= 0:
+        raise ValueError("Expected a positive integer.")
+    return parsed
+
+
 def _get_session_dir(cfg: Dict[str, Any]) -> Path:
     """Return the TraceML session directory for the current run."""
     logs_dir = Path(str(cfg.get("logs_dir", DEFAULT_LOGS_DIR)))
@@ -224,6 +234,9 @@ def read_traceml_env() -> Dict[str, Any]:
                 str(DEFAULT_SUMMARY_WINDOW_ROWS),
             )
         ),
+        "trace_max_steps": _parse_optional_positive_int(
+            os.environ.get("TRACEML_TRACE_MAX_STEPS")
+        ),
         "disable_traceml": os.environ.get("TRACEML_DISABLED", "0") == "1",
     }
 
@@ -261,6 +274,7 @@ def build_runtime_settings(cfg: Dict[str, Any]) -> TraceMLSettings:
         logs_dir=str(cfg["logs_dir"]),
         session_id=str(cfg["session_id"]),
         summary_window_rows=int(cfg["summary_window_rows"]),
+        trace_max_steps=cfg.get("trace_max_steps"),
         aggregator=AggregatorTransportSettings(
             connect_host=str(cfg["aggregator_host"]),
             bind_host=str(cfg["aggregator_bind_host"]),

--- a/src/traceml_ai/runtime/runtime.py
+++ b/src/traceml_ai/runtime/runtime.py
@@ -14,6 +14,12 @@ from traceml_ai.runtime.config import config
 from traceml_ai.runtime.identity import resolve_runtime_identity
 from traceml_ai.runtime.sampler_registry import build_samplers
 from traceml_ai.runtime.sender import SenderIdentity, TelemetryPublisher
+from traceml_ai.runtime.state import (
+    TraceMLRecordingStatus,
+    configure_trace_recording,
+    get_trace_recording_state,
+    mark_trace_recording_drained,
+)
 from traceml_ai.runtime.stdout_stderr_capture import StreamCapture
 from traceml_ai.samplers.base_sampler import BaseSampler
 from traceml_ai.transport.tcp_transport import TCPClient, TCPConfig
@@ -38,6 +44,7 @@ class TraceMLRuntime:
         settings: Optional[TraceMLSettings] = None,
     ) -> None:
         self._settings = settings or TraceMLSettings()
+        configure_trace_recording(self._settings.trace_max_steps)
 
         # Global config
         config.enable_logging = bool(self._settings.enable_logging)
@@ -107,7 +114,7 @@ class TraceMLRuntime:
             logger=self._logger,
         )
 
-    def _tick(self) -> None:
+    def _tick(self, samplers: Optional[List[BaseSampler]] = None) -> None:
         """
         Run all samplers once and delegate publishing.
 
@@ -121,23 +128,59 @@ class TraceMLRuntime:
         TelemetryPublisher flushes sampler writers, collects incremental
         payloads, and sends a single TCP batch.
         """
-        for sampler in self._samplers:
+        target_samplers = self._samplers if samplers is None else samplers
+
+        for sampler in target_samplers:
             _safe(
                 self._logger,
                 f"{sampler.sampler_name}.sample failed",
                 sampler.sample,
             )
 
-        self._publisher.publish(self._samplers)
+        self._publisher.publish(target_samplers)
+
+    def _drain_recording_samplers(self) -> None:
+        """Drain queue-backed samplers after recording has stopped."""
+        drain_samplers = [
+            sampler
+            for sampler in self._samplers
+            if bool(getattr(sampler, "drain_on_recording_stop", False))
+        ]
+        if drain_samplers:
+            self._tick(drain_samplers)
+        pending = any(
+            bool(sampler.has_pending_recording_data())
+            for sampler in drain_samplers
+        )
+        if not pending:
+            mark_trace_recording_drained()
 
     def _sampler_loop(self) -> None:
         """Sampler loop (all ranks)."""
         while not self._stop_event.is_set():
+            status = get_trace_recording_state().status
+            if status == TraceMLRecordingStatus.COMPLETE:
+                return
+            if status == TraceMLRecordingStatus.DRAINING:
+                self._drain_recording_samplers()
+                if (
+                    get_trace_recording_state().status
+                    == TraceMLRecordingStatus.COMPLETE
+                ):
+                    return
+                self._stop_event.wait(
+                    float(self._settings.sampler_interval_sec)
+                )
+                continue
+
             self._tick()
             self._stop_event.wait(float(self._settings.sampler_interval_sec))
 
-        # final tick
-        self._tick()
+        status = get_trace_recording_state().status
+        if status == TraceMLRecordingStatus.RECORDING:
+            self._tick()
+        elif status == TraceMLRecordingStatus.DRAINING:
+            self._drain_recording_samplers()
 
     def start(self) -> None:
         """

--- a/src/traceml_ai/runtime/sampler_registry.py
+++ b/src/traceml_ai/runtime/sampler_registry.py
@@ -39,6 +39,7 @@ class SamplerSpec:
     profiles: Optional[tuple[str, ...]] = None
     modes: Optional[tuple[str, ...]] = None
     rank_zero_only: bool = False
+    drain_on_recording_stop: bool = False
 
     def enabled_for(
         self,
@@ -65,6 +66,7 @@ def _spec(
     profiles: Optional[Iterable[str]] = None,
     modes: Optional[Iterable[str]] = None,
     rank_zero_only: bool = False,
+    drain_on_recording_stop: bool = False,
 ) -> tuple[str, SamplerSpec]:
     """Build one registry item with the key stored inside the spec."""
     spec = SamplerSpec(
@@ -73,6 +75,7 @@ def _spec(
         profiles=tuple(profiles) if profiles is not None else None,
         modes=tuple(modes) if modes is not None else None,
         rank_zero_only=rank_zero_only,
+        drain_on_recording_stop=bool(drain_on_recording_stop),
     )
     return key, spec
 
@@ -82,26 +85,47 @@ DEFAULT_SAMPLER_REGISTRY: Registry[SamplerSpec] = Registry(
         _spec("system", SystemSampler, rank_zero_only=True),
         _spec("process", ProcessSampler),
         _spec("stdout_stderr", StdoutStderrSampler, modes=("cli",)),
-        _spec("step_time", StepTimeSampler, profiles=("run", "deep")),
-        _spec("step_memory", StepMemorySampler, profiles=("run", "deep")),
-        _spec("layer_memory", LayerMemorySampler, profiles=("deep",)),
+        _spec(
+            "step_time",
+            StepTimeSampler,
+            profiles=("run", "deep"),
+            drain_on_recording_stop=True,
+        ),
+        _spec(
+            "step_memory",
+            StepMemorySampler,
+            profiles=("run", "deep"),
+            drain_on_recording_stop=True,
+        ),
+        _spec(
+            "layer_memory",
+            LayerMemorySampler,
+            profiles=("deep",),
+            drain_on_recording_stop=True,
+        ),
         _spec(
             "layer_forward_memory",
             LayerForwardMemorySampler,
             profiles=("deep",),
+            drain_on_recording_stop=True,
         ),
         _spec(
             "layer_backward_memory",
             LayerBackwardMemorySampler,
             profiles=("deep",),
+            drain_on_recording_stop=True,
         ),
         _spec(
-            "layer_forward_time", LayerForwardTimeSampler, profiles=("deep",)
+            "layer_forward_time",
+            LayerForwardTimeSampler,
+            profiles=("deep",),
+            drain_on_recording_stop=True,
         ),
         _spec(
             "layer_backward_time",
             LayerBackwardTimeSampler,
             profiles=("deep",),
+            drain_on_recording_stop=True,
         ),
     ]
 )
@@ -158,6 +182,7 @@ def build_samplers(
                 exc,
             )
             continue
+        sampler.drain_on_recording_stop = bool(spec.drain_on_recording_stop)
         samplers.append(sampler)
     return samplers
 

--- a/src/traceml_ai/runtime/settings.py
+++ b/src/traceml_ai/runtime/settings.py
@@ -16,6 +16,7 @@ This module defines the shared configuration dataclasses used by:
 """
 
 from dataclasses import dataclass
+from typing import Optional
 
 from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
 
@@ -73,3 +74,4 @@ class TraceMLSettings:
     history_enabled: bool = True
     db_path: str = ""
     summary_window_rows: int = DEFAULT_SUMMARY_WINDOW_ROWS
+    trace_max_steps: Optional[int] = None

--- a/src/traceml_ai/runtime/state.py
+++ b/src/traceml_ai/runtime/state.py
@@ -10,7 +10,17 @@ small compatibility facade for existing imports.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from threading import RLock
+from typing import Optional
+
+
+class TraceMLRecordingStatus(Enum):
+    """Lifecycle state for TraceML telemetry recording."""
+
+    RECORDING = "recording"
+    DRAINING = "draining"
+    COMPLETE = "complete"
 
 
 @dataclass
@@ -80,7 +90,70 @@ class TraceSessionState:
         return value
 
 
+@dataclass
+class TraceMLRecordingState:
+    """
+    Process-local state controlling whether TraceML should record telemetry.
+
+    Patch installation is separate from recording state: patches may remain
+    installed after the step budget is reached, but they should no-op.
+    """
+
+    max_steps: Optional[int] = None
+    _status: TraceMLRecordingStatus = field(
+        default=TraceMLRecordingStatus.RECORDING, init=False, repr=False
+    )
+    _lock: RLock = field(default_factory=RLock, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.max_steps is not None:
+            self.max_steps = self._validate_max_steps(self.max_steps)
+
+    @property
+    def status(self) -> TraceMLRecordingStatus:
+        """Return the current recording lifecycle status."""
+        with self._lock:
+            return self._status
+
+    def should_record(self) -> bool:
+        """Return True while instrumentation should emit telemetry."""
+        return self.status == TraceMLRecordingStatus.RECORDING
+
+    def mark_step_flushed(self, step: int) -> TraceMLRecordingStatus:
+        """
+        Update recording state after a TraceML step has been flushed.
+
+        The configured max step is inclusive: max_steps=100 records and flushes
+        step 100, then moves the runtime into final-drain mode.
+        """
+        TraceSessionState._validate_step(step)
+        with self._lock:
+            if (
+                self.max_steps is not None
+                and step >= self.max_steps
+                and self._status == TraceMLRecordingStatus.RECORDING
+            ):
+                self._status = TraceMLRecordingStatus.DRAINING
+            return self._status
+
+    def mark_drained(self) -> TraceMLRecordingStatus:
+        """Mark recording complete after the runtime performs its final drain."""
+        with self._lock:
+            if self._status == TraceMLRecordingStatus.DRAINING:
+                self._status = TraceMLRecordingStatus.COMPLETE
+            return self._status
+
+    @staticmethod
+    def _validate_max_steps(value: int) -> int:
+        if not isinstance(value, int):
+            raise TypeError("TraceML recording max_steps must be an integer.")
+        if value <= 0:
+            raise ValueError("TraceML recording max_steps must be positive.")
+        return value
+
+
 _DEFAULT_TRACE_SESSION_STATE = TraceSessionState()
+_DEFAULT_TRACE_RECORDING_STATE = TraceMLRecordingState()
 
 
 def get_trace_session_state() -> TraceSessionState:
@@ -98,8 +171,44 @@ def reset_trace_session_state(step: int = 0) -> int:
     return _DEFAULT_TRACE_SESSION_STATE.reset(step)
 
 
+def configure_trace_recording(
+    max_steps: Optional[int] = None,
+) -> TraceMLRecordingState:
+    """Configure process-local TraceML recording state."""
+    global _DEFAULT_TRACE_RECORDING_STATE
+    _DEFAULT_TRACE_RECORDING_STATE = TraceMLRecordingState(max_steps=max_steps)
+    return _DEFAULT_TRACE_RECORDING_STATE
+
+
+def get_trace_recording_state() -> TraceMLRecordingState:
+    """Return the active process-local TraceML recording state."""
+    return _DEFAULT_TRACE_RECORDING_STATE
+
+
+def should_record_trace_events() -> bool:
+    """Return True while TraceML instrumentation should emit telemetry."""
+    return _DEFAULT_TRACE_RECORDING_STATE.should_record()
+
+
+def mark_trace_step_flushed(step: int) -> TraceMLRecordingStatus:
+    """Update recording state after a TraceML step has been flushed."""
+    return _DEFAULT_TRACE_RECORDING_STATE.mark_step_flushed(step)
+
+
+def mark_trace_recording_drained() -> TraceMLRecordingStatus:
+    """Mark recording complete after runtime queue draining finishes."""
+    return _DEFAULT_TRACE_RECORDING_STATE.mark_drained()
+
+
 __all__ = [
+    "TraceMLRecordingState",
+    "TraceMLRecordingStatus",
     "TraceSessionState",
+    "configure_trace_recording",
+    "get_trace_recording_state",
     "get_trace_session_state",
+    "mark_trace_recording_drained",
+    "mark_trace_step_flushed",
     "reset_trace_session_state",
+    "should_record_trace_events",
 ]

--- a/src/traceml_ai/samplers/base_sampler.py
+++ b/src/traceml_ai/samplers/base_sampler.py
@@ -56,6 +56,7 @@ class BaseSampler(ABC):
             self.sender.max_rows_per_flush = int(max_rows_per_flush)
 
         self.enable_send: bool = True
+        self.drain_on_recording_stop: bool = False
 
     def _add_record(
         self,
@@ -81,3 +82,12 @@ class BaseSampler(ABC):
         with training.
         """
         raise NotImplementedError("Must be implemented by subclasses.")
+
+    def has_pending_recording_data(self) -> bool:
+        """
+        Return True while a queue-backed sampler still has unresolved data.
+
+        Most samplers drain synchronously and can use the default. Async GPU
+        timing samplers override this while waiting for CUDA events to resolve.
+        """
+        return False

--- a/src/traceml_ai/samplers/layer_backward_time_sampler.py
+++ b/src/traceml_ai/samplers/layer_backward_time_sampler.py
@@ -76,3 +76,7 @@ class LayerBackwardTimeSampler(BaseSampler):
 
         except Exception as e:
             self.logger.error(f"[TraceML] LayerBackwardTimeSampler error: {e}")
+
+    def has_pending_recording_data(self) -> bool:
+        """Return True while unresolved layer timing events remain buffered."""
+        return bool(self._local_buffer)

--- a/src/traceml_ai/samplers/layer_forward_time_sampler.py
+++ b/src/traceml_ai/samplers/layer_forward_time_sampler.py
@@ -77,3 +77,7 @@ class LayerForwardTimeSampler(BaseSampler):
 
         except Exception as e:
             self.logger.error(f"[TraceML] LayerForwardTimeSampler error: {e}")
+
+    def has_pending_recording_data(self) -> bool:
+        """Return True while unresolved layer timing events remain buffered."""
+        return bool(self._local_buffer)

--- a/src/traceml_ai/samplers/step_time_sampler.py
+++ b/src/traceml_ai/samplers/step_time_sampler.py
@@ -130,3 +130,7 @@ class StepTimeSampler(BaseSampler):
 
         except Exception as e:
             self.logger.error(f"[TraceML] StepTimeSampler error: {e}")
+
+    def has_pending_recording_data(self) -> bool:
+        """Return True while unresolved step timing batches remain buffered."""
+        return bool(self._pending)

--- a/src/traceml_ai/sdk/instrumentation.py
+++ b/src/traceml_ai/sdk/instrumentation.py
@@ -52,7 +52,11 @@ from traceml_ai.instrumentation.patches.forward_auto_timer_patch import (
 from traceml_ai.instrumentation.patches.h2d_auto_timer_patch import (
     h2d_auto_timer,
 )
-from traceml_ai.runtime.state import TraceSessionState, get_trace_session_state
+from traceml_ai.runtime.state import (
+    TraceSessionState,
+    get_trace_session_state,
+    mark_trace_step_flushed,
+)
 from traceml_ai.utils.entry_hook import attach_execution_entry_hooks
 from traceml_ai.utils.flush_buffers import flush_step_events
 from traceml_ai.utils.layer_parameter_memory import (
@@ -200,6 +204,14 @@ def trace_step(model: nn.Module):
             flush_step_events(model, trace_state.step)
         except Exception as exc:
             _log_instrumentation_error("flush failed", exc)
+
+        if step_completed:
+            try:
+                mark_trace_step_flushed(trace_state.step)
+            except Exception as exc:
+                _log_instrumentation_error(
+                    "recording state update failed", exc
+                )
 
 
 def trace_model_instance(

--- a/src/traceml_ai/sdk/summary_client.py
+++ b/src/traceml_ai/sdk/summary_client.py
@@ -12,8 +12,10 @@ from typing import Any, Dict, Optional
 
 from traceml_ai.sdk.protocol import (
     build_final_summary_request,
+    get_final_summary_json_path,
     get_final_summary_request_path,
     get_final_summary_response_path,
+    get_final_summary_txt_path,
     is_primary_rank,
     load_json_or_none,
     request_to_json,
@@ -31,6 +33,24 @@ def _read_text_or_empty(path: Path) -> str:
         return Path(path).read_text(encoding="utf-8")
     except Exception:
         return ""
+
+
+def _load_existing_final_summary(
+    session_root: Path,
+    *,
+    print_text: bool,
+) -> Optional[Dict[str, Any]]:
+    """Load existing canonical final-summary artifacts when available."""
+    summary = load_json_or_none(get_final_summary_json_path(session_root))
+    if summary is None:
+        return None
+
+    if print_text:
+        text = _read_text_or_empty(get_final_summary_txt_path(session_root))
+        if text:
+            print(text)
+
+    return summary
 
 
 def final_summary(
@@ -77,6 +97,13 @@ def final_summary(
         raise RuntimeError(
             "TraceML final_summary() requires history to be enabled."
         )
+
+    existing = _load_existing_final_summary(
+        ctx.session_root,
+        print_text=print_text,
+    )
+    if existing is not None:
+        return existing
 
     request = build_final_summary_request()
     request_path = get_final_summary_request_path(ctx.session_root)

--- a/src/traceml_ai/utils/flush_buffers.py
+++ b/src/traceml_ai/utils/flush_buffers.py
@@ -14,6 +14,7 @@ from traceml_ai.instrumentation.hooks.layer_forward_memory_hooks import (
 from traceml_ai.instrumentation.hooks.layer_forward_time_hooks import (
     flush_layer_forward_time_buffers,
 )
+from traceml_ai.runtime.state import should_record_trace_events
 
 from .step_memory import flush_step_memory_buffer
 from .timing import flush_step_time_buffer
@@ -22,7 +23,7 @@ TRACEML_DISABLED = os.environ.get("TRACEML_DISABLED") == "1"
 
 
 def flush_step_events(model: nn.Module, step: int) -> None:
-    if TRACEML_DISABLED:
+    if TRACEML_DISABLED or not should_record_trace_events():
         return
 
     flush_layer_forward_memory_buffers(model, step)

--- a/src/traceml_ai/utils/step_memory.py
+++ b/src/traceml_ai/utils/step_memory.py
@@ -7,6 +7,8 @@ from typing import Dict, Optional
 import torch
 import torch.nn as nn
 
+from traceml_ai.runtime.state import should_record_trace_events
+
 step_memory_queue: Queue = Queue(maxsize=2048)
 
 _temp_step_memory_buffer: Dict = {}
@@ -33,7 +35,7 @@ class StepMemoryTracker:
     """
 
     def __init__(self, model: nn.Module):
-        if TRACEML_DISABLED:
+        if TRACEML_DISABLED or not should_record_trace_events():
             return  # BYPASS: Do not attach any trackers
 
         self.model = model
@@ -50,7 +52,7 @@ class StepMemoryTracker:
         """
         Reset CUDA peak memory counters at step start.
         """
-        if TRACEML_DISABLED:
+        if TRACEML_DISABLED or not should_record_trace_events():
             return
 
         if self.device.type == "cuda":
@@ -66,7 +68,7 @@ class StepMemoryTracker:
           treat step memory as not applicable instead of a real zero-valued
           measurement
         """
-        if TRACEML_DISABLED:
+        if TRACEML_DISABLED or not should_record_trace_events():
             return
 
         if self.device.type == "cuda":
@@ -91,7 +93,7 @@ class StepMemoryTracker:
 
 
 def flush_step_memory_buffer(model: nn.Module, step: int) -> None:
-    if TRACEML_DISABLED:
+    if TRACEML_DISABLED or not should_record_trace_events():
         return
 
     model_id = id(model)

--- a/src/traceml_ai/utils/timing.py
+++ b/src/traceml_ai/utils/timing.py
@@ -23,6 +23,7 @@ from typing import Deque, List, Optional
 
 import torch
 
+from traceml_ai.runtime.state import should_record_trace_events
 from traceml_ai.utils.cuda_event_pool import get_cuda_event, return_cuda_event
 
 TRACEML_DISABLED = os.environ.get("TRACEML_DISABLED") == "1"
@@ -152,7 +153,7 @@ def record_event(evt: TimeEvent) -> None:
     STEP events are buffered until flush.
     GLOBAL events are enqueued immediately.
     """
-    if TRACEML_DISABLED:
+    if TRACEML_DISABLED or not should_record_trace_events():
         return
     if evt.scope == TimeScope.STEP:
         _STEP_BUFFER.append(evt)
@@ -166,7 +167,7 @@ def flush_step_time_buffer(step: int) -> None:
 
     Called once per optimizer step.
     """
-    if TRACEML_DISABLED:
+    if TRACEML_DISABLED or not should_record_trace_events():
         return
     if not _STEP_BUFFER:
         return
@@ -195,7 +196,7 @@ def timed_region(
     - Timing is best-effort
     - User exceptions are never swallowed
     """
-    if TRACEML_DISABLED:
+    if TRACEML_DISABLED or not should_record_trace_events():
         yield
         return
 

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -30,7 +30,12 @@ sys.modules.setdefault(
     ),
 )
 
-from traceml_ai.runtime.executor import extract_script_args, run_user_script
+from traceml_ai.runtime.executor import (
+    build_runtime_settings,
+    extract_script_args,
+    read_traceml_env,
+    run_user_script,
+)
 
 
 def test_extract_script_args_uses_separator_when_present(monkeypatch):
@@ -121,3 +126,32 @@ def test_run_user_script_restores_sys_argv_and_sys_path(tmp_path, monkeypatch):
     assert output_path.read_text(encoding="utf-8").endswith("--epochs|2")
     assert sys.argv == original_argv
     assert sys.path == original_path
+
+
+def test_read_traceml_env_parses_trace_max_steps(monkeypatch):
+    monkeypatch.setenv("TRACEML_SCRIPT_PATH", "train.py")
+    monkeypatch.setenv("TRACEML_TRACE_MAX_STEPS", "123")
+
+    cfg = read_traceml_env()
+
+    assert cfg["trace_max_steps"] == 123
+
+
+def test_build_runtime_settings_carries_trace_max_steps():
+    settings = build_runtime_settings(
+        {
+            "mode": "summary",
+            "profile": "run",
+            "interval": 1.0,
+            "enable_logging": False,
+            "logs_dir": "./logs",
+            "session_id": "test",
+            "summary_window_rows": 200,
+            "trace_max_steps": 5,
+            "aggregator_host": "127.0.0.1",
+            "aggregator_bind_host": "127.0.0.1",
+            "aggregator_port": 29765,
+        }
+    )
+
+    assert settings.trace_max_steps == 5

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -55,6 +55,7 @@ def test_build_parser_preserves_launch_commands() -> None:
     assert args.run_name == ""
     assert args.session_id == ""
     assert args.summary_window_rows == DEFAULT_SUMMARY_WINDOW_ROWS
+    assert args.trace_max_steps is None
     assert args.args == ["--epochs", "1"]
 
     default_args = parser.parse_args(["watch", "train.py"])
@@ -139,6 +140,28 @@ def test_summary_window_rows_must_be_positive() -> None:
         run_name="",
         session_id="",
         summary_window_rows=0,
+    )
+
+    with pytest.raises(SystemExit):
+        validate_launch_args(args)
+
+
+def test_trace_max_steps_must_be_positive() -> None:
+    args = argparse.Namespace(
+        mode="cli",
+        no_history=False,
+        nnodes=1,
+        nproc_per_node=1,
+        node_rank=0,
+        master_addr="127.0.0.1",
+        master_port=29500,
+        aggregator_host=None,
+        aggregator_bind_host=None,
+        aggregator_port=29765,
+        run_name="",
+        session_id="",
+        summary_window_rows=DEFAULT_SUMMARY_WINDOW_ROWS,
+        trace_max_steps=0,
     )
 
     with pytest.raises(SystemExit):

--- a/tests/runtime/test_sampler_registry.py
+++ b/tests/runtime/test_sampler_registry.py
@@ -4,6 +4,13 @@ from traceml_ai.runtime.sampler_registry import (
     build_samplers,
     select_sampler_specs,
 )
+from traceml_ai.runtime.runtime import TraceMLRuntime
+from traceml_ai.runtime.state import (
+    TraceMLRecordingStatus,
+    configure_trace_recording,
+    get_trace_recording_state,
+    mark_trace_step_flushed,
+)
 from traceml_ai.samplers import process_sampler
 from traceml_ai.samplers.base_sampler import BaseSampler
 from traceml_ai.samplers.process_sampler import ProcessSampler
@@ -15,8 +22,10 @@ class _FakeSampler(BaseSampler):
             sampler_name="FakeSampler",
             table_name="fake_samples",
         )
+        self.sample_idx = 0
 
     def sample(self) -> None:
+        self.sample_idx += 1
         return None
 
 
@@ -26,6 +35,27 @@ class _FakeLogger:
 
     def exception(self, message: str, *args: object) -> None:
         self.exceptions.append((message, args))
+
+
+class _FakePublisher:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, ...]] = []
+
+    def publish(self, samplers) -> None:
+        self.published.append(
+            tuple(getattr(s, "sampler_name", "") for s in samplers)
+        )
+
+
+class _PendingDrainSampler(_FakeSampler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.sampler_name = "PendingDrainSampler"
+        self.drain_on_recording_stop = True
+        self.pending = True
+
+    def has_pending_recording_data(self) -> bool:
+        return self.pending
 
 
 def _selected_keys(
@@ -197,6 +227,79 @@ def test_build_samplers_logs_and_skips_constructor_failures() -> None:
     assert isinstance(samplers[0], _FakeSampler)
     assert len(logger.exceptions) == 1
     assert "Failed to initialize sampler" in logger.exceptions[0][0]
+
+
+def test_queue_backed_samplers_are_marked_for_final_recording_drain() -> None:
+    specs = {
+        spec.key: spec
+        for spec in select_sampler_specs(
+            profile="deep",
+            mode="summary",
+            is_ddp=False,
+            local_rank=0,
+        )
+    }
+
+    assert specs["system"].drain_on_recording_stop is False
+    assert specs["process"].drain_on_recording_stop is False
+    assert specs["step_time"].drain_on_recording_stop is True
+    assert specs["step_memory"].drain_on_recording_stop is True
+    assert specs["layer_forward_time"].drain_on_recording_stop is True
+
+
+def test_runtime_final_recording_drain_skips_periodic_samplers() -> None:
+    periodic = _FakeSampler()
+    periodic.sampler_name = "PeriodicSampler"
+    drain = _FakeSampler()
+    drain.sampler_name = "DrainSampler"
+    drain.drain_on_recording_stop = True
+
+    publisher = _FakePublisher()
+    runtime = TraceMLRuntime.__new__(TraceMLRuntime)
+    runtime._samplers = [periodic, drain]
+    runtime._publisher = publisher
+    runtime._logger = _FakeLogger()
+
+    configure_trace_recording(max_steps=1)
+    mark_trace_step_flushed(1)
+    runtime._drain_recording_samplers()
+
+    assert periodic.sample_idx == 0
+    assert drain.sample_idx == 1
+    assert publisher.published == [("DrainSampler",)]
+    assert (
+        get_trace_recording_state().status == TraceMLRecordingStatus.COMPLETE
+    )
+
+    configure_trace_recording()
+
+
+def test_runtime_recording_drain_waits_for_pending_timing_data() -> None:
+    drain = _PendingDrainSampler()
+    publisher = _FakePublisher()
+    runtime = TraceMLRuntime.__new__(TraceMLRuntime)
+    runtime._samplers = [drain]
+    runtime._publisher = publisher
+    runtime._logger = _FakeLogger()
+
+    configure_trace_recording(max_steps=1)
+    mark_trace_step_flushed(1)
+    runtime._drain_recording_samplers()
+
+    assert drain.sample_idx == 1
+    assert (
+        get_trace_recording_state().status == TraceMLRecordingStatus.DRAINING
+    )
+
+    drain.pending = False
+    runtime._drain_recording_samplers()
+
+    assert drain.sample_idx == 2
+    assert (
+        get_trace_recording_state().status == TraceMLRecordingStatus.COMPLETE
+    )
+
+    configure_trace_recording()
 
 
 def test_process_sampler_does_not_set_cuda_device_when_unavailable(

--- a/tests/runtime/test_trace_session_state.py
+++ b/tests/runtime/test_trace_session_state.py
@@ -1,9 +1,16 @@
 import pytest
 
 from traceml_ai.runtime.state import (
+    TraceMLRecordingState,
+    TraceMLRecordingStatus,
     TraceSessionState,
+    configure_trace_recording,
+    get_trace_recording_state,
     get_trace_session_state,
+    mark_trace_recording_drained,
+    mark_trace_step_flushed,
     reset_trace_session_state,
+    should_record_trace_events,
 )
 from traceml_ai.sdk.instrumentation import TraceState
 
@@ -58,3 +65,52 @@ def test_decorators_import_path_shares_trace_state():
     assert TraceState.step == 2
     assert decorators.TraceState.step == 2
     assert decorators.trace_step is not None
+
+
+def test_trace_recording_state_is_unlimited_by_default():
+    state = TraceMLRecordingState()
+
+    assert state.should_record() is True
+    assert state.mark_step_flushed(1000) == TraceMLRecordingStatus.RECORDING
+    assert state.should_record() is True
+
+
+def test_trace_recording_state_transitions_after_max_step():
+    state = TraceMLRecordingState(max_steps=2)
+
+    assert state.mark_step_flushed(1) == TraceMLRecordingStatus.RECORDING
+    assert state.should_record() is True
+    assert state.mark_step_flushed(2) == TraceMLRecordingStatus.DRAINING
+    assert state.should_record() is False
+    assert state.mark_drained() == TraceMLRecordingStatus.COMPLETE
+    assert state.should_record() is False
+
+
+def test_global_trace_recording_helpers_configure_active_state():
+    configure_trace_recording(max_steps=1)
+
+    assert should_record_trace_events() is True
+    assert mark_trace_step_flushed(1) == TraceMLRecordingStatus.DRAINING
+    assert should_record_trace_events() is False
+    assert mark_trace_recording_drained() == TraceMLRecordingStatus.COMPLETE
+    assert (
+        get_trace_recording_state().status == TraceMLRecordingStatus.COMPLETE
+    )
+
+    configure_trace_recording()
+
+
+def test_timed_region_noops_when_recording_is_complete():
+    import traceml_ai.utils.timing as timing
+
+    configure_trace_recording(max_steps=1)
+    mark_trace_step_flushed(1)
+    mark_trace_recording_drained()
+
+    original_size = len(timing._STEP_BUFFER)
+    with timing.timed_region("_test_region", scope=timing.TimeScope.STEP):
+        pass
+
+    assert len(timing._STEP_BUFFER) == original_size
+
+    configure_trace_recording()

--- a/tests/sdk/test_init_and_wrappers.py
+++ b/tests/sdk/test_init_and_wrappers.py
@@ -459,6 +459,12 @@ def test_wrap_optimizer_preserves_identity_and_times_step(monkeypatch):
         yield
 
     monkeypatch.setattr(wrappers, "timed_region", fake_timed_region)
+    monkeypatch.setattr(
+        torch.optim.Optimizer,
+        "_traceml_opt_hooks_installed",
+        False,
+        raising=False,
+    )
 
     class DummyOptimizer:
         def __init__(self):

--- a/tests/sdk/test_init_and_wrappers.py
+++ b/tests/sdk/test_init_and_wrappers.py
@@ -298,6 +298,67 @@ def test_trace_step_only_auto_installs_optimizer_timing(monkeypatch):
     )
 
 
+def test_trace_step_marks_recording_draining_after_configured_step(
+    monkeypatch,
+):
+    from traceml_ai.runtime.state import (
+        TraceMLRecordingStatus,
+        configure_trace_recording,
+        get_trace_recording_state,
+        reset_trace_session_state,
+    )
+
+    instrumentation = _reload_instrumentation_module()
+    reset_trace_session_state()
+    configure_trace_recording(max_steps=1)
+
+    monkeypatch.setattr(
+        instrumentation,
+        "timed_region",
+        _noop_context_manager,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "forward_auto_timer",
+        _noop_context_manager,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "backward_auto_timer",
+        _noop_context_manager,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "h2d_auto_timer",
+        _noop_context_manager,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "StepMemoryTracker",
+        _NoopStepMemoryTracker,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "flush_step_events",
+        lambda model, step: None,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "ensure_optimizer_timing_installed",
+        lambda: None,
+    )
+
+    with instrumentation.trace_step(nn.Linear(2, 2)):
+        pass
+
+    assert (
+        get_trace_recording_state().status == TraceMLRecordingStatus.DRAINING
+    )
+
+    configure_trace_recording()
+    reset_trace_session_state()
+
+
 def test_wrap_dataloader_fetch_allows_custom_iterator_when_torch_patch_active(
     monkeypatch,
 ):


### PR DESCRIPTION

## What changed

- Added `--trace-max-steps` / `TRACEML_TRACE_MAX_STEPS` to record only the first N TraceML steps while training continues.
- Added internal recording state so timing, memory, sampler publishing, DB writes, and TCP sends stop cleanly after the trace budget is reached.
- Added final-drain behavior for queue-backed samplers so in-flight step telemetry is flushed before recording completes.
- Made `final_summary()` / `summary()` reuse an existing canonical `final_summary.json` instead of regenerating repeatedly.
- Added a short telemetry-settle step before first summary generation.
- Cleaned backward auto-timer scoped state restoration.
- Added Ray + Lightning example command docs and small public API / FAQ updates.

## Why

This lets users run TraceML on only a small number of training steps, which is useful for adoption, demos, and production jobs where continuous tracing overhead is not desired.

It also makes summary logging cleaner for W&B/MLflow-style workflows: users can call `traceml.summary()` near the end of training and get one stable compact payload, while `final_summary()` remains the full detailed artifact.

## How I tested

- [x] Unit tests
- [x] Integration or smoke test
- [x] Example training script
- [ ] Docs-only change
- [ ] Not run; reason:

Commands run:

```bash
python -m pytest tests/runtime tests/sdk/test_init_and_wrappers.py tests/test_h2d_timing.py -q
python -m pytest tests/integrations/test_hf_trainer.py -q
python -m pytest tests/sdk/test_summary_client.py tests/aggregator/test_summary_service.py -q
python -m pytest tests/sdk tests/aggregator tests/runtime -q
git diff --check
```

Manual smoke checks included Ray + Lightning 2-node runs showing input straggler and compute straggler summaries.

## Runtime impact

- [ ] No training-path runtime impact
- [x] May affect training-path overhead
- [x] May affect distributed launch, telemetry, or aggregator behavior
- [ ] Not applicable

Notes:

The added training-path checks are lightweight recording-state gates. After `--trace-max-steps` is reached, installed patches remain in place but should no-op and stop producing telemetry.

## Documentation

- [ ] README updated
- [x] User docs updated
- [x] Examples updated
- [ ] API docs updated
- [ ] Not needed

## Risk checklist

- [x] Does not add unnecessary CUDA synchronizations
- [x] Does not add blocking I/O on the training path
- [x] Fails safely without crashing user training
- [x] Keeps new dependencies optional unless discussed
- [x] Redacts or avoids sensitive training-environment data in examples

## Screenshots or output

Example compact tracker payload from `traceml.summary(print_text=True)`:

```python
{
  "traceml/schema_version": 1.4,
  "traceml/system/status": "NORMAL",
  "traceml/process/status": "NORMAL",
  "traceml/step_time/status": "WAIT-HEAVY",
  "traceml/step_time/total_step_ms": 83.57,
  "traceml/step_time/dataloader_ms": 1.05,
  "traceml/step_time/compute_ms": 27.07,
  "traceml/step_time/wait_ms": 55.45,
  "traceml/step_memory/status": "NO GPU"
}
```
