### PR TITLE
Harden instrumentation-state (Stage 1): self-verifying telemetry completeness + order-independent tests

### DIFF
--- a/src/traceml_ai/instrumentation/hooks/optimizer_hooks.py
+++ b/src/traceml_ai/instrumentation/hooks/optimizer_hooks.py
@@ -99,3 +99,28 @@ def ensure_optimizer_timing_installed() -> None:
         return
     install_optimizer_time_hooks()
     torch.optim.Optimizer._traceml_opt_hooks_installed = True
+
+
+def reset_optimizer_timing() -> None:
+    """
+    Remove the global optimizer-step timing hooks, clear in-flight state, and
+    reset the installed flag.
+
+    Inverse of ``ensure_optimizer_timing_installed()``; intended for tests and
+    re-initialization. Best-effort and never raises. After this call,
+    ``wrap_optimizer()`` is permitted again and the auto path can re-install.
+    """
+    global _HANDLES
+    if _HANDLES is not None:
+        for handle in _HANDLES:
+            try:
+                handle.remove()
+            except Exception:
+                pass
+        _HANDLES = None
+    _OPT_INFLIGHT.clear()
+    try:
+        if hasattr(torch.optim.Optimizer, "_traceml_opt_hooks_installed"):
+            torch.optim.Optimizer._traceml_opt_hooks_installed = False
+    except Exception:
+        pass

--- a/src/traceml_ai/integrations/_capability.py
+++ b/src/traceml_ai/integrations/_capability.py
@@ -1,0 +1,58 @@
+"""
+Fail-loud capability assertion for TraceML integrations.
+
+When an integration becomes active but the runtime's patch configuration will
+NOT capture the telemetry streams the integration owes, emit a clear warning
+naming the dark streams — so silent absence becomes *loud* absence (the #88
+class). Warn, never raise (fail-open: instrumentation must never break training).
+
+`is_initialized()` alone is insufficient: `init(mode="manual")` is initialized
+yet installs no patches, so we inspect the config *flags*, not init-ness.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Logical stream -> the init-config flag that must be True to capture it.
+# (step_time/optimizer are not patch-gated — emitted by trace_step / auto hooks —
+# so they are intentionally not checked here.)
+_PATCH_GATED = {
+    "dataloader_fetch": "patch_dataloader",
+    "forward": "patch_forward",
+    "backward": "patch_backward",
+    "h2d": "patch_h2d",
+}
+
+
+def warn_if_missing_streams(integration: str, requires: set[str]) -> None:
+    """
+    Warn (never raise) if patch-gated streams the integration owes won't be
+    captured under the current TraceML init config.
+    """
+    if os.environ.get("TRACEML_DISABLED") == "1":
+        return
+    try:
+        from traceml_ai.sdk.initial import get_init_config
+
+        cfg = get_init_config()
+        missing = []
+        for stream in sorted(requires):
+            flag = _PATCH_GATED.get(stream)
+            if flag is None:
+                continue  # not patch-gated; not checked here
+            if cfg is None or not getattr(cfg, flag, False):
+                missing.append(stream)
+
+        if missing:
+            logger.warning(
+                "[TraceML] %s is active but these telemetry streams will NOT be "
+                "captured: %s. Call traceml_ai.init(mode='auto') before training "
+                "to enable them.",
+                integration,
+                ", ".join(missing),
+            )
+    except Exception:
+        # Capability check is best-effort; it must never break training.
+        pass

--- a/src/traceml_ai/integrations/_capability.py
+++ b/src/traceml_ai/integrations/_capability.py
@@ -16,8 +16,10 @@ import os
 logger = logging.getLogger(__name__)
 
 # Logical stream -> the init-config flag that must be True to capture it.
-# (step_time/optimizer are not patch-gated — emitted by trace_step / auto hooks —
-# so they are intentionally not checked here.)
+# (step_time is emitted directly by trace_step. optimizer is mode-gated:
+# since upstream #146 the auto hooks install only when init mode == "auto".
+# Neither is flag-gated, so neither is checked here; warning on a dark
+# optimizer stream in manual/selective mode is a possible follow-up.)
 _PATCH_GATED = {
     "dataloader_fetch": "patch_dataloader",
     "forward": "patch_forward",

--- a/src/traceml_ai/integrations/huggingface.py
+++ b/src/traceml_ai/integrations/huggingface.py
@@ -135,6 +135,25 @@ class TraceMLTrainerCallback(TrainerCallback if HAS_TRANSFORMERS else object):
         if _traceml_disabled():
             return
 
+        # Fail-loud capability check (#88-class): warn, never raise,
+        # when the current init config leaves telemetry streams this
+        # integration owes dark. on_train_begin runs once per train()
+        # call, after user setup, so it reflects post-init() state and
+        # stays off the per-step hot path. Covers both the direct
+        # callback path and the TraceMLTrainer wrapper (which installs
+        # this callback).
+        try:
+            from traceml_ai.integrations._capability import (
+                warn_if_missing_streams,
+            )
+
+            warn_if_missing_streams(
+                "HuggingFace TraceMLTrainerCallback",
+                {"dataloader_fetch", "forward", "backward", "h2d"},
+            )
+        except Exception:
+            pass
+
         # Self-heal before training starts. If this callback instance is
         # reused and a previous run crashed mid-step, the leaked trace_step is
         # still suspended with its auto-timer flags armed. With

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,16 +22,22 @@ import pytest  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
-def _reset_optimizer_timing_between_tests():
+def _reset_traceml_global_state_between_tests():
     """
