### PR TITLE
Add DDP gradient-sync (all_reduce) timing via comm hook   (TRA-16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,4 +89,6 @@ jobs:
             tests/runtime/test_sampler_registry.py \
             tests/runtime/test_telemetry_publisher.py \
             tests/reporting/compare \
+            tests/test_ddp_comm_hook.py \
+            tests/sdk/test_instrumentation_namespace.py \
             -q

--- a/examples/README.md
+++ b/examples/README.md
@@ -45,6 +45,7 @@ These examples are still user-facing, but they are more about showing specific T
 |---|---|---|---|
 | `dataloader_bottleneck_demo.py` | Slow input pipeline or input-bound training | CPU / CUDA | Simulates dataloader delay |
 | `input_straggler_ddp_demo.py` | Input straggler in single-node DDP | CPU / CUDA | One rank is deliberately slower in the input path |
+| `ddp_comm_hook_demo.py` | DDP gradient-sync (all_reduce) timing per step | CPU / CUDA | Single- or multi-node; prints a per-step table of all step phases incl. comm |
 
 These are useful when you want to see how TraceML behaves on a known bottleneck.
 

--- a/examples/ddp_comm_hook_demo.py
+++ b/examples/ddp_comm_hook_demo.py
@@ -72,9 +72,24 @@ NUM_SAMPLES = 8192
 NUM_STEPS = 30
 
 COMM_EVENT = "_traceml_comm:ddp_grad_sync"
+DATA_EVENT = "_traceml_internal:dataloader_next"
+H2D_EVENT = "_traceml_internal:h2d_time"
 FWD_EVENT = "_traceml_internal:forward_time"
 BWD_EVENT = "_traceml_internal:backward_time"
+OPT_EVENT = "_traceml_internal:optimizer_step"
 STEP_EVENT = "_traceml_internal:step_time"
+
+# (column label, event name) — every step-scoped stream TraceML records,
+# in training-step execution order. Comm is the TRA-16 addition.
+COLUMNS = [
+    ("Data", DATA_EVENT),
+    ("H2D", H2D_EVENT),
+    ("Fwd", FWD_EVENT),
+    ("Bwd", BWD_EVENT),
+    ("Opt", OPT_EVENT),
+    ("Comm", COMM_EVENT),
+    ("Total", STEP_EVENT),
+]
 
 
 class TinyMLP(nn.Module):
@@ -128,13 +143,14 @@ def find_db() -> str | None:
     return None
 
 
-def _table_header() -> None:
-    print(
-        f"\n{'Step':>5}  {'Comm (ms)':>10}  {'Buckets':>7}  "
-        f"{'Forward (ms)':>13}  {'Backward (ms)':>14}  {'Step (ms)':>10}",
-        flush=True,
+def _print_header(lead: str) -> int:
+    """Print the timing-table header; return its width for separators."""
+    header = (
+        lead + "".join(f"{label:>9}" for label, _ in COLUMNS) + f"{'Bkts':>6}"
     )
-    print("-" * 70, flush=True)
+    print("\n" + header + "   (all times in ms)", flush=True)
+    print("-" * len(header), flush=True)
+    return len(header)
 
 
 def print_inprocess_results(use_cuda: bool) -> None:
@@ -174,45 +190,39 @@ def print_inprocess_results(use_cuda: bool) -> None:
             return evt.gpu_time_ms
         return (evt.cpu_end - evt.cpu_start) * 1000.0
 
-    _table_header()
-    total_comm = 0.0
+    width = _print_header(f"{'Step':>5}")
+    col_totals = {label: 0.0 for label, _ in COLUMNS}
     total_buckets = 0
+    n = len(batches)
+
     for batch in sorted(batches, key=lambda b: b.step):
-        comm_ms = 0.0
-        buckets = 0
-        fwd = bwd = step_ms = None
+        # Sum per event name: a step can carry several events of the same
+        # stream (e.g. one h2d per .to() call, one comm per DDP bucket).
+        sums: dict = {}
+        counts: dict = {}
         for evt in batch.events:
             d = duration_ms(evt)
-            if evt.name == COMM_EVENT:
-                comm_ms += d
-                buckets += 1
-            elif evt.name == FWD_EVENT:
-                fwd = d
-            elif evt.name == BWD_EVENT:
-                bwd = d
-            elif evt.name == STEP_EVENT:
-                step_ms = d
+            sums[evt.name] = sums.get(evt.name, 0.0) + d
+            counts[evt.name] = counts.get(evt.name, 0) + 1
 
-        total_comm += comm_ms
+        buckets = counts.get(COMM_EVENT, 0)
         total_buckets += buckets
 
-        def fmt(v):
-            return f"{v:.2f}" if v is not None else "—"
+        row = f"{batch.step:>5}"
+        for label, name in COLUMNS:
+            v = sums.get(name)
+            row += f"{v:>9.2f}" if v is not None else f"{'-':>9}"
+            if v is not None:
+                col_totals[label] += v
+        row += f"{buckets:>6}"
+        print(row, flush=True)
 
-        print(
-            f"{batch.step:>5}  {comm_ms:>10.2f}  {buckets:>7}  "
-            f"{fmt(fwd):>13}  {fmt(bwd):>14}  {fmt(step_ms):>10}",
-            flush=True,
-        )
-
-    n = len(batches)
-    print("-" * 70, flush=True)
-    print(
-        f"steps={n}  total_comm={total_comm:.1f} ms  "
-        f"avg_comm/step={total_comm / n:.2f} ms  "
-        f"avg_buckets/step={total_buckets / n:.1f}",
-        flush=True,
-    )
+    print("-" * width, flush=True)
+    avg_row = f"{'avg':>5}"
+    for label, _ in COLUMNS:
+        avg_row += f"{col_totals[label] / n:>9.2f}"
+    avg_row += f"{total_buckets / n:>6.1f}"
+    print(avg_row, flush=True)
 
 
 def print_db_results(db_path: str) -> None:
@@ -239,12 +249,7 @@ def print_db_results(db_path: str) -> None:
     rows = cur.fetchall()
     conn.close()
 
-    print(
-        f"\n{'Step':>5}  {'Rank':>4}  {'Comm (ms)':>10}  {'Buckets':>7}  "
-        f"{'Forward (ms)':>13}  {'Backward (ms)':>14}",
-        flush=True,
-    )
-    print("-" * 64, flush=True)
+    _print_header(f"{'Step':>5} {'Rank':>5}")
 
     for step, rank, events_json in rows:
         events = json.loads(events_json) if events_json else {}
@@ -255,16 +260,13 @@ def print_db_results(db_path: str) -> None:
                 v = device_stats.get(key)
                 if v is not None:
                     return fmt.format(v)
-            return "—"
+            return "-"
 
-        print(
-            f"{step:>5}  {rank:>4}  "
-            f"{stat(COMM_EVENT):>10}  "
-            f"{stat(COMM_EVENT, key='n_calls', fmt='{:.0f}'):>7}  "
-            f"{stat(FWD_EVENT):>13}  "
-            f"{stat(BWD_EVENT):>14}",
-            flush=True,
-        )
+        row = f"{step:>5} {rank:>5}"
+        for _, name in COLUMNS:
+            row += f"{stat(name):>9}"
+        row += f"{stat(COMM_EVENT, key='n_calls', fmt='{:.0f}'):>6}"
+        print(row, flush=True)
 
 
 def main() -> None:

--- a/examples/ddp_comm_hook_demo.py
+++ b/examples/ddp_comm_hook_demo.py
@@ -37,7 +37,6 @@ Notes
   no communication happened).
 - Comm timing overlaps with backward compute for early buckets. Only the
   last bucket's all_reduce is pure communication (backward is done).
-  See ``deep_dive_bucket_ordering_and_overlap.md`` for details.
 - Data-only for now: ``_traceml_comm:ddp_grad_sync`` events are persisted to
   the telemetry DB but are NOT yet surfaced in the terminal/dashboard or the
   diagnosis engine (until then the comm wall-time stays folded into the
@@ -262,7 +261,10 @@ def print_db_results(db_path: str) -> None:
                     return fmt.format(v)
             return "-"
 
-        row = f"{step:>5} {rank:>5}"
+        # step/rank are nullable in the schema (best-effort writer).
+        step_s = step if step is not None else "-"
+        rank_s = rank if rank is not None else "-"
+        row = f"{step_s:>5} {rank_s:>5}"
         for _, name in COLUMNS:
             row += f"{stat(name):>9}"
         row += f"{stat(COMM_EVENT, key='n_calls', fmt='{:.0f}'):>6}"
@@ -365,6 +367,12 @@ def main() -> None:
         drop_last=True,
     )
 
+    if len(loader) == 0:
+        raise SystemExit(
+            "[demo] zero batches per rank (drop_last=True): lower "
+            "BATCH_SIZE or world size so each rank gets a full batch."
+        )
+
     model.train()
     step = 0
     epoch = 0
@@ -417,34 +425,41 @@ def main() -> None:
 
     under_launcher = bool(os.environ.get("TRACEML_SESSION_ID", "").strip())
 
-    if not under_launcher:
-        # Plain torchrun: no sampler drained the step-time queue, so each
-        # rank can print its own per-step table from in-process data.
-        log("per-step timings (in-process, this rank only):")
-        print_inprocess_results(use_cuda)
-    else:
-        # Under `traceml run`: the sampler shipped everything to the
-        # aggregator; read the per-rank timings back from the session DB.
-        traceml.final_summary()
-        if rank == 0:
-            db_path = find_db()
-            if db_path:
-                print(f"\n[demo] session DB: {db_path}", flush=True)
-                print_db_results(db_path)
-            else:
-                print(
-                    "DB not found on this node (it lives on node 0).",
-                    file=sys.stderr,
-                )
+    # Timing readout is best-effort: a failure here must not turn an
+    # otherwise successful training run into a non-zero exit.
+    try:
+        if not under_launcher:
+            # Plain torchrun: no sampler drained the step-time queue, so
+            # each rank can print its own per-step table from in-process
+            # data.
+            log("per-step timings (in-process, this rank only):")
+            print_inprocess_results(use_cuda)
+        else:
+            # Under `traceml run`: the sampler shipped everything to the
+            # aggregator; read the per-rank timings back from the DB.
+            traceml.final_summary()
+            if rank == 0:
+                db_path = find_db()
+                if db_path:
+                    print(f"\n[demo] session DB: {db_path}", flush=True)
+                    print_db_results(db_path)
+                else:
+                    print(
+                        "DB not found on this node (it lives on node 0).",
+                        file=sys.stderr,
+                    )
+    except Exception as exc:
+        print(f"[demo] timing readout failed: {exc}", file=sys.stderr)
 
     if rank == 0:
         print(
             "\nWhat you just saw: TraceML's comm hook wrapped DDP's "
-            "gradient all_reduce and timed every bucket with CUDA events "
-            "while training ran at full speed. Early buckets overlap "
-            "backward compute; only the last bucket is pure comm wait. "
-            f"Under `traceml run` these land in SQLite as {COMM_EVENT} "
-            "(dashboard/diagnosis wiring is the TRA-30 follow-up).",
+            "gradient all_reduce and timed every bucket asynchronously "
+            "(CUDA events on GPU, wall-clock on CPU) while training ran "
+            "at full speed. Early buckets overlap backward compute; only "
+            "the last bucket is pure comm wait. Under `traceml run` "
+            f"these land in SQLite as {COMM_EVENT} (dashboard/diagnosis "
+            "wiring is the TRA-30 follow-up).",
             flush=True,
         )
 

--- a/examples/ddp_comm_hook_demo.py
+++ b/examples/ddp_comm_hook_demo.py
@@ -1,0 +1,128 @@
+"""
+DDP gradient-sync timing demo.
+
+Shows ``traceml.wrap_ddp(model)`` instrumenting the DDP comm hook to
+capture per-step NCCL all_reduce timing as ``_traceml_comm:ddp_grad_sync``
+events.
+
+Run with torchrun::
+
+    torchrun --nproc_per_node=2 examples/ddp_comm_hook_demo.py
+
+Or via the TraceML CLI::
+
+    traceml run examples/ddp_comm_hook_demo.py
+
+Convention
+----------
+- Pass the DDP **wrapper** to ``trace_step(model)`` — this triggers
+  auto-install of the comm hook.
+- Pass ``model.module`` (the inner module) to ``trace_model_instance()``
+  for layer hooks.
+
+Notes
+-----
+- During ``ddp_model.no_sync()`` accumulation steps, DDP suppresses the
+  hook — those steps produce zero ``ddp_grad_sync`` events (correct:
+  no communication happened).
+- Comm timing overlaps with backward compute for early buckets. Only the
+  last bucket's all_reduce is pure communication (backward is done).
+  See ``deep_dive_bucket_ordering_and_overlap.md`` for details.
+"""
+
+import os
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader, DistributedSampler, TensorDataset
+
+import traceml_ai as traceml
+
+NUM_STEPS = 10
+BATCH_SIZE = 32
+
+
+class TinyMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(128, 256),
+            nn.ReLU(),
+            nn.Linear(256, 10),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+def main() -> None:
+    rank = int(os.environ.get("RANK", 0))
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+
+    use_cuda = torch.cuda.is_available()
+    backend = "nccl" if use_cuda else "gloo"
+
+    dist.init_process_group(backend=backend, rank=rank, world_size=world_size)
+
+    if use_cuda:
+        torch.cuda.set_device(local_rank)
+        device = torch.device("cuda", local_rank)
+    else:
+        device = torch.device("cpu")
+
+    traceml.init(mode="auto")
+
+    inner_model = TinyMLP().to(device)
+
+    if use_cuda:
+        model = torch.nn.parallel.DistributedDataParallel(
+            inner_model,
+            device_ids=[local_rank],
+            output_device=local_rank,
+        )
+    else:
+        model = torch.nn.parallel.DistributedDataParallel(inner_model)
+
+    # Explicit wrap_ddp — alternatively, just pass `model` (the DDP
+    # wrapper) to trace_step() and auto-install handles it.
+    traceml.wrap_ddp(model)
+
+    optimizer = optim.SGD(model.parameters(), lr=0.01)
+    criterion = nn.CrossEntropyLoss()
+
+    x = torch.randn(256, 128)
+    y = torch.randint(0, 10, (256,))
+    dataset = TensorDataset(x, y)
+    sampler = DistributedSampler(dataset, num_replicas=world_size, rank=rank)
+    loader = DataLoader(dataset, batch_size=BATCH_SIZE, sampler=sampler)
+
+    model.train()
+
+    for step, (batch_x, batch_y) in enumerate(loader):
+        if step >= NUM_STEPS:
+            break
+
+        batch_x = batch_x.to(device)
+        batch_y = batch_y.to(device)
+
+        with traceml.trace_step(model):
+            optimizer.zero_grad()
+            logits = model(batch_x)
+            loss = criterion(logits, batch_y)
+            loss.backward()
+            optimizer.step()
+
+        if rank == 0:
+            print(f"Step {step}: loss={loss.item():.4f}")
+
+    if rank == 0:
+        print("Done.")
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ddp_comm_hook_demo.py
+++ b/examples/ddp_comm_hook_demo.py
@@ -1,17 +1,23 @@
 """
 DDP gradient-sync timing demo.
 
-Shows ``traceml.wrap_ddp(model)`` instrumenting the DDP comm hook to
-capture per-step NCCL all_reduce timing as ``_traceml_comm:ddp_grad_sync``
-events.
+Shows TraceML timing each DDP gradient all_reduce during
+``loss.backward()`` via the comm hook, emitted per bucket as
+``_traceml_comm:ddp_grad_sync`` events.
 
-Run with torchrun::
+Run with torchrun (2 ranks shown; per-step timings printed from the
+in-process queue at the end — each rank prints its own table)::
 
-    torchrun --nproc_per_node=2 examples/ddp_comm_hook_demo.py
+    torchrun --nnodes=2 --nproc_per_node=1 --node_rank=<0|1> \\
+        --master_addr=<node0-ip> --master_port=29400 \\
+        examples/ddp_comm_hook_demo.py
 
-Or via the TraceML CLI::
+Or via the TraceML CLI (full pipeline; per-step comm timings are read back
+from the session SQLite DB and printed at the end)::
 
-    traceml run examples/ddp_comm_hook_demo.py
+    traceml run examples/ddp_comm_hook_demo.py --mode summary \\
+        --run-name ddp_comm_demo --nnodes 2 --node-rank <0|1> \\
+        --master-addr <node0-ip> --aggregator-bind-host 0.0.0.0
 
 Convention
 ----------
@@ -37,9 +43,17 @@ Notes
   diagnosis engine (until then the comm wall-time stays folded into the
   ``wait_ms`` residual, as ``wait_ms`` always has for DDP). Wiring a comm
   bucket + comm-bound diagnosis is the TRA-30 follow-up.
+- The session DB lives on the node-0 machine (the aggregator owner), so the
+  DB-backed timing table prints on global rank 0 only.
 """
 
+import glob
+import json
 import os
+import socket
+import sqlite3
+import sys
+from queue import Empty
 
 import torch
 import torch.distributed as dist
@@ -49,27 +63,217 @@ from torch.utils.data import DataLoader, DistributedSampler, TensorDataset
 
 import traceml_ai as traceml
 
-NUM_STEPS = 10
-BATCH_SIZE = 32
+SEED = 42
+INPUT_DIM = 512
+HIDDEN_DIM = 1024
+NUM_CLASSES = 10
+BATCH_SIZE = 512
+NUM_SAMPLES = 8192
+NUM_STEPS = 30
+
+COMM_EVENT = "_traceml_comm:ddp_grad_sync"
+FWD_EVENT = "_traceml_internal:forward_time"
+BWD_EVENT = "_traceml_internal:backward_time"
+STEP_EVENT = "_traceml_internal:step_time"
 
 
 class TinyMLP(nn.Module):
     def __init__(self):
         super().__init__()
         self.net = nn.Sequential(
-            nn.Linear(128, 256),
-            nn.ReLU(),
-            nn.Linear(256, 10),
+            nn.Linear(INPUT_DIM, HIDDEN_DIM),
+            nn.GELU(),
+            nn.Linear(HIDDEN_DIM, NUM_CLASSES),
         )
 
     def forward(self, x):
         return self.net(x)
 
 
+def find_db() -> str | None:
+    """
+    Locate the TraceML SQLite DB for this session.
+
+    The aggregator writes to ``{session_root}/aggregator/telemetry`` (no
+    .db extension). The launcher sets TRACEML_SESSION_ID and TRACEML_LOGS_DIR
+    in the executor environment, so we can derive the path directly.
+    """
+    session_id = os.environ.get("TRACEML_SESSION_ID", "").strip()
+    logs_dir = os.environ.get("TRACEML_LOGS_DIR", "").strip()
+    if session_id and logs_dir:
+        launch_cwd = (
+            os.environ.get("TRACEML_LAUNCH_CWD", "").strip() or os.getcwd()
+        )
+        logs_dir_abs = (
+            os.path.join(launch_cwd, logs_dir)
+            if not os.path.isabs(logs_dir)
+            else logs_dir
+        )
+        db = os.path.join(logs_dir_abs, session_id, "aggregator", "telemetry")
+        if os.path.exists(db):
+            return db
+
+    for root in [
+        os.path.join(os.path.dirname(__file__), "logs"),
+        os.path.join(os.getcwd(), "logs"),
+    ]:
+        matches = sorted(
+            glob.glob(
+                os.path.join(root, "**/aggregator/telemetry"), recursive=True
+            )
+        )
+        if matches:
+            return matches[-1]
+
+    return None
+
+
+def _table_header() -> None:
+    print(
+        f"\n{'Step':>5}  {'Comm (ms)':>10}  {'Buckets':>7}  "
+        f"{'Forward (ms)':>13}  {'Backward (ms)':>14}  {'Step (ms)':>10}",
+        flush=True,
+    )
+    print("-" * 70, flush=True)
+
+
+def print_inprocess_results(use_cuda: bool) -> None:
+    """
+    Per-step timing table from the in-process step-time queue.
+
+    Under plain torchrun there is no TraceML runtime/sampler, so the
+    StepTimeBatch objects flushed by ``trace_step`` stay in the process-local
+    queue. Draining it here is demo-only introspection — under
+    ``traceml run`` the sampler consumes this queue and the data lands in
+    the session SQLite DB instead (see ``print_db_results``).
+    """
+    from traceml_ai.utils.timing import get_step_time_queue
+
+    if use_cuda:
+        torch.cuda.synchronize()
+
+    batches = []
+    q = get_step_time_queue()
+    while True:
+        try:
+            batches.append(q.get_nowait())
+        except Empty:
+            break
+
+    if not batches:
+        print(
+            "No buffered step batches (running under `traceml run`? "
+            "The sampler consumed them — see the DB table instead).",
+            flush=True,
+        )
+        return
+
+    def duration_ms(evt) -> float:
+        evt.try_resolve()
+        if evt.gpu_time_ms is not None:
+            return evt.gpu_time_ms
+        return (evt.cpu_end - evt.cpu_start) * 1000.0
+
+    _table_header()
+    total_comm = 0.0
+    total_buckets = 0
+    for batch in sorted(batches, key=lambda b: b.step):
+        comm_ms = 0.0
+        buckets = 0
+        fwd = bwd = step_ms = None
+        for evt in batch.events:
+            d = duration_ms(evt)
+            if evt.name == COMM_EVENT:
+                comm_ms += d
+                buckets += 1
+            elif evt.name == FWD_EVENT:
+                fwd = d
+            elif evt.name == BWD_EVENT:
+                bwd = d
+            elif evt.name == STEP_EVENT:
+                step_ms = d
+
+        total_comm += comm_ms
+        total_buckets += buckets
+
+        def fmt(v):
+            return f"{v:.2f}" if v is not None else "—"
+
+        print(
+            f"{batch.step:>5}  {comm_ms:>10.2f}  {buckets:>7}  "
+            f"{fmt(fwd):>13}  {fmt(bwd):>14}  {fmt(step_ms):>10}",
+            flush=True,
+        )
+
+    n = len(batches)
+    print("-" * 70, flush=True)
+    print(
+        f"steps={n}  total_comm={total_comm:.1f} ms  "
+        f"avg_comm/step={total_comm / n:.2f} ms  "
+        f"avg_buckets/step={total_buckets / n:.1f}",
+        flush=True,
+    )
+
+
+def print_db_results(db_path: str) -> None:
+    """Per-step, per-rank timing table read back from the session DB."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    tables = [r[0] for r in cur.fetchall()]
+
+    if "step_time_samples" not in tables:
+        print(
+            "step_time_samples table not found — aggregator may not have "
+            "flushed.",
+            flush=True,
+        )
+        conn.close()
+        return
+
+    cur.execute(
+        "SELECT step, rank, events_json FROM step_time_samples "
+        "ORDER BY step, rank"
+    )
+    rows = cur.fetchall()
+    conn.close()
+
+    print(
+        f"\n{'Step':>5}  {'Rank':>4}  {'Comm (ms)':>10}  {'Buckets':>7}  "
+        f"{'Forward (ms)':>13}  {'Backward (ms)':>14}",
+        flush=True,
+    )
+    print("-" * 64, flush=True)
+
+    for step, rank, events_json in rows:
+        events = json.loads(events_json) if events_json else {}
+
+        def stat(event_name, key="duration_ms", fmt="{:.2f}"):
+            entry = events.get(event_name, {})
+            for device_stats in entry.values():
+                v = device_stats.get(key)
+                if v is not None:
+                    return fmt.format(v)
+            return "—"
+
+        print(
+            f"{step:>5}  {rank:>4}  "
+            f"{stat(COMM_EVENT):>10}  "
+            f"{stat(COMM_EVENT, key='n_calls', fmt='{:.0f}'):>7}  "
+            f"{stat(FWD_EVENT):>13}  "
+            f"{stat(BWD_EVENT):>14}",
+            flush=True,
+        )
+
+
 def main() -> None:
     rank = int(os.environ.get("RANK", 0))
     local_rank = int(os.environ.get("LOCAL_RANK", 0))
     world_size = int(os.environ.get("WORLD_SIZE", 1))
+
+    def log(msg: str) -> None:
+        print(f"[rank {rank}] {msg}", flush=True)
 
     use_cuda = torch.cuda.is_available()
     backend = "nccl" if use_cuda else "gloo"
@@ -79,12 +283,50 @@ def main() -> None:
     if use_cuda:
         torch.cuda.set_device(local_rank)
         device = torch.device("cuda", local_rank)
+        device_name = torch.cuda.get_device_name(local_rank)
     else:
         device = torch.device("cpu")
+        device_name = "cpu"
 
     traceml.init(mode="auto")
 
+    torch.manual_seed(SEED)
     inner_model = TinyMLP().to(device)
+
+    n_params = sum(p.numel() for p in inner_model.parameters())
+    grad_mb = n_params * 4 / (1024 * 1024)
+    batches_per_epoch = NUM_SAMPLES // world_size // BATCH_SIZE
+
+    if rank == 0:
+        print("=" * 70, flush=True)
+        print("DDP gradient-sync timing demo (TRA-16)", flush=True)
+        print("=" * 70, flush=True)
+        print(f"world_size       : {world_size} ranks", flush=True)
+        print(f"backend          : {backend}", flush=True)
+        print(
+            f"model            : TinyMLP {INPUT_DIM}->{HIDDEN_DIM}"
+            f"->{NUM_CLASSES} ({n_params:,} params, "
+            f"{grad_mb:.2f} MB fp32 grads to all_reduce per step)",
+            flush=True,
+        )
+        print(
+            f"data             : {NUM_SAMPLES} samples, batch {BATCH_SIZE} "
+            f"-> {batches_per_epoch} batches/epoch/rank",
+            flush=True,
+        )
+        print(
+            f"steps            : {NUM_STEPS} "
+            f"(~{-(-NUM_STEPS // max(batches_per_epoch, 1))} epochs)",
+            flush=True,
+        )
+        print(
+            "what is timed    : every DDP gradient all_reduce (per bucket) "
+            f"during loss.backward(), emitted as {COMM_EVENT}",
+            flush=True,
+        )
+        print("=" * 70, flush=True)
+
+    log(f"host={socket.gethostname()} device={device_name}")
 
     if use_cuda:
         model = torch.nn.parallel.DistributedDataParallel(
@@ -99,37 +341,110 @@ def main() -> None:
     # above already auto-installs the comm hook on the first forward.
     # It is required in manual / selective mode.
     traceml.wrap_ddp(model)
+    log(
+        "comm hook installed="
+        f"{getattr(model, '_traceml_ddp_comm_hook_installed', False)} "
+        "(explicit wrap_ddp; init(mode='auto') would also auto-install "
+        "on first forward)"
+    )
 
-    optimizer = optim.SGD(model.parameters(), lr=0.01)
+    optimizer = optim.AdamW(model.parameters(), lr=1e-3)
     criterion = nn.CrossEntropyLoss()
 
-    x = torch.randn(256, 128)
-    y = torch.randint(0, 10, (256,))
+    x = torch.randn(NUM_SAMPLES, INPUT_DIM)
+    y = torch.randint(0, NUM_CLASSES, (NUM_SAMPLES,))
     dataset = TensorDataset(x, y)
     sampler = DistributedSampler(dataset, num_replicas=world_size, rank=rank)
-    loader = DataLoader(dataset, batch_size=BATCH_SIZE, sampler=sampler)
+    loader = DataLoader(
+        dataset,
+        batch_size=BATCH_SIZE,
+        sampler=sampler,
+        pin_memory=use_cuda,
+        drop_last=True,
+    )
 
     model.train()
+    step = 0
+    epoch = 0
 
-    for step, (batch_x, batch_y) in enumerate(loader):
-        if step >= NUM_STEPS:
-            break
+    # Epoch loop so NUM_STEPS is honored even when it exceeds one epoch.
+    while step < NUM_STEPS:
+        sampler.set_epoch(epoch)
+        for batch_x, batch_y in loader:
+            if step >= NUM_STEPS:
+                break
 
-        batch_x = batch_x.to(device)
-        batch_y = batch_y.to(device)
+            with traceml.trace_step(model):
+                batch_x = batch_x.to(device, non_blocking=True)
+                batch_y = batch_y.to(device, non_blocking=True)
 
-        with traceml.trace_step(model):
-            optimizer.zero_grad()
-            logits = model(batch_x)
-            loss = criterion(logits, batch_y)
-            loss.backward()
-            optimizer.step()
+                optimizer.zero_grad(set_to_none=True)
+                logits = model(batch_x)
+                loss = criterion(logits, batch_y)
+                loss.backward()
+                optimizer.step()
 
+            step += 1
+            if rank == 0 and step % 5 == 0:
+                print(
+                    f"step {step:>3}/{NUM_STEPS} | epoch {epoch} | "
+                    f"loss {loss.item():.4f}",
+                    flush=True,
+                )
+        epoch += 1
+
+    # Sanity: after DDP all_reduce, every rank must hold identical grads.
+    # (The comm hook only TIMES the sync; it must not alter gradients.)
+    grad_norm = torch.sqrt(
+        sum((p.grad.detach() ** 2).sum() for p in inner_model.parameters())
+    )
+    norms = [torch.zeros_like(grad_norm) for _ in range(world_size)]
+    dist.all_gather(norms, grad_norm)
+    if rank == 0:
+        norm_strs = ", ".join(
+            f"r{i}={n.item():.6f}" for i, n in enumerate(norms)
+        )
+        identical = all(
+            torch.allclose(norms[0], n, rtol=1e-6, atol=1e-9) for n in norms
+        )
+        print(
+            f"\ngrad-norm check  : {norm_strs} | identical across ranks: "
+            f"{identical}",
+            flush=True,
+        )
+
+    under_launcher = bool(os.environ.get("TRACEML_SESSION_ID", "").strip())
+
+    if not under_launcher:
+        # Plain torchrun: no sampler drained the step-time queue, so each
+        # rank can print its own per-step table from in-process data.
+        log("per-step timings (in-process, this rank only):")
+        print_inprocess_results(use_cuda)
+    else:
+        # Under `traceml run`: the sampler shipped everything to the
+        # aggregator; read the per-rank timings back from the session DB.
+        traceml.final_summary()
         if rank == 0:
-            print(f"Step {step}: loss={loss.item():.4f}")
+            db_path = find_db()
+            if db_path:
+                print(f"\n[demo] session DB: {db_path}", flush=True)
+                print_db_results(db_path)
+            else:
+                print(
+                    "DB not found on this node (it lives on node 0).",
+                    file=sys.stderr,
+                )
 
     if rank == 0:
-        print("Done.")
+        print(
+            "\nWhat you just saw: TraceML's comm hook wrapped DDP's "
+            "gradient all_reduce and timed every bucket with CUDA events "
+            "while training ran at full speed. Early buckets overlap "
+            "backward compute; only the last bucket is pure comm wait. "
+            f"Under `traceml run` these land in SQLite as {COMM_EVENT} "
+            "(dashboard/diagnosis wiring is the TRA-30 follow-up).",
+            flush=True,
+        )
 
     dist.destroy_process_group()
 

--- a/examples/ddp_comm_hook_demo.py
+++ b/examples/ddp_comm_hook_demo.py
@@ -15,8 +15,12 @@ Or via the TraceML CLI::
 
 Convention
 ----------
-- Pass the DDP **wrapper** to ``trace_step(model)`` — this triggers
-  auto-install of the comm hook.
+- ``traceml.init(mode="auto")`` patches ``DDP.forward`` so the comm hook
+  auto-installs on each DDP model's first forward (no explicit call needed).
+  ``traceml.wrap_ddp(model)`` is the explicit equivalent and is required in
+  ``manual`` / ``selective`` mode.
+- Pass the DDP **wrapper** (not ``model.module``) to ``trace_step(model)``
+  so step-time and layer-buffer flushes route by the right model id.
 - Pass ``model.module`` (the inner module) to ``trace_model_instance()``
   for layer hooks.
 
@@ -86,8 +90,9 @@ def main() -> None:
     else:
         model = torch.nn.parallel.DistributedDataParallel(inner_model)
 
-    # Explicit wrap_ddp — alternatively, just pass `model` (the DDP
-    # wrapper) to trace_step() and auto-install handles it.
+    # Explicit wrap_ddp. Optional in auto mode: traceml.init(mode="auto")
+    # above already auto-installs the comm hook on the first forward.
+    # It is required in manual / selective mode.
     traceml.wrap_ddp(model)
 
     optimizer = optim.SGD(model.parameters(), lr=0.01)

--- a/examples/ddp_comm_hook_demo.py
+++ b/examples/ddp_comm_hook_demo.py
@@ -32,6 +32,11 @@ Notes
 - Comm timing overlaps with backward compute for early buckets. Only the
   last bucket's all_reduce is pure communication (backward is done).
   See ``deep_dive_bucket_ordering_and_overlap.md`` for details.
+- Data-only for now: ``_traceml_comm:ddp_grad_sync`` events are persisted to
+  the telemetry DB but are NOT yet surfaced in the terminal/dashboard or the
+  diagnosis engine (until then the comm wall-time stays folded into the
+  ``wait_ms`` residual, as ``wait_ms`` always has for DDP). Wiring a comm
+  bucket + comm-bound diagnosis is the TRA-30 follow-up.
 """
 
 import os

--- a/src/traceml_ai/__init__.py
+++ b/src/traceml_ai/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "wrap_forward",
     "wrap_backward",
     "wrap_optimizer",
+    "wrap_ddp",
     "wrap_h2d",
 ]
 
