### PR TITLE
primary_diagnosis

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [**Compare Runs**](docs/user_guide/compare.md) •
 [**Read Output**](docs/user_guide/reading-output.md) •
 [**Use With Your Stack**](docs/user_guide/integrations.md) •
+[**Ask for Help**](https://github.com/traceopt-ai/traceml/discussions) •
 [**FAQ**](docs/user_guide/faq.md)
 
 **Training bottleneck guides:**
@@ -200,12 +201,14 @@ changing the final saved artifacts.
 
 ---
 
-## Feedback
+## Feedback and Help
 
-For bugs, unexpected results, or feature requests, open a GitHub issue and use
-the matching issue template. The templates ask for the details we need to
-reproduce training-environment problems, including hardware, topology, launch
-command, TraceML version, PyTorch/CUDA versions, and redacted summary output.
+If you want help interpreting a TraceML run, open a
+[GitHub Discussion](https://github.com/traceopt-ai/traceml/discussions) and paste
+your `final_summary.txt`, `final_summary.json`, or terminal summary.
+
+Use Issues for bugs, unexpected results, feature requests, and reproducible
+problems with TraceML itself:
 
 GitHub issues: [open an issue](https://github.com/traceopt-ai/traceml/issues)
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ PyTorch training can look normal while step time is lost to a slow input
 pipeline, low GPU utilization, memory growth, distributed rank skew, or a
 run-to-run regression.
 
-TraceML runs alongside your training loop and gives each run a **structured
-performance fingerprint** with low overhead (<2% in our current benchmark runs).
-It helps answer the questions that usually come before heavyweight operator-level
-profiling:
+TraceML runs alongside your PyTorch training loop and writes a compact
+runtime performance report at the end of each run. With low overhead
+(<2% in our current benchmark runs), it helps you see where step time and
+memory went before opening heavier tools like `torch.profiler` or Nsight.
+It helps answer:
 
 - Are my GPUs waiting on a slow dataloader?
 - Is one distributed rank consistently slower than the others?
@@ -48,6 +49,10 @@ balance, memory behavior, distributed rank skew, and run-to-run change.
 ```bash
 pip install traceml-ai
 ```
+
+Using Hugging Face Trainer, PyTorch Lightning, Ray Train, W&B, or MLflow?
+Start with the native integration path in
+[Use With Your Stack](docs/user_guide/integrations.md).
 
 ### 2. Wrap your training step
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # TraceML
 
-**Find slow PyTorch training bottlenecks: DataLoader stalls, low GPU utilization, DDP/FSDP rank stragglers, memory creep, and run regressions.**
+**A lightweight runtime health check for PyTorch training runs.**
 
 [![PyPI version](https://img.shields.io/pypi/v/traceml-ai.svg)](https://pypi.org/project/traceml-ai/)
 [![CI](https://github.com/traceopt-ai/traceml/actions/workflows/ci.yml/badge.svg)](https://github.com/traceopt-ai/traceml/actions/workflows/ci.yml)
@@ -16,39 +16,28 @@
 [**Compare Runs**](docs/user_guide/compare.md) •
 [**Read Output**](docs/user_guide/reading-output.md) •
 [**Use With Your Stack**](docs/user_guide/integrations.md) •
-[**Ask for Help**](https://github.com/traceopt-ai/traceml/discussions) •
 [**FAQ**](docs/user_guide/faq.md)
-
-**Training bottleneck guides:**
-[Slow PyTorch Training](docs/guides/slow-pytorch-training.md) •
-[DataLoader Bottlenecks](docs/guides/pytorch-dataloader-bottleneck.md) •
-[Low GPU Utilization](docs/guides/low-gpu-utilization-pytorch.md) •
-[DDP Rank Stragglers](docs/guides/ddp-slow-training-rank-straggler.md) •
-[Memory Creep](docs/guides/pytorch-memory-creep.md)
 
 </div>
 
-TraceML gives every PyTorch training run a **structured performance fingerprint**
-with low overhead (<2% in our current benchmark runs). It answers the questions
-that usually come before heavyweight operator-level profiling:
+### Is your GPU training, waiting on data, or blocked by one slow rank?
 
-- Are my GPUs waiting on a slow dataloader (input-bound)?
-- Is one distributed rank consistently slower than the others (straggler)?
-- Is memory usage silently creeping upward during the run (memory creep)?
-- Did a recent code or infrastructure change slow training down (regression)?
+PyTorch training can look normal while step time is lost to a slow input
+pipeline, low GPU utilization, memory growth, distributed rank skew, or a
+run-to-run regression.
 
-## Where TraceML Fits in the Stack
+TraceML runs alongside your training loop and gives each run a **structured
+performance fingerprint** with low overhead (<2% in our current benchmark runs).
+It helps answer the questions that usually come before heavyweight operator-level
+profiling:
 
-TraceML does not replace `torch.profiler`. It is the low-overhead, always-on
-first pass that tells you where to aim heavier profiling tools.
+- Are my GPUs waiting on a slow dataloader?
+- Is one distributed rank consistently slower than the others?
+- Is memory usage silently creeping upward during the run?
+- Did a recent code, data, or infrastructure change slow training down?
 
-| Tool | Best used for | Output | Cost / overhead |
-|---|---|---|---|
-| TraceML | Classifying high-level bottlenecks: input, compute, wait, memory, rank skew | JSON fingerprint, text summary, live views | <2% in current benchmark runs; small code wrapper |
-| `torch.profiler` | Inspecting expensive ops, kernels, and CUDA activity | Profiler trace | Higher overhead; requires profiler context |
-| Nsight Systems | Debugging low-level CUDA and kernel behavior | GPU timeline | Separate profiler run |
-| W&B / MLflow | Tracking training metrics and experiment history | Metrics dashboard / run history | Logging integration |
-| `nvidia-smi` | Checking machine-level GPU health and utilization | Terminal metrics | No code changes |
+Here, **health** means runtime performance health: step time, input/compute/wait
+balance, memory behavior, distributed rank skew, and run-to-run change.
 
 ---
 
@@ -61,6 +50,9 @@ pip install traceml-ai
 ```
 
 ### 2. Wrap your training step
+
+Add TraceML around the core training step. You do not need to change your model,
+optimizer, loss function, or dataloader.
 
 ```python
 import traceml_ai as traceml
@@ -85,7 +77,9 @@ traceml run train.py
 For DDP, FSDP, and multi-node runs, see
 [Distributed Training](docs/user_guide/distributed-training.md).
 
-## What You Get: The Output
+---
+
+## What You Get
 
 TraceML writes two end-of-run artifacts:
 
@@ -101,7 +95,9 @@ traceml view logs/<run_name>/final_summary.json
 ```
 
 Instead of guessing why training feels slow, you get a compact diagnosis of
-where step time and memory went:
+where step time and memory went.
+
+Example TraceML output:
 
 ```text
 +----------------------------------------------------------------------------+
@@ -123,7 +119,24 @@ to get a flat dict of diagnosis statuses and average metrics. Keep
 
 ---
 
-### Catching Regressions (Compare Mode)
+## What TraceML Helps You Triage
+
+TraceML is meant to be the first check when a training run is slower than
+expected. It points you to the likely area before you decide whether to open a
+heavier profiler.
+
+| Area | What TraceML surfaces | What to inspect next |
+|---|---|---|
+| Input pipeline | High input time or slow input rank | `num_workers`, `pin_memory`, transforms, tokenization, `collate_fn`, dataset/storage latency |
+| GPU utilization / wait | Step time split across input, compute, and wait | input pipeline, CPU/GPU handoff, synchronization, distributed coordination |
+| Distributed skew | One DDP/FSDP rank slower than the others | rank-local dataloading, data imbalance, node variance, storage/network differences |
+| Memory creep | Memory usage growing during the run | retained tensors, logging references, loss accumulation, cached activations |
+| Run regression | Changed metrics versus a known-good run | code changes, data changes, batch size, container, driver, hardware, infrastructure |
+| Compute-heavy runs | Most time is spent in compute | open `torch.profiler` or Nsight for operator/kernel-level detail |
+
+---
+
+## Catching Regressions with Compare Mode
 
 Compare a slow run against a known good baseline to identify which metrics
 changed:
@@ -147,6 +160,8 @@ traceml compare input_slow/final_summary.json input_fixed/final_summary.json
 
 See [Compare Runs](docs/user_guide/compare.md) for the full report format.
 
+---
+
 ## Display Modes
 
 TraceML controls what you see during training with the `--mode` flag, without
@@ -160,7 +175,7 @@ changing the final saved artifacts.
 
 ---
 
-## Current support
+## Current Support
 
 **Works today:**
 
@@ -178,15 +193,34 @@ changing the final saved artifacts.
 
 ---
 
-## Overhead
+## Where TraceML Fits in the Stack
 
-**Overhead:** In our benchmark runs, TraceML adds <2% overhead on single GPU and <1% on single-node multi-GPU at default settings.
+TraceML does not replace `torch.profiler`. It is the low-overhead first pass that
+helps you decide where to aim heavier profiling tools.
+
+| Tool | Best used for | Output | Cost / overhead |
+|---|---|---|---|
+| TraceML | Classifying high-level bottlenecks: input, compute, wait, memory, rank skew | JSON fingerprint, text summary, live views | <2% in current benchmark runs; small code wrapper |
+| `torch.profiler` | Inspecting expensive ops, kernels, and CUDA activity | Profiler trace | Higher overhead; requires profiler context |
+| Nsight Systems | Debugging low-level CUDA and kernel behavior | GPU timeline | Separate profiler run |
+| W&B / MLflow | Tracking training metrics and experiment history | Metrics dashboard / run history | Logging integration |
+| `nvidia-smi` | Checking machine-level GPU health and utilization | Terminal metrics | No code changes |
 
 ---
 
-## Learn More
+## Overhead
 
-- [Quickstart](docs/user_guide/quickstart.md)
+In our benchmark runs, TraceML adds:
+
+- <2% overhead on single GPU at default settings
+- <1% overhead on single-node multi-GPU at default settings
+
+---
+
+## Troubleshooting Guides
+
+These guides cover the common bottlenecks TraceML is designed to identify:
+
 - [Find why PyTorch training is slow](docs/guides/slow-pytorch-training.md)
 - [Find DataLoader Bottlenecks](docs/guides/pytorch-dataloader-bottleneck.md)
 - [Debug Low GPU Utilization](docs/guides/low-gpu-utilization-pytorch.md)
@@ -201,14 +235,12 @@ changing the final saved artifacts.
 
 ---
 
-## Feedback and Help
+## Feedback
 
-If you want help interpreting a TraceML run, open a
-[GitHub Discussion](https://github.com/traceopt-ai/traceml/discussions) and paste
-your `final_summary.txt`, `final_summary.json`, or terminal summary.
-
-Use Issues for bugs, unexpected results, feature requests, and reproducible
-problems with TraceML itself:
+For bugs, unexpected results, or feature requests, open a GitHub issue and use
+the matching issue template. The templates ask for the details we need to
+reproduce training-environment problems, including hardware, topology, launch
+command, TraceML version, PyTorch/CUDA versions, and redacted summary output.
 
 GitHub issues: [open an issue](https://github.com/traceopt-ai/traceml/issues)
 

--- a/docs/user_guide/compare.md
+++ b/docs/user_guide/compare.md
@@ -96,6 +96,7 @@ The compare report is designed to stay compact and useful.
 It typically focuses on:
 
 - overall duration
+- primary diagnosis changes
 - step-time diagnosis changes
 - average step time changes
 - wait-time changes

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -18,17 +18,31 @@ The concepts are the same in both.
 
 TraceML output has two layers:
 
-1. **Diagnosis**
-   - the short answer
-   - example: `INPUT-BOUND`, `COMPUTE STRAGGLER`, `MEMORY CREEP`
+1. **Primary Diagnosis**
+   - the first answer in the end-of-run summary
+   - focused on why training was slow
+   - example: `INPUT-BOUND`, `COMPUTE STRAGGLER`, `WAIT-HEAVY`
 
-2. **Evidence**
+2. **Section Diagnoses**
+   - detailed findings for System, Process, Step Time, and Step Memory
+   - includes performance findings and health/resource findings
+   - example: `HIGH GPU TEMP`, `MEMORY CREEP`, `HIGH PROCESS CPU`
+
+3. **Evidence**
    - the numbers and trends that support the diagnosis
    - example: step breakdown, skew, wait time, memory peaks
 
-The diagnosis is the best place to start.
+The top-level primary diagnosis is the best place to start when asking why a
+run was slow. Section diagnoses explain the details and keep health warnings
+visible.
 
 The tables and charts are there to explain **why** that diagnosis was chosen.
+
+The primary diagnosis is intentionally performance-focused. A high GPU
+temperature, memory creep, or high RSS finding can be important, but it stays
+in its section unless TraceML has step-time evidence that it explains slow
+training. GPU utilization is treated as supporting context or as an
+unexplained-utilization fallback, not as root-cause proof by itself.
 
 ---
 

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -4,6 +4,14 @@ TraceML emits a sorted list of `DiagnosticIssue` findings or states per final
 summary section. `issues[0]` is the primary diagnosis, and final-summary JSON
 also copies that same item to `diagnosis`.
 
+The final summary also includes a top-level `primary_diagnosis`. That field is
+a run-level performance finding promoted from existing section diagnoses. It is
+not a replacement for section diagnoses and it is not a health-warning rollup.
+In schema `1.5`, Step Time drives the top-level primary diagnosis; System GPU
+utilization can appear as supporting evidence or as an unexplained-utilization
+fallback. System, Process, and Step Memory resource findings remain canonical
+inside their sections.
+
 Use `kind` as the stable internal key for logic and comparisons. Use `status`
 as the user-facing display label. In many cases they are similar, but they are
 not required to match; System statuses intentionally use compact labels such as

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -65,6 +65,23 @@ supporting evidence, except for the fallback
 cause. Process, System health, and Step Memory health findings remain in their
 section diagnoses.
 
+Selection policy:
+
+- `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`, and `STRAGGLER` use rank-comparison
+  evidence and are promoted from `step_time.diagnosis`.
+- `WAIT_HEAVY`, `INPUT_BOUND`, and `COMPUTE_BOUND` use phase-share evidence
+  and are promoted from `step_time.diagnosis`.
+- `LOW_GPU_UTILIZATION_UNEXPLAINED` appears only when Step Time is `BALANCED`
+  and System reports `LOW_GPU_UTILIZATION` or `MODERATE_GPU_UTILIZATION`.
+- `NO_CLEAR_PERFORMANCE_BOTTLENECK` appears when Step Time is `BALANCED` and
+  GPU utilization is not low/moderate.
+- `INSUFFICIENT_STEP_TIME_DATA` appears when Step Time is `NO_DATA` or
+  `WARMUP`.
+
+High temperature, memory pressure, memory creep, high RSS, high CPU, and other
+resource-health findings are not promoted into `primary_diagnosis` in schema
+`1.5`. They remain available under their section's `diagnosis` and `issues`.
+
 Primary diagnosis evidence uses a small union:
 
 ```json

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -1,6 +1,6 @@
 # Final Summary JSON
 
-TraceML writes one end-of-run JSON file. The current schema version is `1.4`.
+TraceML writes one end-of-run JSON file. The current schema version is `1.5`.
 Each section has the same outer shape so the output is easy to store, diff, and
 consume from tooling.
 
@@ -16,7 +16,7 @@ Sections:
 
 ```json
 {
-  "schema_version": 1.4,
+  "schema_version": 1.5,
   "generated_at": "...",
   "duration_s": null,
   "meta": {
@@ -26,6 +26,7 @@ Sections:
     "nodes_observed": null,
     "gpus_observed": null
   },
+  "primary_diagnosis": {},
   "system": {},
   "process": {},
   "step_time": {},
@@ -36,6 +37,83 @@ Sections:
 
 `meta` contains run-level identity and observed topology. Section-level
 `metadata` remains section-specific coverage and metric-contract information.
+
+`primary_diagnosis` is a top-level performance finding promoted from existing
+section diagnoses. It answers "why was training slow?" and is intentionally
+narrower than section-level health/resource diagnoses.
+
+## Primary Diagnosis Shape
+
+```json
+{
+  "kind": "INPUT_BOUND",
+  "status": "INPUT-BOUND",
+  "severity": "info | warn | crit",
+  "section": "step_time | system",
+  "scope": "performance",
+  "summary": "...",
+  "action": "...",
+  "evidence": {}
+}
+```
+
+`primary_diagnosis` is derived from already-built section payloads. It does not
+read telemetry tables or recompute diagnostics. In schema `1.5`, Step Time
+diagnoses drive primary performance diagnosis. System GPU utilization is only
+supporting evidence, except for the fallback
+`LOW_GPU_UTILIZATION_UNEXPLAINED` when Step Time has no useful performance
+cause. Process, System health, and Step Memory health findings remain in their
+section diagnoses.
+
+Primary diagnosis evidence uses a small union:
+
+```json
+{
+  "type": "phase_share",
+  "basis": "average",
+  "steps_analyzed": 256,
+  "total_step_ms": 272.3,
+  "dataloader_ms": 161.0,
+  "h2d_ms": 0.1,
+  "compute_ms": 109.6,
+  "wait_ms": 1.6,
+  "shares": {
+    "dataloader_pct": 59.1,
+    "h2d_pct": 0.0,
+    "compute_pct": 40.3,
+    "wait_pct": 0.6
+  },
+  "gpu_util_avg_percent": 37.8
+}
+```
+
+`phase_share` is used for `INPUT_BOUND`, `WAIT_HEAVY`, and `COMPUTE_BOUND`.
+Values come from `step_time.global.average`.
+
+```json
+{
+  "type": "rank_comparison",
+  "metric": "dataloader_ms",
+  "phase": "dataloader",
+  "steps_analyzed": 256,
+  "median": {"rank": 0, "value_ms": 0.7},
+  "worst": {"rank": 2, "value_ms": 180.9},
+  "delta_ms": 180.2,
+  "ratio": 262.4,
+  "gpu_util_avg_percent": 80.0
+}
+```
+
+`rank_comparison` is used for `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`, and
+`STRAGGLER`. Values come from `step_time.global.median[metric]` and
+`step_time.global.worst[metric]`. Generic `STRAGGLER` may contain a
+`comparisons` array instead of a single metric comparison.
+
+Fallback evidence types are:
+
+- `utilization_fallback` for `LOW_GPU_UTILIZATION_UNEXPLAINED`
+- `no_clear_bottleneck` for `NO_CLEAR_PERFORMANCE_BOTTLENECK`
+- `insufficient_data` for `INSUFFICIENT_STEP_TIME_DATA`
 
 ## Section Shape
 

--- a/src/traceml_ai/reporting/compare/core.py
+++ b/src/traceml_ai/reporting/compare/core.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from traceml_ai.reporting.compare.io import derive_compare_labels
+from traceml_ai.reporting.compare.model import CompareDiagnosis
 from traceml_ai.reporting.compare.sections import SECTION_COMPARERS
 from traceml_ai.reporting.compare.verdict import build_compare_verdict
 
@@ -29,6 +30,18 @@ def _as_float(value: Any) -> float | None:
 def _utc_now_iso() -> str:
     """Return a UTC timestamp without importing the training SDK."""
     return datetime.now(timezone.utc).isoformat()
+
+
+def _primary_diagnosis_status(payload: Dict[str, Any]) -> str | None:
+    """Return the top-level primary diagnosis status, if present."""
+    block = payload.get("primary_diagnosis")
+    if not isinstance(block, dict):
+        return None
+    value = block.get("status")
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
 
 
 def build_compare_payload(
@@ -76,6 +89,10 @@ def build_compare_payload(
                 "lhs": _as_float(lhs_payload.get("duration_s")),
                 "rhs": _as_float(rhs_payload.get("duration_s")),
             },
+            "primary_diagnosis": CompareDiagnosis(
+                lhs=_primary_diagnosis_status(lhs_payload),
+                rhs=_primary_diagnosis_status(rhs_payload),
+            ).to_dict(),
         },
         "text": "",
     }

--- a/src/traceml_ai/reporting/compare/formatters.py
+++ b/src/traceml_ai/reporting/compare/formatters.py
@@ -196,6 +196,21 @@ def _append_wrapped_card_line(lines: List[str], text: str) -> None:
         _append_card_line(lines, wrapped)
 
 
+def _format_primary_diagnosis(overview: Dict[str, Any]) -> Optional[str]:
+    """Return the run-level primary diagnosis comparison line."""
+    primary = overview.get("primary_diagnosis")
+    if not isinstance(primary, dict):
+        return None
+    lhs_raw = primary.get("lhs")
+    rhs_raw = primary.get("rhs")
+    if lhs_raw is None and rhs_raw is None:
+        return None
+    lhs = lhs_raw or "n/a"
+    rhs = rhs_raw or "n/a"
+    delta = "changed" if primary.get("changed") else "same"
+    return f"Primary diagnosis: {lhs} -> {rhs} ({delta})"
+
+
 class CompareTextFormatter(Formatter[Dict[str, Any], str]):
     """Render compare JSON as a compact table."""
 
@@ -204,6 +219,7 @@ class CompareTextFormatter(Formatter[Dict[str, Any], str]):
     def format(self, payload: Dict[str, Any]) -> str:
         lhs = payload.get("lhs", {})
         rhs = payload.get("rhs", {})
+        overview = payload.get("overview", {})
         verdict = payload.get("verdict", {})
         sections = payload.get("sections", {})
 
@@ -217,6 +233,11 @@ class CompareTextFormatter(Formatter[Dict[str, Any], str]):
         _append_wrapped_card_line(lines, f"A: {lhs.get('label', 'A')}")
         _append_wrapped_card_line(lines, f"B: {rhs.get('label', 'B')}")
         _append_card_line(lines, "Delta: B - A")
+
+        primary_line = _format_primary_diagnosis(overview)
+        if primary_line:
+            _append_wrapped_card_line(lines, primary_line)
+
         _append_card_line(lines)
         _append_wrapped_card_line(
             lines,

--- a/src/traceml_ai/reporting/final.py
+++ b/src/traceml_ai/reporting/final.py
@@ -19,6 +19,7 @@ from traceml_ai.reporting.config import (
     DEFAULT_SUMMARY_WINDOW_ROWS,
     normalize_summary_window_rows,
 )
+from traceml_ai.reporting.primary_diagnosis import build_primary_diagnosis
 from traceml_ai.reporting.schema import empty_section_payload
 from traceml_ai.reporting.sections.base import SummarySection
 from traceml_ai.reporting.sections.process import ProcessSummarySection
@@ -282,8 +283,31 @@ def _append_wrapped_card_lines(
             lines.append(row(wrapped, width=SUMMARY_WIDTH))
 
 
+def _append_primary_diagnosis_lines(
+    lines: List[str],
+    primary_diagnosis: Dict[str, Any],
+) -> None:
+    """Append the top-level primary diagnosis block to final text."""
+    status = str(primary_diagnosis.get("status") or "NO DATA")
+    summary = str(primary_diagnosis.get("summary") or "")
+    action = str(primary_diagnosis.get("action") or "")
+    block = [
+        "Primary Diagnosis",
+        f"- Diagnosis: {status}",
+    ]
+    if summary:
+        block.append(f"- Why: {summary}")
+    if action:
+        block.append(f"- Next: {action}")
+
+    for line in block:
+        for wrapped in wrap_lines(line, SUMMARY_INNER_TEXT_WIDTH):
+            lines.append(row(wrapped, width=SUMMARY_WIDTH))
+
+
 def _build_final_summary_text_from_sections(
     *,
+    primary_diagnosis: Dict[str, Any],
     system_summary: Dict[str, Any],
     process_summary: Dict[str, Any],
     step_time_summary: Dict[str, Any],
@@ -311,8 +335,16 @@ def _build_final_summary_text_from_sections(
         ),
         border(width=SUMMARY_WIDTH),
         row(width=SUMMARY_WIDTH),
-        row("System", width=SUMMARY_WIDTH),
     ]
+
+    _append_primary_diagnosis_lines(lines, primary_diagnosis)
+
+    lines.extend(
+        [
+            row(width=SUMMARY_WIDTH),
+            row("System", width=SUMMARY_WIDTH),
+        ]
+    )
 
     _append_wrapped_card_lines(
         lines,
@@ -399,9 +431,9 @@ class FinalReportGenerator:
         """
         Generate the structured final summary payload.
 
-        Section failures are isolated and logged. A failed section contributes a
-        schema-valid ``NO DATA`` payload so one broken report domain does not
-        prevent artifact generation during aggregator shutdown.
+        Section failures are isolated and logged. A failed section contributes
+        a schema-valid ``NO DATA`` payload so one broken report domain does
+        not prevent artifact generation during aggregator shutdown.
         """
         results: Dict[str, SummaryResult] = {}
         for section in self.sections:
@@ -409,7 +441,8 @@ class FinalReportGenerator:
                 result = section.build(db_path)
             except Exception as exc:
                 _log_final_report_error(
-                    f"Final summary section failed: {getattr(section, 'name', section)}",
+                    "Final summary section failed: "
+                    f"{getattr(section, 'name', section)}",
                     exc,
                 )
                 result = _fallback_section_result(section)
@@ -428,7 +461,15 @@ class FinalReportGenerator:
             results.get("step_memory", SummaryResult("step_memory")).payload
         )
 
+        primary_diagnosis = build_primary_diagnosis(
+            system_summary=system_summary,
+            process_summary=process_summary,
+            step_time_summary=step_time_summary,
+            step_memory_summary=step_memory_summary,
+        )
+
         final_text = _build_final_summary_text_from_sections(
+            primary_diagnosis=primary_diagnosis,
             system_summary=system_summary,
             process_summary=process_summary,
             step_time_summary=step_time_summary,
@@ -436,7 +477,7 @@ class FinalReportGenerator:
         )
 
         return {
-            "schema_version": 1.4,
+            "schema_version": 1.5,
             "generated_at": utc_now_iso(),
             "duration_s": _summary_duration_s(
                 step_time_summary,
@@ -450,6 +491,7 @@ class FinalReportGenerator:
                 step_time_summary=step_time_summary,
                 step_memory_summary=step_memory_summary,
             ),
+            "primary_diagnosis": primary_diagnosis,
             "system": system_summary,
             "process": process_summary,
             "step_time": step_time_summary,

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -1,0 +1,591 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Primary performance diagnosis for final run summaries.
+
+This module promotes existing section-level diagnoses into one top-level
+performance finding. It does not read telemetry databases or recompute
+diagnostics from tables; it only interprets already-built final-summary section
+payloads.
+
+Policy priority, from most actionable to least:
+1. INPUT_STRAGGLER
+2. COMPUTE_STRAGGLER
+3. STRAGGLER
+4. WAIT_HEAVY
+5. INPUT_BOUND
+6. COMPUTE_BOUND
+7. LOW_GPU_UTILIZATION_UNEXPLAINED
+8. NO_CLEAR_PERFORMANCE_BOTTLENECK
+9. INSUFFICIENT_STEP_TIME_DATA
+
+Section-level system, process, and memory diagnoses remain canonical for
+resource health. The primary diagnosis answers a narrower question: "why was
+training slow?"
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Mapping, Optional, Sequence
+
+JsonDict = Dict[str, Any]
+
+STEP_TIME_SECTION = "step_time"
+PERFORMANCE_SCOPE = "performance"
+
+PHASE_SHARE_KINDS = {"INPUT_BOUND", "WAIT_HEAVY", "COMPUTE_BOUND"}
+STRAGGLER_KINDS = {
+    "INPUT_STRAGGLER",
+    "COMPUTE_STRAGGLER",
+    "STRAGGLER",
+}
+INSUFFICIENT_STEP_TIME_KINDS = {"NO_DATA", "WARMUP"}
+LOW_GPU_UTIL_KINDS = {
+    "LOW_GPU_UTILIZATION",
+    "MODERATE_GPU_UTILIZATION",
+}
+
+PHASE_METRICS = (
+    "dataloader_ms",
+    "h2d_ms",
+    "compute_ms",
+    "wait_ms",
+)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    """Return a mapping or an empty mapping for malformed payload blocks."""
+    return value if isinstance(value, Mapping) else {}
+
+
+def _sequence(value: Any) -> Sequence[Any]:
+    """Return a sequence or an empty tuple for malformed payload blocks."""
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return value
+    return ()
+
+
+def _float_or_none(value: Any) -> Optional[float]:
+    """Return a finite-enough float for summary evidence, else ``None``."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except Exception:
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _int_or_none(value: Any) -> Optional[int]:
+    """Return an integer rank/index value when one is available."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except Exception:
+        return None
+
+
+def _round(value: Optional[float], ndigits: int = 3) -> Optional[float]:
+    """Round numeric evidence without hiding missing values."""
+    if value is None:
+        return None
+    return round(float(value), ndigits)
+
+
+def _diagnosis(section: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return a section's primary diagnosis block."""
+    return _mapping(section.get("diagnosis"))
+
+
+def _global(section: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return a section's global rollup block."""
+    return _mapping(section.get("global"))
+
+
+def _global_average(section: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return a section's global average metric block."""
+    return _mapping(_global(section).get("average"))
+
+
+def _global_window(section: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return a section's global analysis window block."""
+    return _mapping(_global(section).get("window"))
+
+
+def _point(
+    section: Mapping[str, Any],
+    *,
+    block: str,
+    metric: str,
+) -> Mapping[str, Any]:
+    """Return one ``global.median/worst[metric]`` point."""
+    return _mapping(_mapping(_global(section).get(block)).get(metric))
+
+
+def _gpu_util_avg(system_summary: Mapping[str, Any]) -> Optional[float]:
+    """Return average system GPU utilization when available."""
+    return _float_or_none(
+        _global_average(system_summary).get("gpu_util_percent")
+    )
+
+
+def _steps_analyzed(step_time_summary: Mapping[str, Any]) -> Optional[int]:
+    """Return the number of aligned steps behind the step-time summary."""
+    return _int_or_none(
+        _global_window(step_time_summary).get("steps_analyzed")
+    )
+
+
+def _diag_field(
+    diagnosis: Mapping[str, Any],
+    key: str,
+    default: str = "",
+) -> str:
+    """Read a string diagnosis field."""
+    value = diagnosis.get(key)
+    return str(value) if value is not None else default
+
+
+def _primary_payload(
+    *,
+    kind: str,
+    status: str,
+    severity: str,
+    section: str,
+    summary: str,
+    action: str,
+    evidence: Mapping[str, Any],
+) -> JsonDict:
+    """Build the stable top-level primary diagnosis payload."""
+    return {
+        "kind": str(kind),
+        "status": str(status),
+        "severity": str(severity),
+        "section": str(section),
+        "scope": PERFORMANCE_SCOPE,
+        "summary": str(summary),
+        "action": str(action),
+        "evidence": dict(evidence),
+    }
+
+
+def _phase_share_evidence(
+    *,
+    step_time_summary: Mapping[str, Any],
+    system_summary: Mapping[str, Any],
+) -> JsonDict:
+    """Build evidence for diagnoses based on average step-time shares."""
+    average = _global_average(step_time_summary)
+    total_ms = _float_or_none(average.get("total_step_ms"))
+    evidence: JsonDict = {
+        "type": "phase_share",
+        "basis": "average",
+        "steps_analyzed": _steps_analyzed(step_time_summary),
+        "total_step_ms": _round(total_ms),
+    }
+
+    for metric in PHASE_METRICS:
+        evidence[metric] = _round(_float_or_none(average.get(metric)))
+
+    shares: JsonDict = {}
+    for metric in PHASE_METRICS:
+        value = _float_or_none(average.get(metric))
+        key = metric.replace("_ms", "_pct")
+        shares[key] = (
+            _round(100.0 * value / total_ms)
+            if value is not None and total_ms and total_ms > 0.0
+            else None
+        )
+    evidence["shares"] = shares
+    evidence["gpu_util_avg_percent"] = _round(_gpu_util_avg(system_summary))
+    return evidence
+
+
+def _metric_for_step_time_issue(issue: Mapping[str, Any]) -> Optional[str]:
+    """Map one step-time issue to the public metric used for comparison."""
+    kind = str(issue.get("kind") or "")
+    if kind == "INPUT_STRAGGLER":
+        return "dataloader_ms"
+    if kind == "COMPUTE_STRAGGLER":
+        phase = str(issue.get("phase") or "").lower()
+        if phase in {"forward", "backward", "optimizer"}:
+            return f"{phase}_ms"
+        return "compute_ms"
+    return None
+
+
+def _metric_for_primary_diagnosis(
+    diagnosis: Mapping[str, Any],
+) -> Optional[str]:
+    """Map a primary step-time diagnosis to the public comparison metric."""
+    kind = str(diagnosis.get("kind") or "")
+    if kind == "INPUT_STRAGGLER":
+        return "dataloader_ms"
+    if kind == "COMPUTE_STRAGGLER":
+        phase = str(diagnosis.get("phase") or "").lower()
+        if phase in {"forward", "backward", "optimizer"}:
+            return f"{phase}_ms"
+        return "compute_ms"
+    return None
+
+
+def _rank_point_json(point: Mapping[str, Any]) -> JsonDict:
+    """Convert a global point into the primary evidence rank/value shape."""
+    return {
+        "rank": _int_or_none(point.get("idx")),
+        "value_ms": _round(_float_or_none(point.get("value"))),
+    }
+
+
+def _comparison(
+    *,
+    step_time_summary: Mapping[str, Any],
+    metric: str,
+    phase: Optional[str] = None,
+) -> JsonDict:
+    """Build a median-vs-worst comparison for one step-time metric."""
+    median = _rank_point_json(
+        _point(step_time_summary, block="median", metric=metric)
+    )
+    worst = _rank_point_json(
+        _point(step_time_summary, block="worst", metric=metric)
+    )
+    median_value = _float_or_none(median.get("value_ms"))
+    worst_value = _float_or_none(worst.get("value_ms"))
+    delta_ms = (
+        worst_value - median_value
+        if worst_value is not None and median_value is not None
+        else None
+    )
+    ratio = (
+        worst_value / median_value
+        if worst_value is not None
+        and median_value is not None
+        and median_value > 0.0
+        else None
+    )
+    return {
+        "metric": metric,
+        "phase": phase or metric.replace("_ms", ""),
+        "median": median,
+        "worst": worst,
+        "delta_ms": _round(delta_ms),
+        "ratio": _round(ratio),
+    }
+
+
+def _rank_comparison_evidence(
+    *,
+    step_time_summary: Mapping[str, Any],
+    system_summary: Mapping[str, Any],
+    diagnosis: Mapping[str, Any],
+) -> JsonDict:
+    """Build evidence for diagnoses based on cross-rank comparisons."""
+    kind = str(diagnosis.get("kind") or "")
+    evidence: JsonDict = {
+        "type": "rank_comparison",
+        "steps_analyzed": _steps_analyzed(step_time_summary),
+        "gpu_util_avg_percent": _round(_gpu_util_avg(system_summary)),
+    }
+
+    if kind == "STRAGGLER":
+        comparisons = _straggler_comparisons(
+            step_time_summary=step_time_summary,
+            issues=_sequence(step_time_summary.get("issues")),
+        )
+        evidence["comparisons"] = comparisons
+        return evidence
+
+    metric = _metric_for_primary_diagnosis(diagnosis)
+    if metric is None:
+        metric = "total_step_ms"
+    comparison = _comparison(
+        step_time_summary=step_time_summary,
+        metric=metric,
+        phase=str(diagnosis.get("phase") or metric.replace("_ms", "")),
+    )
+    evidence.update(comparison)
+    return evidence
+
+
+def _straggler_comparisons(
+    *,
+    step_time_summary: Mapping[str, Any],
+    issues: Sequence[Any],
+) -> list[JsonDict]:
+    """Return comparisons for the atomic issues behind a STRAGGLER primary."""
+    out: list[JsonDict] = []
+    seen: set[str] = set()
+    for raw_issue in issues:
+        issue = _mapping(raw_issue)
+        metric = _metric_for_step_time_issue(issue)
+        if metric is None or metric in seen:
+            continue
+        seen.add(metric)
+        out.append(
+            _comparison(
+                step_time_summary=step_time_summary,
+                metric=metric,
+                phase=str(issue.get("phase") or metric.replace("_ms", "")),
+            )
+        )
+
+    if out:
+        return out
+
+    return [
+        _comparison(
+            step_time_summary=step_time_summary,
+            metric="dataloader_ms",
+            phase="dataloader",
+        ),
+        _comparison(
+            step_time_summary=step_time_summary,
+            metric="compute_ms",
+            phase="compute",
+        ),
+    ]
+
+
+def _phase_share_summary(kind: str, evidence: Mapping[str, Any]) -> str:
+    """Return a concise primary summary for phase-share diagnoses."""
+    total = _float_or_none(evidence.get("total_step_ms"))
+    if kind == "INPUT_BOUND":
+        value = _float_or_none(evidence.get("dataloader_ms"))
+        if value is not None and total is not None:
+            return (
+                f"Input loading took {value:.1f}ms of a "
+                f"{total:.1f}ms average step."
+            )
+        return "Input loading took a large share of step time."
+    if kind == "WAIT_HEAVY":
+        value = _float_or_none(evidence.get("wait_ms"))
+        if value is not None and total is not None:
+            return (
+                f"Wait time took {value:.1f}ms of a "
+                f"{total:.1f}ms average step."
+            )
+        return "Wait time took a large share of step time."
+    if kind == "COMPUTE_BOUND":
+        value = _float_or_none(evidence.get("compute_ms"))
+        if value is not None and total is not None:
+            return (
+                f"Model compute took {value:.1f}ms of a "
+                f"{total:.1f}ms average step."
+            )
+        return "Most step time was model compute."
+    return "Step time was dominated by one phase."
+
+
+def _rank_comparison_summary(
+    kind: str,
+    evidence: Mapping[str, Any],
+) -> str:
+    """Return a concise primary summary for rank-comparison diagnoses."""
+    if kind == "STRAGGLER":
+        return "Input and compute varied across ranks."
+
+    metric = str(evidence.get("metric") or "step_time")
+    phase = str(evidence.get("phase") or metric.replace("_ms", ""))
+    median = _mapping(evidence.get("median"))
+    worst = _mapping(evidence.get("worst"))
+    worst_rank = _int_or_none(worst.get("rank"))
+    median_rank = _int_or_none(median.get("rank"))
+    worst_value = _float_or_none(worst.get("value_ms"))
+    median_value = _float_or_none(median.get("value_ms"))
+
+    if (
+        worst_rank is not None
+        and median_rank is not None
+        and worst_value is not None
+        and median_value is not None
+    ):
+        return (
+            f"Rank r{worst_rank} {phase} was {worst_value:.1f}ms "
+            f"vs median rank r{median_rank} at {median_value:.1f}ms."
+        )
+    return "One rank was materially slower than its peers."
+
+
+def _promote_step_time_primary(
+    *,
+    kind: str,
+    system_summary: Mapping[str, Any],
+    step_time_summary: Mapping[str, Any],
+    diagnosis: Mapping[str, Any],
+) -> JsonDict:
+    """Promote an actionable Step Time diagnosis to primary diagnosis."""
+    if kind in PHASE_SHARE_KINDS:
+        evidence = _phase_share_evidence(
+            step_time_summary=step_time_summary,
+            system_summary=system_summary,
+        )
+        summary = _phase_share_summary(kind, evidence)
+    else:
+        evidence = _rank_comparison_evidence(
+            step_time_summary=step_time_summary,
+            system_summary=system_summary,
+            diagnosis=diagnosis,
+        )
+        summary = _rank_comparison_summary(kind, evidence)
+
+    return _primary_payload(
+        kind=kind,
+        status=_diag_field(diagnosis, "status", kind),
+        severity=_diag_field(diagnosis, "severity", "info"),
+        section=STEP_TIME_SECTION,
+        summary=summary or _diag_field(diagnosis, "summary", ""),
+        action=_diag_field(diagnosis, "action", ""),
+        evidence=evidence,
+    )
+
+
+def _insufficient_step_time_primary(
+    diagnosis: Mapping[str, Any],
+    *,
+    step_time_summary: Mapping[str, Any],
+    system_summary: Mapping[str, Any],
+) -> JsonDict:
+    """Build the primary fallback for missing or unstable timing data."""
+    evidence = {
+        "type": "insufficient_data",
+        "step_time_status": _diag_field(diagnosis, "status", "NO DATA"),
+        "steps_analyzed": _steps_analyzed(step_time_summary),
+        "gpu_util_avg_percent": _round(_gpu_util_avg(system_summary)),
+    }
+    return _primary_payload(
+        kind="INSUFFICIENT_STEP_TIME_DATA",
+        status="INSUFFICIENT STEP-TIME DATA",
+        severity="info",
+        section=STEP_TIME_SECTION,
+        summary=(
+            "Not enough completed step-time samples were available for a "
+            "stable performance diagnosis."
+        ),
+        action="Run for more steps or ensure step timing is recorded.",
+        evidence=evidence,
+    )
+
+
+def _low_gpu_util_unexplained_primary(
+    *,
+    system_summary: Mapping[str, Any],
+    step_time_summary: Mapping[str, Any],
+    step_time_diagnosis: Mapping[str, Any],
+) -> JsonDict:
+    """Build the primary fallback for low GPU utilization without a cause."""
+    evidence = {
+        "type": "utilization_fallback",
+        "gpu_util_avg_percent": _round(_gpu_util_avg(system_summary)),
+        "step_time_status": _diag_field(
+            step_time_diagnosis,
+            "status",
+            "BALANCED",
+        ),
+        "steps_analyzed": _steps_analyzed(step_time_summary),
+    }
+    return _primary_payload(
+        kind="LOW_GPU_UTILIZATION_UNEXPLAINED",
+        status="LOW GPU UTILIZATION",
+        severity="info",
+        section="system",
+        summary=(
+            "GPU utilization was low, but step timing did not identify input, "
+            "wait, compute-skew, or rank-skew as the cause."
+        ),
+        action=(
+            "Inspect untraced work, validation/checkpointing, kernel "
+            "efficiency, or missing instrumentation."
+        ),
+        evidence=evidence,
+    )
+
+
+def _no_clear_bottleneck_primary(
+    *,
+    system_summary: Mapping[str, Any],
+    step_time_summary: Mapping[str, Any],
+    diagnosis: Mapping[str, Any],
+) -> JsonDict:
+    """Build the primary fallback when step timing is healthy enough."""
+    evidence = _phase_share_evidence(
+        step_time_summary=step_time_summary,
+        system_summary=system_summary,
+    )
+    evidence["type"] = "no_clear_bottleneck"
+    evidence["step_time_status"] = _diag_field(diagnosis, "status", "BALANCED")
+    return _primary_payload(
+        kind="NO_CLEAR_PERFORMANCE_BOTTLENECK",
+        status="NO CLEAR PERFORMANCE BOTTLENECK",
+        severity="info",
+        section=STEP_TIME_SECTION,
+        summary=(
+            "Step timing did not show material input, wait, compute-skew, or "
+            "rank-skew bottlenecks."
+        ),
+        action=(
+            "No data-pipeline or rank-skew bottleneck was detected; use "
+            "model/kernel-level profiling if more speed is needed."
+        ),
+        evidence=evidence,
+    )
+
+
+def build_primary_diagnosis(
+    *,
+    system_summary: Mapping[str, Any],
+    process_summary: Mapping[str, Any],
+    step_time_summary: Mapping[str, Any],
+    step_memory_summary: Mapping[str, Any],
+) -> JsonDict:
+    """
+    Build the top-level primary performance diagnosis.
+
+    Parameters are already-built section payloads from the final report. The
+    process and step-memory summaries are accepted now to keep the public
+    function signature aligned with the full report, even though v1 does not
+    promote their health/resource findings into the primary performance
+    diagnosis.
+    """
+    del process_summary, step_memory_summary
+
+    step_diag = _diagnosis(step_time_summary)
+    kind = _diag_field(step_diag, "kind", "NO_DATA")
+    if kind in STRAGGLER_KINDS or kind in PHASE_SHARE_KINDS:
+        return _promote_step_time_primary(
+            kind=kind,
+            system_summary=system_summary,
+            step_time_summary=step_time_summary,
+            diagnosis=step_diag,
+        )
+
+    if kind in INSUFFICIENT_STEP_TIME_KINDS:
+        return _insufficient_step_time_primary(
+            step_diag,
+            step_time_summary=step_time_summary,
+            system_summary=system_summary,
+        )
+
+    system_kind = _diag_field(_diagnosis(system_summary), "kind", "")
+    if kind == "BALANCED" and system_kind in LOW_GPU_UTIL_KINDS:
+        return _low_gpu_util_unexplained_primary(
+            system_summary=system_summary,
+            step_time_summary=step_time_summary,
+            step_time_diagnosis=step_diag,
+        )
+
+    return _no_clear_bottleneck_primary(
+        system_summary=system_summary,
+        step_time_summary=step_time_summary,
+        diagnosis=step_diag,
+    )
+
+
+__all__ = [
+    "build_primary_diagnosis",
+]

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -6,25 +6,67 @@
 
 """Primary performance diagnosis for final run summaries.
 
-This module promotes existing section-level diagnoses into one top-level
-performance finding. It does not read telemetry databases or recompute
-diagnostics from tables; it only interprets already-built final-summary section
-payloads.
+The final summary already contains section-local diagnoses:
 
-Policy priority, from most actionable to least:
-1. INPUT_STRAGGLER
-2. COMPUTE_STRAGGLER
-3. STRAGGLER
-4. WAIT_HEAVY
-5. INPUT_BOUND
-6. COMPUTE_BOUND
-7. LOW_GPU_UTILIZATION_UNEXPLAINED
-8. NO_CLEAR_PERFORMANCE_BOTTLENECK
-9. INSUFFICIENT_STEP_TIME_DATA
+- ``system.diagnosis``
+- ``process.diagnosis``
+- ``step_time.diagnosis``
+- ``step_memory.diagnosis``
 
-Section-level system, process, and memory diagnoses remain canonical for
-resource health. The primary diagnosis answers a narrower question: "why was
-training slow?"
+Those section diagnoses remain the detailed source of truth for their domain.
+This module adds one run-level finding, ``primary_diagnosis``, for the first
+question most users ask after a run: "why was training slow?"
+
+The implementation is intentionally a promotion policy over existing final
+summary JSON. It does not read telemetry databases, query SQLite tables, or
+recompute diagnostics. Keeping the logic here pure makes the policy easy to
+test and easy for contributors to evolve.
+
+Primary diagnosis policy
+------------------------
+1. Step-time rank-skew findings become primary performance findings:
+   ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``, ``STRAGGLER``.
+2. Step-time phase-share findings become primary performance findings:
+   ``WAIT_HEAVY``, ``INPUT_BOUND``, ``COMPUTE_BOUND``.
+3. If Step Time is ``BALANCED`` and System reports low or moderate GPU
+   utilization, the primary becomes ``LOW_GPU_UTILIZATION_UNEXPLAINED``.
+   GPU utilization is treated as a symptom or fallback, not root-cause proof.
+4. If Step Time is ``BALANCED`` and GPU utilization is not low/moderate, the
+   primary becomes ``NO_CLEAR_PERFORMANCE_BOTTLENECK``.
+5. If Step Time is ``NO_DATA`` or ``WARMUP``, the primary becomes
+   ``INSUFFICIENT_STEP_TIME_DATA``.
+
+The v1 policy deliberately does not promote System, Process, or Step Memory
+health/resource findings such as high GPU temperature, memory pressure, memory
+creep, high RSS, or high CPU. Those findings can matter, but they do not by
+themselves prove why step time was slow. They stay visible in their section
+diagnoses. If TraceML needs top-level health surfacing later, add a separate
+``run_health_warnings`` style field instead of overloading the performance
+primary.
+
+Evidence policy
+---------------
+``phase_share``
+    Used for ``INPUT_BOUND``, ``WAIT_HEAVY``, and ``COMPUTE_BOUND``. Values
+    come from ``step_time.global.average`` because the diagnosis describes
+    where the average step time went.
+
+``rank_comparison``
+    Used for ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``, and ``STRAGGLER``.
+    Values come from ``step_time.global.median[metric]`` and
+    ``step_time.global.worst[metric]`` because the diagnosis compares ranks.
+
+``utilization_fallback``
+    Used only when Step Time is balanced and System GPU utilization is low or
+    moderate. This says utilization is unexplained by Step Time, not that GPU
+    utilization itself is the root cause.
+
+``no_clear_bottleneck``
+    Used when Step Time has enough data and no material performance bottleneck
+    is found.
+
+``insufficient_data``
+    Used when Step Time cannot make a stable diagnosis.
 """
 
 from __future__ import annotations
@@ -556,6 +598,10 @@ def build_primary_diagnosis(
 
     step_diag = _diagnosis(step_time_summary)
     kind = _diag_field(step_diag, "kind", "NO_DATA")
+
+    # The primary diagnosis is performance-first. Step Time is the only direct
+    # source of root-cause candidates in v1; System GPU utilization is a
+    # fallback symptom when Step Time is balanced.
     if kind in STRAGGLER_KINDS or kind in PHASE_SHARE_KINDS:
         return _promote_step_time_primary(
             kind=kind,

--- a/src/traceml_ai/sdk/summary_projection.py
+++ b/src/traceml_ai/sdk/summary_projection.py
@@ -69,6 +69,12 @@ def compact_summary(
     _set_scalar(out, "schema_version", payload.get("schema_version"))
     _set_scalar(out, "duration_s", payload.get("duration_s"))
 
+    primary = _mapping(payload.get("primary_diagnosis"))
+    _set_scalar(out, "primary/kind", primary.get("kind"))
+    _set_scalar(out, "primary/status", primary.get("status"))
+    _set_scalar(out, "primary/severity", primary.get("severity"))
+    _set_scalar(out, "primary/section", primary.get("section"))
+
     for section in SECTIONS:
         section_payload = _mapping(payload.get(section))
         if not section_payload:

--- a/tests/reporting/compare/test_compare.py
+++ b/tests/reporting/compare/test_compare.py
@@ -140,6 +140,20 @@ def _payload_with_sections(
     return payload
 
 
+def _set_primary(payload: dict, status: str) -> dict:
+    payload["primary_diagnosis"] = {
+        "kind": status.replace("-", "_").replace(" ", "_"),
+        "status": status,
+        "severity": "warn",
+        "section": "step_time",
+        "scope": "performance",
+        "summary": "primary summary",
+        "action": "primary action",
+        "evidence": {},
+    }
+    return payload
+
+
 def _build_compare(lhs: dict, rhs: dict) -> dict:
     return build_compare_payload(
         lhs_payload=lhs,
@@ -466,6 +480,33 @@ def test_compare_payload_has_section_based_json_and_table_text() -> None:
     assert "+114.1 ms (+18.4%)" in text
     assert "Peak reserved" in text
     assert "+2.70 GB (+43.5%)" in text
+
+
+def test_compare_includes_top_level_primary_diagnosis_change() -> None:
+    lhs = _set_primary(
+        _payload_with_sections(
+            step_time=_step_time_section(status="INPUT-BOUND"),
+        ),
+        "INPUT-BOUND",
+    )
+    rhs = _set_primary(
+        _payload_with_sections(
+            step_time=_step_time_section(status="COMPUTE-BOUND"),
+        ),
+        "COMPUTE-BOUND",
+    )
+
+    compare_payload = _build_compare(lhs, rhs)
+    text = build_compare_text(compare_payload)
+
+    assert compare_payload["overview"]["primary_diagnosis"] == {
+        "lhs": "INPUT-BOUND",
+        "rhs": "COMPUTE-BOUND",
+        "changed": True,
+    }
+    assert "Primary diagnosis" in text
+    assert "INPUT-BOUND -> COMPUTE-BOUND" in text
+    assert compare_payload["verdict"]["primary_domain"] == "compare"
 
 
 def test_compare_shows_system_gpu_utilization_diagnosis_change() -> None:

--- a/tests/reporting/summary/test_final.py
+++ b/tests/reporting/summary/test_final.py
@@ -19,9 +19,8 @@ class _StaticSection:
     duration_s: float | None = None
 
     def build(self, db_path: str) -> SummaryResult:
-        payload = {
-            "card": f"TraceML {self.name.replace('_', ' ').title()} Summary\n- Status: OK"
-        }
+        title = self.name.replace("_", " ").title()
+        payload = {"card": f"TraceML {title} Summary\n- Status: OK"}
         if self.duration_s is not None:
             payload["duration_s"] = self.duration_s
         return SummaryResult(
@@ -54,13 +53,14 @@ def test_final_report_generator_preserves_summary_schema_and_order():
         ),
     )
 
-    assert payload["schema_version"] == 1.4
+    assert payload["schema_version"] == 1.5
     assert payload["duration_s"] == 10.0
     assert list(payload.keys()) == [
         "schema_version",
         "generated_at",
         "duration_s",
         "meta",
+        "primary_diagnosis",
         "system",
         "process",
         "step_time",
@@ -74,7 +74,11 @@ def test_final_report_generator_preserves_summary_schema_and_order():
         "nodes_observed": None,
         "gpus_observed": None,
     }
+    assert payload["primary_diagnosis"]["kind"] == (
+        "INSUFFICIENT_STEP_TIME_DATA"
+    )
     assert "TraceML Run Summary | duration 10.0s" in payload["text"]
+    assert "Primary Diagnosis" in payload["text"]
     assert "System" in payload["text"]
     assert "Step Memory" in payload["text"]
 
@@ -99,6 +103,9 @@ def test_final_report_generator_fails_open_for_one_section():
         "rows": {},
     }
     assert payload["process"]["units"] == {}
+    assert payload["primary_diagnosis"]["kind"] == (
+        "INSUFFICIENT_STEP_TIME_DATA"
+    )
     assert "Process" in payload["text"]
 
 

--- a/tests/reporting/summary/test_fixtures.py
+++ b/tests/reporting/summary/test_fixtures.py
@@ -6,9 +6,9 @@
 
 """SQLite fixture coverage for final-report summary sections.
 
-These tests keep section assertions schema-oriented instead of snapshotting full
-cards. The goal is to make contributor changes safe while leaving copy/layout
-free to evolve intentionally.
+These tests keep section assertions schema-oriented instead of snapshotting
+full cards. The goal is to make contributor changes safe while leaving
+copy/layout free to evolve intentionally.
 """
 
 from __future__ import annotations
@@ -833,12 +833,13 @@ def test_final_summary_fixture_schema_contains_all_sections(
 
     payload = build_summary_payload(str(db_path))
 
-    assert payload["schema_version"] == 1.4
+    assert payload["schema_version"] == 1.5
     assert set(payload) == {
         "schema_version",
         "generated_at",
         "duration_s",
         "meta",
+        "primary_diagnosis",
         "system",
         "process",
         "step_time",
@@ -852,6 +853,9 @@ def test_final_summary_fixture_schema_contains_all_sections(
         "nodes_observed",
         "gpus_observed",
     }
+    assert payload["primary_diagnosis"]["kind"] == (
+        "INSUFFICIENT_STEP_TIME_DATA"
+    )
     assert payload["meta"] == {
         "run_name": None,
         "mode": "single_node",
@@ -868,4 +872,5 @@ def test_final_summary_fixture_schema_contains_all_sections(
         assert "- Next:" not in payload[key]["card"]
     assert payload["system"]["diagnosis"]["status"] == "NORMAL"
     assert "NO GPU" not in payload["system"]["card"]
-    assert "- Next:" not in payload["text"]
+    assert "Primary Diagnosis" in payload["text"]
+    assert "- Next:" in payload["text"]

--- a/tests/reporting/summary/test_primary_diagnosis.py
+++ b/tests/reporting/summary/test_primary_diagnosis.py
@@ -1,0 +1,250 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from traceml_ai.reporting.primary_diagnosis import build_primary_diagnosis
+
+
+def _system(kind: str = "NORMAL", gpu_util: float = 87.0) -> dict:
+    status_by_kind = {
+        "NORMAL": "NORMAL",
+        "LOW_GPU_UTILIZATION": "LOW GPU UTIL",
+        "MODERATE_GPU_UTILIZATION": "MODERATE GPU UTIL",
+    }
+    return {
+        "diagnosis": {
+            "kind": kind,
+            "status": status_by_kind.get(kind, kind),
+            "severity": "info",
+            "summary": "system summary",
+            "action": "system action",
+        },
+        "global": {
+            "average": {
+                "gpu_util_percent": gpu_util,
+            }
+        },
+    }
+
+
+def _step_time(
+    kind: str,
+    *,
+    status: str | None = None,
+    phase: str | None = None,
+    issues: list[dict] | None = None,
+) -> dict:
+    diagnosis = {
+        "kind": kind,
+        "status": status or kind.replace("_", "-"),
+        "severity": "warn",
+        "summary": "step-time summary",
+        "action": "step-time action",
+        "metric": None,
+        "phase": phase,
+    }
+    if issues is None:
+        issues = [diagnosis]
+    return {
+        "diagnosis": diagnosis,
+        "issues": issues,
+        "global": {
+            "window": {"steps_analyzed": 256},
+            "average": {
+                "total_step_ms": 200.0,
+                "dataloader_ms": 50.0,
+                "h2d_ms": 10.0,
+                "compute_ms": 120.0,
+                "wait_ms": 20.0,
+            },
+            "median": {
+                "dataloader_ms": {"value": 5.0, "idx": "0"},
+                "compute_ms": {"value": 100.0, "idx": "1"},
+                "optimizer_ms": {"value": 10.0, "idx": "3"},
+            },
+            "worst": {
+                "dataloader_ms": {"value": 80.0, "idx": "2"},
+                "compute_ms": {"value": 180.0, "idx": "2"},
+                "optimizer_ms": {"value": 90.0, "idx": "2"},
+            },
+        },
+    }
+
+
+def _primary(step_time: dict, system: dict | None = None) -> dict:
+    return build_primary_diagnosis(
+        system_summary=system or _system(),
+        process_summary={},
+        step_time_summary=step_time,
+        step_memory_summary={},
+    )
+
+
+def test_input_bound_uses_phase_share_evidence() -> None:
+    primary = _primary(
+        _step_time("INPUT_BOUND", status="INPUT-BOUND"),
+        _system(gpu_util=38.0),
+    )
+
+    assert primary["kind"] == "INPUT_BOUND"
+    assert primary["section"] == "step_time"
+    assert primary["scope"] == "performance"
+    assert primary["summary"] == (
+        "Input loading took 50.0ms of a 200.0ms average step."
+    )
+    assert primary["evidence"] == {
+        "type": "phase_share",
+        "basis": "average",
+        "steps_analyzed": 256,
+        "total_step_ms": 200.0,
+        "dataloader_ms": 50.0,
+        "h2d_ms": 10.0,
+        "compute_ms": 120.0,
+        "wait_ms": 20.0,
+        "shares": {
+            "dataloader_pct": 25.0,
+            "h2d_pct": 5.0,
+            "compute_pct": 60.0,
+            "wait_pct": 10.0,
+        },
+        "gpu_util_avg_percent": 38.0,
+    }
+
+
+def test_wait_heavy_uses_wait_phase_share() -> None:
+    primary = _primary(_step_time("WAIT_HEAVY", status="WAIT-HEAVY"))
+
+    assert primary["kind"] == "WAIT_HEAVY"
+    assert primary["summary"] == (
+        "Wait time took 20.0ms of a 200.0ms average step."
+    )
+    assert primary["evidence"]["type"] == "phase_share"
+    assert primary["evidence"]["shares"]["wait_pct"] == 10.0
+
+
+def test_compute_bound_uses_neutral_compute_phase_share() -> None:
+    primary = _primary(_step_time("COMPUTE_BOUND", status="COMPUTE-BOUND"))
+
+    assert primary["kind"] == "COMPUTE_BOUND"
+    assert primary["summary"] == (
+        "Model compute took 120.0ms of a 200.0ms average step."
+    )
+    assert primary["evidence"]["shares"]["compute_pct"] == 60.0
+
+
+def test_input_straggler_uses_rank_comparison_evidence() -> None:
+    primary = _primary(
+        _step_time(
+            "INPUT_STRAGGLER",
+            status="INPUT STRAGGLER",
+            phase="dataloader",
+        )
+    )
+
+    assert primary["kind"] == "INPUT_STRAGGLER"
+    assert primary["summary"] == (
+        "Rank r2 dataloader was 80.0ms vs median rank r0 at 5.0ms."
+    )
+    assert primary["evidence"] == {
+        "type": "rank_comparison",
+        "steps_analyzed": 256,
+        "gpu_util_avg_percent": 87.0,
+        "metric": "dataloader_ms",
+        "phase": "dataloader",
+        "median": {"rank": 0, "value_ms": 5.0},
+        "worst": {"rank": 2, "value_ms": 80.0},
+        "delta_ms": 75.0,
+        "ratio": 16.0,
+    }
+
+
+def test_compute_straggler_uses_diagnosed_compute_phase() -> None:
+    primary = _primary(
+        _step_time(
+            "COMPUTE_STRAGGLER",
+            status="COMPUTE STRAGGLER",
+            phase="optimizer",
+        )
+    )
+
+    assert primary["kind"] == "COMPUTE_STRAGGLER"
+    assert primary["evidence"]["metric"] == "optimizer_ms"
+    assert primary["evidence"]["phase"] == "optimizer"
+    assert primary["evidence"]["median"] == {"rank": 3, "value_ms": 10.0}
+    assert primary["evidence"]["worst"] == {"rank": 2, "value_ms": 90.0}
+    assert primary["evidence"]["delta_ms"] == 80.0
+    assert primary["evidence"]["ratio"] == 9.0
+
+
+def test_straggler_includes_input_and_compute_comparisons() -> None:
+    issues = [
+        {
+            "kind": "STRAGGLER",
+            "status": "STRAGGLER",
+            "severity": "crit",
+            "summary": "mixed",
+            "action": "inspect",
+        },
+        {
+            "kind": "INPUT_STRAGGLER",
+            "phase": "dataloader",
+        },
+        {
+            "kind": "COMPUTE_STRAGGLER",
+            "phase": "compute",
+        },
+    ]
+    primary = _primary(_step_time("STRAGGLER", issues=issues))
+
+    assert primary["kind"] == "STRAGGLER"
+    assert primary["evidence"]["type"] == "rank_comparison"
+    comparisons = primary["evidence"]["comparisons"]
+    assert [item["metric"] for item in comparisons] == [
+        "dataloader_ms",
+        "compute_ms",
+    ]
+
+
+def test_balanced_with_low_gpu_utilization_uses_utilization_fallback() -> None:
+    primary = _primary(
+        _step_time("BALANCED", status="BALANCED"),
+        _system(kind="LOW_GPU_UTILIZATION", gpu_util=38.0),
+    )
+
+    assert primary["kind"] == "LOW_GPU_UTILIZATION_UNEXPLAINED"
+    assert primary["section"] == "system"
+    assert primary["evidence"] == {
+        "type": "utilization_fallback",
+        "gpu_util_avg_percent": 38.0,
+        "step_time_status": "BALANCED",
+        "steps_analyzed": 256,
+    }
+
+
+def test_balanced_without_low_gpu_utilization_reports_no_clear_bottleneck() -> (
+    None
+):
+    primary = _primary(_step_time("BALANCED", status="BALANCED"))
+
+    assert primary["kind"] == "NO_CLEAR_PERFORMANCE_BOTTLENECK"
+    assert primary["section"] == "step_time"
+    assert primary["evidence"]["type"] == "no_clear_bottleneck"
+    assert primary["evidence"]["step_time_status"] == "BALANCED"
+
+
+@pytest.mark.parametrize("kind", ["WARMUP", "NO_DATA"])
+def test_warmup_and_no_data_report_insufficient_step_time_data(
+    kind: str,
+) -> None:
+    primary = _primary(_step_time(kind, status=kind.replace("_", " ")))
+
+    assert primary["kind"] == "INSUFFICIENT_STEP_TIME_DATA"
+    assert primary["status"] == "INSUFFICIENT STEP-TIME DATA"
+    assert primary["evidence"]["type"] == "insufficient_data"
+    assert primary["evidence"]["step_time_status"] == kind.replace("_", " ")

--- a/tests/sdk/test_summary_client.py
+++ b/tests/sdk/test_summary_client.py
@@ -68,6 +68,12 @@ def test_summary_projects_existing_final_payload(monkeypatch, tmp_path):
             {
                 "schema_version": "1",
                 "duration_s": 3.0,
+                "primary_diagnosis": {
+                    "kind": "NO_CLEAR_PERFORMANCE_BOTTLENECK",
+                    "status": "NO CLEAR PERFORMANCE BOTTLENECK",
+                    "severity": "info",
+                    "section": "step_time",
+                },
                 "system": {
                     "diagnosis": {
                         "status": "NORMAL",
@@ -89,6 +95,10 @@ def test_summary_projects_existing_final_payload(monkeypatch, tmp_path):
     assert result == {
         "traceml/schema_version": "1",
         "traceml/duration_s": 3.0,
+        "traceml/primary/kind": "NO_CLEAR_PERFORMANCE_BOTTLENECK",
+        "traceml/primary/status": "NO CLEAR PERFORMANCE BOTTLENECK",
+        "traceml/primary/severity": "info",
+        "traceml/primary/section": "step_time",
         "traceml/system/status": "NORMAL",
         "traceml/system/severity": "ok",
         "traceml/system/cpu_percent": 22.0,


### PR DESCRIPTION
## What changed

Added a top-level `primary_diagnosis` to final summaries and compare output.

The final JSON now includes `primary_diagnosis` near the top of the payload, and
the final text output shows a `Primary Diagnosis` block before the section-level
diagnoses. Compare output also reports when the primary diagnosis changes
between two runs.

## Why

The existing section diagnoses are useful but can be too much to parse when a
user mainly wants to know why training was slow.

This adds one performance-focused answer on top of the existing section
diagnoses, without replacing them. Step Time remains the main source of truth
for the primary diagnosis. System GPU utilization is used only as supporting or
fallback evidence, while health/resource findings such as memory creep, high GPU
temperature, or high RSS remain in their section diagnoses.

## How I tested

- [x] Tests added or updated
- [x] Existing tests run
- [ ] Manual smoke test
- [ ] Not run; reason:

Commands run:

```bash
python -m pytest tests/reporting/summary/test_primary_diagnosis.py tests/reporting/summary/test_final.py tests/reporting/summary/test_fixtures.py tests/sdk/test_summary_client.py
python -m pytest tests/reporting/compare/test_compare.py
python -m pytest tests/reporting tests/sdk tests/aggregator/test_summary_service.py tests/runtime/test_launcher.py
```

Result:

```text
122 passed, 1 skipped
```

## Runtime impact

- [x] No training-path impact
- [ ] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes:

This is reporting-only. It builds `primary_diagnosis` from already-generated
section summary payloads and does not read telemetry tables, change tracing,
sampling, transport, aggregation, or distributed runtime behavior.

## Docs

- [x] Updated
- [ ] Not needed

Updated schema and user-facing docs for:

- `primary_diagnosis`
- schema version `1.5`
- evidence shapes
- the policy that section diagnoses remain canonical for detailed health and
  resource findings

## Extra context

The primary diagnosis is intentionally narrow: it answers "why was training
slow?" rather than trying to summarize every warning in the run.

If Step Time has no useful performance cause, the fallback can report low GPU
utilization as unexplained. Otherwise, GPU utilization, memory, process, and
system health findings remain visible in their existing sections.