-    Reset global optimizer-hook state after every test (fixes the TRA-28
-    order-dependent ``wrap_optimizer`` poisoning).
+    Reset process-global TraceML state after every test.
 
-    ``trace_step`` installs process-global optimizer-step hooks (via
-    ``ensure_optimizer_timing_installed``) and the installed-flag is never
-    cleared, so a later test calling ``wrap_optimizer()`` is refused purely
-    because of test order. Clearing the hooks + flag on teardown makes the
-    suite order-independent. Best-effort; never fails a test.
+    1. Optimizer-hook state: ``trace_step`` installs process-global
+       optimizer-step hooks (via ``ensure_optimizer_timing_installed``) and
+       the installed-flag is never cleared, so a later test calling
+       ``wrap_optimizer()`` is refused purely because of test order.
+    2. Recording state (#143): a test that leaks
+       ``configure_trace_recording(max_steps=N)`` after flushing past step N
+       silences ALL telemetry process-wide, which would make unrelated
+       emission tests (e.g. the StreamContract conformance gate) report
+       streams dark. Upstream tests reset this only inline, which is not
+       exception-safe.
+
+    Both resets are best-effort and never fail a test.
     """
     yield
     try:
@@ -40,5 +46,11 @@ def _reset_optimizer_timing_between_tests():
         )
 
         reset_optimizer_timing()
+    except Exception:
+        pass
+    try:
+        from traceml_ai.runtime.state import configure_trace_recording
+
+        configure_trace_recording()
     except Exception:
         pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,3 +16,29 @@ SRC = ROOT / "src"
 
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+
+
+import pytest  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_optimizer_timing_between_tests():
+    """
+    Reset global optimizer-hook state after every test (fixes the TRA-28
+    order-dependent ``wrap_optimizer`` poisoning).
+
+    ``trace_step`` installs process-global optimizer-step hooks (via
+    ``ensure_optimizer_timing_installed``) and the installed-flag is never
+    cleared, so a later test calling ``wrap_optimizer()`` is refused purely
+    because of test order. Clearing the hooks + flag on teardown makes the
+    suite order-independent. Best-effort; never fails a test.
+    """
+    yield
+    try:
+        from traceml_ai.instrumentation.hooks.optimizer_hooks import (
+            reset_optimizer_timing,
+        )
+
+        reset_optimizer_timing()
+    except Exception:
+        pass

--- a/tests/integrations/test_capability.py
+++ b/tests/integrations/test_capability.py
@@ -23,9 +23,7 @@ def _messages(caplog) -> str:
 
 
 def test_warns_when_not_initialized(monkeypatch, caplog):
-    monkeypatch.setattr(
-        "traceml_ai.sdk.initial.get_init_config", lambda: None
-    )
+    monkeypatch.setattr("traceml_ai.sdk.initial.get_init_config", lambda: None)
     with caplog.at_level(logging.WARNING):
         warn_if_missing_streams("HF", HF_REQUIRES)
     assert "dataloader_fetch" in _messages(caplog)
@@ -60,9 +58,7 @@ def test_silent_in_auto_mode(monkeypatch, caplog):
 
 def test_disabled_env_is_silent(monkeypatch, caplog):
     monkeypatch.setenv("TRACEML_DISABLED", "1")
-    monkeypatch.setattr(
-        "traceml_ai.sdk.initial.get_init_config", lambda: None
-    )
+    monkeypatch.setattr("traceml_ai.sdk.initial.get_init_config", lambda: None)
     with caplog.at_level(logging.WARNING):
         warn_if_missing_streams("HF", HF_REQUIRES)
     assert _messages(caplog) == ""

--- a/tests/integrations/test_capability.py
+++ b/tests/integrations/test_capability.py
@@ -1,0 +1,81 @@
+"""Unit tests for the fail-loud capability assertion (warn, never raise)."""
+
+import logging
+
+from traceml_ai.integrations._capability import warn_if_missing_streams
+from traceml_ai.sdk.initial import TraceMLInitConfig
+
+HF_REQUIRES = {"dataloader_fetch", "forward", "backward", "h2d"}
+
+
+def _cfg(mode: str, **patches) -> TraceMLInitConfig:
+    return TraceMLInitConfig(
+        mode=mode,
+        patch_dataloader=patches.get("patch_dataloader", False),
+        patch_forward=patches.get("patch_forward", False),
+        patch_backward=patches.get("patch_backward", False),
+        patch_h2d=patches.get("patch_h2d", False),
+    )
+
+
+def _messages(caplog) -> str:
+    return " ".join(r.getMessage() for r in caplog.records)
+
+
+def test_warns_when_not_initialized(monkeypatch, caplog):
+    monkeypatch.setattr(
+        "traceml_ai.sdk.initial.get_init_config", lambda: None
+    )
+    with caplog.at_level(logging.WARNING):
+        warn_if_missing_streams("HF", HF_REQUIRES)
+    assert "dataloader_fetch" in _messages(caplog)
+
+
+def test_warns_in_manual_mode_names_all_dark_streams(monkeypatch, caplog):
+    monkeypatch.setattr(
+        "traceml_ai.sdk.initial.get_init_config", lambda: _cfg("manual")
+    )
+    with caplog.at_level(logging.WARNING):
+        warn_if_missing_streams("HF", HF_REQUIRES)
+    msg = _messages(caplog)
+    for stream in ("dataloader_fetch", "forward", "backward", "h2d"):
+        assert stream in msg, f"{stream} not named in warning: {msg!r}"
+
+
+def test_silent_in_auto_mode(monkeypatch, caplog):
+    monkeypatch.setattr(
+        "traceml_ai.sdk.initial.get_init_config",
+        lambda: _cfg(
+            "auto",
+            patch_dataloader=True,
+            patch_forward=True,
+            patch_backward=True,
+            patch_h2d=True,
+        ),
+    )
+    with caplog.at_level(logging.WARNING):
+        warn_if_missing_streams("HF", HF_REQUIRES)
+    assert "will NOT be captured" not in _messages(caplog)
+
+
+def test_disabled_env_is_silent(monkeypatch, caplog):
+    monkeypatch.setenv("TRACEML_DISABLED", "1")
+    monkeypatch.setattr(
+        "traceml_ai.sdk.initial.get_init_config", lambda: None
+    )
+    with caplog.at_level(logging.WARNING):
+        warn_if_missing_streams("HF", HF_REQUIRES)
+    assert _messages(caplog) == ""
+
+
+def test_never_raises_on_partial_config(monkeypatch, caplog):
+    # selective mode with only dataloader on: forward/backward/h2d are dark.
+    monkeypatch.setattr(
+        "traceml_ai.sdk.initial.get_init_config",
+        lambda: _cfg("selective", patch_dataloader=True),
+    )
+    with caplog.at_level(logging.WARNING):
+        warn_if_missing_streams("HF", HF_REQUIRES)
+    msg = _messages(caplog)
+    assert "dataloader_fetch" not in msg  # captured
+    assert "forward" in msg and "backward" in msg and "h2d" in msg  # dark

--- a/tests/integrations/test_hf_trainer.py
+++ b/tests/integrations/test_hf_trainer.py
@@ -220,6 +220,10 @@ def test_hf_trainer_callback_grad_accum_folds_microbatches():
     events, validating that sub-phase auto-timers stay armed across the
     accumulated micro-batches within a single trace_step bracket.
     """
+    # The forward/backward auto-timers this test counts are no-ops unless
+    # the process-wide patches are installed; init() is the documented
+    # path and idempotent, so the test passes regardless of test order.
+    init()
     _reset_traceml_state()
     max_steps = 3
     grad_accum = 2

--- a/tests/integrations/test_hf_trainer.py
+++ b/tests/integrations/test_hf_trainer.py
@@ -456,3 +456,63 @@ def test_hf_init_enables_dataloader_and_h2d_patches():
         "huggingface.init() must enable the H2D Tensor.to patch the "
         "per-step auto-timer relies on."
     )