@@ -38,6 +39,7 @@ if TYPE_CHECKING:
         trace_step,
         wrap_backward,
         wrap_dataloader_fetch,
+        wrap_ddp,
         wrap_forward,
         wrap_h2d,
         wrap_optimizer,

--- a/src/traceml_ai/api.py
+++ b/src/traceml_ai/api.py
@@ -114,6 +114,7 @@ def init(
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
     patch_h2d: Optional[bool] = None,
+    patch_ddp_comm: Optional[bool] = None,
 ) -> TraceMLInitConfig:
     """Initialize TraceML instrumentation for this process."""
     from traceml_ai.sdk.initial import init as _init
@@ -124,6 +125,7 @@ def init(
         patch_forward=patch_forward,
         patch_backward=patch_backward,
         patch_h2d=patch_h2d,
+        patch_ddp_comm=patch_ddp_comm,
     )
 
 
@@ -134,6 +136,7 @@ def start(
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
     patch_h2d: Optional[bool] = None,
+    patch_ddp_comm: Optional[bool] = None,
 ) -> TraceMLInitConfig:
     """Alias for `traceml.init(...)`."""
     from traceml_ai.sdk.initial import start as _start
@@ -144,6 +147,7 @@ def start(
         patch_forward=patch_forward,
         patch_backward=patch_backward,
         patch_h2d=patch_h2d,
+        patch_ddp_comm=patch_ddp_comm,
     )
 
 

