### PR TITLE
Docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@
 [**Use With Your Stack**](docs/user_guide/integrations.md) •
 [**FAQ**](docs/user_guide/faq.md)
 
-[**Slow PyTorch Training**](docs/guides/slow-pytorch-training.md) •
-[**DataLoader Bottlenecks**](docs/guides/pytorch-dataloader-bottleneck.md) •
-[**Low GPU Utilization**](docs/guides/low-gpu-utilization-pytorch.md) •
-[**DDP Rank Stragglers**](docs/guides/ddp-slow-training-rank-straggler.md) •
-[**Memory Creep**](docs/guides/pytorch-memory-creep.md)
+**Training bottleneck guides:**
+[Slow PyTorch Training](docs/guides/slow-pytorch-training.md) •
+[DataLoader Bottlenecks](docs/guides/pytorch-dataloader-bottleneck.md) •
+[Low GPU Utilization](docs/guides/low-gpu-utilization-pytorch.md) •
+[DDP Rank Stragglers](docs/guides/ddp-slow-training-rank-straggler.md) •
+[Memory Creep](docs/guides/pytorch-memory-creep.md)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # TraceML
 
-**Runtime bottleneck detection for PyTorch training jobs.**
+**Find slow PyTorch training bottlenecks: DataLoader stalls, low GPU utilization, DDP/FSDP rank stragglers, memory creep, and run regressions.**
 
 [![PyPI version](https://img.shields.io/pypi/v/traceml-ai.svg)](https://pypi.org/project/traceml-ai/)
 [![CI](https://github.com/traceopt-ai/traceml/actions/workflows/ci.yml/badge.svg)](https://github.com/traceopt-ai/traceml/actions/workflows/ci.yml)
@@ -14,12 +14,15 @@
 
 [**Quickstart**](docs/user_guide/quickstart.md) •
 [**Compare Runs**](docs/user_guide/compare.md) •
-[**How to Read Output**](docs/user_guide/reading-output.md) •
+[**Read Output**](docs/user_guide/reading-output.md) •
 [**Use With Your Stack**](docs/user_guide/integrations.md) •
-[**FAQ**](docs/user_guide/faq.md) •
-[**Security**](SECURITY.md) •
-[**Issues**](https://github.com/traceopt-ai/traceml/issues) •
-[**Discussions**](https://github.com/traceopt-ai/traceml/discussions)
+[**FAQ**](docs/user_guide/faq.md)
+
+[**Slow PyTorch Training**](docs/guides/slow-pytorch-training.md) •
+[**DataLoader Bottlenecks**](docs/guides/pytorch-dataloader-bottleneck.md) •
+[**Low GPU Utilization**](docs/guides/low-gpu-utilization-pytorch.md) •
+[**DDP Rank Stragglers**](docs/guides/ddp-slow-training-rank-straggler.md) •
+[**Memory Creep**](docs/guides/pytorch-memory-creep.md)
 
 </div>
 
@@ -182,6 +185,11 @@ changing the final saved artifacts.
 ## Learn More
 
 - [Quickstart](docs/user_guide/quickstart.md)
+- [Find why PyTorch training is slow](docs/guides/slow-pytorch-training.md)
+- [Find DataLoader Bottlenecks](docs/guides/pytorch-dataloader-bottleneck.md)
+- [Debug Low GPU Utilization](docs/guides/low-gpu-utilization-pytorch.md)
+- [Debug DDP Rank Stragglers](docs/guides/ddp-slow-training-rank-straggler.md)
+- [Find PyTorch Memory Creep](docs/guides/pytorch-memory-creep.md)
 - [Distributed Training](docs/user_guide/distributed-training.md)
 - [Running on Slurm](docs/user_guide/slurm.md)
 - [Use With Your Stack](docs/user_guide/integrations.md)

--- a/docs/guides/ddp-slow-training-rank-straggler.md
+++ b/docs/guides/ddp-slow-training-rank-straggler.md
@@ -1,0 +1,99 @@
+# Debug slow DDP training and rank stragglers
+
+Use this guide when PyTorch DDP training is slow, uneven, or controlled by one
+slow rank.
+
+TraceML compares worst-rank and median-rank timing in distributed runs. It can
+surface input stragglers, compute stragglers, mixed stragglers, and wait-heavy
+windows.
+
+## Run DDP with TraceML
+
+For single-node DDP:
+
+```bash
+traceml run train.py --nproc-per-node=4
+```
+
+For multi-node DDP, use the same `--run-name`, `--nnodes`,
+`--nproc-per-node`, and `--master-addr` on every node. See
+[Distributed Training](../user_guide/distributed-training.md).
+
+On Slurm, use the [Slurm guide](../user_guide/slurm.md) instead of writing
+the node flags by hand.
+
+## What to look for
+
+Start with the Step Time diagnosis.
+
+| Diagnosis | Meaning |
+|---|---|
+| `INPUT STRAGGLER` | one rank has meaningfully more dataloader burden than a typical rank |
+| `COMPUTE STRAGGLER` | one rank has meaningfully more forward, backward, or optimizer burden than a typical rank |
+| `STRAGGLER` | input and compute are both materially uneven |
+| `INPUT-BOUND` | input work is broad, not just one bad rank |
+| `WAIT-HEAVY` | meaningful residual time is not attributed to dataloader, H2D, forward, backward, or optimizer work |
+
+Then inspect:
+
+- `Worst Rank`
+- worst vs median timing
+- `Dataloader Fetch`
+- `Forward`
+- `Backward`
+- `Optimizer Step`
+- `Wait`
+
+## How to triage the worst rank
+
+If the diagnosis is `INPUT STRAGGLER`, inspect input loading on the worst rank:
+
+- uneven shards or batch construction
+- rank-local preprocessing jitter
+- slow storage path on one host
+- custom collation or tokenization on one rank
+
+If the diagnosis is `COMPUTE STRAGGLER`, inspect model-side work on the worst
+rank:
+
+- uneven input shapes
+- rank-local branching
+- extra forward, backward, or optimizer work
+- framework hooks or callbacks that run on one rank
+
+If the diagnosis is `STRAGGLER`, reduce the problem one phase at a time. Start
+with the phase that has the largest worst-vs-median gap.
+
+If the diagnosis is `WAIT-HEAVY`, remember that TraceML reports wait as
+residual time. It is not direct NCCL or all-reduce timing. Inspect logging,
+checkpointing, validation, CPU stalls, framework orchestration, and unobserved
+transfer paths before assuming the cause.
+
+## FSDP note
+
+TraceML supports single-node multi-GPU DDP and FSDP in the current public docs.
+Multi-node DDP summary reports are supported. Multi-node FSDP uses the same
+distributed launch path as DDP, but should be validated in your environment.
+
+Use this guide for rank-skew symptoms in FSDP runs, but do not treat it as
+FSDP-specific collective timing.
+
+## Compare a fix
+
+After changing data loading, batching, model logic, or host placement, compare
+the old and new summaries:
+
+```bash
+traceml compare old_run/final_summary.json new_run/final_summary.json
+```
+
+Look for changes in total step time, worst-rank skew, input time, compute time,
+wait time, and diagnosis.
+
+## Related
+
+- [Find why PyTorch training is slow](slow-pytorch-training.md)
+- [Find DataLoader Bottlenecks](pytorch-dataloader-bottleneck.md)
+- [Distributed Training](../user_guide/distributed-training.md)
+- [Running on Slurm](../user_guide/slurm.md)
+- [How to Read TraceML Output](../user_guide/reading-output.md)

--- a/docs/guides/low-gpu-utilization-pytorch.md
+++ b/docs/guides/low-gpu-utilization-pytorch.md
@@ -1,0 +1,87 @@
+# Debug low GPU utilization in PyTorch training
+
+Use this guide when PyTorch training is slow and GPU utilization is low,
+moderate, uneven, or bursty.
+
+Low GPU utilization is a symptom. TraceML helps decide whether the likely cause
+is input loading, host-to-device transfer, wait time, rank skew, memory
+pressure, or model-side compute behavior.
+
+## Confirm the symptom
+
+Run your training script:
+
+```bash
+traceml run train.py
+```
+
+In the System section, TraceML can report GPU utilization symptoms as:
+
+| Structured kind | Text status | Meaning |
+|---|---|---|
+| `LOW_GPU_UTILIZATION` | `LOW GPU UTIL` | average GPU utilization was below 30% |
+| `MODERATE_GPU_UTILIZATION` | `MODERATE GPU UTIL` | average GPU utilization was from 30% through 70% |
+
+Above 70%, TraceML does not emit a GPU-utilization issue unless another System
+rule fires.
+
+## Explain it with Step Time
+
+After confirming low or moderate GPU utilization, read the Step Time diagnosis.
+
+| Step Time diagnosis | What to do |
+|---|---|
+| `INPUT-BOUND` | Inspect the DataLoader and input path. |
+| `INPUT STRAGGLER` | Inspect the slow input rank. |
+| `WAIT-HEAVY` | Inspect work outside traced phases, such as logging, checkpointing, validation, CPU stalls, framework orchestration, or unobserved transfers. |
+| `COMPUTE-BOUND` | Inspect forward, backward, and optimizer time before changing the DataLoader. |
+| `COMPUTE STRAGGLER` or `STRAGGLER` | Inspect rank skew and the called-out worst rank. |
+| `BALANCED` | Compare against a known good run or use a heavier profiler for lower-level detail. |
+
+Low GPU utilization plus `INPUT-BOUND` is a strong signal to start with the
+[DataLoader bottleneck guide](pytorch-dataloader-bottleneck.md). Low GPU
+utilization by itself is not enough.
+
+## Checks that match TraceML evidence
+
+If input time is high:
+
+- inspect `DataLoader(num_workers=...)`
+- inspect CPU preprocessing, decoding, tokenization, and collation
+- check slow storage or network filesystems
+- compare with a synthetic-data run
+
+If H2D time is high:
+
+- check host-to-device transfer behavior
+- for CUDA training, check whether the input path uses `pin_memory=True` and
+  non-blocking transfer where appropriate
+
+If wait time is high:
+
+- inspect logging, checkpointing, validation, and framework work around the
+  traced training step
+- inspect CPU or RAM pressure in the System and Process sections
+
+If one rank is worse than the others:
+
+- use the [DDP rank straggler guide](ddp-slow-training-rank-straggler.md)
+- compare the worst rank with the median rank
+
+## Compare a fix
+
+After changing the suspected cause, compare the before and after summaries:
+
+```bash
+traceml compare old_run/final_summary.json new_run/final_summary.json
+```
+
+Check whether GPU utilization, total step time, input time, wait time, or the
+primary diagnosis changed.
+
+## Related
+
+- [Find why PyTorch training is slow](slow-pytorch-training.md)
+- [Find DataLoader Bottlenecks](pytorch-dataloader-bottleneck.md)
+- [Debug DDP Rank Stragglers](ddp-slow-training-rank-straggler.md)
+- [How to Read TraceML Output](../user_guide/reading-output.md)

--- a/docs/guides/pytorch-dataloader-bottleneck.md
+++ b/docs/guides/pytorch-dataloader-bottleneck.md
@@ -1,0 +1,156 @@
+# Find PyTorch DataLoader bottlenecks
+
+Use this guide when PyTorch training feels slow, GPU utilization is low, or
+distributed workers spend time waiting for an input rank to catch up.
+
+A DataLoader bottleneck means the input path is taking enough time to affect
+training throughput. In TraceML, start by checking whether step time is going
+to dataloader fetch, host-to-device transfer, compute, wait time, or rank skew.
+
+For whole-run triage, start with
+[Find why PyTorch training is slow](slow-pytorch-training.md). This page stays
+focused on the DataLoader and input-fetch path.
+
+## Symptoms
+
+A PyTorch DataLoader bottleneck can look like:
+
+- low or uneven GPU utilization
+- long gaps between training steps
+- real data is slower than synthetic data
+- batch collation, decoding, tokenization, or preprocessing feels expensive
+- one DDP or FSDP rank reaches compute later than the others
+- changing `num_workers` or input preprocessing changes throughput
+
+Low GPU utilization alone is not proof of a DataLoader bottleneck. Confirm
+where step time goes before changing the input pipeline.
+
+## Run TraceML
+
+If your script is not instrumented yet, start with the
+[Quickstart](../user_guide/quickstart.md).
+
+Run your training script in the default summary mode:
+
+```bash
+traceml run train.py
+```
+
+TraceML writes:
+
+```text
+logs/<run_name>/final_summary.json
+logs/<run_name>/final_summary.txt
+```
+
+You can re-print the saved text summary later:
+
+```bash
+traceml view logs/<run_name>/final_summary.json
+```
+
+## What to look for
+
+Start with the `Step Time` section.
+
+For DataLoader problems, the most relevant diagnoses are:
+
+- `INPUT-BOUND`: dataloader or input work is taking a large share of the
+  typical step
+- `INPUT STRAGGLER`: one rank has meaningfully more dataloader burden than a
+  typical rank
+
+Example:
+
+```text
+Step Time
+- Diagnosis: INPUT STRAGGLER
+- Stats: total 303.7ms | input 254.5ms | compute 259.5ms | wait 40.5ms
+- Why: r0 input was slower than median global rank (254.5/3.8ms).
+```
+
+Read this as:
+
+- input time is large enough to affect training speed
+- rank 0 is slower in the input path than the typical rank
+- other ranks may wait because distributed training follows the slowest rank
+
+If the diagnosis is `INPUT-BOUND`, inspect the whole input path. If the
+diagnosis is `INPUT STRAGGLER`, inspect the called-out rank first.
+
+## Check the input path
+
+Change one thing at a time, then rerun TraceML.
+
+Good first checks:
+
+- increase `DataLoader(num_workers=...)` gradually
+- reduce expensive CPU transforms, decoding, tokenization, or collation
+- move repeated preprocessing out of the training loop
+- check slow storage, network filesystems, or uneven dataset shards
+- compare against a synthetic-data run
+- in DDP or FSDP, inspect the worst input rank for host-side jitter or uneven
+  batches
+
+For CUDA training, also check whether your existing input path uses
+`pin_memory=True` and non-blocking host-to-device transfer where appropriate.
+TraceML separates dataloader fetch, H2D, compute, and wait time. Use that split
+to avoid treating a transfer, compute, or wait issue as a DataLoader issue.
+
+## Compare before and after
+
+After changing the input path, compare the old and new final summaries:
+
+```bash
+traceml compare old_run/final_summary.json new_run/final_summary.json
+```
+
+Use the compare output to check whether total step time, input time, wait time,
+or the diagnosis changed.
+
+## When this is not the right guide
+
+Use a different guide when the primary symptom is not DataLoader fetch time:
+
+- low or moderate GPU utilization without an input diagnosis:
+  [Debug Low GPU Utilization](low-gpu-utilization-pytorch.md)
+- distributed rank skew beyond the input path:
+  [Debug DDP Rank Stragglers](ddp-slow-training-rank-straggler.md)
+- rising GPU memory:
+  [Find PyTorch Memory Creep](pytorch-memory-creep.md)
+- run-to-run slowdown after a change:
+  [Compare Runs](../user_guide/compare.md)
+
+## Custom loaders and Ray Data
+
+TraceML automatically instruments `torch.utils.data.DataLoader` when initialized
+with `traceml.init(mode="auto")`.
+
+If your input iterator is not a PyTorch `DataLoader`, wrap the fetch path:
+
+```python
+train_loader = traceml.wrap_dataloader_fetch(train_loader)
+```
+
+This is the pattern used for Ray Data iterators, because Ray
+`iter_torch_batches(...)` is not a PyTorch `DataLoader`.
+
+## When to use a heavier profiler
+
+Use TraceML first to decide whether the input path is likely the problem.
+
+Use `torch.profiler` when you need operator-level or timeline detail for a
+specific window. Use Nsight Systems when you need lower-level CUDA or system
+timeline detail.
+
+TraceML does not replace those tools. It tells you whether the next profiler
+run should focus on DataLoader fetches, H2D copies, a specific rank, or a
+specific slow window.
+
+## Related
+
+- [Quickstart](../user_guide/quickstart.md)
+- [Find why PyTorch training is slow](slow-pytorch-training.md)
+- [How to Read TraceML Output](../user_guide/reading-output.md)
+- [Compare Runs](../user_guide/compare.md)
+- [Ray Train](../user_guide/integrations/ray.md)

--- a/docs/guides/pytorch-memory-creep.md
+++ b/docs/guides/pytorch-memory-creep.md
@@ -1,0 +1,88 @@
+# Find PyTorch memory creep during training
+
+Use this guide when PyTorch GPU memory rises during training, memory headroom
+shrinks over time, or a run eventually gets close to out-of-memory behavior.
+
+TraceML step-memory diagnostics separate memory pressure, memory imbalance, and
+memory growth over the observed window.
+
+## Run TraceML
+
+Run your training script:
+
+```bash
+traceml run train.py
+```
+
+Then read the Step Memory section in:
+
+```text
+logs/<run_name>/final_summary.txt
+logs/<run_name>/final_summary.json
+```
+
+## What to look for
+
+The most relevant Step Memory diagnoses are:
+
+| Diagnosis status | Structured kind | Meaning |
+|---|---|---|
+| `MEMORY CREEP` | `CREEP_CONFIRMED` | memory is rising across the window |
+| `MEMORY RISING` | `CREEP_EARLY` | memory is rising from early to recent steps |
+| `HIGH PRESSURE` | `HIGH_PRESSURE` | memory is near device capacity |
+| `IMBALANCE` | `IMBALANCE` | peak memory differs materially across ranks |
+
+Start with the diagnosis, then inspect the note, worst rank, and memory trend.
+
+## What to check after `MEMORY CREEP`
+
+Common causes to inspect:
+
+- graph-backed tensors retained across steps
+- appending `loss`, `logits`, hidden states, or activations to a list without
+  detaching them
+- caches that grow during training
+- step-local state that stays referenced after the step ends
+- validation or logging code that stores tensors instead of scalar values
+
+If a worst rank is shown, inspect that rank first.
+
+## What to check after `MEMORY RISING`
+
+`MEMORY RISING` is an early signal. It means the observed window is moving up,
+but it is weaker than `MEMORY CREEP`.
+
+Good next steps:
+
+- let the run continue long enough to collect another window
+- check whether the same trend appears again
+- compare with a known stable run
+
+## Pressure and imbalance are different
+
+`HIGH PRESSURE` means the run is close to device memory capacity. It does not
+by itself prove memory is growing.
+
+`IMBALANCE` means one rank is using materially more memory than the typical
+rank. Inspect per-rank workload, input shapes, and rank-local branches.
+
+System GPU memory and process GPU memory are useful context, but Step Memory is
+the section that diagnoses training-step memory trend.
+
+## Compare a fix
+
+After detaching tensors, clearing caches, changing logging, or reducing memory
+load, compare the before and after summaries:
+
+```bash
+traceml compare old_run/final_summary.json new_run/final_summary.json
+```
+
+Check whether Step Memory diagnosis, peak memory, memory trend, and worst-rank
+skew changed.
+
+## Related
+
+- [Find why PyTorch training is slow](slow-pytorch-training.md)
+- [How to Read TraceML Output](../user_guide/reading-output.md)
+- [Compare Runs](../user_guide/compare.md)

--- a/docs/guides/slow-pytorch-training.md
+++ b/docs/guides/slow-pytorch-training.md
@@ -1,0 +1,80 @@
+# Find why PyTorch training is slow
+
+Use this guide when PyTorch training is slow and you do not yet know whether
+the bottleneck is input loading, GPU utilization, distributed rank skew, memory
+growth, wait time, or a run-to-run regression.
+
+This is a triage guide. It points to focused guides instead of repeating every
+TraceML diagnosis.
+
+## Run one summary
+
+If your script is not instrumented yet, start with the
+[Quickstart](../user_guide/quickstart.md).
+
+Run your training script:
+
+```bash
+traceml run train.py
+```
+
+TraceML writes:
+
+```text
+logs/<run_name>/final_summary.json
+logs/<run_name>/final_summary.txt
+```
+
+Start with the final summary, then follow the branch that matches your
+diagnosis or symptom.
+
+## Choose the right path
+
+| What you see | Start here |
+|---|---|
+| Step Time says `INPUT-BOUND` | [Find DataLoader Bottlenecks](pytorch-dataloader-bottleneck.md) |
+| System says `LOW_GPU_UTILIZATION` or `MODERATE_GPU_UTILIZATION` | [Debug Low GPU Utilization](low-gpu-utilization-pytorch.md) |
+| Step Time says `INPUT STRAGGLER`, `COMPUTE STRAGGLER`, or `STRAGGLER` | [Debug DDP Rank Stragglers](ddp-slow-training-rank-straggler.md) |
+| Step Memory says `MEMORY CREEP` or `MEMORY RISING` | [Find PyTorch Memory Creep](pytorch-memory-creep.md) |
+| A recent change made the run slower | [Compare Runs](../user_guide/compare.md) |
+| Step Time says `COMPUTE-BOUND` or `WAIT-HEAVY` | [How to Read TraceML Output](../user_guide/reading-output.md) |
+
+## Quick interpretation
+
+`INPUT-BOUND` means dataloader or input work is taking a large share of the
+typical step. Confirm the input path before tuning model compute.
+
+`LOW_GPU_UTILIZATION` and `MODERATE_GPU_UTILIZATION` are system-level symptoms.
+They say the GPU was not fully busy, not why it was not fully busy. Pair them
+with Step Time.
+
+`INPUT STRAGGLER`, `COMPUTE STRAGGLER`, and `STRAGGLER` are distributed
+signals. Inspect the called-out worst rank and compare it with the median rank.
+
+`MEMORY CREEP` and `MEMORY RISING` are step-memory trend signals. Inspect
+retained tensors, caches, and per-step state that may stay alive.
+
+`COMPUTE-BOUND` means forward, backward, or optimizer time dominates the
+observed step. Use TraceML to choose the hot phase, then use an operator-level
+profiler if you need kernel or operator detail.
+
+`WAIT-HEAVY` is residual time not attributed to dataloader, H2D, forward,
+backward, or optimizer work. Inspect logging, checkpointing, validation,
+CPU-side stalls, framework orchestration, or unobserved transfers.
+
+## What not to assume
+
+- Low GPU utilization alone does not prove a DataLoader bottleneck.
+- A DDP slowdown is not always NCCL. TraceML currently reports rank skew and
+  residual wait, not explicit collective timing.
+- `BALANCED` means no clear bottleneck in the observed window. It does not
+  prove the run is globally optimal.
+- A single slow run is easier to trust after comparing it with a known good
+  `final_summary.json`.
+
+## Related
+
+- [Quickstart](../user_guide/quickstart.md)
+- [How to Read TraceML Output](../user_guide/reading-output.md)
+- [Compare Runs](../user_guide/compare.md)
+- [Distributed Training](../user_guide/distributed-training.md)

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -455,7 +455,7 @@ What to do next:
 
 ---
 
-### `MEMORY CREEP (EARLY)`
+### `MEMORY RISING`
 
 Meaning:
 
@@ -464,9 +464,9 @@ Meaning:
 
 In the current policy, this is based on:
 
-- multiple head-vs-tail slice comparisons
+- early, middle, and recent memory bands increasing
 - both worst and median memory rising
-- a meaningful absolute increase
+- growth that has not yet crossed the stronger confirmed-creep threshold
 
 Common causes:
 
@@ -489,7 +489,7 @@ Meaning:
 
 - memory growth is stronger and more consistent across the visible window
 
-This is a stronger signal than `MEMORY CREEP (EARLY)`.
+This is a stronger signal than `MEMORY RISING`.
 
 Common causes:
 
@@ -671,7 +671,7 @@ Use these as context cards:
 | `COMPUTE STRAGGLER` | inspect compute path on the worst rank |
 | `STRAGGLER` | inspect both input and compute unevenness |
 | `WAIT-HEAVY` | inspect logging, checkpointing, validation, CPU stalls, and unobserved transfer paths |
-| `MEMORY CREEP (EARLY)` | inspect retained state and watch the next window |
+| `MEMORY RISING` | inspect retained state and watch the next window |
 | `MEMORY CREEP` | inspect retained tensors and growing caches |
 | `HIGH PRESSURE` | reduce memory load |
 | `IMBALANCE` | inspect per-rank memory workload |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,12 @@ markdown_extensions:
   - toc: { permalink: true }
 
 nav:
+  - Guides:
+      - Slow PyTorch Training: guides/slow-pytorch-training.md
+      - Find DataLoader Bottlenecks: guides/pytorch-dataloader-bottleneck.md
+      - Low GPU Utilization: guides/low-gpu-utilization-pytorch.md
+      - DDP Rank Stragglers: guides/ddp-slow-training-rank-straggler.md
+      - Memory Creep: guides/pytorch-memory-creep.md
   - User Guide:
       - Quickstart: user_guide/quickstart.md
       - Distributed Training: user_guide/distributed-training.md


### PR DESCRIPTION
## What changed

- Added focused problem guides for common PyTorch training bottleneck searches:
  - slow PyTorch training
  - PyTorch DataLoader bottlenecks
  - low GPU utilization
  - DDP rank stragglers
  - PyTorch memory creep
- Updated the README subtitle and top navigation to separate core docs from training bottleneck guides.
- Added the new guides to `mkdocs.yml`.
- Updated the Step Memory wording in `reading-output.md` from `MEMORY CREEP (EARLY)` to the code-backed output label `MEMORY RISING`.
- Enabled blank GitHub issues through `.github/ISSUE_TEMPLATE/config.yml`.

## Why

This makes the GitHub repo easier to discover for users searching for concrete PyTorch training symptoms such as slow training, DataLoader stalls, low GPU utilization, DDP rank stragglers, and memory creep.

The new pages are intentionally separated by symptom so they can serve as focused entry points without duplicating the full reference docs. The wording was checked against TraceML's implemented CLI, output artifacts, diagnosis labels, and support boundaries so users should not see docs that promise behavior the code does not provide.

## How I tested

- [ ] Tests added or updated
- [ ] Existing tests run
- [x] Manual smoke test
- [x] Not run; reason: docs-only change; local MkDocs build could not run because `mkdocs` is not installed in this environment.

Manual verification commands:

```bash
rg -n "Training bottleneck guides|Slow PyTorch Training|DataLoader Bottlenecks|Low GPU Utilization|DDP Rank Stragglers|Memory Creep" README.md
rg -n "Slow PyTorch Training|Find DataLoader Bottlenecks|Low GPU Utilization|DDP Rank Stragglers|Memory Creep" mkdocs.yml docs/guides
rg -n "MEMORY CREEP \\(EARLY\\)" docs README.md
rg -n "MEMORY RISING|CREEP_EARLY|CREEP_CONFIRMED|LOW_GPU_UTILIZATION|MODERATE_GPU_UTILIZATION|INPUT-BOUND|INPUT STRAGGLER|COMPUTE STRAGGLER|WAIT-HEAVY|COMPUTE-BOUND|STRAGGLER" docs/guides docs/user_guide/reading-output.md src/traceml_ai/diagnostics tests/diagnostics tests/reporting/summary
rg -n "traceml run train.py|traceml view logs/<run_name>/final_summary.json|traceml compare old_run/final_summary.json new_run/final_summary.json|logs/<run_name>/final_summary.json|logs/<run_name>/final_summary.txt|--nproc-per-node=4|--run-name|--nnodes|wrap_dataloader_fetch|iter_torch_batches" docs/guides README.md docs/user_guide src/traceml_ai tests examples
test -f docs/guides/slow-pytorch-training.md && test -f docs/guides/pytorch-dataloader-bottleneck.md && test -f docs/guides/low-gpu-utilization-pytorch.md && test -f docs/guides/ddp-slow-training-rank-straggler.md && test -f docs/guides/pytorch-memory-creep.md
```

MkDocs build attempted:

```bash
python3 -m mkdocs build --strict
```

Result:

```text
No module named mkdocs
```

The GitHub Docs workflow installs docs dependencies and runs `mkdocs build --strict` on push to `main`.

## Runtime impact

- [x] No training-path impact
- [ ] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes:

Docs and GitHub issue-template configuration only. No tracing, sampler, transport, aggregator, runtime, or reporting code was changed.

## Docs

- [x] Updated
- [ ] Not needed

## Extra context

The guide content was checked against implemented TraceML labels and behavior, including `INPUT-BOUND`, `INPUT STRAGGLER`, `COMPUTE STRAGGLER`, `STRAGGLER`, `WAIT-HEAVY`, `LOW_GPU_UTILIZATION`, `MODERATE_GPU_UTILIZATION`, `MEMORY RISING`, `MEMORY CREEP`, `HIGH PRESSURE`, and `IMBALANCE`.