+
+
+# --- TraceML telemetry-completeness guard (instrumentation hardening) -------
+# test_hf_init_enables_dataloader_and_h2d_patches proves init() REQUESTS the
+# DataLoader patch (config flags). This guard goes one step further and
+# proves the stream actually EMITS during a real Trainer run. Absences (a
+# stream silently dark) are the costly failure mode; a config flag cannot
+# catch a broken patch, a renamed event, or a buffer that never flushes.
+
+DATALOADER_STREAM = "_traceml_internal:dataloader_next"
+
+
+@pytest.mark.skipif(not HAS_TRANSFORMERS, reason="transformers not installed")
+def test_hf_callback_run_emits_dataloader_fetch_events():
+    """
+    COMPLETENESS guard: with huggingface.init() called, a vanilla Trainer +
+    TraceMLTrainerCallback run must land `_traceml_internal:dataloader_next`
+    TimeEvents in the flushed StepTimeBatches, not merely set the
+    patch_dataloader config flag. Gates the full path: patch install ->
+    fetch timing -> step-buffer fold -> per-step flush.
+    """
+    _reset_traceml_state()
+
+    # Drop STEP-scope events still sitting in the unflushed buffer from
+    # earlier tests; they would otherwise fold into this run's first batch
+    # and could fake a pass.
+    from traceml_ai.utils.timing import _STEP_BUFFER
+
+    _STEP_BUFFER.clear()
+
+    # Explicit init is the documented HF path; the DataLoader fetch patch
+    # is process-wide and only installed here, never by the callback.
+    # init() is idempotent for the same effective config, so this is safe
+    # whether or not the patch-flag test already ran.
+    init()
+
+    max_steps = 5
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_dir = Path(tmp_dir) / "results"
+        model = _build_tiny_model()
+        train_dataset = _TinyTokenizedDataset()
+        training_args = _build_training_args(
+            str(output_dir), max_steps=max_steps
+        )
+
+        trainer = Trainer(
+            model=model,
+            args=training_args,
+            train_dataset=train_dataset,
+            callbacks=[TraceMLTrainerCallback()],
+        )
+        trainer.train()
+
+    batches = _drain_step_time_queue()
+    names = sorted({evt.name for batch in batches for evt in batch.events})
+    assert DATALOADER_STREAM in names, (
+        "DataLoader-fetch telemetry is DARK: the HF run did not emit "
+        f"'{DATALOADER_STREAM}'. Streams seen: {names}"
+    )