--- a/src/traceml_ai/api.py
+++ b/src/traceml_ai/api.py
@@ -91,6 +91,13 @@ def wrap_optimizer(*args: Any, **kwargs: Any) -> Any:
     return _wrap_optimizer(*args, **kwargs)
 
 
+def wrap_ddp(*args: Any, **kwargs: Any) -> Any:
+    """Instrument DDP gradient-sync comm timing."""
+    from traceml_ai.sdk.wrappers import wrap_ddp as _wrap_ddp
+
+    return _wrap_ddp(*args, **kwargs)
+
+
 def wrap_h2d(*args: Any, **kwargs: Any) -> Any:
     """
     Lazily resolve and apply TraceML H2D transfer wrapping.
@@ -151,5 +158,6 @@ __all__ = [
     "wrap_forward",
     "wrap_backward",
     "wrap_optimizer",
+    "wrap_ddp",
     "wrap_h2d",
 ]

--- a/src/traceml_ai/instrumentation/hooks/ddp_comm_hook.py
+++ b/src/traceml_ai/instrumentation/hooks/ddp_comm_hook.py
@@ -100,7 +100,12 @@ def _traceml_ddp_comm_hook_factory(
 
         def _on_complete(fut: Any) -> torch.Tensor:
             # .then() passes the Future itself, not the resolved value.
-            result = fut.value()[0]
+            # base_hook's future already resolves to the reduced bucket
+            # tensor (allreduce_hook does the list-extraction internally),
+            # so pass it through unchanged. DDP consumes this return value
+            # as the bucket gradient -- slicing it (e.g. [0]) feeds DDP a
+            # wrong-shaped tensor and silently corrupts gradients.
+            result = fut.value()
 
             try:
                 cpu_end = time.time()
@@ -152,9 +157,11 @@ def install_ddp_comm_hook(
     ddp_model:
         A ``DistributedDataParallel``-wrapped model.
     base_hook:
-        Optional user-supplied comm hook (e.g. ``fp16_compress_hook``,
-        PowerSGD).  When ``None``, delegates to PyTorch's default
-        ``allreduce_hook``.
+        Optional user-supplied comm hook whose future resolves to the
+        reduced bucket tensor (e.g. ``fp16_compress_hook``).  Registered
+        with ``state=None``, so ``state``-bearing hooks such as PowerSGD
+        are not yet supported.  When ``None``, delegates to PyTorch's
+        default ``allreduce_hook``.
 
     Returns
     -------
@@ -224,4 +231,14 @@ def ensure_ddp_comm_hook_installed(model: torch.nn.Module) -> None:
     if not isinstance(model, DistributedDataParallel):
         return
 
-    install_ddp_comm_hook(model)
+    # Auto-path (called from the init() forward patch on every DDP forward):
+    # instrumentation must never break training, so swallow and report any
+    # failure. The explicit wrap_ddp() path calls install_ddp_comm_hook
+    # directly and still surfaces errors to the caller.
+    try:
+        install_ddp_comm_hook(model)
+    except Exception as exc:
+        print(
+            f"[TraceML] DDP comm-hook auto-install failed: {exc}",
+            file=sys.stderr,
+        )

--- a/src/traceml_ai/instrumentation/hooks/ddp_comm_hook.py
+++ b/src/traceml_ai/instrumentation/hooks/ddp_comm_hook.py
@@ -1,0 +1,227 @@
+"""
+DDP gradient-sync timing via ``register_comm_hook``.
+
+What it catches
+---------------
+Per-bucket NCCL ``all_reduce`` wall-time during ``loss.backward()`` on a
+``DistributedDataParallel`` model.  One ``TimeEvent`` per bucket per step,
+aggregated per step by ``StepTimeSampler`` via the existing
+``(name, device, is_gpu)`` key.
+
+What it does NOT catch
+----------------------
+- User-issued ``dist.all_reduce()`` calls (no DDP gradient sync).
+- FSDP ``reduce_scatter`` / ``all_gather`` (different API surface).
+- Collectives outside ``loss.backward()`` (barrier, broadcast, etc.).
+
+Wire name
+---------
+``_traceml_comm:ddp_grad_sync``
+
+Implementation notes
+--------------------
+- Hook entry runs on the **compute stream** (autograd thread inside
+  ``loss.backward()``).  ``gpu_start.record()`` lands on this stream.
+- ``.then()`` callback runs on a **pool stream** (not the NCCL comm
+  stream — see ``ivalue_inl.h:1180-1201``).  ``gpu_end.record()`` lands
+  there, after the pool stream synchronises with the NCCL end-event.
+- ``gpu_start.elapsed_time(gpu_end)`` therefore spans the NCCL kernel
+  wall-time (cross-stream, device-global clock).
+- ``cpu_start`` / ``cpu_end`` measure kernel-launch overhead only
+  (Future resolves at NCCL enqueue, not completion).
+
+Cross-stream sync contract (load-bearing):
+    ``reducer.cpp:979-986`` TODO comment: "As long as autograd uses the
+    default stream … these operations are implicitly sequenced."
+    ``async_op=True`` collectives fork a comm stream synced with the
+    current stream at launch.  Our event pair is well-defined.
+"""
+
+import sys
+import time
+from typing import Any, Callable, Optional
+
+import torch
+import torch.distributed as dist
+
+from traceml_ai.utils.cuda_event_pool import get_cuda_event, return_cuda_event
+from traceml_ai.utils.timing import TimeEvent, TimeScope, record_event
+
+_WIRE_NAME = "_traceml_comm:ddp_grad_sync"
+
+
+def _traceml_ddp_comm_hook_factory(
+    base_hook: Callable[..., torch.futures.Future[torch.Tensor]],
+) -> Callable[..., torch.futures.Future[torch.Tensor]]:
+    """
+    Return an instrumented comm hook that wraps *base_hook* with timing.
+
+    The returned closure records per-bucket CUDA events around
+    ``base_hook(state, bucket)`` and chains a ``.then()`` callback to
+    emit a ``TimeEvent`` when the NCCL collective completes.
+
+    Parameters
+    ----------
+    base_hook:
+        The hook that performs the actual collective (e.g.
+        ``default_hooks.allreduce_hook``).  Must return a
+        ``Future[Tensor]``.
+    """
+
+    def instrumented_hook(
+        state: Any,
+        bucket: dist.GradBucket,
+    ) -> torch.futures.Future[torch.Tensor]:
+        cpu_start = time.time()
+
+        gpu_start: Optional[torch.cuda.Event] = None
+        gpu_end: Optional[torch.cuda.Event] = None
+        device = "cpu"
+
+        if torch.cuda.is_available():
+            try:
+                device = f"cuda:{torch.cuda.current_device()}"
+                gpu_start = get_cuda_event()
+                gpu_end = get_cuda_event()
+                gpu_start.record()
+            except Exception:
+                gpu_start = gpu_end = None
+                device = "cpu"
+
+        try:
+            fut = base_hook(state, bucket)
+        except Exception:
+            # base_hook raised synchronously, before returning a Future.
+            # _on_complete never runs, so the events acquired above would
+            # leak from the pool.  Return them, then re-raise unchanged.
+            return_cuda_event(gpu_start)
+            return_cuda_event(gpu_end)
+            raise
+
+        def _on_complete(fut: Any) -> torch.Tensor:
+            # .then() passes the Future itself, not the resolved value.
+            result = fut.value()[0]
+
+            try:
+                cpu_end = time.time()
+
+                if gpu_start is not None and gpu_end is not None:
+                    gpu_end.record()
+                    evt = TimeEvent(
+                        name=_WIRE_NAME,
+                        device=device,
+                        cpu_start=cpu_start,
+                        cpu_end=cpu_end,
+                        gpu_start=gpu_start,
+                        gpu_end=gpu_end,
+                        scope=TimeScope.STEP,
+                    )
+                else:
+                    evt = TimeEvent(
+                        name=_WIRE_NAME,
+                        device=device,
+                        cpu_start=cpu_start,
+                        cpu_end=cpu_end,
+                        scope=TimeScope.STEP,
+                    )
+
+                record_event(evt)
+
+            except Exception:
+                return_cuda_event(gpu_start)
+                return_cuda_event(gpu_end)
+
+            return result
+
+        return fut.then(_on_complete)
+
+    return instrumented_hook
+
+
+def install_ddp_comm_hook(
+    ddp_model: torch.nn.parallel.DistributedDataParallel,
+    base_hook: Optional[
+        Callable[..., torch.futures.Future[torch.Tensor]]
+    ] = None,
+) -> torch.nn.parallel.DistributedDataParallel:
+    """
+    Install TraceML timing on a DDP model's gradient-sync hook.
+
+    Parameters
+    ----------
+    ddp_model:
+        A ``DistributedDataParallel``-wrapped model.
+    base_hook:
+        Optional user-supplied comm hook (e.g. ``fp16_compress_hook``,
+        PowerSGD).  When ``None``, delegates to PyTorch's default
+        ``allreduce_hook``.
+
+    Returns
+    -------
+    The same ``ddp_model`` instance (in-place, like ``wrap_optimizer``).
+
+    Notes
+    -----
+    - Idempotent via ``_traceml_ddp_comm_hook_installed`` sentinel.
+    - PyTorch allows ONE hook per DDP instance.  If the user already
+      registered a hook directly (not through ``wrap_ddp``), our
+      ``register_comm_hook`` call raises ``RuntimeError``.  We catch it,
+      warn to stderr, and return ``ddp_model`` unchanged (fail-open).
+    - Installing ANY comm hook causes PyTorch to lose the fused
+      copy+divide optimisation in ``reducer.cpp:383-384`` vs ``:417-421``.
+      Cost: one extra tensor scan per bucket per step (sub-microsecond).
+    """
+    from torch.nn.parallel import DistributedDataParallel
+
+    if not isinstance(ddp_model, DistributedDataParallel):
+        raise TypeError(
+            "install_ddp_comm_hook() expects a "
+            "DistributedDataParallel instance, "
+            f"got {type(ddp_model).__name__}."
+        )
+
+    if getattr(ddp_model, "_traceml_ddp_comm_hook_installed", False):
+        return ddp_model
+
+    if base_hook is None:
+        from torch.distributed.algorithms.ddp_comm_hooks.default_hooks import (
+            allreduce_hook,
+        )
+
+        base_hook = allreduce_hook
+
+    if not callable(base_hook):
+        raise TypeError(
+            "base_hook must be callable, " f"got {type(base_hook).__name__}."
+        )
+
+    instrumented = _traceml_ddp_comm_hook_factory(base_hook)
+
+    try:
+        ddp_model.register_comm_hook(state=None, hook=instrumented)
+    except RuntimeError as exc:
+        print(
+            f"[TraceML] cannot register DDP comm hook: {exc}",
+            file=sys.stderr,
+        )
+        return ddp_model
+
+    ddp_model._traceml_ddp_comm_hook_installed = True  # type: ignore[attr-defined]
+    return ddp_model
+
+
+def ensure_ddp_comm_hook_installed(model: torch.nn.Module) -> None:
+    """
+    Auto-install DDP comm-hook timing when *model* is a DDP wrapper.
+
+    No-op for non-DDP models.  Idempotent and best-effort, mirroring
+    ``ensure_optimizer_timing_installed``: this is the auto-path entry
+    point called from ``trace_step``.  Errors never propagate into the
+    user's training loop.
+    """
+    from torch.nn.parallel import DistributedDataParallel
+
+    if not isinstance(model, DistributedDataParallel):
+        return
+
+    install_ddp_comm_hook(model)

--- a/src/traceml_ai/instrumentation/hooks/ddp_comm_hook.py
+++ b/src/traceml_ai/instrumentation/hooks/ddp_comm_hook.py
@@ -223,7 +223,9 @@ def ensure_ddp_comm_hook_installed(model: torch.nn.Module) -> None:
 
     No-op for non-DDP models.  Idempotent and best-effort, mirroring
     ``ensure_optimizer_timing_installed``: this is the auto-path entry
-    point called from ``trace_step``.  Errors never propagate into the
+    point, invoked on each DDP instance's first forward by the
+    ``DDP.forward`` patch that ``init()`` installs (see
+    ``patches/ddp_comm_patch.py``).  Errors never propagate into the
     user's training loop.
     """
     from torch.nn.parallel import DistributedDataParallel

