### PR TITLE
newer straggler added

### DIFF
--- a/docs/developer_guide/architecture.md
+++ b/docs/developer_guide/architecture.md
@@ -104,8 +104,8 @@ Architectural risks and known structural debt. Day-to-day bugs live in the issue
 | Step / trace_step | A training iteration; `with trace_step(model)` marks the boundary that phase timing is computed against. |
 | Wait (wait_proxy) | Residual step time, `max(0, step - h2d - forward - backward - optimizer)`. |
 | INPUT_BOUND / COMPUTE_BOUND | The step is dominated by dataloading versus compute. |
-| INPUT_STRAGGLER / COMPUTE_STRAGGLER / STRAGGLER | One or more ranks are slower than typical on input, on compute, or on both. |
-| WAIT_HEAVY | A large share of step time is unattributed wait. |
+| INPUT_STRAGGLER / COMPUTE_STRAGGLER / H2D_STRAGGLER / WAIT_STRAGGLER / STRAGGLER | One rank is slower than typical after clean-step backward-wait discount; the label names the dominant excess, or `STRAGGLER` when mixed. |
+| WAIT_HEAVY | A large window-wide share of step time is unattributed wait. |
 | HIGH_PRESSURE / IMBALANCE | GPU memory is near capacity, or uneven across ranks. |
 | CREEP_EARLY / CREEP_CONFIRMED | Direction-confirmed GPU-memory growth across the run, early or confirmed. |
 | final_summary | The end-of-run `final_summary.{json,txt}`; the JSON carries `schema_version` (currently 1.4). |

--- a/docs/guides/ddp-slow-training-rank-straggler.md
+++ b/docs/guides/ddp-slow-training-rank-straggler.md
@@ -92,15 +92,18 @@ Start with the Step Time diagnosis.
 | Diagnosis | Meaning |
 |---|---|
 | `INPUT STRAGGLER` | one rank has meaningfully more dataloader burden than a typical rank |
-| `COMPUTE STRAGGLER` | one rank has meaningfully more forward, backward, or optimizer burden than a typical rank |
-| `STRAGGLER` | input and compute are both materially uneven |
+| `COMPUTE STRAGGLER` | one rank has meaningfully more clean compute burden than a typical rank |
+| `H2D STRAGGLER` | one rank has meaningfully more host-to-device transfer burden than a typical rank |
+| `WAIT STRAGGLER` | one rank has meaningfully more rank-local residual `wait_proxy` than a typical rank |
+| `STRAGGLER` | one rank is slower, but dataloader, clean compute, H2D, and wait excess are mixed |
 | `INPUT-BOUND` | input work is broad, not just one bad rank |
 | `WAIT-HEAVY` | meaningful residual time is not attributed to dataloader, H2D, forward, backward, or optimizer work |
 
-For `COMPUTE STRAGGLER`, TraceML uses DDP-aware rank attribution before blaming
-backward directly. DDP can make a slowdown on one rank show up later during
-synchronization on another rank, so TraceML checks nearby forward and optimizer
-evidence before selecting the reported phase and rank.
+For rank-local stragglers, TraceML uses clean-step attribution before blaming a
+component. It discounts backward time that can be explained by another rank's
+non-backward work, then compares clean step across ranks. The component label is
+the largest worst-rank excess over peer median among dataloader, clean compute,
+H2D, and wait, and it must dominate the next-largest excess by `1.25x`.
 
 Then inspect:
 
@@ -129,8 +132,16 @@ rank:
 - extra forward, backward, or optimizer work
 - framework hooks or callbacks that run on one rank
 
+If the diagnosis is `H2D STRAGGLER`, inspect host-to-device transfer on the
+worst rank: batch shapes, transfer placement, pinned memory, and transfer
+jitter.
+
+If the diagnosis is `WAIT STRAGGLER`, inspect rank-local host-side work on the
+worst rank: logging, checkpointing, validation, callbacks, CPU stalls, or
+unobserved transfer work.
+
 If the diagnosis is `STRAGGLER`, reduce the problem one phase at a time. Start
-with the phase that has the largest worst-vs-median gap.
+with the largest clean-step component gap.
 
 If the diagnosis is `WAIT-HEAVY`, remember that TraceML reports wait as
 residual time. It is not direct NCCL or all-reduce timing. Inspect logging,

--- a/docs/guides/low-gpu-utilization-pytorch.md
+++ b/docs/guides/low-gpu-utilization-pytorch.md
@@ -33,6 +33,8 @@ After confirming low or moderate GPU utilization, read the Step Time diagnosis.
 |---|---|
 | `INPUT-BOUND` | Inspect the DataLoader and input path. |
 | `INPUT STRAGGLER` | Inspect the slow input rank. |
+| `H2D STRAGGLER` | Inspect host-to-device transfer on the worst rank. |
+| `WAIT STRAGGLER` | Inspect rank-local host-side work on the worst rank. |
 | `WAIT-HEAVY` | Inspect work outside traced phases, such as logging, checkpointing, validation, CPU stalls, framework orchestration, or unobserved transfers. |
 | `COMPUTE-BOUND` | Inspect forward, backward, and optimizer time before changing the DataLoader. |
 | `COMPUTE STRAGGLER` or `STRAGGLER` | Inspect rank skew and the called-out worst rank. |

--- a/docs/guides/slow-pytorch-training.md
+++ b/docs/guides/slow-pytorch-training.md
@@ -34,7 +34,7 @@ diagnosis or symptom.
 |---|---|
 | Step Time says `INPUT-BOUND` | [Find DataLoader Bottlenecks](pytorch-dataloader-bottleneck.md) |
 | System says `LOW_GPU_UTILIZATION` or `MODERATE_GPU_UTILIZATION` | [Debug Low GPU Utilization](low-gpu-utilization-pytorch.md) |
-| Step Time says `INPUT STRAGGLER`, `COMPUTE STRAGGLER`, or `STRAGGLER` | [Debug DDP Rank Stragglers](ddp-slow-training-rank-straggler.md) |
+| Step Time says `INPUT STRAGGLER`, `COMPUTE STRAGGLER`, `H2D STRAGGLER`, `WAIT STRAGGLER`, or `STRAGGLER` | [Debug DDP Rank Stragglers](ddp-slow-training-rank-straggler.md) |
 | Step Memory says `MEMORY CREEP` or `MEMORY RISING` | [Find PyTorch Memory Creep](pytorch-memory-creep.md) |
 | A recent change made the run slower | [Compare Runs](../user_guide/compare.md) |
 | Step Time says `COMPUTE-BOUND` or `WAIT-HEAVY` | [How to Read TraceML Output](../user_guide/reading-output.md) |
@@ -48,8 +48,9 @@ typical step. Confirm the input path before tuning model compute.
 They say the GPU was not fully busy, not why it was not fully busy. Pair them
 with Step Time.
 
-`INPUT STRAGGLER`, `COMPUTE STRAGGLER`, and `STRAGGLER` are distributed
-signals. Inspect the called-out worst rank and compare it with the median rank.
+`INPUT STRAGGLER`, `COMPUTE STRAGGLER`, `H2D STRAGGLER`, `WAIT STRAGGLER`, and
+`STRAGGLER` are distributed clean-step signals. Inspect the called-out worst
+rank and compare it with the median rank.
 
 `MEMORY CREEP` and `MEMORY RISING` are step-memory trend signals. Inspect
 retained tensors, caches, and per-step state that may stay alive.

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -336,9 +336,10 @@ See:
 
 It means one rank is slower in the input path than the typical rank.
 
-In distributed runs, this can still be the primary diagnosis when backward or
-compute skew is also visible, because a slow input rank can push synchronization
-wait into peer ranks.
+In distributed runs, TraceML first discounts backward time that can be explained
+by another rank's non-backward work. `INPUT STRAGGLER` means dataloader excess
+on the worst clean-step rank dominates compute, H2D, and wait excess by at
+least `1.25x`.
 
 Common causes:
 
@@ -354,11 +355,13 @@ See:
 
 ## What does `COMPUTE STRAGGLER` mean?
 
-It means one rank is slower in compute than the typical rank.
+It means one rank is slower in clean compute than the typical rank.
 
-If input and compute skew appear together, TraceML first checks whether the
-input excess is large enough to explain the compute skew. If yes, the primary
-diagnosis is `INPUT STRAGGLER`; otherwise the mixed case remains `STRAGGLER`.
+Clean compute is forward plus optimizer plus backward after discounting
+backward time that can be explained by another rank's non-backward work. TraceML
+uses `COMPUTE STRAGGLER` when clean-compute excess dominates dataloader, H2D,
+and wait excess by at least `1.25x`; otherwise the mixed case remains
+`STRAGGLER`.
 
 Common causes:
 

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -213,16 +213,15 @@ Meaning:
 
 TraceML uses this idea:
 
-- compare the worst rank to the median rank
-- measure how much extra dataloader work the worst rank is carrying
-- normalize that by a typical local step burden
+- compute each rank's clean step after discounting backward time that can be
+  explained by another rank's non-backward work
+- compare the worst clean step to the median clean step
+- blame dataloader when its worst-rank excess over peer median dominates the
+  other clean-step excesses by at least `1.25x`
 
 In simpler words:
 
 - one rank is slower in the input path, enough to matter to the overall run
-- this can remain the primary diagnosis even when compute or backward skew is
-  also visible, if the input excess is large enough to plausibly explain
-  downstream synchronization effects
 
 Common causes:
 
@@ -236,7 +235,7 @@ What to look at:
 - `Dataloader Fetch`
 - worst rank
 - skew (%)
-- diagnosis note
+- diagnosis evidence
 
 What to do next:
 
@@ -254,10 +253,10 @@ Meaning:
 
 TraceML uses this idea:
 
-- compare worst compute vs median compute
-- normalize the excess by a typical local step burden
-- for DDP, check nearby forward and optimizer evidence before blaming backward
-  directly
+- compute clean compute as `forward + clean_backward + optimizer`
+- compare the worst rank's clean compute to peer median
+- blame compute when clean-compute excess dominates dataloader, H2D, and wait
+  excesses by at least `1.25x`
 
 In simpler words:
 
@@ -286,33 +285,75 @@ What to do next:
 
 ---
 
+### `H2D STRAGGLER`
+
+Meaning:
+
+- one rank spends meaningfully more time in host-to-device transfer than a
+  typical rank
+
+TraceML uses the same clean-step comparison and reports this when H2D excess is
+the dominant worst-rank component.
+
+Common causes:
+
+- uneven CPU tensor sizes
+- rank-local transfer path differences
+- pinned-memory or device-transfer jitter on one rank
+
+What to do next:
+
+- inspect batch shapes and transfer placement on the worst rank
+- compare CPU-to-GPU copy timing across ranks
+
+---
+
+### `WAIT STRAGGLER`
+
+Meaning:
+
+- one rank has meaningfully more rank-local residual `wait_proxy` than a
+  typical rank
+
+This is rank-local excess wait. It differs from `WAIT-HEAVY`, which describes a
+window-wide residual wait share.
+
+Common causes:
+
+- rank-local logging, checkpointing, validation, callbacks, CPU stalls, or
+  unobserved transfer work inside the timed step
+
+What to do next:
+
+- inspect host-side work on the worst rank
+- compare callbacks and per-rank side effects
+
+---
+
 ### `STRAGGLER`
 
 Meaning:
 
-- both input and compute are materially uneven in the same window
+- one rank is slower after clean-step backward-wait discount, but no single
+  component clearly dominates
 
 In the current policy, this is used when:
 
-- input straggler score is high
-- compute straggler score is high
+- the clean-step score is at least `0.10`
+- the largest worst-rank excess among dataloader, clean compute, H2D, and wait
+  is less than `1.25x` the next-largest excess
 
 This is a mixed unevenness case.
-
-TraceML keeps this diagnosis when the mixed signal is not clearly explained by
-input skew alone. If input excess is within the configured tolerance of compute
-excess, TraceML reports `INPUT STRAGGLER` instead and keeps the compute signal
-as secondary evidence.
 
 Common causes:
 
 - one bad rank with multiple problems
-- one phase uneven in input and another uneven in compute
+- one phase uneven in input and another uneven in compute, H2D, or wait
 - more than one imbalance pattern at the same time
 
 What to do next:
 
-- inspect both dataloader and compute signals
+- inspect dataloader, H2D, compute, and wait signals
 - inspect the worst rank and the largest uneven phases
 - reduce complexity by isolating one issue at a time
 
@@ -706,7 +747,9 @@ Use these as context cards:
 | `COMPUTE-BOUND` | inspect forward/backward/optimizer cost |
 | `INPUT STRAGGLER` | inspect input path on the worst rank |
 | `COMPUTE STRAGGLER` | inspect compute path on the worst rank |
-| `STRAGGLER` | inspect both input and compute unevenness |
+| `H2D STRAGGLER` | inspect host-to-device transfer on the worst rank |
+| `WAIT STRAGGLER` | inspect rank-local host-side work on the worst rank |
+| `STRAGGLER` | inspect mixed clean-step unevenness |
 | `WAIT-HEAVY` | inspect logging, checkpointing, validation, CPU stalls, and unobserved transfer paths |
 | `MEMORY RISING` | inspect retained state and watch the next window |
 | `MEMORY CREEP` | inspect retained tensors and growing caches |

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -65,9 +65,11 @@ Training-step timing.
 - `NO_DATA`: no usable step-time data.
 - `WARMUP`: some data exists, but not enough for a stable diagnosis.
 - `BALANCED`: no clear timing bottleneck or rank straggler.