--- a/tests/integrations/test_telemetry_conformance.py
+++ b/tests/integrations/test_telemetry_conformance.py
@@ -15,11 +15,11 @@ DISCIPLINE: a new telemetry stream (e.g. all_reduce) is not "done" until it is
 added to REQUIRED_STEP_TIME below AND emitted by every integration that owes it.
 
 SCOPE (Stage 1, additive, zero training-path/import behavior change): POSITIVE
-conformance only — it calls `init(mode='auto')` explicitly, so it regression-
-gates the init() path (e.g. catches a future change that drops the DataLoader
-patch from auto mode). The NEGATIVE control (assert the bare/no-init path lacks
-a stream and that this harness DETECTS it) requires decoupling the integration
-import from the legacy auto-init side-effect -> Stage 2.
+conformance only — it calls the integration's documented `init()` entry point,
+so it regression-gates that path (e.g. catches a future change that drops the
+DataLoader patch from auto mode). The NEGATIVE control (assert the bare/no-init
+path lacks a stream and that this harness DETECTS it) became feasible when
+upstream #146 removed the legacy import-time auto-init -> Stage 2.
 """
 
 import importlib.util
@@ -28,7 +28,6 @@ from pathlib import Path
 
 import pytest
 
-from traceml_ai.sdk.initial import init
 from traceml_ai.samplers.utils import drain_queue_nowait
 from traceml_ai.utils.timing import _STEP_BUFFER, get_step_time_queue
 
@@ -84,7 +83,10 @@ def _run_huggingface() -> set[str]:
         TrainingArguments,
     )
 
-    from traceml_ai.integrations.huggingface import TraceMLTrainer
+    from traceml_ai.integrations.huggingface import (
+        TraceMLTrainer,
+        init as hf_init,
+    )
 
     class _TinyDS(torch.utils.data.Dataset):
         def __init__(self, n=20, seq=16, vocab=128, labels=4):
@@ -103,7 +105,9 @@ def _run_huggingface() -> set[str]:
         def __getitem__(self, i):
             return self._rows[i]
 
-    init(mode="auto")  # documented path; idempotent if already auto
+    # Canonical documented path (#135); == traceml_ai.init(mode="auto"),
+    # idempotent if already initialized with the same effective config.
+    hf_init()
     drain_queue_nowait(get_step_time_queue())
     _STEP_BUFFER.clear()
 

--- a/tests/integrations/test_telemetry_conformance.py
+++ b/tests/integrations/test_telemetry_conformance.py
@@ -1,0 +1,162 @@
+"""
+Cross-integration telemetry-completeness conformance test (the StreamContract gate).
+
+WHY THIS EXISTS
+---------------
+TraceML integrations can be individually correct yet silently emit INCOMPLETE
+telemetry (a stream goes dark with no error). Diff-review and feature-scoped
+tests catch what is *present*; the costly misses are *absences*. This turns
+"the maintainer remembers HF should emit the same streams as Lightning" into a
+CI gate: each integration DECLARES the telemetry streams it owes, and this test
+runs a tiny end-to-end CPU run under the integration's documented `init()` path
+and asserts every declared stream actually emitted >= 1 row.
+
+DISCIPLINE: a new telemetry stream (e.g. all_reduce) is not "done" until it is
+added to REQUIRED_STEP_TIME below AND emitted by every integration that owes it.
+
+SCOPE (Stage 1, additive, zero training-path/import behavior change): POSITIVE
+conformance only — it calls `init(mode='auto')` explicitly, so it regression-
+gates the init() path (e.g. catches a future change that drops the DataLoader
+patch from auto mode). The NEGATIVE control (assert the bare/no-init path lacks
+a stream and that this harness DETECTS it) requires decoupling the integration
+import from the legacy auto-init side-effect -> Stage 2.
+"""
+
+import importlib.util
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from traceml_ai.sdk.initial import init
+from traceml_ai.samplers.utils import drain_queue_nowait
+from traceml_ai.utils.timing import _STEP_BUFFER, get_step_time_queue
+
+# --- StreamContract registry -------------------------------------------------
+# Logical stream name -> wire name (utils/timing TimeEvent.name).
+STEP_TIME_WIRE = {
+    "step_time": "_traceml_internal:step_time",
+    "forward": "_traceml_internal:forward_time",
+    "backward": "_traceml_internal:backward_time",
+    "optimizer": "_traceml_internal:optimizer_step",
+    "dataloader_fetch": "_traceml_internal:dataloader_next",
+    "h2d": "_traceml_internal:h2d_time",  # GPU-only (arming-gated) -> not on CPU
+}
+
+# Each integration declares the STEP-TIME streams it owes on a CPU run.
+# (h2d is GPU-only; step_memory rides a separate queue -> both tracked separately.)
+REQUIRED_STEP_TIME = {
+    "huggingface": {
+        "step_time",
+        "forward",
+        "backward",
+        "optimizer",
+        "dataloader_fetch",  # the #88/#135 stream
+    },
+    "lightning": {
+        "step_time",
+        "forward",
+        "backward",
+        "optimizer",
+        "dataloader_fetch",
+    },
+}
+
+
+def _have(*mods: str) -> bool:
+    return all(importlib.util.find_spec(m) is not None for m in mods)
+
+
+def _drain_step_time_names() -> set[str]:
+    names: set[str] = set()
+    for batch in drain_queue_nowait(get_step_time_queue()):
+        for evt in getattr(batch, "events", []):
+            names.add(evt.name)
+    return names
+
+
+# --- Per-integration runnable harnesses --------------------------------------
+def _run_huggingface() -> set[str]:
+    import torch
+    from transformers import (
+        BertConfig,
+        BertForSequenceClassification,
+        TrainingArguments,
+    )
+
+    from traceml_ai.integrations.huggingface import TraceMLTrainer
+
+    class _TinyDS(torch.utils.data.Dataset):
+        def __init__(self, n=20, seq=16, vocab=128, labels=4):
+            self._rows = [
+                {
+                    "input_ids": (torch.arange(seq) % vocab) + (i % 7),
+                    "attention_mask": torch.ones(seq, dtype=torch.long),
+                    "labels": torch.tensor(i % labels),
+                }
+                for i in range(n)
+            ]
+
+        def __len__(self):
+            return len(self._rows)
+
+        def __getitem__(self, i):
+            return self._rows[i]
+
+    init(mode="auto")  # documented path; idempotent if already auto
+    drain_queue_nowait(get_step_time_queue())
+    _STEP_BUFFER.clear()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        model = BertForSequenceClassification(
+            BertConfig(
+                vocab_size=128,
+                hidden_size=32,
+                num_hidden_layers=2,
+                num_attention_heads=4,
+                intermediate_size=64,
+                max_position_embeddings=32,
+                num_labels=4,
+            )
+        )
+        args = TrainingArguments(
+            output_dir=str(Path(tmp) / "r"),
+            per_device_train_batch_size=4,
+            max_steps=5,
+            logging_steps=1,
+            use_cpu=not torch.cuda.is_available(),
+            save_strategy="no",
+        )
+        TraceMLTrainer(
+            model=model,
+            args=args,
+            train_dataset=_TinyDS(),
+            traceml_enabled=True,
+        ).train()
+
+    return _drain_step_time_names()
+
+
+# integration -> (runner, required deps). No entry => no runnable harness yet.
+_HARNESSES = {
+    "huggingface": (_run_huggingface, ("torch", "transformers")),
+}
+
+
+@pytest.mark.parametrize("integration", sorted(REQUIRED_STEP_TIME))
+def test_declared_step_time_streams_emit(integration: str):
+    """Every declared step-time stream must emit >= 1 row end-to-end."""
+    harness = _HARNESSES.get(integration)
+    if harness is None:
+        pytest.skip(f"no runnable conformance harness for {integration} yet")
+    runner, deps = harness
+    if not _have(*deps):
+        pytest.skip(f"{integration}: required deps not installed: {deps}")
+
+    emitted = runner()
+    required = {STEP_TIME_WIRE[k] for k in REQUIRED_STEP_TIME[integration]}
+    dark = sorted(w for w in required if w not in emitted)
+    assert not dark, (
+        f"{integration}: declared telemetry stream(s) DARK: {dark}. "
+        f"Emitted: {sorted(emitted)}"
+    )


### PR DESCRIPTION
Addresses #141 (Stage 1). Follows up the DataLoader-completeness discussion from #88 / #135 (now merged; this branch is rebased onto current `main`). Stage 2 (the negative-control conformance test, unblocked by #146 removing the legacy import-time auto-init) is a separate follow-up.

## What changed

Additive instrumentation-state hardening. No change to the training path, public API, or wire format (+453 lines, 7 files, all additions):

- **DataLoader-fetch completeness guard (HF):** `test_hf_init_enables_dataloader_and_h2d_patches` proves `init()` *requests* the DataLoader patch; this guard goes one step further and proves the stream actually *emits* during a real `Trainer` + `TraceMLTrainerCallback` run, with `_traceml_internal:dataloader_next` events landing in flushed StepTimeBatches (`tests/integrations/test_hf_trainer.py`). A config flag can't catch a broken patch, a renamed event, or a buffer that never flushes.
- **Cross-integration conformance gate:** each integration declares the telemetry streams it owes (`StreamContract`); a parametrized test runs a tiny end-to-end CPU run via the integration's documented `init()` entry point and asserts every declared stream emitted (`tests/integrations/test_telemetry_conformance.py`). Wires HF now; Lightning skips until it's a test dependency.
- **Fail-loud capability assertion:** when the callback is active but the init config leaves owed streams dark, emit one best-effort warning naming them, once per `train()` call in `on_train_begin`; never raises, never touches the per-step hot path (`src/traceml_ai/integrations/_capability.py`, wired into `TraceMLTrainerCallback`).
- **Global-state reset between tests:** public `reset_optimizer_timing()` plus an autouse conftest teardown that clears the global optimizer-hook handles/flag and restores default trace-recording state (`.../hooks/optimizer_hooks.py`, `tests/conftest.py`). Makes the suite order-independent.
- **Fix: `test_hf_trainer_callback_grad_accum_folds_microbatches` is red on current `main`** (run the file standalone: 1 failed, 6 passed; it counts forward/backward auto-timer events but nothing installs the patches before it in file order, and CI doesn't run `tests/integrations/`, so it's invisible there). One `init()` call makes it self-initializing. Fittingly, the new capability warning named the cause in the failure log: `... these telemetry streams will NOT be captured: backward, dataloader_fetch, forward, h2d`.

## Why

The callback-based HF integration (#88 / #135) originally emitted DataLoader-fetch timing only *incidentally*, and nothing verified completeness; the gap was caught by maintainer review, not by the system. Separately, a global optimizer-hook flag was never reset, so `wrap_optimizer` tests passed or failed depending on suite order, and the grad-accum test on `main` fails for the same class of reason today. One root cause: ungoverned global instrumentation state. This PR makes telemetry completeness a self-verifying property and the suite order-independent, without touching the training path.

## How I tested

```bash
PYTHONPATH=src python3 -m pytest -q
# 359 passed, 2 skipped in 9.08s

# previously order-dependent pairs, now green in any order:
PYTHONPATH=src python3 -m pytest tests/integrations/test_hf_trainer.py \
  "tests/sdk/test_init_and_wrappers.py::test_wrap_optimizer_preserves_identity_and_times_step" -q
# 9 passed

PYTHONPATH=src python3 -m pytest \
  "tests/integrations/test_hf_trainer.py::test_hf_trainer_callback_grad_accum_folds_microbatches" -q
# 1 passed  (fails standalone on main)
```

Each new test was written fails-first / passes-after (TDD). `black`/`ruff` clean on touched files.

- [x] Unit tests
- [x] Integration or smoke test
- [ ] Example training script
- [ ] Docs-only change
- [ ] Not run; reason:

## Runtime impact

- [x] No training-path runtime impact
- [ ] May affect training-path overhead
- [ ] May affect distributed launch, telemetry, or aggregator behavior
- [ ] Not applicable

Notes: Additive. New tests, a test-only reset hook, and a best-effort warning that fires once per `train()` call in `on_train_begin` (outside the step loop), only when an integration is active but unconfigured.

## Documentation

- [ ] README updated
- [ ] User docs updated
- [ ] Examples updated
- [ ] API docs updated
- [x] Not needed

Stage 1 is internal hardening; the public `init()` + callback flow is unchanged.

## Risk checklist

- [x] Does not add unnecessary CUDA synchronizations
- [x] Does not add blocking I/O on the training path
- [x] Fails safely without crashing user training
- [x] Keeps new dependencies optional unless discussed
- [x] Redacts or avoids sensitive training-environment data in examples

## Screenshots or output

```
$ PYTHONPATH=src python3 -m pytest -q
........................................................................ [100%]
359 passed, 2 skipped in 9.08s
```

The capability warning in action (from the pre-fix grad-accum failure log):

```
WARNING traceml_ai.integrations._capability: [TraceML] HuggingFace
TraceMLTrainerCallback is active but these telemetry streams will NOT be
captured: backward, dataloader_fetch, forward, h2d. Call
traceml_ai.init(mode='auto') before training to enable them.
```