--- a/src/traceml_ai/instrumentation/patches/ddp_comm_patch.py
+++ b/src/traceml_ai/instrumentation/patches/ddp_comm_patch.py
@@ -1,0 +1,53 @@
+"""
+DDP gradient-sync comm-hook auto-patch.
+
+Patches ``DistributedDataParallel.forward`` once at ``traceml.init()`` time so
+each DDP instance gets the TraceML comm hook installed on its first forward.
+Mirrors the forward / h2d auto-patches: a single class-level patch installed by
+``patch_ddp_comm()``.
+
+Why first-forward (lazy), not ``__init__``
+------------------------------------------
+- A class-level patch catches DDP instances regardless of construction order
+  (even ones an integration created before ``init()`` ran).
+- Installing at first forward (inside the training loop) rather than at
+  construction lets a user register their own comm hook first; if they did,
+  ``install_ddp_comm_hook`` fail-opens instead of preempting it.
+- It removes the old fragility where auto-install keyed on the model object
+  passed to ``trace_step`` and silently skipped when an integration passed the
+  unwrapped model (e.g. the HuggingFace Trainer callback).
+
+Wire name: ``_traceml_comm:ddp_grad_sync`` (emitted by the installed hook).
+"""
+
+from typing import Any
+
+import torch.nn as nn
+
+from traceml_ai.instrumentation.hooks.ddp_comm_hook import (
+    ensure_ddp_comm_hook_installed,
+)
+
+_ORIG_DDP_FORWARD = None
+
+
+def _traceml_ddp_forward(self: nn.Module, *args: Any, **kwargs: Any) -> Any:
+    # One-shot lazy install on first forward (covers success and fail-open so
+    # a pre-registered user hook does not retry / spam stderr every step).
+    if not getattr(self, "_traceml_ddp_comm_patch_attempted", False):
+        self._traceml_ddp_comm_patch_attempted = True
+        ensure_ddp_comm_hook_installed(self)
+    return _ORIG_DDP_FORWARD(self, *args, **kwargs)
+
+
+def patch_ddp_comm() -> None:
+    """Patch ``DistributedDataParallel.forward`` once. Safe to call repeatedly."""
+    from torch.nn.parallel import DistributedDataParallel as _DDP
+
+    if getattr(_DDP, "_traceml_ddp_comm_patched", False):
+        return
+
+    global _ORIG_DDP_FORWARD
+    _ORIG_DDP_FORWARD = _DDP.forward
+    _DDP.forward = _traceml_ddp_forward  # type: ignore[assignment]
+    _DDP._traceml_ddp_comm_patched = True  # type: ignore[attr-defined]

--- a/src/traceml_ai/integrations/lightning.py
+++ b/src/traceml_ai/integrations/lightning.py
@@ -39,6 +39,11 @@ def init():
     DataLoader fetch timing plus the H2D Tensor.to patch. The callback turns H2D
     timing on only around Lightning's batch transfer hooks and wraps
     LightningModule.forward directly for model-forward timing.
+
+    ``patch_ddp_comm`` is enabled for parity with the HF/Ray integrations:
+    when Lightning's DDPStrategy wraps the module in DistributedDataParallel,
+    the DDP.forward patch installs the gradient-sync comm hook on first
+    forward. It is a no-op for non-DDP (single-device) Lightning runs.
     """
     import traceml_ai as traceml
 
@@ -46,6 +51,7 @@ def init():
         mode="selective",
         patch_dataloader=True,
         patch_h2d=True,
+        patch_ddp_comm=True,
     )
 
 

--- a/src/traceml_ai/integrations/lightning.py
+++ b/src/traceml_ai/integrations/lightning.py
@@ -39,11 +39,6 @@ def init():
     DataLoader fetch timing plus the H2D Tensor.to patch. The callback turns H2D
     timing on only around Lightning's batch transfer hooks and wraps
     LightningModule.forward directly for model-forward timing.
-
-    ``patch_ddp_comm`` is enabled for parity with the HF/Ray integrations:
-    when Lightning's DDPStrategy wraps the module in DistributedDataParallel,
-    the DDP.forward patch installs the gradient-sync comm hook on first
-    forward. It is a no-op for non-DDP (single-device) Lightning runs.
     """
     import traceml_ai as traceml
 
@@ -51,7 +46,6 @@ def init():
         mode="selective",
         patch_dataloader=True,
         patch_h2d=True,
-        patch_ddp_comm=True,
     )
 
 

--- a/src/traceml_ai/sdk/initial.py
+++ b/src/traceml_ai/sdk/initial.py
@@ -18,6 +18,7 @@ class TraceMLInitConfig:
     patch_forward: bool
     patch_backward: bool
     patch_h2d: bool
+    patch_ddp_comm: bool
     source: str = "user"
 
     def same_effective_configuration(self, other: "TraceMLInitConfig") -> bool:
@@ -30,6 +31,7 @@ class TraceMLInitConfig:
             and self.patch_forward == other.patch_forward
             and self.patch_backward == other.patch_backward
             and self.patch_h2d == other.patch_h2d
+            and self.patch_ddp_comm == other.patch_ddp_comm
         )
 
 
@@ -59,6 +61,7 @@ def _build_config(
     patch_forward: Optional[bool],
     patch_backward: Optional[bool],
     patch_h2d: Optional[bool],
+    patch_ddp_comm: Optional[bool],
     source: str,
 ) -> TraceMLInitConfig:
     """Validate user input and return the initialization config."""
@@ -68,13 +71,14 @@ def _build_config(
         patch_forward,
         patch_backward,
         patch_h2d,
+        patch_ddp_comm,
     )
     has_overrides = any(value is not None for value in override_values)
 
     if canonical_mode in {"auto", "manual"} and has_overrides:
         raise ValueError(
-            "patch_dataloader, patch_forward, patch_backward, and patch_h2d "
-            "may only be provided when mode='selective'. "
+            "patch_dataloader, patch_forward, patch_backward, patch_h2d, and "
+            "patch_ddp_comm may only be provided when mode='selective'. "
             f"Received overrides with mode={canonical_mode!r}."
         )
 
@@ -85,6 +89,7 @@ def _build_config(
             patch_forward=True,
             patch_backward=True,
             patch_h2d=True,
+            patch_ddp_comm=True,
             source=source,
         )
 
@@ -95,6 +100,7 @@ def _build_config(
             patch_forward=False,
             patch_backward=False,
             patch_h2d=False,
+            patch_ddp_comm=False,
             source=source,
         )
 
@@ -108,8 +114,9 @@ def _build_config(
     fwd = bool(patch_forward) if patch_forward is not None else False
     bwd = bool(patch_backward) if patch_backward is not None else False
     h2d = bool(patch_h2d) if patch_h2d is not None else False
+    ddp = bool(patch_ddp_comm) if patch_ddp_comm is not None else False
 
-    if not any((dl, fwd, bwd, h2d)):
+    if not any((dl, fwd, bwd, h2d, ddp)):
         raise ValueError(
             "mode='selective' must enable at least one automatic patch. "
             "Use mode='manual' when you want zero automatic patches."
@@ -121,6 +128,7 @@ def _build_config(
         patch_forward=fwd,
         patch_backward=bwd,
         patch_h2d=h2d,
+        patch_ddp_comm=ddp,
         source=source,
     )
 
@@ -133,6 +141,7 @@ def _apply_requested_patches(config: TraceMLInitConfig) -> None:
             config.patch_forward,
             config.patch_backward,
             config.patch_h2d,
+            config.patch_ddp_comm,
         )
     ):
         return
@@ -165,6 +174,13 @@ def _apply_requested_patches(config: TraceMLInitConfig) -> None:
             )
 
             patch_h2d()