-- `STRAGGLER`: one rank has materially slower total step time.
+- `STRAGGLER`: one rank has a mixed clean-step straggler signal.
 - `INPUT_STRAGGLER`: one rank has materially higher dataloader time.
-- `COMPUTE_STRAGGLER`: one rank has materially higher compute time.
+- `COMPUTE_STRAGGLER`: one rank has materially higher clean compute time.
+- `H2D_STRAGGLER`: one rank has materially higher host-to-device transfer time.
+- `WAIT_STRAGGLER`: one rank has materially higher residual `wait_proxy`.
 - `INPUT_BOUND`: dataloader time dominates the typical step.
 - `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical step.
 - `WAIT_HEAVY`: unattributed residual time is a material share of the step.
@@ -83,11 +85,22 @@ wait_ms = traced_step_ms - known_step_ms
 total_step_ms = dataloader_ms + traced_step_ms
 ```
 
-When input and compute straggler signals appear together, step-time diagnosis
-attributes the primary cause to `INPUT_STRAGGLER` if dataloader excess is within
-the configured tolerance of compute excess. Otherwise the primary diagnosis
-stays `STRAGGLER`, with both input and compute findings preserved as secondary
-issues.
+Rank-local stragglers use clean-step evidence. TraceML first discounts backward
+time that can be explained by another rank's non-backward work:
+
+```text
+wait_r = wait_proxy_r
+non_bwd_r = dataloader_r + h2d_r + forward_r + optimizer_r + wait_r
+clean_bwd_r = max(0, backward_r - max(0, max(non_bwd) - non_bwd_r))
+clean_compute_r = forward_r + clean_bwd_r + optimizer_r
+clean_step_r = dataloader_r + h2d_r + clean_compute_r + wait_r
+score = (max(clean_step) - median(clean_step)) / median(actual_step)
+```
+
+If `score < 0.10`, TraceML does not report a rank-local straggler. Otherwise it
+blames the largest worst-rank excess over peer median among dataloader, clean
+compute, H2D, and wait. The largest excess must dominate the next-largest
+excess by `1.25x`; otherwise the diagnosis stays mixed `STRAGGLER`.
 
 It can include validation, checkpointing, logging, framework orchestration, CPU
 stalls, unobserved transfer stalls, or other work inside the timed step but