+
+        if config.patch_ddp_comm:
+            from traceml_ai.instrumentation.patches.ddp_comm_patch import (
+                patch_ddp_comm,
+            )
+
+            patch_ddp_comm()
     except Exception as exc:
         raise RuntimeError(
             "TraceML initialization failed while installing automatic "
@@ -196,6 +212,7 @@ def init(
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
     patch_h2d: Optional[bool] = None,
+    patch_ddp_comm: Optional[bool] = None,
     _source: str = "user",
 ) -> TraceMLInitConfig:
     """
@@ -242,6 +259,7 @@ def init(
         patch_forward=patch_forward,
         patch_backward=patch_backward,
         patch_h2d=patch_h2d,
+        patch_ddp_comm=patch_ddp_comm,
         source=_source,
     )
 
@@ -260,12 +278,14 @@ def init(
                 f"patch_forward={_INIT_CONFIG.patch_forward}, "
                 f"patch_backward={_INIT_CONFIG.patch_backward}, "
                 f"patch_h2d={_INIT_CONFIG.patch_h2d}, "
+                f"patch_ddp_comm={_INIT_CONFIG.patch_ddp_comm}, "
                 f"source={_INIT_CONFIG.source!r}. "
                 f"Requested config: mode={requested.mode!r}, "
                 f"patch_dataloader={requested.patch_dataloader}, "
                 f"patch_forward={requested.patch_forward}, "
                 f"patch_backward={requested.patch_backward}, "
                 f"patch_h2d={requested.patch_h2d}, "
+                f"patch_ddp_comm={requested.patch_ddp_comm}, "
                 f"source={requested.source!r}. "
                 "Initialize TraceML exactly once per process with the intended "
                 "mode at the start of the run."
@@ -283,6 +303,7 @@ def start(
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
     patch_h2d: Optional[bool] = None,
+    patch_ddp_comm: Optional[bool] = None,
 ) -> TraceMLInitConfig:
     """
     Alias for `init()` for the current transition period.
@@ -296,6 +317,7 @@ def start(
         patch_forward=patch_forward,
         patch_backward=patch_backward,
         patch_h2d=patch_h2d,
+        patch_ddp_comm=patch_ddp_comm,
         _source="user",
     )
 

--- a/src/traceml_ai/sdk/initial.py
+++ b/src/traceml_ai/sdk/initial.py
@@ -232,6 +232,12 @@ def init(
         Selective-mode-only override controlling forward timing patching.
     patch_backward:
         Selective-mode-only override controlling backward timing patching.
+    patch_h2d:
+        Selective-mode-only override controlling host-to-device
+        (``Tensor.to``) timing patching.
+    patch_ddp_comm:
+        Selective-mode-only override controlling DDP gradient-sync
+        comm-hook patching (``DistributedDataParallel.forward``).
 
     Returns
     -------

--- a/src/traceml_ai/sdk/instrumentation.py
+++ b/src/traceml_ai/sdk/instrumentation.py
@@ -23,7 +23,11 @@ from contextlib import contextmanager
 from typing import Callable, List, Optional
 
 import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel
 
+from traceml_ai.instrumentation.hooks.ddp_comm_hook import (
+    ensure_ddp_comm_hook_installed,
+)
 from traceml_ai.instrumentation.hooks.layer_backward_memory_hooks import (
     attach_layer_backward_memory_hooks,
 )
@@ -122,6 +126,45 @@ def _should_auto_install_optimizer_timing() -> bool:
     return getattr(cfg, "mode", "auto") == "auto"
 
 
+def _should_auto_install_ddp_comm_timing() -> bool:
+    """
+    Return True when `trace_step(...)` should auto-install DDP gradient-sync
+    timing.
+
+    Gated identically to optimizer timing: only the 'auto' init mode installs
+    automatically. manual / selective users opt in via `traceml.wrap_ddp(...)`.
+    """
+    try:
+        from traceml_ai.sdk.initial import get_init_config
+    except Exception:
+        return False
+
+    cfg = get_init_config()
+    if cfg is None:
+        return False
+
+    return getattr(cfg, "mode", "auto") == "auto"
+
+
+def _maybe_unwrap_ddp(model: nn.Module) -> nn.Module:
+    """
+    Return the inner module if *model* is a DDP wrapper, else *model*.
+
+    Load-bearing: step-memory and layer hooks key their buffers by
+    ``id(model)`` (`flush_step_memory_buffer`, `flush_layer_*_time_buffers`),
+    and `trace_model_instance(inner_module)` registers layer hooks by
+    ``id(inner_module)``. Without unwrap, ``id(ddp_wrapper) != id(inner)`` and
+    those step-boundary flushes silently drain nothing.
+
+    NOTE: `forward_auto_timer` is the exception and must keep the wrapper,
+    since it already registers the wrapper id, its `.module`, and FSDP
+    `_fsdp_wrapped_module` (forward_auto_timer_patch.py).
+    """
+    if isinstance(model, DistributedDataParallel):
+        return model.module
+    return model
+
+
 class _TraceStateMeta(type):
     @property
     def step(cls) -> int:
@@ -166,7 +209,10 @@ def trace_step(model: nn.Module):
         return
 
     trace_state = get_trace_session_state()
-    mem_tracker = StepMemoryTracker(model)
+    # DDP wrappers route step-memory/layer flushes by id(model); unwrap so the
+    # inner module (where trace_model_instance registered hooks) matches.
+    effective_model = _maybe_unwrap_ddp(model)
+    mem_tracker = StepMemoryTracker(effective_model)
     step_completed = False
 
     try:
@@ -185,6 +231,10 @@ def trace_step(model: nn.Module):
             ):
                 if _should_auto_install_optimizer_timing():
                     ensure_optimizer_timing_installed()
+                if _should_auto_install_ddp_comm_timing() and isinstance(
+                    model, DistributedDataParallel
+                ):
+                    ensure_ddp_comm_hook_installed(model)
                 yield
                 step_completed = True
     finally:
@@ -197,7 +247,7 @@ def trace_step(model: nn.Module):
             _log_instrumentation_error("record failed", exc)
 
         try:
-            flush_step_events(model, trace_state.step)
+            flush_step_events(effective_model, trace_state.step)
         except Exception as exc:
             _log_instrumentation_error("flush failed", exc)
 

--- a/src/traceml_ai/sdk/instrumentation.py
+++ b/src/traceml_ai/sdk/instrumentation.py
@@ -25,9 +25,6 @@ from typing import Callable, List, Optional
 import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel
 
-from traceml_ai.instrumentation.hooks.ddp_comm_hook import (
-    ensure_ddp_comm_hook_installed,
-)
 from traceml_ai.instrumentation.hooks.layer_backward_memory_hooks import (
     attach_layer_backward_memory_hooks,
 )
@@ -126,26 +123,6 @@ def _should_auto_install_optimizer_timing() -> bool:
     return getattr(cfg, "mode", "auto") == "auto"
 
 
-def _should_auto_install_ddp_comm_timing() -> bool:
-    """
-    Return True when `trace_step(...)` should auto-install DDP gradient-sync
-    timing.
-
-    Gated identically to optimizer timing: only the 'auto' init mode installs
-    automatically. manual / selective users opt in via `traceml.wrap_ddp(...)`.
-    """
-    try:
-        from traceml_ai.sdk.initial import get_init_config
-    except Exception:
-        return False
-
-    cfg = get_init_config()
-    if cfg is None:
-        return False
-
-    return getattr(cfg, "mode", "auto") == "auto"
-
-
 def _maybe_unwrap_ddp(model: nn.Module) -> nn.Module:
     """
     Return the inner module if *model* is a DDP wrapper, else *model*.
@@ -231,10 +208,6 @@ def trace_step(model: nn.Module):
             ):
                 if _should_auto_install_optimizer_timing():
                     ensure_optimizer_timing_installed()
-                if _should_auto_install_ddp_comm_timing() and isinstance(
-                    model, DistributedDataParallel
-                ):
-                    ensure_ddp_comm_hook_installed(model)
                 yield
                 step_completed = True
     finally:

--- a/src/traceml_ai/sdk/wrappers.py
+++ b/src/traceml_ai/sdk/wrappers.py
@@ -267,6 +267,31 @@ def wrap_optimizer(optimizer: Any) -> Any:
     return optimizer
 
 
+def wrap_ddp(ddp_model: Any, base_hook: Any = None) -> Any:
+    """
+    Instrument a DDP model's gradient sync for per-step comm timing.
+
+    Installs a ``register_comm_hook`` that wraps *base_hook* (or PyTorch's
+    default ``allreduce_hook`` when ``None``) with CUDA-event timing. Events
+    flow through the existing step-time pipeline as
+    ``_traceml_comm:ddp_grad_sync``.
+
+    This preserves model identity (returns the same ``ddp_model`` instance,
+    like ``wrap_optimizer``) and is idempotent. Use the explicit path when you
+    pass a custom ``base_hook`` (e.g. ``fp16_compress_hook``, PowerSGD); the
+    default auto-install path (``trace_step`` under ``init(mode='auto')``) uses
+    PyTorch's default hook.
+
+    Note: installing any comm hook unfuses DDP's fused copy+divide-by-world-size
+    (sub-microsecond per bucket, numerically identical results).
+    """
+    from traceml_ai.instrumentation.hooks.ddp_comm_hook import (
+        install_ddp_comm_hook,
+    )
+
+    return install_ddp_comm_hook(ddp_model, base_hook=base_hook)
+
+
 class _WrappedH2D:
     """
     Proxy for a tensor or batch object that times ``.to(...)`` calls.
@@ -361,5 +386,6 @@ __all__ = [
     "wrap_forward",
     "wrap_backward",
     "wrap_optimizer",
+    "wrap_ddp",
     "wrap_h2d",
 ]

--- a/src/traceml_ai/sdk/wrappers.py
+++ b/src/traceml_ai/sdk/wrappers.py
@@ -278,9 +278,10 @@ def wrap_ddp(ddp_model: Any, base_hook: Any = None) -> Any:
 
     This preserves model identity (returns the same ``ddp_model`` instance,
     like ``wrap_optimizer``) and is idempotent. Use the explicit path when you
-    pass a custom ``base_hook`` (e.g. ``fp16_compress_hook``, PowerSGD); the
-    default auto-install path (``trace_step`` under ``init(mode='auto')``) uses
-    PyTorch's default hook.
+    pass a custom ``base_hook`` (e.g. ``fp16_compress_hook``); state-bearing
+    hooks like PowerSGD are not yet supported. The auto-install path
+    (``init(mode='auto')`` patches ``DDP.forward`` to install the default hook
+    on first forward) needs no explicit call.
 
     Note: installing any comm hook unfuses DDP's fused copy+divide-by-world-size
     (sub-microsecond per bucket, numerically identical results).

--- a/tests/sdk/test_instrumentation_namespace.py
+++ b/tests/sdk/test_instrumentation_namespace.py
@@ -7,11 +7,16 @@ def test_canonical_instrumentation_namespace_imports():
     optimizer_hooks = importlib.import_module(
         "traceml_ai.instrumentation.hooks.optimizer_hooks"
     )
+    ddp_comm_hook = importlib.import_module(
+        "traceml_ai.instrumentation.hooks.ddp_comm_hook"
+    )
     forward_patch = importlib.import_module(
         "traceml_ai.instrumentation.patches.forward_auto_timer_patch"
     )
 
     assert optimizer_hooks.ensure_optimizer_timing_installed is not None
+    assert ddp_comm_hook.ensure_ddp_comm_hook_installed is not None
+    assert ddp_comm_hook.install_ddp_comm_hook is not None
     assert forward_patch.patch_forward is not None
 
 

--- a/tests/test_ddp_comm_hook.py
+++ b/tests/test_ddp_comm_hook.py
@@ -319,6 +319,35 @@ class TestBaseHookComposition:
 class TestDDPCommPatch:
     """patch_ddp_comm installs the comm hook lazily on first DDP forward."""
 
+    @pytest.fixture(autouse=True)
+    def _reset_ddp_comm_patch(self):
+        """
+        Keep this class order-independent w.r.t. the global DDP.forward patch.
+
+        ``patch_ddp_comm()`` mutates process-global state
+        (``DistributedDataParallel.forward`` + the ``_traceml_ddp_comm_patched``
+        sentinel) with no built-in teardown, so any prior test that ran
+        ``init(mode="auto")`` would leave it installed and make the idempotency
+        assertion below fail. Snapshot-restore to a clean unpatched state around
+        each test so the leak can neither reach us nor escape us. (Proper home
+        for this is the central instrumentation-state reset in #141.)
+        """
+        from traceml_ai.instrumentation.patches import ddp_comm_patch
+
+        def _restore() -> None:
+            if getattr(
+                DistributedDataParallel, "_traceml_ddp_comm_patched", False
+            ):
+                if ddp_comm_patch._ORIG_DDP_FORWARD is not None:
+                    DistributedDataParallel.forward = (
+                        ddp_comm_patch._ORIG_DDP_FORWARD
+                    )
+                DistributedDataParallel._traceml_ddp_comm_patched = False
+
+        _restore()
+        yield
+        _restore()
+
     def test_patch_replaces_forward_and_is_idempotent(self):
         from traceml_ai.instrumentation.patches import ddp_comm_patch
 

--- a/tests/test_ddp_comm_hook.py
+++ b/tests/test_ddp_comm_hook.py
@@ -1,0 +1,542 @@
+"""
+Tests for DDP gradient-sync timing via register_comm_hook.
+
+Covers:
+- install_ddp_comm_hook: sentinel, idempotency, type checks, fail-open
+- Per-bucket event emission and step aggregation
+- base_hook composition and CUDA event pool cleanup
+- Auto-install via trace_step + DDP unwrap
+- 2-rank gloo smoke test (gated)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel
+
+from traceml_ai.instrumentation.hooks.ddp_comm_hook import (
+    _WIRE_NAME,
+    _traceml_ddp_comm_hook_factory,
+    install_ddp_comm_hook,
+)
+from traceml_ai.utils.timing import (
+    TimeScope,
+    _STEP_BUFFER,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_ddp(*, hook_raises: bool = False) -> MagicMock:
+    """
+    Return a MagicMock that quacks like a DistributedDataParallel instance.
+
+    ``isinstance(mock, DistributedDataParallel)`` returns True via
+    ``spec=DistributedDataParallel``.
+    """
+    mock = MagicMock(spec=DistributedDataParallel)
+    mock._traceml_ddp_comm_hook_installed = False
+
+    if hook_raises:
+        mock.register_comm_hook.side_effect = RuntimeError(
+            "user hook already registered"
+        )
+
+    return mock
+
+
+def _make_fake_bucket(index: int = 0, is_last: bool = False) -> MagicMock:
+    """Return a MagicMock that quacks like a dist.GradBucket."""
+    bucket = MagicMock(spec=dist.GradBucket)
+    bucket.index.return_value = index
+    bucket.is_last.return_value = is_last
+    bucket.buffer.return_value = torch.zeros(10)
+    return bucket
+
+
+def _make_fake_future(
+    tensor: torch.Tensor | None = None,
+) -> MagicMock:
+    """
+    Return a MagicMock Future whose .then() fires the callback.
+
+    Mirrors real PyTorch .then() semantics: callback receives the
+    Future itself and must call .value() to get the result.
+    """
+    if tensor is None:
+        tensor = torch.zeros(10)
+
+    fut = MagicMock()
+    fut.value.return_value = [tensor]
+
+    def then_impl(callback):
+        result_fut = MagicMock()
+        result = callback(fut)
+        result_fut.wait.return_value = result
+        result_fut.value.return_value = [result]
+        return result_fut
+
+    fut.then.side_effect = then_impl
+    return fut
+
+
+# ---------------------------------------------------------------------------
+# Commit 5: install + sentinel + error paths
+# ---------------------------------------------------------------------------
+
+
+class TestInstallDDPCommHook:
+    """install_ddp_comm_hook: sentinel, idempotency, type checks."""
+
+    def test_rejects_non_ddp_model(self):
+        with pytest.raises(TypeError, match="DistributedDataParallel"):
+            install_ddp_comm_hook(nn.Linear(10, 10))
+
+    def test_rejects_non_callable_base_hook(self):
+        mock = _make_mock_ddp()
+        with pytest.raises(TypeError, match="callable"):
+            install_ddp_comm_hook(mock, base_hook="not_callable")
+
+    def test_installs_hook_and_sets_sentinel(self):
+        mock = _make_mock_ddp()
+
+        result = install_ddp_comm_hook(mock)
+
+        assert result is mock
+        mock.register_comm_hook.assert_called_once()
+        assert mock._traceml_ddp_comm_hook_installed is True
+
+    def test_idempotent_second_call_is_noop(self):
+        mock = _make_mock_ddp()
+        install_ddp_comm_hook(mock)
+        mock.register_comm_hook.reset_mock()
+
+        install_ddp_comm_hook(mock)
+
+        mock.register_comm_hook.assert_not_called()
+
+    def test_graceful_failopen_when_hook_already_registered(self, capsys):
+        mock = _make_mock_ddp(hook_raises=True)
+
+        result = install_ddp_comm_hook(mock)
+
+        assert result is mock
+        assert mock._traceml_ddp_comm_hook_installed is False
+        captured = capsys.readouterr()
+        assert "[TraceML]" in captured.err
+        assert "cannot register" in captured.err
+
+    def test_default_base_hook_is_allreduce(self):
+        mock = _make_mock_ddp()
+        install_ddp_comm_hook(mock, base_hook=None)
+
+        call_kwargs = mock.register_comm_hook.call_args
+        assert call_kwargs is not None
+        hook_fn = call_kwargs[1].get(
+            "hook", call_kwargs[0][1] if len(call_kwargs[0]) > 1 else None
+        )
+        assert callable(hook_fn)
+
+
+# ---------------------------------------------------------------------------
+# Commit 6: per-bucket emission + per-step aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestPerBucketEmission:
+    """Hook emits one TimeEvent per bucket; events land in _STEP_BUFFER."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_step_buffer(self):
+        _STEP_BUFFER.clear()
+        yield
+        _STEP_BUFFER.clear()
+
+    def _drive_hook(self, hook, n_buckets: int = 3):
+        """Simulate n_buckets through the hook."""
+        for i in range(n_buckets):
+            bucket = _make_fake_bucket(index=i, is_last=(i == n_buckets - 1))
+            hook(None, bucket)
+
+    def test_emits_one_event_per_bucket(self):
+        def base_hook(state, bucket):
+            return _make_fake_future()
+
+        hook = _traceml_ddp_comm_hook_factory(base_hook)
+        self._drive_hook(hook, n_buckets=3)
+
+        events = [e for e in _STEP_BUFFER if e.name == _WIRE_NAME]
+        assert len(events) == 3
+
+    def test_events_have_correct_scope(self):
+        def base_hook(state, bucket):
+            return _make_fake_future()
+
+        hook = _traceml_ddp_comm_hook_factory(base_hook)
+        self._drive_hook(hook, n_buckets=2)
+
+        for evt in _STEP_BUFFER:
+            assert evt.scope == TimeScope.STEP
+
+    def test_events_have_nonzero_cpu_times(self):
+        def base_hook(state, bucket):
+            return _make_fake_future()
+
+        hook = _traceml_ddp_comm_hook_factory(base_hook)
+        self._drive_hook(hook, n_buckets=1)
+
+        evt = list(_STEP_BUFFER)[0]
+        assert evt.cpu_start > 0
+        assert evt.cpu_end >= evt.cpu_start
+
+    def test_events_from_separate_steps_stay_separate(self):
+        """Two rounds of driving produce independent events."""
+
+        def base_hook(state, bucket):
+            return _make_fake_future()
+
+        hook = _traceml_ddp_comm_hook_factory(base_hook)
+
+        self._drive_hook(hook, n_buckets=2)
+        step_1_events = list(_STEP_BUFFER)
+        _STEP_BUFFER.clear()
+
+        self._drive_hook(hook, n_buckets=2)
+        step_2_events = list(_STEP_BUFFER)
+
+        assert len(step_1_events) == 2
+        assert len(step_2_events) == 2
+
+
+# ---------------------------------------------------------------------------
+# Commit 7: base_hook composition + pool cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestBaseHookComposition:
+    """Verify user-supplied base_hook is called and TraceML still emits."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_step_buffer(self):
+        _STEP_BUFFER.clear()
+        yield
+        _STEP_BUFFER.clear()
+
+    def test_counting_base_hook_called_per_bucket(self):
+        call_count = 0
+
+        def counting_hook(state, bucket):
+            nonlocal call_count
+            call_count += 1
+            return _make_fake_future()
+
+        hook = _traceml_ddp_comm_hook_factory(counting_hook)
+
+        for i in range(3):
+            bucket = _make_fake_bucket(index=i)
+            hook(None, bucket)
+
+        assert call_count == 3
+        events = [e for e in _STEP_BUFFER if e.name == _WIRE_NAME]
+        assert len(events) == 3
+
+    def test_base_hook_exception_propagates(self):
+        """If base_hook raises before returning a Future, it propagates."""
+
+        def exploding_hook(state, bucket):
+            raise ValueError("boom from base_hook")
+
+        hook = _traceml_ddp_comm_hook_factory(exploding_hook)
+        bucket = _make_fake_bucket()
+
+        with pytest.raises(ValueError, match="boom from base_hook"):
+            hook(None, bucket)
+
+    def test_base_hook_exception_returns_cuda_events_to_pool(self):
+        """If base_hook raises synchronously on a CUDA device, the
+        gpu_start/gpu_end events acquired before the call must be
+        returned to the pool (the ``.then()`` callback never runs, so
+        the hook body itself is responsible for cleanup)."""
+        outstanding = {"n": 0}
+
+        def fake_get():
+            outstanding["n"] += 1
+            return MagicMock()  # quacks like torch.cuda.Event
+
+        def fake_return(evt):
+            if evt is not None:
+                outstanding["n"] -= 1
+
+        def exploding_hook(state, bucket):
+            raise ValueError("boom from base_hook")
+
+        mod = "traceml_ai.instrumentation.hooks.ddp_comm_hook"
+        with (
+            patch(f"{mod}.torch.cuda.is_available", return_value=True),
+            patch(f"{mod}.torch.cuda.current_device", return_value=0),
+            patch(f"{mod}.get_cuda_event", side_effect=fake_get),
+            patch(f"{mod}.return_cuda_event", side_effect=fake_return),
+        ):
+            hook = _traceml_ddp_comm_hook_factory(exploding_hook)
+            bucket = _make_fake_bucket()
+
+            with pytest.raises(ValueError, match="boom from base_hook"):
+                hook(None, bucket)
+
+        assert outstanding["n"] == 0, "CUDA events leaked from the pool"
+
+    def test_then_callback_exception_does_not_crash(self):
+        """If .then() callback has internal error, result still returns."""
+        tensor = torch.zeros(10)
+
+        def base_hook(state, bucket):
+            return _make_fake_future(tensor)
+
+        hook = _traceml_ddp_comm_hook_factory(base_hook)
+
+        with patch(
+            "traceml_ai.instrumentation.hooks.ddp_comm_hook.record_event",
+            side_effect=RuntimeError("record_event exploded"),
+        ):
+            bucket = _make_fake_bucket()
+            hook(None, bucket)
+
+
+# ---------------------------------------------------------------------------
+# Commit 7.5: auto-install + DDP unwrap via trace_step
+# ---------------------------------------------------------------------------
+
+
+class TestAutoInstallViaTraceStep:
+    """trace_step auto-installs DDP comm hook when model is DDP wrapper."""
+
+    def _trace_step_patches(self):
+        """Context manager that mocks all trace_step internals."""
+        from contextlib import ExitStack
+
+        stack = ExitStack()
+        patches = {
+            "ensure_ddp": stack.enter_context(
+                patch(
+                    "traceml_ai.sdk.instrumentation."
+                    "ensure_ddp_comm_hook_installed"
+                )
+            ),
+            "unwrap": stack.enter_context(
+                patch(
+                    "traceml_ai.sdk.instrumentation._maybe_unwrap_ddp",
+                    return_value=MagicMock(spec=nn.Module),
+                )
+            ),
+            "mem_tracker": stack.enter_context(
+                patch("traceml_ai.sdk.instrumentation.StepMemoryTracker")
+            ),
+            "flush": stack.enter_context(
+                patch("traceml_ai.sdk.instrumentation.flush_step_events")
+            ),
+            "timed": stack.enter_context(
+                patch("traceml_ai.sdk.instrumentation.timed_region")
+            ),
+            "fwd": stack.enter_context(
+                patch("traceml_ai.sdk.instrumentation.forward_auto_timer")
+            ),
+            "bwd": stack.enter_context(
+                patch("traceml_ai.sdk.instrumentation.backward_auto_timer")
+            ),
+            "h2d": stack.enter_context(
+                patch("traceml_ai.sdk.instrumentation.h2d_auto_timer")
+            ),
+            "opt": stack.enter_context(
+                patch(
+                    "traceml_ai.sdk.instrumentation."
+                    "ensure_optimizer_timing_installed"
+                )
+            ),
+            "gate": stack.enter_context(
+                patch(
+                    "traceml_ai.sdk.instrumentation."
+                    "_should_auto_install_ddp_comm_timing",
+                    return_value=True,
+                )
+            ),
+        }
+        return stack, patches
+
+    def test_auto_install_on_ddp_wrapper(self):
+        """trace_step(ddp_model) calls ensure_ddp_comm_hook_installed."""
+        mock_ddp = _make_mock_ddp()
+        stack, patches = self._trace_step_patches()
+
+        with stack:
+            from traceml_ai.sdk.instrumentation import trace_step
+
+            with trace_step(mock_ddp):
+                pass
+
+            patches["ensure_ddp"].assert_called_once_with(mock_ddp)
+
+    def test_no_auto_install_on_plain_module(self):
+        """trace_step(nn.Module) does NOT call ensure_ddp_comm_hook."""
+        model = nn.Linear(10, 10)
+        stack, patches = self._trace_step_patches()
+
+        with stack:
+            from traceml_ai.sdk.instrumentation import trace_step
+
+            with trace_step(model):
+                pass
+
+            patches["ensure_ddp"].assert_not_called()
+
+    def test_no_auto_install_when_gate_closed(self):
+        """When the init-mode gate is closed, no auto-install.
+
+        Mirrors init(mode='manual'/'selective') or no init config, where
+        `_should_auto_install_ddp_comm_timing()` returns False.
+        """
+        mock_ddp = _make_mock_ddp()
+        stack, patches = self._trace_step_patches()
+
+        with stack:
+            # _trace_step_patches opens the gate by default; close it here.
+            patches["gate"].return_value = False
+
+            from traceml_ai.sdk.instrumentation import trace_step
+
+            with trace_step(mock_ddp):
+                pass
+
+            patches["ensure_ddp"].assert_not_called()
+
+    def test_explicit_wrap_ddp_then_auto_install_is_idempotent(self):
+        """wrap_ddp + trace_step on same model doesn't double-install."""
+        mock_ddp = _make_mock_ddp()
+        install_ddp_comm_hook(mock_ddp)
+        assert mock_ddp._traceml_ddp_comm_hook_installed is True
+
+        stack, patches = self._trace_step_patches()
+
+        with stack:
+            from traceml_ai.sdk.instrumentation import trace_step
+
+            with trace_step(mock_ddp):
+                pass
+
+            assert mock_ddp.register_comm_hook.call_count == 1
+
+
+class TestDDPUnwrap:
+    """trace_step unwraps DDP for downstream id()-keyed operations."""
+
+    def test_maybe_unwrap_ddp_returns_module(self):
+        from traceml_ai.sdk.instrumentation import _maybe_unwrap_ddp
+
+        inner = nn.Linear(10, 10)
+        mock_ddp = MagicMock(spec=DistributedDataParallel)
+        mock_ddp.module = inner
+
+        result = _maybe_unwrap_ddp(mock_ddp)
+        assert result is inner
+
+    def test_maybe_unwrap_ddp_passthrough_for_plain(self):
+        from traceml_ai.sdk.instrumentation import _maybe_unwrap_ddp
+
+        model = nn.Linear(10, 10)
+        result = _maybe_unwrap_ddp(model)
+        assert result is model
+
+
+# ---------------------------------------------------------------------------
+# Commit 8: 2-rank gloo smoke test (gated)
+# ---------------------------------------------------------------------------
+
+_RUN_DIST_TESTS = os.environ.get("TRACEML_RUN_DIST_TESTS", "0") == "1"
+
+_GLOO_WORKER_SCRIPT = """\
+import os, sys, torch, torch.nn as nn, torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+sys.path.insert(0, os.environ["TRACEML_SRC"])
+from traceml_ai.instrumentation.hooks.ddp_comm_hook import install_ddp_comm_hook
+from traceml_ai.utils.timing import _STEP_BUFFER
+
+dist.init_process_group(backend="gloo")
+rank = dist.get_rank()
+
+model = DDP(nn.Linear(10, 10))
+install_ddp_comm_hook(model)
+
+x = torch.randn(4, 10)
+loss = model(x).sum()
+loss.backward()
+
+events = [e for e in _STEP_BUFFER if e.name == "_traceml_comm:ddp_grad_sync"]
+print(f"RANK={rank} EVENTS={len(events)}", flush=True)
+
+assert len(events) >= 1, f"rank {rank}: expected >=1 event, got {len(events)}"
+
+for evt in events:
+    assert evt.cpu_end >= evt.cpu_start, "cpu_end < cpu_start"
+
+dist.destroy_process_group()
+print(f"RANK={rank} OK", flush=True)
+"""
+
+
+@pytest.mark.skipif(
+    not _RUN_DIST_TESTS,
+    reason="Set TRACEML_RUN_DIST_TESTS=1 to run distributed tests",
+)
+def test_two_rank_gloo_ddp_grad_sync_fires(tmp_path):
+    """
+    Spawn 2 gloo ranks, run one backward step, verify each rank
+    produces at least one _traceml_comm:ddp_grad_sync event.
+    """
+    import subprocess
+
+    script_path = tmp_path / "gloo_worker.py"
+    script_path.write_text(_GLOO_WORKER_SCRIPT)
+
+    src_path = os.path.join(os.path.dirname(__file__), "..", "src")
+
+    env = {
+        **os.environ,
+        "TRACEML_SRC": os.path.abspath(src_path),
+        "MASTER_ADDR": "127.0.0.1",
+        "MASTER_PORT": "29500",
+    }
+
+    procs = []
+    for rank in range(2):
+        rank_env = {
+            **env,
+            "RANK": str(rank),
+            "LOCAL_RANK": str(rank),
+            "WORLD_SIZE": "2",
+        }
+        p = subprocess.Popen(
+            [sys.executable, str(script_path)],
+            env=rank_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        procs.append(p)
+
+    for p in procs:
+        stdout, stderr = p.communicate(timeout=60)
+        output = stdout.decode()
+        assert p.returncode == 0, (
+            f"Worker failed (rc={p.returncode}):\n"
+            f"stdout: {output}\n"
+            f"stderr: {stderr.decode()}"
+        )
+        assert "OK" in output

--- a/tests/test_ddp_comm_hook.py
+++ b/tests/test_ddp_comm_hook.py
@@ -316,122 +316,55 @@ class TestBaseHookComposition:
 # ---------------------------------------------------------------------------
 
 
-class TestAutoInstallViaTraceStep:
-    """trace_step auto-installs DDP comm hook when model is DDP wrapper."""
+class TestDDPCommPatch:
+    """patch_ddp_comm installs the comm hook lazily on first DDP forward."""
 
-    def _trace_step_patches(self):
-        """Context manager that mocks all trace_step internals."""
-        from contextlib import ExitStack
+    def test_patch_replaces_forward_and_is_idempotent(self):
+        from traceml_ai.instrumentation.patches import ddp_comm_patch
 
-        stack = ExitStack()
-        patches = {
-            "ensure_ddp": stack.enter_context(
-                patch(
-                    "traceml_ai.sdk.instrumentation."
-                    "ensure_ddp_comm_hook_installed"
-                )
+        orig = DistributedDataParallel.forward
+        try:
+            ddp_comm_patch.patch_ddp_comm()
+            assert DistributedDataParallel.forward is not orig
+            assert DistributedDataParallel._traceml_ddp_comm_patched is True
+
+            patched = DistributedDataParallel.forward
+            ddp_comm_patch.patch_ddp_comm()  # second call is a no-op
+            assert DistributedDataParallel.forward is patched
+        finally:
+            DistributedDataParallel.forward = orig
+            DistributedDataParallel._traceml_ddp_comm_patched = False
+
+    def test_first_forward_installs_hook_once(self):
+        """The patched forward installs once, then delegates to the original."""
+        from traceml_ai.instrumentation.patches import ddp_comm_patch
+
+        class _FakeDDP:
+            pass
+
+        fake_self = _FakeDDP()
+        calls = []
+
+        with (
+            patch.object(
+                ddp_comm_patch,
+                "_ORIG_DDP_FORWARD",
+                lambda self, *a, **k: "fwd_result",
             ),
-            "unwrap": stack.enter_context(
-                patch(
-                    "traceml_ai.sdk.instrumentation._maybe_unwrap_ddp",
-                    return_value=MagicMock(spec=nn.Module),
-                )
+            patch.object(
+                ddp_comm_patch,
+                "ensure_ddp_comm_hook_installed",
+                side_effect=lambda m: calls.append(m),
             ),
-            "mem_tracker": stack.enter_context(
-                patch("traceml_ai.sdk.instrumentation.StepMemoryTracker")
-            ),
-            "flush": stack.enter_context(
-                patch("traceml_ai.sdk.instrumentation.flush_step_events")
-            ),
-            "timed": stack.enter_context(
-                patch("traceml_ai.sdk.instrumentation.timed_region")
-            ),
-            "fwd": stack.enter_context(
-                patch("traceml_ai.sdk.instrumentation.forward_auto_timer")
-            ),
-            "bwd": stack.enter_context(
-                patch("traceml_ai.sdk.instrumentation.backward_auto_timer")
-            ),
-            "h2d": stack.enter_context(
-                patch("traceml_ai.sdk.instrumentation.h2d_auto_timer")
-            ),
-            "opt": stack.enter_context(
-                patch(
-                    "traceml_ai.sdk.instrumentation."
-                    "ensure_optimizer_timing_installed"
-                )
-            ),
-            "gate": stack.enter_context(
-                patch(
-                    "traceml_ai.sdk.instrumentation."
-                    "_should_auto_install_ddp_comm_timing",
-                    return_value=True,
-                )
-            ),
-        }
-        return stack, patches
+        ):
+            r1 = ddp_comm_patch._traceml_ddp_forward(fake_self, 1)
+            r2 = ddp_comm_patch._traceml_ddp_forward(fake_self, 2)
 
-    def test_auto_install_on_ddp_wrapper(self):
-        """trace_step(ddp_model) calls ensure_ddp_comm_hook_installed."""
-        mock_ddp = _make_mock_ddp()
-        stack, patches = self._trace_step_patches()
-
-        with stack:
-            from traceml_ai.sdk.instrumentation import trace_step
-
-            with trace_step(mock_ddp):
-                pass
-
-            patches["ensure_ddp"].assert_called_once_with(mock_ddp)
-
-    def test_no_auto_install_on_plain_module(self):
-        """trace_step(nn.Module) does NOT call ensure_ddp_comm_hook."""
-        model = nn.Linear(10, 10)
-        stack, patches = self._trace_step_patches()
-
-        with stack:
-            from traceml_ai.sdk.instrumentation import trace_step
-
-            with trace_step(model):
-                pass
-
-            patches["ensure_ddp"].assert_not_called()
-
-    def test_no_auto_install_when_gate_closed(self):
-        """When the init-mode gate is closed, no auto-install.
-
-        Mirrors init(mode='manual'/'selective') or no init config, where
-        `_should_auto_install_ddp_comm_timing()` returns False.
-        """
-        mock_ddp = _make_mock_ddp()
-        stack, patches = self._trace_step_patches()
-
-        with stack:
-            # _trace_step_patches opens the gate by default; close it here.
-            patches["gate"].return_value = False
-
-            from traceml_ai.sdk.instrumentation import trace_step
-
-            with trace_step(mock_ddp):
-                pass
-
-            patches["ensure_ddp"].assert_not_called()
-
-    def test_explicit_wrap_ddp_then_auto_install_is_idempotent(self):
-        """wrap_ddp + trace_step on same model doesn't double-install."""
-        mock_ddp = _make_mock_ddp()
-        install_ddp_comm_hook(mock_ddp)
-        assert mock_ddp._traceml_ddp_comm_hook_installed is True
-
-        stack, patches = self._trace_step_patches()
-
-        with stack:
-            from traceml_ai.sdk.instrumentation import trace_step
-
-            with trace_step(mock_ddp):
-                pass
-
-            assert mock_ddp.register_comm_hook.call_count == 1
+        assert r1 == "fwd_result"
+        assert r2 == "fwd_result"
+        # Installed exactly once across two forwards (one-shot guard).
+        assert calls == [fake_self]
+        assert fake_self._traceml_ddp_comm_patch_attempted is True
 
 
 class TestDDPUnwrap:

--- a/tests/test_ddp_comm_hook.py
+++ b/tests/test_ddp_comm_hook.py
@@ -439,6 +439,33 @@ class TestDDPUnwrap:
         assert result is model
 
 
+class TestIntegrationCommParity:
+    """
+    Every DDP-capable integration must enable ``patch_ddp_comm`` so the
+    ``_traceml_comm:ddp_grad_sync`` stream installs consistently. A flag left
+    unset would silently darken the stream for that integration (the
+    #88 / #135 absence class). Pins HF and Lightning so drift fails loudly.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_init(self):
+        from traceml_ai.sdk import initial
+
+        initial._INIT_CONFIG = None
+        yield
+        initial._INIT_CONFIG = None
+
+    def test_hf_integration_enables_patch_ddp_comm(self):
+        from traceml_ai.integrations.huggingface import init as hf_init
+
+        assert hf_init().patch_ddp_comm is True
+
+    def test_lightning_integration_enables_patch_ddp_comm(self):
+        from traceml_ai.integrations.lightning import init as lit_init
+
+        assert lit_init().patch_ddp_comm is True
+
+
 # ---------------------------------------------------------------------------
 # Commit 8: 2-rank gloo smoke test (gated)
 # ---------------------------------------------------------------------------
@@ -493,28 +520,50 @@ dist.destroy_process_group()
 print(f"RANK={rank} OK", flush=True)
 """
 
+# Exercises the REAL auto-install chain end-to-end: init(mode="auto") patches
+# DDP.forward, and the comm hook must install on the first forward with NO
+# explicit wrap_ddp/install_ddp_comm_hook call. The unit test of this path
+# mocks both the original forward and the installer, so this is the only check
+# that the patched dispatch actually reaches register_comm_hook and lands rows.
+_GLOO_PATCH_CHAIN_SCRIPT = """\
+import os, sys, torch, torch.nn as nn, torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
 
-@pytest.mark.skipif(
-    not _RUN_DIST_TESTS,
-    reason="Set TRACEML_RUN_DIST_TESTS=1 to run distributed tests",
+sys.path.insert(0, os.environ["TRACEML_SRC"])
+import traceml_ai as traceml
+from traceml_ai.utils.timing import _STEP_BUFFER
+
+dist.init_process_group(backend="gloo")
+rank = dist.get_rank()
+
+traceml.init(mode="auto")  # patches DDP.forward; no explicit wrap_ddp below
+model = DDP(nn.Linear(10, 10))
+model(torch.randn(4, 10)).sum().backward()
+
+assert getattr(model, "_traceml_ddp_comm_hook_installed", False), (
+    f"rank {rank}: comm hook not auto-installed via the DDP.forward patch"
 )
-def test_two_rank_gloo_ddp_grad_sync_fires(tmp_path):
-    """
-    Spawn 2 gloo ranks, run one backward step, verify each rank
-    produces at least one _traceml_comm:ddp_grad_sync event.
-    """
+events = [e for e in _STEP_BUFFER if e.name == "_traceml_comm:ddp_grad_sync"]
+assert len(events) >= 1, f"rank {rank}: expected >=1 grad_sync event"
+
+dist.destroy_process_group()
+print(f"RANK={rank} OK", flush=True)
+"""
+
+
+def _run_gloo_workers(script_text, tmp_path, port):
+    """Spawn 2 gloo ranks running *script_text*; assert each prints OK."""
     import subprocess
 
     script_path = tmp_path / "gloo_worker.py"
-    script_path.write_text(_GLOO_WORKER_SCRIPT)
+    script_path.write_text(script_text)
 
     src_path = os.path.join(os.path.dirname(__file__), "..", "src")
-
     env = {
         **os.environ,
         "TRACEML_SRC": os.path.abspath(src_path),
         "MASTER_ADDR": "127.0.0.1",
-        "MASTER_PORT": "29500",
+        "MASTER_PORT": str(port),
     }
 
     procs = []
@@ -525,13 +574,14 @@ def test_two_rank_gloo_ddp_grad_sync_fires(tmp_path):
             "LOCAL_RANK": str(rank),
             "WORLD_SIZE": "2",
         }
-        p = subprocess.Popen(
-            [sys.executable, str(script_path)],
-            env=rank_env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+        procs.append(
+            subprocess.Popen(
+                [sys.executable, str(script_path)],
+                env=rank_env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
         )
-        procs.append(p)
 
     for p in procs:
         stdout, stderr = p.communicate(timeout=60)
@@ -542,3 +592,28 @@ def test_two_rank_gloo_ddp_grad_sync_fires(tmp_path):
             f"stderr: {stderr.decode()}"
         )
         assert "OK" in output
+
+
+@pytest.mark.skipif(
+    not _RUN_DIST_TESTS,
+    reason="Set TRACEML_RUN_DIST_TESTS=1 to run distributed tests",
+)
+def test_two_rank_gloo_ddp_grad_sync_fires(tmp_path):
+    """
+    Spawn 2 gloo ranks; verify each rank emits >=1 grad_sync event and that
+    the comm hook leaves gradients numerically identical to a no-hook run.
+    """
+    _run_gloo_workers(_GLOO_WORKER_SCRIPT, tmp_path, port=29500)
+
+
+@pytest.mark.skipif(
+    not _RUN_DIST_TESTS,
+    reason="Set TRACEML_RUN_DIST_TESTS=1 to run distributed tests",
+)
+def test_two_rank_gloo_auto_install_chain(tmp_path):
+    """
+    Real auto-install chain: init(mode="auto") -> DDP.forward patch -> first
+    forward installs the comm hook -> grad_sync rows land, with NO explicit
+    wrap_ddp call. Closes the gap where this path is only mock-tested.
+    """
+    _run_gloo_workers(_GLOO_PATCH_CHAIN_SCRIPT, tmp_path, port=29501)

--- a/tests/test_ddp_comm_hook.py
+++ b/tests/test_ddp_comm_hook.py
@@ -5,8 +5,9 @@ Covers:
 - install_ddp_comm_hook: sentinel, idempotency, type checks, fail-open
 - Per-bucket event emission and step aggregation
 - base_hook composition and CUDA event pool cleanup
-- Auto-install via trace_step + DDP unwrap
-- 2-rank gloo smoke test (gated)
+- Auto-install via the init() DDP.forward patch + DDP unwrap in trace_step
+- Integration parity for patch_ddp_comm
+- 2-rank gloo smoke tests (gated): grad correctness + auto-install chain
 """
 
 from __future__ import annotations
@@ -94,7 +95,7 @@ def _make_fake_future(
 
 
 # ---------------------------------------------------------------------------
-# Commit 5: install + sentinel + error paths
+# install + sentinel + error paths
 # ---------------------------------------------------------------------------
 
 
@@ -152,7 +153,7 @@ class TestInstallDDPCommHook:
 
 
 # ---------------------------------------------------------------------------
-# Commit 6: per-bucket emission + per-step aggregation
+# per-bucket emission + per-step aggregation
 # ---------------------------------------------------------------------------
 
 
@@ -222,7 +223,7 @@ class TestPerBucketEmission:
 
 
 # ---------------------------------------------------------------------------
-# Commit 7: base_hook composition + pool cleanup
+# base_hook composition + pool cleanup
 # ---------------------------------------------------------------------------
 
 
@@ -334,7 +335,7 @@ class TestBaseHookComposition:
 
 
 # ---------------------------------------------------------------------------
-# Commit 7.5: auto-install + DDP unwrap via trace_step
+# init() forward-patch auto-install + DDP unwrap + integration parity
 # ---------------------------------------------------------------------------
 
 
@@ -441,16 +442,28 @@ class TestDDPUnwrap:
 
 class TestIntegrationCommParity:
     """
-    Every DDP-capable integration must enable ``patch_ddp_comm`` so the
-    ``_traceml_comm:ddp_grad_sync`` stream installs consistently. A flag left
-    unset would silently darken the stream for that integration (the
-    #88 / #135 absence class). Pins HF and Lightning so drift fails loudly.
+    DDP-capable integrations should enable ``patch_ddp_comm`` so the
+    ``_traceml_comm:ddp_grad_sync`` stream installs consistently. A flag
+    left unset silently darkens the stream for that integration (the
+    #88 / #135 absence class).
+
+    Currently pinned: HF (``mode="auto"``). Lightning and Ray are left
+    dark deliberately: ``TraceMLRayConfig`` cannot express
+    ``patch_ddp_comm`` yet, and enabling it in ``lightning.init()`` alone
+    would make the documented Ray+Lightning selective recipe fail
+    re-initialization. Per-integration enablement lands together as a
+    follow-up.
     """
 
     @pytest.fixture(autouse=True)
-    def _reset_init(self):
+    def _reset_init(self, monkeypatch):
         from traceml_ai.sdk import initial
 
+        # Assert effective configs only; never install real global patches
+        # from a unit test (they have no uninstall).
+        monkeypatch.setattr(
+            initial, "_apply_requested_patches", lambda cfg: None
+        )
         initial._INIT_CONFIG = None
         yield
         initial._INIT_CONFIG = None
@@ -460,14 +473,9 @@ class TestIntegrationCommParity:
 
         assert hf_init().patch_ddp_comm is True
 
-    def test_lightning_integration_enables_patch_ddp_comm(self):
-        from traceml_ai.integrations.lightning import init as lit_init
-
-        assert lit_init().patch_ddp_comm is True
-
 
 # ---------------------------------------------------------------------------
-# Commit 8: 2-rank gloo smoke test (gated)
+# 2-rank gloo smoke tests (gated)
 # ---------------------------------------------------------------------------
 
 _RUN_DIST_TESTS = os.environ.get("TRACEML_RUN_DIST_TESTS", "0") == "1"

--- a/tests/test_ddp_comm_hook.py
+++ b/tests/test_ddp_comm_hook.py
@@ -27,8 +27,8 @@ from traceml_ai.instrumentation.hooks.ddp_comm_hook import (
     install_ddp_comm_hook,
 )
 from traceml_ai.utils.timing import (
-    TimeScope,
     _STEP_BUFFER,
+    TimeScope,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ddp_comm_hook.py
+++ b/tests/test_ddp_comm_hook.py
@@ -69,20 +69,24 @@ def _make_fake_future(
     """
     Return a MagicMock Future whose .then() fires the callback.
 
-    Mirrors real PyTorch .then() semantics: callback receives the
-    Future itself and must call .value() to get the result.
+    Mirrors real PyTorch .then() semantics: callback receives the Future
+    itself and must call .value() to get the result. The resolved value is
+    a **bare tensor**, matching the real ``allreduce_hook`` (which extracts
+    the tensor from the raw collective's list internally). Resolving to a
+    list here would let a buggy ``fut.value()[0]`` pass tests while
+    corrupting real gradients.
     """
     if tensor is None:
         tensor = torch.zeros(10)
 
     fut = MagicMock()
-    fut.value.return_value = [tensor]
+    fut.value.return_value = tensor
 
     def then_impl(callback):
         result_fut = MagicMock()
         result = callback(fut)
         result_fut.wait.return_value = result
-        result_fut.value.return_value = [result]
+        result_fut.value.return_value = result
         return result_fut
 
     fut.then.side_effect = then_impl
@@ -310,6 +314,24 @@ class TestBaseHookComposition:
             bucket = _make_fake_bucket()
             hook(None, bucket)
 
+    def test_returned_future_resolves_to_reduced_tensor_unchanged(self):
+        """
+        Regression guard: the instrumented hook must pass base_hook's
+        reduced tensor through UNCHANGED. DDP consumes this future value as
+        the bucket gradient, so slicing it (e.g. ``fut.value()[0]``)
+        silently corrupts gradients. base_hook's future resolves to a bare
+        tensor, exactly like the real ``allreduce_hook``.
+        """
+        reduced = torch.arange(10, dtype=torch.float32)
+
+        def base_hook(state, bucket):
+            return _make_fake_future(reduced)
+
+        hook = _traceml_ddp_comm_hook_factory(base_hook)
+        result_fut = hook(None, _make_fake_bucket())
+
+        assert result_fut.value() is reduced
+
 
 # ---------------------------------------------------------------------------
 # Commit 7.5: auto-install + DDP unwrap via trace_step
@@ -434,20 +456,38 @@ from traceml_ai.utils.timing import _STEP_BUFFER
 dist.init_process_group(backend="gloo")
 rank = dist.get_rank()
 
-model = DDP(nn.Linear(10, 10))
-install_ddp_comm_hook(model)
-
+# Fixed input + identical init so the reference and instrumented runs are
+# directly comparable (same on both ranks).
+torch.manual_seed(1234)
 x = torch.randn(4, 10)
-loss = model(x).sum()
-loss.backward()
+
+def build_model():
+    torch.manual_seed(42)
+    return nn.Linear(10, 10)
+
+# Reference: DDP WITHOUT the TraceML hook.
+ref = DDP(build_model())
+ref(x).sum().backward()
+ref_grads = [p.grad.clone() for p in ref.parameters()]
+
+# Instrumented: identical model WITH the TraceML comm hook.
+model = DDP(build_model())
+install_ddp_comm_hook(model)
+model(x).sum().backward()
 
 events = [e for e in _STEP_BUFFER if e.name == "_traceml_comm:ddp_grad_sync"]
 print(f"RANK={rank} EVENTS={len(events)}", flush=True)
-
 assert len(events) >= 1, f"rank {rank}: expected >=1 event, got {len(events)}"
-
 for evt in events:
     assert evt.cpu_end >= evt.cpu_start, "cpu_end < cpu_start"
+
+# The comm hook only TIMES the all_reduce; gradients must be numerically
+# identical to the no-hook reference. Guards against the value-passthrough
+# corruption class (returning a sliced / wrong-shaped bucket tensor).
+for i, (p, g_ref) in enumerate(zip(model.parameters(), ref_grads)):
+    assert torch.allclose(p.grad, g_ref, atol=1e-6), (
+        f"rank {rank}: grad {i} differs from no-hook reference"
+    )
 
 dist.destroy_process_group()
 print(f"RANK={rank} OK", flush=True)


### PR DESCRIPTION
## What this adds

TraceML currently times dataloader, H2D, forward, backward, and optimizer, but is blind to the
biggest distributed-specific cost: DDP gradient synchronization. This PR adds per-bucket timing
of every DDP all_reduce during `loss.backward()`, emitted as a new step-scoped event
`_traceml_comm:ddp_grad_sync`, with zero changes to user training code.

Why it matters: on a 2-node run (validation below) the per-step summary attributes the
all_reduce time to compute/wait, so a genuinely comm-bound run is indistinguishable from a
compute-bound one. This PR makes the comm signal exist as first-class data.

## How it works

- `instrumentation/hooks/ddp_comm_hook.py`: a comm-hook factory that wraps a base hook
  (default: PyTorch's `allreduce_hook`) with a CUDA-event pair around each bucket's collective.
  `gpu_start` is recorded on the compute stream at hook entry; `gpu_end` in the future's
  `.then()` callback after NCCL completes. Events resolve asynchronously via the existing
  sampler path (no syncs on the hot path). The reduced bucket tensor passes through unchanged.
- `instrumentation/patches/ddp_comm_patch.py`: a class-level patch on
  `DistributedDataParallel.forward`, installed once at `traceml.init()`, that lazily installs
  the comm hook on each DDP instance's first forward. This mirrors the existing `patch_h2d`
  pattern and makes installation structural rather than dependent on which object an
  integration happens to pass around (the failure class from #135 / #141).
- Config: new `patch_ddp_comm` flag on `TraceMLInitConfig`, wired exactly like `patch_h2d`
  (auto=on, manual=off, selective=opt-in). Explicit API: `traceml.wrap_ddp(model, base_hook=None)`.
- Fail-open everywhere: if the user already registered their own comm hook, or install fails
  for any reason, TraceML warns on stderr and training proceeds untouched.

## Scope: data-only (deliberate)

Events flow through the existing name-agnostic pipeline (sampler -> aggregator -> SQLite
`step_time_samples.events_json`) and are queryable today. They are NOT yet surfaced in the
terminal/dashboard renderer or the diagnosis rules; that is a follow-up (internally TRA-30)
because the render layer is a closed allowlist and a comm bucket needs overlap-correction
(early buckets overlap backward compute) plus a comm-bound/comm-straggler rule.

## Validation

- Unit tests: `tests/test_ddp_comm_hook.py` (install/idempotency/fail-open, per-bucket emission,
  base_hook composition, CUDA event pool cleanup on error paths, value pass-through regression
  guard, config parity, order-independent global-state handling). Two gated 2-rank gloo tests
  (`TRACEML_RUN_DIST_TESTS=1`): gradient numerical identity vs a no-hook reference, and the
  real auto-install chain (`init(mode="auto")` -> first forward -> hook installed -> events).
- Real hardware (2x AWS g4dn.xlarge, 1x T4 each, 2-node NCCL over TCP):
  - Full DDP test suite passed on T4.
  - Auto-install chain verified with no explicit `wrap_ddp` call: hook installed on both ranks,
    per-bucket events on every step, gradients bit-identical across ranks.
  - Full-pipeline `traceml run` (multi-node, aggregator on node 0): all 60/60 step rows
    (30 steps x 2 ranks) contain `_traceml_comm:ddp_grad_sync` with GPU-resolved durations in
    SQLite, alongside the five existing internal streams. `final_summary.json` contains no comm
    key, confirming the data-only boundary behaves as intended.
- `examples/ddp_comm_hook_demo.py` (also listed in the examples README): runnable single- or
  multi-node; prints a per-step table of all step phases (data/h2d/fwd/bwd/opt/comm/total) from
  in-process data under plain `torchrun`, or read back from the session DB under `traceml run`.

## Overhead notes

- Timing is two pooled CUDA events per bucket plus one `Future.then` callback; no
  synchronization is added to the training path.
- Installing any comm hook makes PyTorch's reducer take the unfused copy path instead of the
  fused copy+divide (documented in `reducer.cpp`); gradients remain numerically identical
  (asserted in the gated test against a no-hook reference).

## Known limitations (intentional, called out in docstrings)

- Stateful comm hooks (e.g. PowerSGD) are not supported yet: the hook registers with
  `state=None`. `fp16_compress_hook` works (verified).
- HF Trainer gets comm timing automatically (its init uses `mode="auto"`). Lightning and Ray
  integrations do not enable `patch_ddp_comm` yet: `TraceMLRayConfig` cannot express the flag,
  and enabling it for Lightning alone would break re-init for the documented Ray+Lightning
  selective recipe. Enabling both together is a small follow-up.
- During `no_sync()` accumulation steps DDP suppresses comm hooks, so those steps correctly
  produce zero comm events.

## Notes for review

- Commit history is incremental (the branch evolved through review rounds); squash-merge
  recommended, matching how recent PRs landed.
- Branch is rebased on current `main`.