--- a/src/traceml_ai/diagnostics/model_diagnostics.py
+++ b/src/traceml_ai/diagnostics/model_diagnostics.py
@@ -96,6 +96,7 @@ def _log_model_diagnostic_error(message: str, exc: Exception) -> None:
 def build_model_diagnostics_payload(
     *,
     step_time_metrics: Sequence[StepCombinedTimeMetric],
+    step_time_per_rank_timing: Optional[Dict[int, Dict[str, float]]] = None,
     step_memory_metrics: Sequence[StepMemoryCombinedMetric],
     step_memory_status_message: Optional[str] = None,
     gpu_total_bytes: Optional[float] = None,
@@ -111,6 +112,7 @@ def build_model_diagnostics_payload(
     items: List[ModelDiagnosisItem] = []
     context = ModelDiagnosticContext(
         step_time_metrics=step_time_metrics,
+        step_time_per_rank_timing=dict(step_time_per_rank_timing or {}),
         step_memory_metrics=step_memory_metrics,
         step_memory_status_message=step_memory_status_message,
         gpu_total_bytes=gpu_total_bytes,
@@ -147,7 +149,10 @@ def _build_step_time_item(
     context: ModelDiagnosticContext,
 ) -> ModelDiagnosisItem:
     """Build the registered step-time model diagnostic item."""
-    step_time_diag = build_step_diagnosis(context.step_time_metrics)
+    step_time_diag = build_step_diagnosis(
+        context.step_time_metrics,
+        per_rank_timing=context.step_time_per_rank_timing,
+    )
     return ModelDiagnosisItem(
         source="step_time",
         title="Step Time",

--- a/src/traceml_ai/diagnostics/registry.py
+++ b/src/traceml_ai/diagnostics/registry.py
@@ -9,8 +9,8 @@ diagnostics orchestration loop.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Callable, Optional, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional, Sequence
 
 from traceml_ai.core.registry import Registry
 from traceml_ai.renderers.step_memory.schema import StepMemoryCombinedMetric
@@ -29,6 +29,9 @@ class ModelDiagnosticContext:
 
     step_time_metrics: Sequence[StepCombinedTimeMetric]
     step_memory_metrics: Sequence[StepMemoryCombinedMetric]
+    step_time_per_rank_timing: Dict[int, Dict[str, float]] = field(
+        default_factory=dict
+    )
     step_memory_status_message: Optional[str] = None
     gpu_total_bytes: Optional[float] = None
 

--- a/src/traceml_ai/diagnostics/step_time/__init__.py
+++ b/src/traceml_ai/diagnostics/step_time/__init__.py
@@ -13,7 +13,6 @@ while organizing the implementation into smaller modules:
 """
 
 from .api import (
-    ComputeSignal,
     DiagnosisKind,
     Severity,
     StepDiagnosis,
@@ -38,7 +37,6 @@ __all__ = [
     "SUMMARY_STEP_TIME_POLICY",
     "StepTimeDiagnosisPolicy",
     "StepDiagnosis",
-    "ComputeSignal",
     "build_step_diagnosis",
     "build_step_diagnosis_result",
     "format_cli_diagnosis",

--- a/src/traceml_ai/diagnostics/step_time/adapters.py
+++ b/src/traceml_ai/diagnostics/step_time/adapters.py
@@ -230,6 +230,7 @@ def _build_summary_per_rank_timing(
             "optimizer_step": optimizer,
             "step_time": step_effective,
             "wait_proxy": wait,
+            "total_step": dataloader + step_effective,
         }
     return out
 

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Any, Dict, Literal, Optional, Sequence
+from typing import Any, Dict, Literal, Optional, Sequence, cast
 
 from traceml_ai.renderers.step_time.schema import StepCombinedTimeMetric
 
@@ -22,10 +22,7 @@ from ..common import (
     validate_confidence,
 )
 from .context import (
-    ComputeSignal,
     build_step_time_context,
-    compute_median_total,
-    compute_worst_total,
     metric_median_total,
     metric_skew,
     metric_total,
@@ -45,6 +42,8 @@ DiagnosisKind = Literal[
     "STRAGGLER",
     "INPUT_STRAGGLER",
     "COMPUTE_STRAGGLER",
+    "H2D_STRAGGLER",
+    "WAIT_STRAGGLER",
     "INPUT_BOUND",
     "COMPUTE_BOUND",
     "WAIT_HEAVY",
@@ -57,6 +56,8 @@ _STATUS_BY_KIND: dict[DiagnosisKind, str] = {
     "STRAGGLER": "STRAGGLER",
     "INPUT_STRAGGLER": "INPUT STRAGGLER",
     "COMPUTE_STRAGGLER": "COMPUTE STRAGGLER",
+    "H2D_STRAGGLER": "H2D STRAGGLER",
+    "WAIT_STRAGGLER": "WAIT STRAGGLER",
     "INPUT_BOUND": "INPUT-BOUND",
     "COMPUTE_BOUND": "COMPUTE-BOUND",
     "WAIT_HEAVY": "WAIT-HEAVY",
@@ -65,7 +66,9 @@ _STATUS_BY_KIND: dict[DiagnosisKind, str] = {
 _PRIMARY_KIND_PRIORITY: dict[str, int] = {
     "STRAGGLER": 50,
     "INPUT_STRAGGLER": 40,
-    "COMPUTE_STRAGGLER": 39,
+    "COMPUTE_STRAGGLER": 40,
+    "H2D_STRAGGLER": 40,
+    "WAIT_STRAGGLER": 40,
     "INPUT_BOUND": 30,
     "WAIT_HEAVY": 20,
     "COMPUTE_BOUND": 10,
@@ -156,13 +159,6 @@ def _pct(value: float) -> str:
     return f"{non_negative_finite(value) * 100.0:.1f}%"
 
 
-def _ms(value: float) -> str:
-    """
-    Format a millisecond value for compact diagnosis notes.
-    """
-    return f"{non_negative_finite(value):.1f}ms"
-
-
 def _rank_str(rank: Optional[int]) -> str:
     """
     Format a rank identifier for UI text.
@@ -182,66 +178,6 @@ def _primary_issue_rank(issue: DiagnosticIssue) -> int:
     Rank contributor issues for primary-diagnosis selection.
     """
     return _PRIMARY_KIND_PRIORITY.get(issue.kind, 0)
-
-
-def _issue_by_kind(
-    issues: Sequence[DiagnosticIssue],
-    kind: str,
-) -> Optional[DiagnosticIssue]:
-    """
-    Return the first issue matching one issue kind.
-    """
-    for issue in issues:
-        if issue.kind == kind:
-            return issue
-    return None
-
-
-def _input_explains_compute_skew(
-    *,
-    dataloader_excess_ms: float,
-    compute_excess_ms: float,
-    thresholds: DiagnosisThresholds,
-) -> bool:
-    """
-    Return whether input excess can plausibly explain compute skew.
-
-    In distributed training, a slow input rank can surface as extra
-    backward/compute time on peer ranks because synchronization shifts where
-    waiting is observed. Treat input as primary when its absolute excess is
-    close enough to the compute excess, using a policy-controlled tolerance.
-    """
-    tolerance = max(
-        1.0,
-        non_negative_finite(
-            thresholds.input_straggler_compute_excess_tolerance
-        ),
-    )
-    compute_excess = non_negative_finite(compute_excess_ms)
-    if compute_excess <= 0.0:
-        return non_negative_finite(dataloader_excess_ms) > 0.0
-    return non_negative_finite(dataloader_excess_ms) >= (
-        compute_excess / tolerance
-    )
-
-
-def _input_explained_compute_note(
-    *,
-    dataloader_excess_ms: float,
-    compute_excess_ms: float,
-    thresholds: DiagnosisThresholds,
-) -> str:
-    tolerance = max(
-        1.0,
-        non_negative_finite(
-            thresholds.input_straggler_compute_excess_tolerance
-        ),
-    )
-    return (
-        f"Input excess {_ms(dataloader_excess_ms)} can explain compute excess "
-        f"{_ms(compute_excess_ms)} within {tolerance:.1f}x tolerance; "
-        "compute skew may be downstream synchronization."
-    )
 
 
 def _top_rank_entries(
@@ -282,6 +218,30 @@ def _top_rank_entries(
             }
         )
     return out
+
+
+def _rank_summary_values(
+    rank_values: Dict[int, float],
+) -> tuple[float, float, Optional[int], float]:
+    """
+    Return median, worst value, worst rank, and skew for rank values.
+    """
+    if not rank_values:
+        return 0.0, 0.0, None, 0.0
+    clean = {
+        int(rank): non_negative_finite(value)
+        for rank, value in rank_values.items()
+    }
+    ordered = sorted(clean.values())
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        median = float(ordered[mid])
+    else:
+        median = float((ordered[mid - 1] + ordered[mid]) / 2.0)
+    worst_rank = max(clean, key=lambda rank: (clean[rank], -int(rank)))
+    worst = clean[worst_rank]
+    skew = ((worst - median) / median) if median > 0.0 else 0.0
+    return median, worst, int(worst_rank), max(0.0, skew)
 
 
 def _metric_attribution_entry(
@@ -435,161 +395,24 @@ def build_step_diagnosis_result(
     raw_issues = run_step_time_rules(context)
     issue_list = list(raw_issues)
 
-    input_issue = _issue_by_kind(issue_list, "INPUT_STRAGGLER")
-    compute_issue = _issue_by_kind(issue_list, "COMPUTE_STRAGGLER")
-    input_explains_compute = False
-    input_explained_note: Optional[str] = None
-
-    if input_issue is not None and compute_issue is not None:
-        input_explains_compute = _input_explains_compute_skew(
-            dataloader_excess_ms=context.dataloader_excess_ms,
-            compute_excess_ms=context.compute_excess_ms,
-            thresholds=thresholds,
-        )
-        if input_explains_compute:
-            input_explained_note = _input_explained_compute_note(
-                dataloader_excess_ms=context.dataloader_excess_ms,
-                compute_excess_ms=context.compute_excess_ms,
-                thresholds=thresholds,
-            )
-        combined_rank = (
-            context.dataloader_worst_rank
-            if context.input_straggler_score >= context.compute_straggler_score
-            else context.compute_worst_rank
-        )
-        combined_ranks = tuple(
-            sorted(
-                {
-                    rank
-                    for rank in (
-                        context.dataloader_worst_rank,
-                        context.compute_worst_rank,
-                    )
-                    if rank is not None
-                }
-            )
-        )
-        issue_list.append(
-            DiagnosticIssue(
-                kind="STRAGGLER",
-                status="STRAGGLER",
-                severity=_severity(
-                    max(
-                        context.input_straggler_score,
-                        context.compute_straggler_score,
-                    ),
-                    max(
-                        thresholds.input_straggler_score_crit,
-                        thresholds.compute_straggler_score_crit,
-                    ),
-                ),
-                summary="Both input and compute are uneven across ranks.",
-                action="Inspect the slowest rank and both dominant phases.",
-                metric="step_time",
-                phase="combined",
-                score=max(
-                    context.input_straggler_score,
-                    context.compute_straggler_score,
-                ),
-                ranks=combined_ranks
-                or ((combined_rank,) if combined_rank is not None else ()),
-                evidence={
-                    "input_score": context.input_straggler_score,
-                    "compute_score": context.compute_straggler_score,
-                    "dataloader_excess_ms": context.dataloader_excess_ms,
-                    "compute_excess_ms": context.compute_excess_ms,
-                    "input_straggler_compute_excess_tolerance": (
-                        thresholds.input_straggler_compute_excess_tolerance
-                    ),
-                },
-            )
-        )
-        if input_explains_compute:
-            issue_list = [
-                (
-                    replace(
-                        issue,
-                        evidence={
-                            **issue.evidence,
-                            "dataloader_excess_ms": context.dataloader_excess_ms,
-                            "compute_excess_ms": context.compute_excess_ms,
-                            "input_straggler_compute_excess_tolerance": (
-                                thresholds.input_straggler_compute_excess_tolerance
-                            ),
-                            "downstream_synchronization_note": (
-                                input_explained_note
-                            ),
-                        },
-                    )
-                    if issue is input_issue
-                    else issue
-                )
-                for issue in issue_list
-            ]
-            input_issue = _issue_by_kind(issue_list, "INPUT_STRAGGLER")
-
     issues = sort_issues(issue_list)
     primary_issue = _select_primary_issue(issues)
 
-    if input_issue is not None and compute_issue is not None:
-        mixed_severity = _severity(
-            max(
-                context.input_straggler_score,
-                context.compute_straggler_score,
-            ),
-            max(
-                thresholds.input_straggler_score_crit,
-                thresholds.compute_straggler_score_crit,
-            ),
-        )
-        if input_explains_compute:
-            primary = _mk_diag(
-                kind="INPUT_STRAGGLER",
-                severity=mixed_severity,
-                reason=input_issue.summary,
-                action=input_issue.action,
-                steps_used=context.steps_used,
-                worst_rank=context.dataloader_worst_rank,
-                note=input_explained_note,
-            )
-        else:
-            dominant_rank = (
-                context.dataloader_worst_rank
-                if context.input_straggler_score
-                >= context.compute_straggler_score
-                else context.compute_worst_rank
-            )
-            primary = _mk_diag(
-                kind="STRAGGLER",
-                severity=mixed_severity,
-                reason="Both input and compute are uneven across ranks.",
-                action="Inspect the slowest rank and both dominant phases.",
-                steps_used=context.steps_used,
-                worst_rank=dominant_rank,
-                note=(
-                    f"Input score {_pct(context.input_straggler_score)}, "
-                    f"compute score {_pct(context.compute_straggler_score)}."
-                ),
-            )
-    elif input_issue is not None:
+    if primary_issue is not None and primary_issue.kind in {
+        "STRAGGLER",
+        "INPUT_STRAGGLER",
+        "COMPUTE_STRAGGLER",
+        "H2D_STRAGGLER",
+        "WAIT_STRAGGLER",
+    }:
+        worst_rank = primary_issue.ranks[0] if primary_issue.ranks else None
         primary = _mk_diag(
-            kind="INPUT_STRAGGLER",
-            severity=input_issue.severity,
-            reason=input_issue.summary,
-            action=input_issue.action,
+            kind=cast(DiagnosisKind, primary_issue.kind),
+            severity=primary_issue.severity,
+            reason=primary_issue.summary,
+            action=primary_issue.action,
             steps_used=context.steps_used,
-            worst_rank=context.dataloader_worst_rank,
-            note=f"Dataloader share is {_pct(context.dataloader_share)}.",
-        )
-    elif compute_issue is not None:
-        primary = _mk_diag(
-            kind="COMPUTE_STRAGGLER",
-            severity=compute_issue.severity,
-            reason=compute_issue.summary,
-            action=compute_issue.action,
-            steps_used=context.steps_used,
-            worst_rank=context.compute_worst_rank,
-            note=f"Compute share is {_pct(context.compute_share)}.",
+            worst_rank=worst_rank,
         )
     elif primary_issue is not None and primary_issue.kind == "INPUT_BOUND":
         primary = _mk_diag(
@@ -670,15 +493,23 @@ def build_step_diagnosis_result(
     fwd_rank_values = context.rank_values.get("forward", {})
     bwd_rank_values = context.rank_values.get("backward", {})
     opt_rank_values = context.rank_values.get("optimizer_step", {})
-    compute_rank_values: Dict[int, float] = {}
-    for rank in sorted(
-        set(fwd_rank_values) | set(bwd_rank_values) | set(opt_rank_values)
-    ):
-        compute_rank_values[int(rank)] = (
-            non_negative_finite(fwd_rank_values.get(rank, 0.0))
-            + non_negative_finite(bwd_rank_values.get(rank, 0.0))
-            + non_negative_finite(opt_rank_values.get(rank, 0.0))
-        )
+    compute_rank_values = context.clean_rank_values.get("clean_compute", {})
+    if not compute_rank_values:
+        compute_rank_values = {}
+        for rank in sorted(
+            set(fwd_rank_values) | set(bwd_rank_values) | set(opt_rank_values)
+        ):
+            compute_rank_values[int(rank)] = (
+                non_negative_finite(fwd_rank_values.get(rank, 0.0))
+                + non_negative_finite(bwd_rank_values.get(rank, 0.0))
+                + non_negative_finite(opt_rank_values.get(rank, 0.0))
+            )
+    (
+        compute_median_ms,
+        compute_worst_ms,
+        compute_worst_rank,
+        compute_skew,
+    ) = _rank_summary_values(compute_rank_values)
 
     metric_attribution = {
         "dataloader_fetch": _metric_attribution_entry(
@@ -688,6 +519,14 @@ def build_step_diagnosis_result(
             step_total=context.step_total,
             single_rank=context.single_rank,
             phase="dataloader",
+        ),
+        "h2d": _metric_attribution_entry(
+            metric=context.h2d_metric,
+            metric_key="h2d",
+            rank_values=context.rank_values.get("h2d", {}),
+            step_total=context.step_total,
+            single_rank=context.single_rank,
+            phase="h2d",
         ),
         "forward": _metric_attribution_entry(
             metric=context.forward_metric,
@@ -731,24 +570,12 @@ def build_step_diagnosis_result(
         ),
         "compute": {
             "metric": "compute",
-            "phase": (
-                context.dominant_compute.label.lower()
-                if context.dominant_compute is not None
-                else "compute"
-            ),
-            "median_total_ms": compute_median_total(
-                forward=context.forward_metric,
-                backward=context.backward_metric,
-                optimizer=context.optimizer_metric,
-            ),
-            "worst_total_ms": compute_worst_total(
-                forward=context.forward_metric,
-                backward=context.backward_metric,
-                optimizer=context.optimizer_metric,
-            ),
-            "worst_rank": context.compute_worst_rank,
-            "skew_pct": context.compute_skew,
-            "share_pct": context.compute_share,
+            "phase": "clean_compute",
+            "median_total_ms": compute_median_ms,
+            "worst_total_ms": compute_worst_ms,
+            "worst_rank": compute_worst_rank,
+            "skew_pct": compute_skew,
+            "share_pct": share(compute_median_ms, context.step_total),
             "top_ranks": _top_rank_entries(compute_rank_values),
         },
     }
@@ -763,6 +590,8 @@ def build_step_diagnosis_result(
 def build_step_diagnosis(
     metrics: Sequence[StepCombinedTimeMetric],
     thresholds: DiagnosisThresholds = DEFAULT_THRESHOLDS,
+    *,
+    per_rank_timing: Optional[Dict[int, Dict[str, float]]] = None,
 ) -> StepDiagnosis:
     """
     Build one primary diagnosis from step-combined metrics.
@@ -773,6 +602,7 @@ def build_step_diagnosis(
     primary = build_step_diagnosis_result(
         metrics,
         thresholds=thresholds,
+        per_rank_timing=per_rank_timing,
     ).primary
     if not isinstance(primary, StepDiagnosis):
         raise TypeError(
@@ -787,7 +617,6 @@ __all__ = [
     "DiagnosisThresholds",
     "DEFAULT_THRESHOLDS",
     "StepDiagnosis",
-    "ComputeSignal",
     "build_step_warmup_diagnosis",
     "build_step_diagnosis",
     "build_step_diagnosis_result",

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -38,13 +38,35 @@ class ComputeSignal:
 
 
 @dataclass(frozen=True)
+class _CleanStragglerEvidence:
+    """
+    Rank-local straggler evidence after discounting backward wait that can be
+    explained by non-backward rank skew.
+    """
+
+    kind: str
+    status: str
+    component: str
+    metric: str
+    phase: str
+    score: float
+    worst_rank: Optional[int]
+    clean_step_median_ms: float
+    clean_step_worst_ms: float
+    clean_step_slack_ms: float
+    typical_step_ms: float
+    top_excess_ms: float
+    second_excess_ms: float
+    component_excesses_ms: Dict[str, float]
+
+
+@dataclass(frozen=True)
 class StepTimeAnalysisContext:
     """
     Normalized step-time analysis state shared by all step-time diagnosis
     rules.
     """
 
-    metrics: Sequence[StepCombinedTimeMetric]
     thresholds: "DiagnosisThresholds"
     single_rank: bool
     steps_used: int
@@ -60,13 +82,8 @@ class StepTimeAnalysisContext:
 
     step_total: float
     dataloader_total: float
-    h2d_total: float
     wait_total: float
     compute_total: float
-    typical_step_total: float
-    dataloader_excess_ms: float
-    compute_excess_ms: float
-    compute_phase_excess_total: float
 
     dataloader_share: float
     wait_share: float
@@ -75,16 +92,12 @@ class StepTimeAnalysisContext:
     dataloader_skew: float
     compute_skew: float
     dataloader_worst_rank: Optional[int]
-    compute_worst_rank: Optional[int]
 
-    dominant_compute: Optional[ComputeSignal]
     largest_compute: Optional[ComputeSignal]
 
-    input_straggler_score: float
-    compute_straggler_score: float
-
     rank_values: Dict[str, Dict[int, float]]
-    per_rank_timing: Dict[int, Dict[str, float]]
+    clean_rank_values: Dict[str, Dict[int, float]]
+    clean_straggler: Optional[_CleanStragglerEvidence]
 
 
 def non_negative_finite(value: float) -> float:
@@ -108,6 +121,34 @@ def share(value: float, total: float) -> float:
     if total_safe <= 0.0:
         return 0.0
     return max(0.0, non_negative_finite(value) / total_safe)
+
+
+def _median(values: Sequence[float]) -> float:
+    """Return the median of safe non-negative finite values."""
+    clean = sorted(non_negative_finite(value) for value in values)
+    n = len(clean)
+    if n == 0:
+        return 0.0
+    mid = n // 2
+    if n % 2:
+        return float(clean[mid])
+    return float((clean[mid - 1] + clean[mid]) / 2.0)
+
+
+def _rank_stats(
+    rank_values: Dict[int, float],
+) -> tuple[float, float, Optional[int], float]:
+    """Return median, worst value, worst rank, and worst-minus-median."""
+    if not rank_values:
+        return 0.0, 0.0, None, 0.0
+    clean = {
+        int(rank): non_negative_finite(value)
+        for rank, value in rank_values.items()
+    }
+    median = _median(tuple(clean.values()))
+    worst_rank = max(clean, key=lambda rank: (clean[rank], -int(rank)))
+    worst = clean[worst_rank]
+    return median, worst, int(worst_rank), max(0.0, worst - median)
 
 
 def metric_median_total(metric: Optional[StepCombinedTimeMetric]) -> float:
@@ -176,42 +217,6 @@ def metric_worst_rank(
         return None
 
 
-def compute_median_total(
-    *,
-    forward: Optional[StepCombinedTimeMetric],
-    backward: Optional[StepCombinedTimeMetric],
-    optimizer: Optional[StepCombinedTimeMetric],
-) -> float:
-    """
-    Return median-rank compute total.
-    """
-    return (
-        metric_median_total(forward)
-        + metric_median_total(backward)
-        + metric_median_total(optimizer)
-    )
-
-
-def compute_worst_total(
-    *,
-    forward: Optional[StepCombinedTimeMetric],
-    backward: Optional[StepCombinedTimeMetric],
-    optimizer: Optional[StepCombinedTimeMetric],
-) -> float:
-    """
-    Return the sum of per-phase worst totals for compute phases.
-
-    This is an excess detector input, not a real rank-local compute total:
-    worst forward, worst backward, and worst optimizer may come from different
-    ranks in distributed training.
-    """
-    return (
-        metric_worst_total(forward)
-        + metric_worst_total(backward)
-        + metric_worst_total(optimizer)
-    )
-
-
 def compute_total(
     *,
     forward: Optional[StepCombinedTimeMetric],
@@ -229,38 +234,6 @@ def compute_total(
     )
 
 
-def typical_step_total(
-    *,
-    dataloader: Optional[StepCombinedTimeMetric],
-    h2d: Optional[StepCombinedTimeMetric],
-    forward: Optional[StepCombinedTimeMetric],
-    backward: Optional[StepCombinedTimeMetric],
-    optimizer: Optional[StepCombinedTimeMetric],
-    wait: Optional[StepCombinedTimeMetric],
-) -> float:
-    """
-    Return the typical observed step used to normalize straggler scores.
-
-    Definition:
-        median dataloader + median H2D + median forward + median backward
-        + median optimizer + median residual wait
-
-    This keeps straggler scores user-facing: "extra phase time as a share of a
-    normal observed iteration", including residual overhead that is part of the
-    step seen by users.
-    """
-    return (
-        metric_median_total(dataloader)
-        + metric_median_total(h2d)
-        + compute_median_total(
-            forward=forward,
-            backward=backward,
-            optimizer=optimizer,
-        )
-        + metric_median_total(wait)
-    )
-
-
 def metric_excess(metric: Optional[StepCombinedTimeMetric]) -> float:
     """
     Return worst-vs-median excess for one timing metric.
@@ -268,170 +241,191 @@ def metric_excess(metric: Optional[StepCombinedTimeMetric]) -> float:
     return max(0.0, metric_worst_total(metric) - metric_median_total(metric))
 
 
-def compute_phase_excess_total(
-    *,
-    forward: Optional[StepCombinedTimeMetric],
-    backward: Optional[StepCombinedTimeMetric],
-    optimizer: Optional[StepCombinedTimeMetric],
-) -> float:
+def _clean_rank_timings(
+    per_rank_timing: Dict[int, Dict[str, float]],
+) -> Dict[str, Dict[int, float]]:
     """
-    Return total excess across compute phases.
+    Return clean rank-local timings used for straggler diagnosis.
 
-    Detection keeps the existing spirit:
-        (worst forward + worst backward + worst optimizer)
-        - (median forward + median backward + median optimizer)
+    The policy discounts backward time that can be explained by another rank's
+    non-backward work in the same averaged/aligned window:
 
-    Attribution is handled separately by selecting the phase with the largest
-    individual excess.
+        wait_r = current wait_proxy_r
+        non_bwd_r = DL_r + H2D_r + FWD_r + OPT_r + WAIT_r
+        clean_bwd_r = max(0, BWD_r - max(0, max(non_bwd) - non_bwd_r))
+        clean_compute_r = FWD_r + clean_bwd_r + OPT_r
+        clean_step_r = DL_r + H2D_r + clean_compute_r + WAIT_r
+        score = (max(clean_step) - median(clean_step)) / median(actual_step)
     """
-    return max(
-        0.0,
-        compute_worst_total(
-            forward=forward,
-            backward=backward,
-            optimizer=optimizer,
+    if not per_rank_timing:
+        return {}
+
+    ranks = sorted(int(rank) for rank in per_rank_timing)
+    non_bwd = {
+        rank: (
+            non_negative_finite(
+                per_rank_timing[rank].get("dataloader_fetch", 0.0)
+            )
+            + non_negative_finite(per_rank_timing[rank].get("h2d", 0.0))
+            + non_negative_finite(per_rank_timing[rank].get("forward", 0.0))
+            + non_negative_finite(
+                per_rank_timing[rank].get("optimizer_step", 0.0)
+            )
+            + non_negative_finite(per_rank_timing[rank].get("wait_proxy", 0.0))
         )
-        - compute_median_total(
-            forward=forward,
-            backward=backward,
-            optimizer=optimizer,
-        ),
-    )
+        for rank in ranks
+    }
+    non_bwd_max = max(non_bwd.values()) if non_bwd else 0.0
 
-
-def input_straggler_score(
-    *,
-    dataloader: Optional[StepCombinedTimeMetric],
-    h2d: Optional[StepCombinedTimeMetric],
-    forward: Optional[StepCombinedTimeMetric],
-    backward: Optional[StepCombinedTimeMetric],
-    optimizer: Optional[StepCombinedTimeMetric],
-    wait: Optional[StepCombinedTimeMetric],
-) -> float:
-    """
-    Return the normalized input straggler score.
-    """
-    typical = typical_step_total(
-        dataloader=dataloader,
-        h2d=h2d,
-        forward=forward,
-        backward=backward,
-        optimizer=optimizer,
-        wait=wait,
-    )
-    if typical <= 0.0:
-        return 0.0
-
-    excess = metric_excess(dataloader)
-    return excess / typical
-
-
-def compute_straggler_score(
-    *,
-    dataloader: Optional[StepCombinedTimeMetric],
-    h2d: Optional[StepCombinedTimeMetric],
-    forward: Optional[StepCombinedTimeMetric],
-    backward: Optional[StepCombinedTimeMetric],
-    optimizer: Optional[StepCombinedTimeMetric],
-    wait: Optional[StepCombinedTimeMetric],
-) -> float:
-    """
-    Return the normalized compute straggler score.
-
-    Compute straggler detection asks whether compute-phase excess is material
-    relative to a normal observed step. It does not claim that the summed
-    worst phases all came from one rank.
-    """
-    typical = typical_step_total(
-        dataloader=dataloader,
-        h2d=h2d,
-        forward=forward,
-        backward=backward,
-        optimizer=optimizer,
-        wait=wait,
-    )
-    if typical <= 0.0:
-        return 0.0
-
-    excess = compute_phase_excess_total(
-        forward=forward,
-        backward=backward,
-        optimizer=optimizer,
-    )
-    return excess / typical
-
-
-def dominant_compute_signal(
-    *,
-    forward: Optional[StepCombinedTimeMetric],
-    backward: Optional[StepCombinedTimeMetric],
-    optimizer: Optional[StepCombinedTimeMetric],
-    step_total: float,
-    single_rank: bool,
-    backward_attribution_tolerance: float,
-) -> Optional[ComputeSignal]:
-    """
-    Pick the compute phase that best explains a straggler.
-
-    Blame rank selection follows the largest absolute phase excess:
-        worst_phase - median_phase
-
-    DDP-aware rank attribution: backward can be where a peer rank observes a
-    delay from nearby rank-local compute work. If backward only narrowly wins,
-    prefer forward or optimizer when its excess is within the shared tolerance.
-
-    Relative skew is still carried for presentation and secondary thresholds.
-    """
-    candidates: list[ComputeSignal] = []
-
-    for label, metric in (
-        ("Forward", forward),
-        ("Backward", backward),
-        ("Optimizer", optimizer),
-    ):
-        if metric is None:
-            continue
-
-        median = metric_median_total(metric)
-        worst = metric_worst_total(metric)
-        excess = metric_excess(metric)
-        total = metric_total(metric, single_rank=single_rank)
-        if total <= 0.0 and worst <= 0.0:
-            continue
-
-        candidates.append(
-            ComputeSignal(
-                label=label,
-                share=share(total, step_total),
-                skew=metric_skew(metric, single_rank=single_rank),
-                median_ms=median,
-                worst_ms=worst,
-                excess_ms=excess,
-                worst_rank=metric_worst_rank(metric),
+    out = {
+        "dataloader_fetch": {},
+        "h2d": {},
+        "forward": {},
+        "backward": {},
+        "optimizer_step": {},
+        "wait_proxy": {},
+        "total_step": {},
+        "non_backward": {},
+        "clean_backward": {},
+        "clean_compute": {},
+        "clean_step": {},
+    }
+    for rank in ranks:
+        values = per_rank_timing[rank]
+        dataloader = non_negative_finite(values.get("dataloader_fetch", 0.0))
+        h2d = non_negative_finite(values.get("h2d", 0.0))
+        forward = non_negative_finite(values.get("forward", 0.0))
+        backward = non_negative_finite(values.get("backward", 0.0))
+        optimizer = non_negative_finite(values.get("optimizer_step", 0.0))
+        wait = non_negative_finite(values.get("wait_proxy", 0.0))
+        total_step = non_negative_finite(
+            values.get(
+                "total_step",
+                dataloader
+                + max(
+                    non_negative_finite(values.get("step_time", 0.0)),
+                    h2d + forward + backward + optimizer,
+                ),
             )
         )
 
-    if not candidates:
+        explained_bwd_wait = max(0.0, non_bwd_max - non_bwd[rank])
+        clean_backward = max(0.0, backward - explained_bwd_wait)
+        clean_compute = forward + clean_backward + optimizer
+        clean_step = dataloader + h2d + clean_compute + wait
+
+        out["dataloader_fetch"][rank] = dataloader
+        out["h2d"][rank] = h2d
+        out["forward"][rank] = forward
+        out["backward"][rank] = backward
+        out["optimizer_step"][rank] = optimizer
+        out["wait_proxy"][rank] = wait
+        out["total_step"][rank] = total_step
+        out["non_backward"][rank] = non_bwd[rank]
+        out["clean_backward"][rank] = clean_backward
+        out["clean_compute"][rank] = clean_compute
+        out["clean_step"][rank] = clean_step
+
+    return out
+
+
+def _clean_straggler_evidence(
+    *,
+    clean_rank_values: Dict[str, Dict[int, float]],
+    score_threshold: float,
+    dominance_tolerance: float,
+) -> Optional[_CleanStragglerEvidence]:
+    """Return rank-local clean-step straggler evidence, if material."""
+    clean_steps = clean_rank_values.get("clean_step", {})
+    actual_steps = clean_rank_values.get("total_step", {})
+    if len(clean_steps) <= 1 or not actual_steps:
         return None
 
-    winner = max(candidates, key=lambda item: (item.excess_ms, item.share))
-    if winner.label != "Backward":
-        return winner
-
-    tolerance = max(1.0, non_negative_finite(backward_attribution_tolerance))
-    min_excess = (
-        winner.excess_ms / tolerance if winner.excess_ms > 0.0 else 0.0
+    median_clean, worst_clean, worst_rank, clean_slack = _rank_stats(
+        clean_steps
     )
-    alternatives = [
-        item
-        for item in candidates
-        if item.label in {"Forward", "Optimizer"}
-        and item.excess_ms > 0.0
-        and item.excess_ms >= min_excess
-    ]
-    if not alternatives:
-        return winner
-    return max(alternatives, key=lambda item: (item.excess_ms, item.share))
+    typical_step = _median(tuple(actual_steps.values()))
+    if typical_step <= 0.0:
+        return None
+
+    score = clean_slack / typical_step
+    if score < non_negative_finite(score_threshold):
+        return None
+    if worst_rank is None:
+        return None
+
+    components = {
+        "input": (
+            "INPUT_STRAGGLER",
+            "INPUT STRAGGLER",
+            "dataloader_fetch",
+            "dataloader",
+        ),
+        "compute": (
+            "COMPUTE_STRAGGLER",
+            "COMPUTE STRAGGLER",
+            "compute",
+            "compute",
+        ),
+        "h2d": ("H2D_STRAGGLER", "H2D STRAGGLER", "h2d", "h2d"),
+        "wait": (
+            "WAIT_STRAGGLER",
+            "WAIT STRAGGLER",
+            "wait_proxy",
+            "wait",
+        ),
+    }
+    source_by_component = {
+        "input": clean_rank_values.get("dataloader_fetch", {}),
+        "compute": clean_rank_values.get("clean_compute", {}),
+        "h2d": clean_rank_values.get("h2d", {}),
+        "wait": clean_rank_values.get("wait_proxy", {}),
+    }
+    component_excesses = {
+        name: max(
+            0.0,
+            non_negative_finite(values.get(worst_rank, 0.0))
+            - _median(tuple(values.values())),
+        )
+        for name, values in source_by_component.items()
+    }
+    ordered = sorted(
+        component_excesses.items(),
+        key=lambda item: (item[1], item[0]),
+        reverse=True,
+    )
+    top_component, top_excess = ordered[0]
+    second_excess = ordered[1][1] if len(ordered) > 1 else 0.0
+
+    tolerance = max(1.0, non_negative_finite(dominance_tolerance))
+    if top_excess <= 0.0 or top_excess < tolerance * second_excess:
+        kind, status, metric, phase = (
+            "STRAGGLER",
+            "STRAGGLER",
+            "step_time",
+            "mixed",
+        )
+        component = "mixed"
+    else:
+        kind, status, metric, phase = components[top_component]
+        component = top_component
+
+    return _CleanStragglerEvidence(
+        kind=kind,
+        status=status,
+        component=component,
+        metric=metric,
+        phase=phase,
+        score=score,
+        worst_rank=worst_rank,
+        clean_step_median_ms=median_clean,
+        clean_step_worst_ms=worst_clean,
+        clean_step_slack_ms=clean_slack,
+        typical_step_ms=typical_step,
+        top_excess_ms=top_excess,
+        second_excess_ms=second_excess,
+        component_excesses_ms=component_excesses,
+    )
 
 
 def largest_compute_phase(
@@ -522,7 +516,6 @@ def build_step_time_context(
 
     step_total = metric_total(step_metric, single_rank=single_rank)
     dataloader_total = metric_total(dataloader_metric, single_rank=single_rank)
-    h2d_total = metric_total(h2d_metric, single_rank=single_rank)
     wait_total = metric_total(wait_metric, single_rank=single_rank)
     compute_total_value = compute_total(
         forward=forward_metric,
@@ -530,46 +523,12 @@ def build_step_time_context(
         optimizer=optimizer_metric,
         single_rank=single_rank,
     )
-    typical_step_value = typical_step_total(
-        dataloader=dataloader_metric,
-        h2d=h2d_metric,
-        forward=forward_metric,
-        backward=backward_metric,
-        optimizer=optimizer_metric,
-        wait=wait_metric,
-    )
-    dataloader_excess_value = metric_excess(dataloader_metric)
-    compute_excess_value = compute_phase_excess_total(
-        forward=forward_metric,
-        backward=backward_metric,
-        optimizer=optimizer_metric,
-    )
-
-    dominant_compute = dominant_compute_signal(
-        forward=forward_metric,
-        backward=backward_metric,
-        optimizer=optimizer_metric,
-        step_total=step_total,
-        single_rank=single_rank,
-        backward_attribution_tolerance=(
-            thresholds.input_straggler_compute_excess_tolerance
-        ),
-    )
     largest_compute = largest_compute_phase(
         forward=forward_metric,
         backward=backward_metric,
         optimizer=optimizer_metric,
         step_total=step_total,
         single_rank=single_rank,
-    )
-
-    compute_skew_value = (
-        dominant_compute.skew if dominant_compute is not None else 0.0
-    )
-    compute_rank = (
-        dominant_compute.worst_rank
-        if dominant_compute is not None
-        else overall_worst_rank
     )
 
     rank_values = {
@@ -618,8 +577,19 @@ def build_step_time_context(
             },
         }
 
+    clean_rank_values = _clean_rank_timings(local_per_rank_timing)
+    clean_straggler = _clean_straggler_evidence(
+        clean_rank_values=clean_rank_values,
+        score_threshold=thresholds.straggler_score_warn,
+        dominance_tolerance=thresholds.straggler_dominance_tolerance,
+    )
+    clean_compute_values = clean_rank_values.get("clean_compute", {})
+    _compute_median, _, _, _compute_slack = _rank_stats(clean_compute_values)
+    compute_skew_value = (
+        (_compute_slack / _compute_median) if _compute_median > 0.0 else 0.0
+    )
+
     return StepTimeAnalysisContext(
-        metrics=metrics,
         thresholds=thresholds,
         single_rank=single_rank,
         steps_used=steps_used,
@@ -633,13 +603,8 @@ def build_step_time_context(
         optimizer_metric=optimizer_metric,
         step_total=step_total,
         dataloader_total=dataloader_total,
-        h2d_total=h2d_total,
         wait_total=wait_total,
         compute_total=compute_total_value,
-        typical_step_total=typical_step_value,
-        dataloader_excess_ms=dataloader_excess_value,
-        compute_excess_ms=compute_excess_value,
-        compute_phase_excess_total=compute_excess_value,
         dataloader_share=share(dataloader_total, step_total),
         wait_share=share(wait_total, step_total),
         compute_share=share(compute_total_value, step_total),
@@ -648,27 +613,10 @@ def build_step_time_context(
         ),
         compute_skew=compute_skew_value,
         dataloader_worst_rank=metric_worst_rank(dataloader_metric),
-        compute_worst_rank=compute_rank,
-        dominant_compute=dominant_compute,
         largest_compute=largest_compute,
-        input_straggler_score=input_straggler_score(
-            dataloader=dataloader_metric,
-            h2d=h2d_metric,
-            forward=forward_metric,
-            backward=backward_metric,
-            optimizer=optimizer_metric,
-            wait=wait_metric,
-        ),
-        compute_straggler_score=compute_straggler_score(
-            dataloader=dataloader_metric,
-            h2d=h2d_metric,
-            forward=forward_metric,
-            backward=backward_metric,
-            optimizer=optimizer_metric,
-            wait=wait_metric,
-        ),
         rank_values=rank_values,
-        per_rank_timing=local_per_rank_timing,
+        clean_rank_values=clean_rank_values,
+        clean_straggler=clean_straggler,
     )
 
 
@@ -676,11 +624,7 @@ __all__ = [
     "ComputeSignal",
     "StepTimeAnalysisContext",
     "build_step_time_context",
-    "compute_phase_excess_total",
-    "compute_median_total",
     "compute_total",
-    "compute_worst_total",
-    "dominant_compute_signal",
     "largest_compute_phase",
     "metric_median_total",
     "metric_excess",
@@ -691,5 +635,4 @@ __all__ = [
     "non_negative_finite",
     "rank_values_from_metric",
     "share",
-    "typical_step_total",
 ]

--- a/src/traceml_ai/diagnostics/step_time/formatters.py
+++ b/src/traceml_ai/diagnostics/step_time/formatters.py
@@ -26,6 +26,8 @@ def _styled_status(diagnosis: StepDiagnosis) -> str:
     elif diagnosis.kind in {
         "INPUT_STRAGGLER",
         "COMPUTE_STRAGGLER",
+        "H2D_STRAGGLER",
+        "WAIT_STRAGGLER",
         "STRAGGLER",
         "WAIT_HEAVY",
     }:

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -14,15 +14,9 @@ class DiagnosisThresholds:
     the same rules and produce the same diagnosis vocabulary.
     """
 
-    input_straggler_score_warn: float = 0.10
-    input_straggler_score_crit: float = 0.20
-
-    compute_straggler_score_warn: float = 0.10
-    compute_straggler_score_crit: float = 0.20
-    # Shared DDP-aware rank attribution tolerance. The historical name comes
-    # from input-vs-compute handling, but the same ratio now also decides when
-    # forward/optimizer evidence is close enough to avoid blaming backward.
-    input_straggler_compute_excess_tolerance: float = 1.25
+    straggler_score_warn: float = 0.10
+    straggler_score_crit: float = 0.20
+    straggler_dominance_tolerance: float = 1.25
 
     input_share_warn: float = 0.25
     input_share_crit: float = 0.35
@@ -59,10 +53,8 @@ LIVE_STEP_TIME_POLICY = StepTimeDiagnosisPolicy(
 SUMMARY_STEP_TIME_POLICY = StepTimeDiagnosisPolicy(
     name="summary",
     thresholds=DiagnosisThresholds(
-        input_straggler_score_warn=0.10,
-        input_straggler_score_crit=0.18,
-        compute_straggler_score_warn=0.10,
-        compute_straggler_score_crit=0.18,
+        straggler_score_warn=0.10,
+        straggler_score_crit=0.18,
         input_share_warn=0.30,
         input_share_crit=0.40,
         wait_share_warn=0.18,

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -9,7 +9,7 @@ primary diagnosis and building richer result payloads.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Sequence, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 from ..common import DiagnosticIssue, DiagnosticRule
 from .context import StepTimeAnalysisContext, non_negative_finite
@@ -58,6 +58,7 @@ class _BaseStepTimeRule(DiagnosticRule[StepTimeAnalysisContext]):
         share_pct: Optional[float] = None,
         skew_pct: Optional[float] = None,
         ranks: Sequence[Optional[int]] = (),
+        evidence: Optional[Dict[str, Any]] = None,
     ) -> DiagnosticIssue:
         clean_ranks: Tuple[int, ...] = tuple(
             int(rank) for rank in ranks if rank is not None
@@ -80,16 +81,17 @@ class _BaseStepTimeRule(DiagnosticRule[StepTimeAnalysisContext]):
                 non_negative_finite(skew_pct) if skew_pct is not None else None
             ),
             ranks=clean_ranks,
+            evidence=evidence or {},
         )
 
 
 @dataclass(frozen=True)
-class InputStragglerRule(_BaseStepTimeRule):
+class CleanStragglerRule(_BaseStepTimeRule):
     """
-    Detect excess dataloader burden on one rank relative to a typical rank.
+    Detect rank-local clean-step stragglers and classify the dominant cause.
     """
 
-    name: str = "input_straggler"
+    name: str = "clean_straggler"
 
     def evaluate(
         self,
@@ -98,74 +100,60 @@ class InputStragglerRule(_BaseStepTimeRule):
         if context.single_rank:
             return None
 
-        score = context.input_straggler_score
-        if score < context.thresholds.input_straggler_score_warn:
+        evidence = context.clean_straggler
+        if evidence is None:
             return None
 
-        rank = context.dataloader_worst_rank
+        rank = evidence.worst_rank
+        component_label = {
+            "input": "dataloader",
+            "compute": "clean compute",
+            "h2d": "H2D",
+            "wait": "wait",
+            "mixed": "multiple components",
+        }.get(evidence.component, evidence.component)
+        if evidence.kind == "STRAGGLER":
+            summary = (
+                f"{_rank_str(rank)} is slower after backward-wait discount "
+                f"(~{_pct(evidence.score)} of a typical step); no component "
+                "dominates."
+            )
+            action = "Inspect input, H2D, compute, and wait on the slow rank."
+        else:
+            summary = (
+                f"{_rank_str(rank)} has excess {component_label} burden "
+                f"(~{_pct(evidence.score)} of a typical step)."
+            )
+            action = f"Inspect {component_label} on {_rank_str(rank)}."
+
         return self._issue(
-            kind="INPUT_STRAGGLER",
-            status="INPUT STRAGGLER",
+            kind=evidence.kind,
+            status=evidence.status,
             severity=_severity(
-                score, context.thresholds.input_straggler_score_crit
+                evidence.score,
+                context.thresholds.straggler_score_crit,
             ),
-            summary=(
-                f"{_rank_str(rank)} has excess dataloader burden "
-                f"(~{_pct(score)} of a typical local step)."
+            summary=summary,
+            action=action,
+            metric=evidence.metric,
+            phase=evidence.phase,
+            score=evidence.score,
+            skew_pct=(
+                evidence.clean_step_slack_ms / evidence.clean_step_median_ms
+                if evidence.clean_step_median_ms > 0.0
+                else 0.0
             ),
-            action=f"Inspect input loading on {_rank_str(rank)}.",
-            metric="dataloader_fetch",
-            phase="dataloader",
-            score=score,
-            share_pct=context.dataloader_share,
-            skew_pct=context.dataloader_skew,
             ranks=(rank,),
-        )
-
-
-@dataclass(frozen=True)
-class ComputeStragglerRule(_BaseStepTimeRule):
-    """
-    Detect excess compute burden on one rank relative to a typical rank.
-    """
-
-    name: str = "compute_straggler"
-
-    def evaluate(
-        self,
-        context: StepTimeAnalysisContext,
-    ) -> Optional[DiagnosticIssue]:
-        if context.single_rank:
-            return None
-
-        score = context.compute_straggler_score
-        if score < context.thresholds.compute_straggler_score_warn:
-            return None
-
-        rank = context.compute_worst_rank
-        label = (
-            context.dominant_compute.label
-            if context.dominant_compute is not None
-            else "Compute"
-        )
-        return self._issue(
-            kind="COMPUTE_STRAGGLER",
-            status="COMPUTE STRAGGLER",
-            severity=_severity(
-                score,
-                context.thresholds.compute_straggler_score_crit,
-            ),
-            summary=(
-                f"{_rank_str(rank)} {label.lower()} has excess compute "
-                f"burden (~{_pct(score)} of a typical observed step)."
-            ),
-            action=f"Inspect {label.lower()} on {_rank_str(rank)}.",
-            metric="compute",
-            phase=label.lower(),
-            score=score,
-            share_pct=context.compute_share,
-            skew_pct=context.compute_skew,
-            ranks=(rank,),
+            evidence={
+                "component": evidence.component,
+                "clean_step_median_ms": evidence.clean_step_median_ms,
+                "clean_step_worst_ms": evidence.clean_step_worst_ms,
+                "clean_step_slack_ms": evidence.clean_step_slack_ms,
+                "typical_step_ms": evidence.typical_step_ms,
+                "top_excess_ms": evidence.top_excess_ms,
+                "second_excess_ms": evidence.second_excess_ms,
+                "component_excesses_ms": evidence.component_excesses_ms,
+            },
         )
 
 
@@ -257,6 +245,8 @@ class ComputeBoundRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
+        if context.clean_straggler is not None:
+            return None
         if context.compute_share < context.thresholds.compute_bound_share_warn:
             return None
         if context.dataloader_share >= context.thresholds.input_share_warn:
@@ -293,8 +283,7 @@ class ComputeBoundRule(_BaseStepTimeRule):
 DEFAULT_STEP_TIME_RULES: Tuple[
     DiagnosticRule[StepTimeAnalysisContext], ...
 ] = (
-    InputStragglerRule(),
-    ComputeStragglerRule(),
+    CleanStragglerRule(),
     InputBoundRule(),
     WaitHeavyRule(),
     ComputeBoundRule(),
@@ -321,10 +310,9 @@ def run_step_time_rules(
 
 __all__ = [
     "DEFAULT_STEP_TIME_RULES",
+    "CleanStragglerRule",
     "ComputeBoundRule",
-    "ComputeStragglerRule",
     "InputBoundRule",
-    "InputStragglerRule",
     "WaitHeavyRule",
     "run_step_time_rules",
 ]

--- a/src/traceml_ai/diagnostics/step_time/trend.py
+++ b/src/traceml_ai/diagnostics/step_time/trend.py
@@ -110,6 +110,7 @@ def build_step_trend_note(
             in {
                 "COMPUTE_BOUND",
                 "COMPUTE_STRAGGLER",
+                "H2D_STRAGGLER",
                 "STRAGGLER",
             }
             and step_state
@@ -119,7 +120,7 @@ def build_step_trend_note(
                 f"{step_state} ({format_trend_pct(step_tr, deadband_pct=cfg.deadband_pct)})."
             )
 
-        if diagnosis_kind == "WAIT_HEAVY" and wait_state:
+        if diagnosis_kind in {"WAIT_HEAVY", "WAIT_STRAGGLER"} and wait_state:
             return (
                 "Trend: WAIT* is "
                 f"{wait_state} ({format_trend_pct(wait_tr, deadband_pct=cfg.deadband_pct)})."

--- a/src/traceml_ai/renderers/model_diagnostics/renderer.py
+++ b/src/traceml_ai/renderers/model_diagnostics/renderer.py
@@ -65,6 +65,7 @@ class ModelDiagnosticsRenderer(BaseRenderer):
 
             payload: ModelDiagnosticsPayload = build_model_diagnostics_payload(
                 step_time_metrics=step_time.metrics,
+                step_time_per_rank_timing=step_time.per_rank_timing,
                 step_memory_metrics=step_memory.metrics,
                 step_memory_status_message=step_memory.status_message,
                 gpu_total_bytes=None,

--- a/src/traceml_ai/renderers/step_time/compute.py
+++ b/src/traceml_ai/renderers/step_time/compute.py
@@ -204,6 +204,23 @@ class StepCombinedComputer:
         overall_rank_scores = self._overall_rank_scores(
             per_metric_rank_sums, ranks_present
         )
+        per_rank_timing = {
+            int(r): {
+                "dataloader_fetch": float(
+                    per_metric_rank_sums.get("dataloader_fetch", {}).get(
+                        r, 0.0
+                    )
+                ),
+                "h2d": float(h2d_sums.get(r, 0.0)),
+                "forward": float(fwd_sums.get(r, 0.0)),
+                "backward": float(bwd_sums.get(r, 0.0)),
+                "optimizer_step": float(opt_sums.get(r, 0.0)),
+                "step_time": float(step_sums.get(r, 0.0)),
+                "wait_proxy": float(wait_rank_sums.get(r, 0.0)),
+                "total_step": float(overall_rank_scores.get(r, 0.0)),
+            }
+            for r in ranks_present
+        }
         overall_worst_rank = (
             max(overall_rank_scores, key=overall_rank_scores.get)
             if overall_rank_scores
@@ -311,6 +328,7 @@ class StepCombinedComputer:
         return StepCombinedTimeResult(
             metrics=list(metrics.values()),
             status_message=status,
+            per_rank_timing=per_rank_timing,
             rank_heatmap=rank_heatmap,
         )
 
@@ -436,11 +454,13 @@ class StepCombinedComputer:
                 return StepCombinedTimeResult(
                     metrics=self._last_ok.metrics,
                     status_message=msg,
+                    per_rank_timing=self._last_ok.per_rank_timing,
                     rank_heatmap=self._last_ok.rank_heatmap,
                 )
         return StepCombinedTimeResult(
             metrics=[],
             status_message="No fresh step-combined data",
+            per_rank_timing={},
             rank_heatmap=None,
         )
 

--- a/src/traceml_ai/renderers/step_time/renderer.py
+++ b/src/traceml_ai/renderers/step_time/renderer.py
@@ -79,6 +79,7 @@ class StepCombinedRenderer(BaseRenderer):
         diag = build_step_diagnosis(
             metrics,
             thresholds=LIVE_STEP_TIME_POLICY.thresholds,
+            per_rank_timing=payload.per_rank_timing,
         )
         diag_text = format_cli_diagnosis(diag)
 

--- a/src/traceml_ai/renderers/step_time/schema.py
+++ b/src/traceml_ai/renderers/step_time/schema.py
@@ -83,6 +83,7 @@ class StepCombinedRankHeatmap:
 class StepCombinedTimeResult:
     metrics: List[StepCombinedTimeMetric]
     status_message: str = "OK"
+    per_rank_timing: Dict[int, Dict[str, float]] = field(default_factory=dict)
 
     # Optional dashboard payload (safe for older consumers)
     rank_heatmap: Optional[StepCombinedRankHeatmap] = None

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -67,8 +67,9 @@ section diagnoses.
 
 Selection policy:
 
-- `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`, and `STRAGGLER` use rank-comparison
-  evidence and are promoted from `step_time.diagnosis`.
+- `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`, `H2D_STRAGGLER`,
+  `WAIT_STRAGGLER`, and `STRAGGLER` use rank-comparison evidence and are
+  promoted from `step_time.diagnosis`.
 - `WAIT_HEAVY`, `INPUT_BOUND`, and `COMPUTE_BOUND` use phase-share evidence
   and are promoted from `step_time.diagnosis`.
 - `LOW_GPU_UTILIZATION_UNEXPLAINED` appears only when Step Time is `BALANCED`
@@ -121,8 +122,9 @@ Values come from `step_time.global.average`.
 }
 ```
 
-`rank_comparison` is used for `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`, and
-`STRAGGLER`. Values come from `step_time.global.median[metric]` and
+`rank_comparison` is used for `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`,
+`H2D_STRAGGLER`, `WAIT_STRAGGLER`, and `STRAGGLER`. Values come from
+`step_time.global.median[metric]` and
 `step_time.global.worst[metric]`. Generic `STRAGGLER` may contain a
 `comparisons` array instead of a single metric comparison.
 

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -25,7 +25,8 @@ test and easy for contributors to evolve.
 Primary diagnosis policy
 ------------------------
 1. Step-time rank-skew findings become primary performance findings:
-   ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``, ``STRAGGLER``.
+   ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``, ``H2D_STRAGGLER``,
+   ``WAIT_STRAGGLER``, ``STRAGGLER``.
 2. Step-time phase-share findings become primary performance findings:
    ``WAIT_HEAVY``, ``INPUT_BOUND``, ``COMPUTE_BOUND``.
 3. If Step Time is ``BALANCED`` and System reports low or moderate GPU
@@ -52,8 +53,9 @@ Evidence policy
     where the average step time went.
 
 ``rank_comparison``
-    Used for ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``, and ``STRAGGLER``.
-    Values come from ``step_time.global.median[metric]`` and
+    Used for ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``,
+    ``H2D_STRAGGLER``, ``WAIT_STRAGGLER``, and ``STRAGGLER``. Values come
+    from ``step_time.global.median[metric]`` and
     ``step_time.global.worst[metric]`` because the diagnosis compares ranks.
 
 ``utilization_fallback``
@@ -83,6 +85,8 @@ PHASE_SHARE_KINDS = {"INPUT_BOUND", "WAIT_HEAVY", "COMPUTE_BOUND"}
 STRAGGLER_KINDS = {
     "INPUT_STRAGGLER",
     "COMPUTE_STRAGGLER",
+    "H2D_STRAGGLER",
+    "WAIT_STRAGGLER",
     "STRAGGLER",
 }
 INSUFFICIENT_STEP_TIME_KINDS = {"NO_DATA", "WARMUP"}
@@ -258,6 +262,10 @@ def _metric_for_step_time_issue(issue: Mapping[str, Any]) -> Optional[str]:
         if phase in {"forward", "backward", "optimizer"}:
             return f"{phase}_ms"
         return "compute_ms"
+    if kind == "H2D_STRAGGLER":
+        return "h2d_ms"
+    if kind == "WAIT_STRAGGLER":
+        return "wait_ms"
     return None
 
 
@@ -273,6 +281,10 @@ def _metric_for_primary_diagnosis(
         if phase in {"forward", "backward", "optimizer"}:
             return f"{phase}_ms"
         return "compute_ms"
+    if kind == "H2D_STRAGGLER":
+        return "h2d_ms"
+    if kind == "WAIT_STRAGGLER":
+        return "wait_ms"
     return None
 
 
@@ -391,6 +403,16 @@ def _straggler_comparisons(
             metric="compute_ms",
             phase="compute",
         ),
+        _comparison(
+            step_time_summary=step_time_summary,
+            metric="h2d_ms",
+            phase="h2d",
+        ),
+        _comparison(
+            step_time_summary=step_time_summary,
+            metric="wait_ms",
+            phase="wait",
+        ),
     ]
 
 
@@ -430,7 +452,7 @@ def _rank_comparison_summary(
 ) -> str:
     """Return a concise primary summary for rank-comparison diagnoses."""
     if kind == "STRAGGLER":
-        return "Input and compute varied across ranks."
+        return "Multiple clean-step components varied across ranks."
 
     metric = str(evidence.get("metric") or "step_time")
     phase = str(evidence.get("phase") or metric.replace("_ms", ""))

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -323,8 +323,20 @@ def _step_time_card_reason(
             f"{_global_rank_label(stats.compute.worst_global_rank)} compute "
             f"was slower than median global rank ({evidence})."
         )
+    if kind == "H2D_STRAGGLER":
+        evidence = _format_ms_pair(stats.h2d.worst_ms, stats.h2d.median_ms)
+        return (
+            f"{_global_rank_label(stats.h2d.worst_global_rank)} H2D was "
+            f"slower than median global rank ({evidence})."
+        )
+    if kind == "WAIT_STRAGGLER":
+        evidence = _format_ms_pair(stats.wait.worst_ms, stats.wait.median_ms)
+        return (
+            f"{_global_rank_label(stats.wait.worst_global_rank)} wait was "
+            f"higher than median global rank ({evidence})."
+        )
     if kind == "STRAGGLER":
-        return "Input and compute varied across ranks."
+        return "Multiple clean-step components varied across ranks."
     if kind == "INPUT_BOUND":
         evidence = (
             f"{format_ms(stats.input.worst_ms)}/"

--- a/tests/diagnostics/test_registry.py
+++ b/tests/diagnostics/test_registry.py
@@ -60,6 +60,7 @@ def test_model_diagnostics_payload_uses_registered_domains():
         context: ModelDiagnosticContext,
     ) -> ModelDiagnosisItem:
         assert context.step_time_metrics == ()
+        assert context.step_time_per_rank_timing == {}
         assert context.step_memory_metrics == ()
         return ModelDiagnosisItem(
             source="custom_domain",
@@ -92,6 +93,47 @@ def test_model_diagnostics_payload_uses_registered_domains():
 
     assert payload.status_message == "OK"
     assert [item.source for item in payload.items] == ["custom_domain"]
+    assert payload.items[0].status == "BALANCED"
+
+
+def test_model_step_time_diagnostics_receive_per_rank_timing(monkeypatch):
+    import traceml_ai.diagnostics.model_diagnostics as model_diagnostics
+
+    per_rank_timing = {
+        0: {"dataloader_fetch": 1.0, "total_step": 10.0},
+        1: {"dataloader_fetch": 2.0, "total_step": 11.0},
+    }
+    captured = {}
+
+    def fake_diagnosis(metrics, *, per_rank_timing=None, **kwargs):
+        captured["metrics"] = metrics
+        captured["per_rank_timing"] = per_rank_timing
+        return SimpleNamespace(
+            kind="BALANCED",
+            severity="info",
+            status="BALANCED",
+            reason="No timing issue.",
+            action="Keep monitoring.",
+            note=None,
+            confidence=0.75,
+            steps_used=3,
+            worst_rank=1,
+        )
+
+    monkeypatch.setattr(
+        model_diagnostics,
+        "build_step_diagnosis",
+        fake_diagnosis,
+    )
+
+    payload = build_model_diagnostics_payload(
+        step_time_metrics=(),
+        step_time_per_rank_timing=per_rank_timing,
+        step_memory_metrics=(),
+    )
+
+    assert captured["per_rank_timing"] == per_rank_timing
+    assert payload.items[0].source == "step_time"
     assert payload.items[0].status == "BALANCED"
 
 

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -23,10 +23,9 @@ from traceml_ai.diagnostics.step_time.policy import (
     SUMMARY_STEP_TIME_POLICY,
 )
 from traceml_ai.diagnostics.step_time.rules import (
+    CleanStragglerRule,
     ComputeBoundRule,
-    ComputeStragglerRule,
     InputBoundRule,
-    InputStragglerRule,
     WaitHeavyRule,
 )
 from traceml_ai.renderers.step_time.schema import (
@@ -76,10 +75,99 @@ def _time_metric(
     )
 
 
-def _time_context(*metrics: StepCombinedTimeMetric):
+def _time_context(
+    *metrics: StepCombinedTimeMetric,
+    per_rank_timing: dict[int, dict[str, float]] | None = None,
+):
     return build_step_time_context(
         metrics=metrics,
         thresholds=DEFAULT_THRESHOLDS,
+        per_rank_timing=per_rank_timing,
+    )
+
+
+def _median(values: list[float]) -> float:
+    ordered = sorted(float(value) for value in values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+
+def _timing_row(
+    *,
+    dataloader: float = 10.0,
+    h2d: float = 0.0,
+    forward: float = 20.0,
+    backward: float = 30.0,
+    optimizer: float = 10.0,
+    wait: float = 0.0,
+    step_time: float | None = None,
+    total_step: float | None = None,
+) -> dict[str, float]:
+    known_step = h2d + forward + backward + optimizer
+    local_step = known_step + wait if step_time is None else step_time
+    return {
+        "dataloader_fetch": dataloader,
+        "h2d": h2d,
+        "forward": forward,
+        "backward": backward,
+        "optimizer_step": optimizer,
+        "step_time": local_step,
+        "wait_proxy": wait,
+        "total_step": (
+            dataloader + local_step if total_step is None else total_step
+        ),
+    }
+
+
+def _metrics_from_per_rank_timing(
+    per_rank_timing: dict[int, dict[str, float]],
+    *,
+    steps: int = 64,
+) -> tuple[StepCombinedTimeMetric, ...]:
+    metrics: list[StepCombinedTimeMetric] = []
+    world_size = len(per_rank_timing)
+    for key in (
+        "dataloader_fetch",
+        "h2d",
+        "forward",
+        "backward",
+        "optimizer_step",
+        "step_time",
+        "wait_proxy",
+    ):
+        values_by_rank = {
+            int(rank): float(values.get(key, 0.0))
+            for rank, values in per_rank_timing.items()
+        }
+        median = _median(list(values_by_rank.values()))
+        worst_rank = max(
+            values_by_rank,
+            key=lambda rank: (values_by_rank[rank], -rank),
+        )
+        worst = values_by_rank[worst_rank]
+        skew = ((worst - median) / median) if median > 0.0 else 0.0
+        metrics.append(
+            _time_metric(
+                key,
+                median=median,
+                worst=worst,
+                worst_rank=worst_rank,
+                skew=skew,
+                world_size=world_size,
+                steps=steps,
+            )
+        )
+    return tuple(metrics)
+
+
+def _clean_context(
+    per_rank_timing: dict[int, dict[str, float]],
+):
+    return _time_context(
+        *_metrics_from_per_rank_timing(per_rank_timing),
+        per_rank_timing=per_rank_timing,
     )
 
 
@@ -139,39 +227,28 @@ def _single_rank_step_metrics(
 
 
 def test_step_time_rules_trigger_and_no_trigger_cases() -> None:
-    input_ctx = _time_context(
-        _time_metric("step_time", median=220.0, worst=250.0),
-        _time_metric("dataloader_fetch", median=10.0, worst=45.0, skew=0.2),
-        _time_metric("forward", median=40.0, worst=40.0),
-        _time_metric("backward", median=130.0, worst=130.0),
-        _time_metric("optimizer_step", median=20.0, worst=20.0),
-        _time_metric("wait_proxy", median=20.0, worst=20.0),
+    input_ctx = _clean_context(
+        {
+            0: _timing_row(dataloader=10.0),
+            1: _timing_row(dataloader=90.0),
+        }
     )
-    assert InputStragglerRule().evaluate(input_ctx).kind == "INPUT_STRAGGLER"
+    assert CleanStragglerRule().evaluate(input_ctx).kind == "INPUT_STRAGGLER"
     assert (
-        InputStragglerRule().evaluate(
+        CleanStragglerRule().evaluate(
             _time_context(*_single_rank_step_metrics())
         )
         is None
     )
 
-    compute_ctx = _time_context(
-        _time_metric("step_time", median=240.0, worst=310.0),
-        _time_metric("dataloader_fetch", median=10.0, worst=10.0),
-        _time_metric("forward", median=40.0, worst=90.0, skew=0.2),
-        _time_metric("backward", median=130.0, worst=160.0, skew=0.15),
-        _time_metric("optimizer_step", median=20.0, worst=20.0),
-        _time_metric("wait_proxy", median=40.0, worst=40.0),
+    compute_ctx = _clean_context(
+        {
+            0: _timing_row(forward=20.0, backward=30.0),
+            1: _timing_row(forward=90.0, backward=30.0),
+        }
     )
-    assert (
-        ComputeStragglerRule().evaluate(compute_ctx).kind
-        == "COMPUTE_STRAGGLER"
-    )
-    assert (
-        ComputeStragglerRule().evaluate(
-            _time_context(*_single_rank_step_metrics())
-        )
-        is None
+    assert CleanStragglerRule().evaluate(compute_ctx).kind == (
+        "COMPUTE_STRAGGLER"
     )
 
     input_bound = _time_context(
@@ -223,176 +300,106 @@ def test_step_time_rules_trigger_and_no_trigger_cases() -> None:
     )
 
 
-def test_compute_straggler_uses_typical_step_and_phase_blame() -> None:
-    ctx = _time_context(
-        _time_metric("step_time", median=166.6, worst=166.7, world_size=4),
-        _time_metric(
-            "dataloader_fetch",
-            median=0.7,
-            worst=0.7,
-            worst_rank=2,
-            world_size=4,
+def test_clean_backward_discount_removes_telescoped_wait_from_peer() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=100.0,
+            forward=20.0,
+            backward=20.0,
+            optimizer=0.0,
+            total_step=140.0,
         ),
-        _time_metric("h2d", median=0.1, worst=0.1, world_size=4),
-        _time_metric(
-            "forward",
-            median=1.6,
-            worst=25.2,
-            worst_rank=2,
-            skew=14.75,
-            world_size=4,
+        1: _timing_row(
+            dataloader=0.0,
+            forward=20.0,
+            backward=120.0,
+            optimizer=0.0,
+            total_step=140.0,
         ),
-        _time_metric(
-            "backward",
-            median=120.6,
-            worst=121.0,
-            worst_rank=0,
-            skew=0.003,
-            world_size=4,
-        ),
-        _time_metric(
-            "optimizer_step",
-            median=10.1,
-            worst=10.1,
-            worst_rank=3,
-            world_size=4,
-        ),
-        _time_metric(
-            "wait_proxy",
-            median=34.2,
-            worst=34.3,
-            worst_rank=3,
-            world_size=4,
-        ),
-    )
+    }
+    ctx = _clean_context(per_rank)
+    issue = CleanStragglerRule().evaluate(ctx)
 
-    issue = ComputeStragglerRule().evaluate(ctx)
-
+    assert ctx.clean_rank_values["clean_backward"][1] == pytest.approx(20.0)
+    assert ctx.clean_rank_values["clean_compute"][0] == pytest.approx(40.0)
+    assert ctx.clean_rank_values["clean_compute"][1] == pytest.approx(40.0)
+    assert ctx.clean_rank_values["clean_step"][0] == pytest.approx(140.0)
     assert issue is not None
-    assert issue.kind == "COMPUTE_STRAGGLER"
-    assert issue.phase == "forward"
-    assert issue.ranks == (2,)
-    assert ctx.typical_step_total == pytest.approx(167.3)
-    assert ctx.compute_phase_excess_total == pytest.approx(24.0)
-    assert ctx.compute_excess_ms == pytest.approx(24.0)
-    assert ctx.dataloader_excess_ms == pytest.approx(0.0)
-    assert issue.score == pytest.approx(24.0 / 167.3)
-
-
-def test_compute_straggler_prefers_close_optimizer_over_backward() -> None:
-    ctx = _time_context(
-        _time_metric("step_time", median=144.2, worst=144.3),
-        _time_metric("dataloader_fetch", median=1.3, worst=1.3),
-        _time_metric("h2d", median=0.1, worst=0.2),
-        _time_metric("forward", median=2.0, worst=2.1, worst_rank=0),
-        _time_metric(
-            "backward",
-            median=107.1,
-            worst=125.7,
-            worst_rank=1,
-            skew=0.17,
-        ),
-        _time_metric(
-            "optimizer_step",
-            median=14.5,
-            worst=33.1,
-            worst_rank=0,
-            skew=1.28,
-        ),
-        _time_metric("wait_proxy", median=0.5, worst=0.6),
-    )
-
-    issue = ComputeStragglerRule().evaluate(ctx)
-
-    assert issue is not None
-    assert issue.kind == "COMPUTE_STRAGGLER"
-    assert issue.phase == "optimizer"
+    assert issue.kind == "INPUT_STRAGGLER"
     assert issue.ranks == (0,)
-    assert ctx.dominant_compute is not None
-    assert ctx.dominant_compute.label == "Optimizer"
-    assert ctx.compute_worst_rank == 0
-
-
-def test_compute_straggler_keeps_backward_when_no_close_compute_phase() -> (
-    None
-):
-    ctx = _time_context(
-        _time_metric("step_time", median=144.2, worst=144.3),
-        _time_metric("dataloader_fetch", median=1.3, worst=1.3),
-        _time_metric("h2d", median=0.1, worst=0.2),
-        _time_metric("forward", median=2.0, worst=2.1, worst_rank=0),
-        _time_metric(
-            "backward",
-            median=90.0,
-            worst=130.0,
-            worst_rank=1,
-            skew=0.44,
-        ),
-        _time_metric(
-            "optimizer_step",
-            median=14.5,
-            worst=33.1,
-            worst_rank=0,
-            skew=1.28,
-        ),
-        _time_metric("wait_proxy", median=0.5, worst=0.6),
+    assert issue.evidence["component_excesses_ms"]["input"] == pytest.approx(
+        50.0
     )
 
-    issue = ComputeStragglerRule().evaluate(ctx)
 
-    assert issue is not None
-    assert issue.kind == "COMPUTE_STRAGGLER"
-    assert issue.phase == "backward"
-    assert issue.ranks == (1,)
-    assert ctx.dominant_compute is not None
-    assert ctx.dominant_compute.label == "Backward"
-    assert ctx.compute_worst_rank == 1
-
-
-def test_step_time_primary_selection_input_explains_mixed_straggler() -> None:
+@pytest.mark.parametrize(
+    ("per_rank", "expected_kind", "expected_phase"),
+    [
+        (
+            {
+                0: _timing_row(forward=20.0),
+                1: _timing_row(forward=100.0),
+            },
+            "COMPUTE_STRAGGLER",
+            "compute",
+        ),
+        (
+            {
+                0: _timing_row(h2d=0.0),
+                1: _timing_row(h2d=80.0),
+            },
+            "H2D_STRAGGLER",
+            "h2d",
+        ),
+        (
+            {
+                0: _timing_row(wait=0.0),
+                1: _timing_row(wait=80.0),
+            },
+            "WAIT_STRAGGLER",
+            "wait",
+        ),
+        (
+            {
+                0: _timing_row(dataloader=10.0, forward=20.0),
+                1: _timing_row(dataloader=60.0, forward=40.0),
+            },
+            "STRAGGLER",
+            "mixed",
+        ),
+    ],
+)
+def test_clean_straggler_classifies_component_excess(
+    per_rank: dict[int, dict[str, float]],
+    expected_kind: str,
+    expected_phase: str,
+) -> None:
     result = build_step_diagnosis_result(
-        [
-            _time_metric("step_time", median=240.0, worst=330.0),
-            _time_metric(
-                "dataloader_fetch", median=10.0, worst=110.0, skew=0.2
-            ),
-            _time_metric("forward", median=40.0, worst=90.0, skew=0.2),
-            _time_metric("backward", median=130.0, worst=160.0, skew=0.15),
-            _time_metric("optimizer_step", median=20.0, worst=20.0),
-            _time_metric("wait_proxy", median=40.0, worst=40.0),
-        ]
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+    )
+
+    assert result.primary.kind == expected_kind
+    assert result.primary.worst_rank == 1
+    assert result.issues[0].phase == expected_phase
+    assert result.issues[0].evidence["clean_step_slack_ms"] > 0.0
+
+
+def test_step_time_primary_prefers_clean_straggler_over_wait_heavy() -> None:
+    per_rank = {
+        0: _timing_row(dataloader=10.0, wait=80.0),
+        1: _timing_row(dataloader=110.0, wait=80.0),
+    }
+
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
     )
 
     assert result.primary.kind == "INPUT_STRAGGLER"
-    assert result.primary.worst_rank == 1
-    assert result.primary.note is not None
-    assert "downstream synchronization" in result.primary.note
     assert {issue.kind for issue in result.issues} >= {
         "INPUT_STRAGGLER",
-        "COMPUTE_STRAGGLER",
-        "STRAGGLER",
-    }
-
-
-def test_step_time_primary_selection_keeps_unexplained_mixed() -> None:
-    result = build_step_diagnosis_result(
-        [
-            _time_metric("step_time", median=240.0, worst=330.0),
-            _time_metric(
-                "dataloader_fetch", median=10.0, worst=45.0, skew=0.2
-            ),
-            _time_metric("forward", median=40.0, worst=90.0, skew=0.2),
-            _time_metric("backward", median=130.0, worst=160.0, skew=0.15),
-            _time_metric("optimizer_step", median=20.0, worst=20.0),
-            _time_metric("wait_proxy", median=40.0, worst=40.0),
-        ]
-    )
-
-    assert result.primary.kind == "STRAGGLER"
-    assert {issue.kind for issue in result.issues} >= {
-        "INPUT_STRAGGLER",
-        "COMPUTE_STRAGGLER",
-        "STRAGGLER",
+        "WAIT_HEAVY",
     }
 
 
@@ -406,7 +413,7 @@ def test_step_time_live_and_summary_policies_are_explicit() -> None:
         > LIVE_STEP_TIME_POLICY.thresholds.wait_share_warn
     )
     assert (
-        SUMMARY_STEP_TIME_POLICY.thresholds.input_straggler_compute_excess_tolerance
+        SUMMARY_STEP_TIME_POLICY.thresholds.straggler_dominance_tolerance
         == pytest.approx(1.25)
     )
     assert (

--- a/tests/reporting/summary/test_primary_diagnosis.py
+++ b/tests/reporting/summary/test_primary_diagnosis.py
@@ -65,13 +65,17 @@ def _step_time(
             },
             "median": {
                 "dataloader_ms": {"value": 5.0, "idx": "0"},
+                "h2d_ms": {"value": 10.0, "idx": "1"},
                 "compute_ms": {"value": 100.0, "idx": "1"},
                 "optimizer_ms": {"value": 10.0, "idx": "3"},
+                "wait_ms": {"value": 20.0, "idx": "0"},
             },
             "worst": {
                 "dataloader_ms": {"value": 80.0, "idx": "2"},
+                "h2d_ms": {"value": 40.0, "idx": "2"},
                 "compute_ms": {"value": 180.0, "idx": "2"},
                 "optimizer_ms": {"value": 90.0, "idx": "2"},
+                "wait_ms": {"value": 70.0, "idx": "2"},
             },
         },
     }
@@ -180,6 +184,40 @@ def test_compute_straggler_uses_diagnosed_compute_phase() -> None:
     assert primary["evidence"]["worst"] == {"rank": 2, "value_ms": 90.0}
     assert primary["evidence"]["delta_ms"] == 80.0
     assert primary["evidence"]["ratio"] == 9.0
+
+
+def test_h2d_straggler_uses_rank_comparison_evidence() -> None:
+    primary = _primary(
+        _step_time(
+            "H2D_STRAGGLER",
+            status="H2D STRAGGLER",
+            phase="h2d",
+        )
+    )
+
+    assert primary["kind"] == "H2D_STRAGGLER"
+    assert primary["summary"] == (
+        "Rank r2 h2d was 40.0ms vs median rank r1 at 10.0ms."
+    )
+    assert primary["evidence"]["metric"] == "h2d_ms"
+    assert primary["evidence"]["phase"] == "h2d"
+
+
+def test_wait_straggler_uses_rank_comparison_evidence() -> None:
+    primary = _primary(
+        _step_time(
+            "WAIT_STRAGGLER",
+            status="WAIT STRAGGLER",
+            phase="wait",
+        )
+    )
+
+    assert primary["kind"] == "WAIT_STRAGGLER"
+    assert primary["summary"] == (
+        "Rank r2 wait was 70.0ms vs median rank r0 at 20.0ms."
+    )
+    assert primary["evidence"]["metric"] == "wait_ms"
+    assert primary["evidence"]["phase"] == "wait"
 
 
 def test_straggler_includes_input_and_compute_comparisons() -> None:

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -25,19 +25,21 @@ def _rank(
     *,
     steps: int = 64,
     dataloader: float = 5.0,
+    h2d: float = 0.0,
     forward: float = 30.0,
     backward: float = 50.0,
     optimizer: float = 10.0,
     step_cpu: float | None = None,
 ) -> RankStepSummary:
     compute = forward + backward + optimizer
+    known_step = h2d + compute
     effective_step = max(
-        step_cpu if step_cpu is not None else compute, compute
+        step_cpu if step_cpu is not None else known_step, known_step
     )
     return RankStepSummary(
         steps_analyzed=steps,
         avg_dataloader_ms=dataloader,
-        avg_h2d_ms=0.0,
+        avg_h2d_ms=h2d,
         avg_forward_ms=forward,
         avg_backward_ms=backward,
         avg_optimizer_ms=optimizer,
@@ -205,14 +207,12 @@ def test_step_time_input_straggler_card_shows_rank_evidence() -> None:
             0: _rank(
                 dataloader=10.0,
                 forward=40.0,
-                backward=130.0,
-                step_cpu=219.0,
+                backward=190.0,
             ),
             1: _rank(
                 dataloader=70.0,
                 forward=40.0,
                 backward=130.0,
-                step_cpu=219.0,
             ),
         }
     )
@@ -242,7 +242,7 @@ def test_step_time_compute_straggler_card_shows_rank_evidence() -> None:
     assert payload["diagnosis"] == payload["issues"][0]
     assert payload["diagnosis"]["status"] == "COMPUTE STRAGGLER"
     assert (
-        "- Why: r1 forward was slower than peer median (90.0/65.0ms)."
+        "- Why: r1 compute was slower than median global rank (260.0/220.0ms)."
         in payload["card"]
     )
     assert "issues" not in payload["groups"]["rows"]["1"]
@@ -252,37 +252,63 @@ def test_step_time_compute_straggler_card_shows_rank_evidence() -> None:
     _assert_compact_card(payload["card"])
 
 
-def test_step_time_mixed_straggler_can_be_attributed_to_input() -> None:
+def test_step_time_h2d_straggler_card_shows_rank_evidence() -> None:
     payload = _summary(
         {
             0: _rank(
                 dataloader=10.0,
-                forward=40.0,
-                backward=130.0,
+                h2d=0.0,
+                forward=20.0,
+                backward=30.0,
             ),
             1: _rank(
-                dataloader=80.0,
-                forward=90.0,
-                backward=160.0,
+                dataloader=10.0,
+                h2d=80.0,
+                forward=20.0,
+                backward=30.0,
             ),
         }
     )
 
     assert payload["diagnosis"] == payload["issues"][0]
-    assert payload["diagnosis"]["status"] == "INPUT STRAGGLER"
+    assert payload["diagnosis"]["status"] == "H2D STRAGGLER"
     assert (
-        "downstream synchronization"
-        in payload["diagnosis"]["evidence"]["downstream_synchronization_note"]
+        "- Why: r1 H2D was slower than median global rank (80.0/40.0ms)."
+        in payload["card"]
+    )
+    assert {issue["kind"] for issue in payload["issues"]} == {"H2D_STRAGGLER"}
+    _assert_compact_card(payload["card"])
+
+
+def test_step_time_wait_straggler_card_shows_rank_evidence() -> None:
+    payload = _summary(
+        {
+            0: _rank(
+                dataloader=10.0,
+                forward=20.0,
+                backward=30.0,
+                step_cpu=60.0,
+            ),
+            1: _rank(
+                dataloader=10.0,
+                forward=20.0,
+                backward=30.0,
+                step_cpu=140.0,
+            ),
+        }
+    )
+
+    assert payload["diagnosis"] == payload["issues"][0]
+    assert payload["diagnosis"]["status"] == "WAIT STRAGGLER"
+    assert (
+        "- Why: r1 wait was higher than median global rank (80.0/40.0ms)."
+        in payload["card"]
     )
     assert {issue["kind"] for issue in payload["issues"]} >= {
-        "STRAGGLER",
-        "INPUT_STRAGGLER",
-        "COMPUTE_STRAGGLER",
+        "WAIT_STRAGGLER",
+        "WAIT_HEAVY",
     }
     assert "issues" not in payload["groups"]["rows"]["1"]
-    assert (
-        "- Why: r1 input was slower than median global rank" in payload["card"]
-    )
     _assert_compact_card(payload["card"])
 
 
@@ -291,25 +317,24 @@ def test_step_time_unexplained_mixed_straggler_stays_straggler() -> None:
         {
             0: _rank(
                 dataloader=10.0,
-                forward=40.0,
-                backward=130.0,
+                forward=20.0,
+                backward=30.0,
             ),
             1: _rank(
-                dataloader=90.0,
-                forward=160.0,
-                backward=260.0,
+                dataloader=60.0,
+                forward=40.0,
+                backward=30.0,
             ),
         }
     )
 
     assert payload["diagnosis"] == payload["issues"][0]
     assert payload["diagnosis"]["status"] == "STRAGGLER"
-    assert {issue["kind"] for issue in payload["issues"]} >= {
-        "STRAGGLER",
-        "INPUT_STRAGGLER",
-        "COMPUTE_STRAGGLER",
-    }
-    assert "- Why: Input and compute varied across ranks." in payload["card"]
+    assert {issue["kind"] for issue in payload["issues"]} == {"STRAGGLER"}
+    assert (
+        "- Why: Multiple clean-step components varied across ranks."
+        in payload["card"]
+    )
     _assert_compact_card(payload["card"])
 
 
@@ -318,19 +343,19 @@ def test_step_time_priority_prefers_straggler_over_wait_heavy() -> None:
         {
             0: _rank(
                 dataloader=10.0,
-                forward=40.0,
-                backward=130.0,
-                step_cpu=350.0,
+                forward=20.0,
+                backward=90.0,
+                step_cpu=200.0,
             ),
             1: _rank(
                 dataloader=110.0,
-                forward=180.0,
-                backward=270.0,
-                step_cpu=500.0,
+                forward=20.0,
+                backward=30.0,
+                step_cpu=140.0,
             ),
         }
     )
 
-    assert payload["diagnosis"]["status"] == "STRAGGLER"
+    assert payload["diagnosis"]["status"] == "INPUT STRAGGLER"
     assert "WAIT_HEAVY" in {issue["kind"] for issue in payload["issues"]}
-    assert "- Diagnosis: STRAGGLER" in payload["card"]
+    assert "- Diagnosis: INPUT STRAGGLER" in payload["card"]


### PR DESCRIPTION
## What changed

Replaced the old Step Time rank-straggler attribution with the clean-step policy.

- Added clean-step straggler detection that discounts backward time explained by  another rank's non-backward work.
- Classifies the slow clean-step rank by dominant excess among dataloader,  clean compute, H2D, and wait.
- Added public Step Time labels for `H2D_STRAGGLER` / `H2D STRAGGLER` and  `WAIT_STRAGGLER` / `WAIT STRAGGLER`.
- Kept `STRAGGLER` as the mixed rank-local case when no component dominates by
  `1.25x`.
- Wired the same diagnosis path through live CLI/dashboard Step Time,  final-summary Step Time, and model diagnostics.
- Updated docs and reporting text to explain that a straggler means a slow rank   for the distributed step, not necessarily a bad GPU or node.

## Why

A slow dataloader rank can make peer anks appear slow in backward, so phase-wise worst/median comparisons were too
easy to misread.

The clean-step policy gives a clearer rule:

- find the rank with the slowest clean step
- removes backward wait that can be explained by other ranks arriving late
- blame the dominant rank-local excess
- report mixed `STRAGGLER` when input, compute, H2D, and wait are not clearly
  separable

## How I tested

- [x] Tests added or updated
- [x] Existing tests run
- [ ] Manual smoke test
- [ ] Not run; reason:

Commands run:

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/diagnostics/test_registry.py \
  tests/diagnostics/test_step_time.py \
  tests/reporting/summary/test_step_time_card.py \
  tests/reporting/summary/test_primary_diagnosis.py \
  tests/reporting/summary/test_step_time.py
```

Result:

```text
41 passed
```

Broader reporting/display verification:

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/diagnostics/test_step_time.py \
  tests/reporting/summary/test_step_time_card.py \
  tests/reporting/summary/test_primary_diagnosis.py \
  tests/reporting/summary/test_step_time.py \
  tests/reporting/html/test_sections.py \
  tests/reporting/html/test_textutils.py \
  tests/display/test_server_readiness.py \
  tests/display/test_staleness.py \
  tests/display/test_nicegui_driver.py \
  tests/display/test_nicegui_errors.py \
  tests/display/test_nicegui_subscribers.py
```

Result:

```text
82 passed
```

Also ran:

```bash
git diff --check
```

Manual DDP smoke was not run for this change; the focused policy behavior is
covered by unit/reporting tests.

## Runtime impact

- [x] No training-path impact
- [ ] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes:

This changes diagnosis/reporting behavior only. It does not change training execution, tracing hooks, samplers, transport, or the telemetry database schema.

Live/dashboard Step Time now passes aligned per-rank timing into the shared diagnosis path. Final-summary diagnosis uses the Step Time adapters for the same reason: adapters exist to translate summary rank averages into the shared diagnosis input without duplicating policy logic.

## Docs

- [x] Updated
- [ ] Not needed

Updated docs include the diagnosis spec, reading-output guide, DDP rank straggler guide, architecture glossary, FAQ, related guide tables, reporting schema notes, and a short copy-paste developer note:

- `docs/developer_guide/clean-step-straggler-policy.md`

## Extra context

Clean-step policy:

```text
WAIT_r = wait_proxy_r
non_bwd_r = DL_r + H2D_r + FWD_r + OPT_r + WAIT_r
clean_bwd_r = max(0, BWD_r - max(0, max(non_bwd) - non_bwd_r))
clean_compute_r = FWD_r + clean_bwd_r + OPT_r
clean_step_r = DL_r + H2D_r + clean_compute_r + WAIT_r

score = (max(clean_step) - median(clean_step)) / median(actual_step)
```

If `score < 0.10`, TraceML does not report a rank-local straggler. Otherwise, the worst clean-step rank is classified by largest component excess over peer median. The largest excess must be at least `1.25x` the second-largest excess;
otherwise the diagnosis remains mixed `STRAGGLER`.
