### PR TITLE
Improve storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ traceml run train.py --html-report
 traceml view logs/<run_name>/final_summary.json --html   # writes <...>.html
 ```
 
+For very large or slow multi-node jobs, TraceML waits at shutdown for late
+telemetry, SQLite checkpointing, and final summary writing. Tune that single
+end-of-run budget with `--finalize-timeout-sec` or
+`TRACEML_FINALIZE_TIMEOUT_SEC` when running on slow filesystems or congested
+networks.
+
 Instead of guessing where step time and memory went, you get a compact
 diagnosis at the end of every run.
 

--- a/docs/user_guide/distributed-training.md
+++ b/docs/user_guide/distributed-training.md
@@ -55,6 +55,12 @@ Override that only when needed with `--aggregator-bind-host=<bind-host>`.
 `--session-id` remains accepted as a backward-compatible alias for
 `--run-name`.
 
+At the end of a summary run, node 0 waits for rank-finished markers, drains
+late telemetry, checkpoints SQLite, and then writes `final_summary.*`. The
+default finalization budget is 300 seconds. On slow shared filesystems or
+congested networks, increase it with `--finalize-timeout-sec <seconds>` on each
+node, or set `TRACEML_FINALIZE_TIMEOUT_SEC`.
+
 ## Running on Slurm
 
 On a Slurm-managed cluster, derive these flags from the job environment instead

--- a/docs/user_guide/quickstart.md
+++ b/docs/user_guide/quickstart.md
@@ -58,6 +58,10 @@ Add `--html-report` (`traceml run train.py --html-report`) to also write a
 shareable `final_summary.html`. See
 [Reading the output](reading-output.md#shareable-html-report).
 
+TraceML finalizes summaries after training by settling late telemetry, closing
+SQLite cleanly, and checkpointing WAL. Large distributed jobs can raise that
+end-of-run budget with `--finalize-timeout-sec <seconds>`.
+
 For DDP, FSDP, and multi-node launches, see
 [Distributed Training](distributed-training.md).
 

--- a/docs/user_guide/quickstart.md
+++ b/docs/user_guide/quickstart.md
@@ -62,6 +62,12 @@ TraceML finalizes summaries after training by settling late telemetry, closing
 SQLite cleanly, and checkpointing WAL. Large distributed jobs can raise that
 end-of-run budget with `--finalize-timeout-sec <seconds>`.
 
+In `--mode=summary`, if training finishes but TraceML cannot produce
+`final_summary.json`, `traceml run` exits non-zero, so a silently missing
+summary fails loudly instead of passing. (Reused history databases keep any
+rows written by older releases; new runs only write the structured projection
+tables.)
+
 For DDP, FSDP, and multi-node launches, see
 [Distributed Training](distributed-training.md).
 

--- a/docs/user_guide/slurm.md
+++ b/docs/user_guide/slurm.md
@@ -207,6 +207,11 @@ passing the flag on every node in a symmetric launch command is harmless.
 reachable after the job ends. You can compare two runs later with
 [`traceml compare`](compare.md).
 
+Large jobs can spend time flushing late telemetry and checkpointing SQLite at
+shutdown. If your cluster has slow scratch storage or delayed cross-node TCP
+delivery, pass `--finalize-timeout-sec <seconds>` in the shared launch command
+or set `TRACEML_FINALIZE_TIMEOUT_SEC`.
+
 ## Cluster-specific notes
 
 !!! tip "Adapt these for your cluster"

--- a/src/traceml_ai/aggregator/aggregator_main.py
+++ b/src/traceml_ai/aggregator/aggregator_main.py
@@ -38,6 +38,7 @@ from traceml_ai.loggers.error_log import get_error_logger, setup_error_logger
 from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
 from traceml_ai.runtime.lifecycle import start_aggregator
 from traceml_ai.runtime.settings import (
+    DEFAULT_FINALIZE_TIMEOUT_SEC,
     AggregatorTransportSettings,
     TraceMLSettings,
 )
@@ -132,6 +133,15 @@ def read_traceml_env() -> dict[str, Any]:
         "session_id": os.environ.get("TRACEML_SESSION_ID", ""),
         "history_enabled": os.environ.get("TRACEML_HISTORY_ENABLED", "1")
         == "1",
+        "finalize_timeout_sec": float(
+            os.environ.get(
+                "TRACEML_FINALIZE_TIMEOUT_SEC",
+                str(DEFAULT_FINALIZE_TIMEOUT_SEC),
+            )
+        ),
+        "expected_world_size": int(
+            os.environ.get("TRACEML_EXPECTED_WORLD_SIZE", "1")
+        ),
         "summary_window_rows": int(
             os.environ.get(
                 "TRACEML_SUMMARY_WINDOW_ROWS",
@@ -199,6 +209,8 @@ def main() -> None:
             history_enabled=bool(cfg["history_enabled"]),
             summary_window_rows=int(cfg["summary_window_rows"]),
             html_report=bool(cfg["html_report"]),
+            finalize_timeout_sec=float(cfg["finalize_timeout_sec"]),
+            expected_world_size=int(cfg["expected_world_size"]),
             aggregator=AggregatorTransportSettings(
                 connect_host=str(cfg["aggregator_host"]),
                 bind_host=str(cfg["aggregator_bind_host"]),
@@ -222,9 +234,10 @@ def main() -> None:
         if handle is not None:
             try:
                 logger.info("[TraceML] Stopping aggregator")
-                handle.stop(timeout_sec=5.0)
-            except Exception:
-                pass
+                handle.stop(timeout_sec=float(cfg["finalize_timeout_sec"]))
+            except Exception as stop_exc:
+                if err is None:
+                    err = stop_exc
 
         print(
             f"[TraceML] Logs saved under: {session_root}",

--- a/src/traceml_ai/aggregator/sqlite_writer.py
+++ b/src/traceml_ai/aggregator/sqlite_writer.py
@@ -10,7 +10,7 @@ import queue
 import sqlite3
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional
 
@@ -53,6 +53,7 @@ _RETENTION_PARTITION_SQL = {
     "step_time_samples": "COALESCE(global_rank, rank, 0)",
     "step_memory_samples": "COALESCE(global_rank, rank, 0)",
 }
+_RETENTION_PRUNE_INTERVAL_BATCHES = 10
 
 
 @dataclass(frozen=True)
@@ -75,6 +76,39 @@ class SQLiteWriterConfig:
     synchronous: str = "NORMAL"
 
 
+@dataclass(frozen=True)
+class SQLiteFinalizeResult:
+    """Outcome of closing the SQLite history writer at end of run."""
+
+    ok: bool
+    elapsed_sec: float
+    enqueued: int
+    written: int
+    dropped: int
+    queue_size: int
+    checkpoint_ok: bool
+    error: Optional[str] = None
+    prune_ok: bool = True
+    prune_error: Optional[str] = None
+    checkpoint_error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serializable representation for diagnostics."""
+        return {
+            "ok": bool(self.ok),
+            "elapsed_sec": float(self.elapsed_sec),
+            "enqueued": int(self.enqueued),
+            "written": int(self.written),
+            "dropped": int(self.dropped),
+            "queue_size": int(self.queue_size),
+            "checkpoint_ok": bool(self.checkpoint_ok),
+            "error": self.error,
+            "prune_ok": bool(self.prune_ok),
+            "prune_error": self.prune_error,
+            "checkpoint_error": self.checkpoint_error,
+        }
+
+
 class SQLiteWriterSimple:
     """Asynchronous SQLite telemetry writer."""
 
@@ -87,18 +121,22 @@ class SQLiteWriterSimple:
         self._q: "queue.Queue[Any]" = queue.Queue(maxsize=int(cfg.max_queue))
         self._wake = threading.Event()
         self._stop = threading.Event()
+        self._closed = threading.Event()
         self._thread = threading.Thread(
             target=self._run,
             name="TraceML-SQLiteWriter",
             daemon=True,
         )
         self._started = False
+        self._accepting = True
 
         # Stats (best-effort; telemetry doesn't need perfect atomicity)
         self._enqueued = 0
         self._dropped = 0
         self._written = 0
+        self._batches_since_prune = 0
         self._last_error: Optional[str] = None
+        self._finalize_result: Optional[SQLiteFinalizeResult] = None
 
     def start(self) -> None:
         """Start the writer thread (idempotent)."""
@@ -113,7 +151,12 @@ class SQLiteWriterSimple:
 
         If the internal queue is full, the message is dropped.
         """
-        if not self._cfg.enabled or msg is None:
+        if (
+            not self._cfg.enabled
+            or not self._accepting
+            or self._stop.is_set()
+            or msg is None
+        ):
             return
         try:
             self._q.put_nowait(msg)
@@ -122,7 +165,7 @@ class SQLiteWriterSimple:
         except queue.Full:
             self._dropped += 1
 
-    def flush_now(self, timeout_sec: float = 5.0) -> bool:
+    def force_flush(self, timeout_sec: float = 5.0) -> bool:
         """
         Block until all messages enqueued before this call have been flushed.
 
@@ -144,6 +187,10 @@ class SQLiteWriterSimple:
         """
         if not self._cfg.enabled or not self._started:
             return True
+        if self._closed.is_set():
+            return True
+        if self._stop.is_set():
+            return False
 
         done = threading.Event()
         barrier = _FlushBarrier(done=done)
@@ -156,24 +203,73 @@ class SQLiteWriterSimple:
 
         return done.wait(timeout=float(timeout_sec))
 
-    def stop(self, timeout_sec: float = 2.0) -> None:
+    def finalize(self, timeout_sec: float = 300.0) -> SQLiteFinalizeResult:
         """
-        Request stop and flush best-effort.
+        Stop accepting writes, drain queued telemetry, checkpoint WAL, and close.
 
-        The writer thread is daemonized; shutdown should never hang the process.
+        ``force_flush`` is for on-demand readers while the aggregator keeps
+        running. ``finalize`` is the end-of-run close path: after this call the
+        writer is closed and summary generation can safely open a new SQLite
+        reader without racing the writer connection.
         """
+        start = time.monotonic()
         if not self._cfg.enabled:
-            return
+            return SQLiteFinalizeResult(
+                ok=True,
+                elapsed_sec=0.0,
+                enqueued=self._enqueued,
+                written=self._written,
+                dropped=self._dropped,
+                queue_size=0,
+                checkpoint_ok=True,
+                error=None,
+            )
+        if not self._started:
+            return SQLiteFinalizeResult(
+                ok=True,
+                elapsed_sec=0.0,
+                enqueued=self._enqueued,
+                written=self._written,
+                dropped=self._dropped,
+                queue_size=self._q.qsize(),
+                checkpoint_ok=True,
+                error=None,
+            )
 
+        self._accepting = False
         self._stop.set()
         self._wake.set()
 
-        if self._started:
-            self._thread.join(timeout=float(timeout_sec))
-            if self._thread.is_alive():
-                self._log_error(
-                    "[TraceML] SQLiteWriter thread did not terminate cleanly"
-                )
+        if not self._closed.wait(timeout=float(timeout_sec)):
+            error = (
+                "Timed out while finalizing SQLite history writer "
+                f"after {float(timeout_sec):.1f}s."
+            )
+            self._log_error(f"[TraceML] {error}")
+            return SQLiteFinalizeResult(
+                ok=False,
+                elapsed_sec=time.monotonic() - start,
+                enqueued=self._enqueued,
+                written=self._written,
+                dropped=self._dropped,
+                queue_size=self._q.qsize(),
+                checkpoint_ok=False,
+                error=error,
+            )
+
+        result = self._finalize_result
+        if result is None:
+            result = SQLiteFinalizeResult(
+                ok=False,
+                elapsed_sec=0.0,
+                enqueued=self._enqueued,
+                written=self._written,
+                dropped=self._dropped,
+                queue_size=self._q.qsize(),
+                checkpoint_ok=False,
+                error="SQLite writer closed without a finalization result.",
+            )
+        return replace(result, elapsed_sec=time.monotonic() - start)
 
     def stats(self) -> Dict[str, Any]:
         """Return basic counters for debugging/observability."""
@@ -293,6 +389,8 @@ class SQLiteWriterSimple:
         self,
         conn: sqlite3.Connection,
         projection_rows: dict[Any, dict[str, list[tuple]]],
+        *,
+        prune: bool = True,
     ) -> None:
         """Write prepared projection rows in one SQLite transaction."""
         row_count = self._projection_row_count(projection_rows)
@@ -304,7 +402,13 @@ class SQLiteWriterSimple:
         for writer in _PROJECTION_WRITERS:
             writer.insert_rows(conn, projection_rows[writer])
 
-        self._prune_retained_rows(conn, projection_rows)
+        self._batches_since_prune += 1
+        if (
+            prune
+            and self._batches_since_prune >= _RETENTION_PRUNE_INTERVAL_BATCHES
+        ):
+            self._prune_retained_rows(conn, projection_rows)
+            self._batches_since_prune = 0
 
         conn.execute("COMMIT;")
         self._written += row_count
@@ -338,6 +442,20 @@ class SQLiteWriterSimple:
 
             if writer is system_sql_writer:
                 self._prune_system_gpu_samples_to_retained_system_samples(conn)
+
+    def _prune_all_retained_rows(self, conn: sqlite3.Connection) -> None:
+        """Run one final retention pass before checkpointing and closing SQLite."""
+        retention_rows = summary_retention_rows_for_window(
+            self._cfg.summary_window_rows
+        )
+        for table in _RETENTION_TABLES:
+            self._prune_table_by_identity(
+                conn,
+                table=str(table),
+                retention_rows=retention_rows,
+            )
+        self._prune_system_gpu_samples_to_retained_system_samples(conn)
+        self._batches_since_prune = 0
 
     @staticmethod
     def _prune_table_by_identity(
@@ -445,12 +563,25 @@ class SQLiteWriterSimple:
         - Flush pending messages
         - On stop: perform one final best-effort flush
         """
+        run_start = time.monotonic()
+        conn: Optional[sqlite3.Connection] = None
+        fatal_error: Optional[str] = None
+        prune_error: Optional[str] = None
+        checkpoint_error: Optional[str] = None
+        checkpoint_ok = False
         try:
             conn = self._connect()
             for writer in _PROJECTION_WRITERS:
                 writer.init_schema(conn)
         except Exception as exc:
-            self._log_error(f"[TraceML] SQLiteWriter init failed: {exc}")
+            fatal_error = f"SQLiteWriter init failed: {exc}"
+            self._log_error(f"[TraceML] {fatal_error}")
+            self._finalize_result = self._build_finalize_result(
+                elapsed_sec=time.monotonic() - run_start,
+                checkpoint_ok=False,
+                error=fatal_error,
+            )
+            self._closed.set()
             return
 
         interval = float(self._cfg.flush_interval_sec)
@@ -464,9 +595,53 @@ class SQLiteWriterSimple:
                 # Best-effort final flush on stop.
             while not self._q.empty():
                 self._flush_once(conn)
+            try:
+                self._prune_all_retained_rows(conn)
+            except Exception as exc:
+                prune_error = f"Final SQLite retention prune failed: {exc}"
+                self._log_error(f"[TraceML] {prune_error}")
         finally:
             try:
-                conn.execute("PRAGMA wal_checkpoint(TRUNCATE);")
-                conn.close()
-            except Exception:
-                pass
+                if conn is not None:
+                    conn.execute("PRAGMA wal_checkpoint(TRUNCATE);")
+                    checkpoint_ok = True
+                    conn.close()
+            except Exception as exc:
+                checkpoint_ok = False
+                checkpoint_error = f"SQLite checkpoint/close failed: {exc}"
+                fatal_error = checkpoint_error
+                self._log_error(f"[TraceML] {checkpoint_error}")
+            finally:
+                self._finalize_result = self._build_finalize_result(
+                    elapsed_sec=time.monotonic() - run_start,
+                    checkpoint_ok=checkpoint_ok,
+                    error=fatal_error,
+                    prune_error=prune_error,
+                    checkpoint_error=checkpoint_error,
+                )
+                self._closed.set()
+
+    def _build_finalize_result(
+        self,
+        *,
+        elapsed_sec: float,
+        checkpoint_ok: bool,
+        error: Optional[str],
+        prune_error: Optional[str] = None,
+        checkpoint_error: Optional[str] = None,
+    ) -> SQLiteFinalizeResult:
+        """Build a finalization result from current writer counters."""
+        fatal_error = error or checkpoint_error
+        return SQLiteFinalizeResult(
+            ok=bool(fatal_error is None and checkpoint_ok),
+            elapsed_sec=float(elapsed_sec),
+            enqueued=int(self._enqueued),
+            written=int(self._written),
+            dropped=int(self._dropped),
+            queue_size=int(self._q.qsize()),
+            checkpoint_ok=bool(checkpoint_ok),
+            error=fatal_error,
+            prune_ok=prune_error is None,
+            prune_error=prune_error,
+            checkpoint_error=checkpoint_error,
+        )

--- a/src/traceml_ai/aggregator/sqlite_writer.py
+++ b/src/traceml_ai/aggregator/sqlite_writer.py
@@ -34,7 +34,6 @@ from traceml_ai.telemetry.envelope import (
     TelemetryEnvelope,
     normalize_telemetry_envelope,
 )
-from traceml_ai.utils.msgpack_codec import Encoder as MsgpackEncoder
 
 _PROJECTION_WRITERS = [
     system_sql_writer,
@@ -94,8 +93,6 @@ class SQLiteWriterSimple:
             daemon=True,
         )
         self._started = False
-
-        self._encoder = MsgpackEncoder()
 
         # Stats (best-effort; telemetry doesn't need perfect atomicity)
         self._enqueued = 0
@@ -214,26 +211,6 @@ class SQLiteWriterSimple:
         conn.execute("PRAGMA foreign_keys=ON;")
         return conn
 
-    def _init_schema(self, conn: sqlite3.Connection) -> None:
-        """Create the base raw message schema and indexes if needed."""
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS raw_messages (
-                id         INTEGER PRIMARY KEY AUTOINCREMENT,
-                recv_ts_ns INTEGER NOT NULL,
-                rank       INTEGER,
-                sampler    TEXT,
-                payload_mp BLOB NOT NULL
-            );
-            """
-        )
-        conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_raw_sampler_rank_id
-            ON raw_messages(sampler, rank, id);
-            """
-        )
-
     def _drain_nowait(self, max_items: int) -> list[Dict[str, Any]]:
         """Drain up to ``max_items`` messages from the in-memory queue."""
         items: list[Dict[str, Any]] = []
@@ -243,12 +220,6 @@ class SQLiteWriterSimple:
             except queue.Empty:
                 break
         return items
-
-    def _extract_rank_sampler(
-        self, envelope: TelemetryEnvelope
-    ) -> tuple[Optional[int], Optional[str]]:
-        """Extract best-effort ``rank`` and ``sampler`` from envelope metadata."""
-        return envelope.meta.rank, envelope.meta.sampler
 
     def _iter_envelopes(self, msg: Any) -> Iterator[TelemetryEnvelope]:
         """
@@ -271,20 +242,11 @@ class SQLiteWriterSimple:
             if envelope is not None:
                 yield envelope
 
-    def _collect_flush_rows(
+    def _collect_projection_rows(
         self,
         items: list[Dict[str, Any]],
-    ) -> tuple[
-        list[tuple[int, Optional[int], Optional[str], bytes]],
-        dict[Any, dict[str, list[tuple]]],
-    ]:
-        """
-        Convert queued payloads into raw SQLite rows and projection rows.
-
-        All decodable payloads are preserved in ``raw_messages``. A selected
-        subset of samplers is also expanded into structured projection tables.
-        """
-        raw_rows: list[tuple[int, Optional[int], Optional[str], bytes]] = []
+    ) -> dict[Any, dict[str, list[tuple]]]:
+        """Convert queued telemetry payloads into structured projection rows."""
         projection_rows: dict[Any, dict[str, list[tuple]]] = {
             writer: {} for writer in _PROJECTION_WRITERS
         }
@@ -293,9 +255,7 @@ class SQLiteWriterSimple:
             for envelope in self._iter_envelopes(item):
                 try:
                     recv_ts_ns = time.time_ns()
-                    rank, sampler = self._extract_rank_sampler(envelope)
-                    payload = self._encoder.encode(envelope.to_dict())
-                    raw_rows.append((recv_ts_ns, rank, sampler, payload))
+                    sampler = envelope.meta.sampler
 
                     for writer in _PROJECTION_WRITERS:
                         if not writer.accepts_sampler(sampler):
@@ -316,27 +276,30 @@ class SQLiteWriterSimple:
                     # Best-effort persistence: skip malformed payloads and continue.
                     continue
 
-        return raw_rows, projection_rows
+        return projection_rows
 
-    def _write_flush_rows(
+    @staticmethod
+    def _projection_row_count(
+        projection_rows: dict[Any, dict[str, list[tuple]]],
+    ) -> int:
+        """Return the total number of structured projection rows prepared."""
+        return sum(
+            len(rows)
+            for rows_by_table in projection_rows.values()
+            for rows in rows_by_table.values()
+        )
+
+    def _write_projection_rows(
         self,
         conn: sqlite3.Connection,
-        raw_rows: list[tuple[int, Optional[int], Optional[str], bytes]],
         projection_rows: dict[Any, dict[str, list[tuple]]],
     ) -> None:
-        """
-        Write prepared raw rows and projection rows in one SQLite transaction.
-        """
-        if not raw_rows:
+        """Write prepared projection rows in one SQLite transaction."""
+        row_count = self._projection_row_count(projection_rows)
+        if row_count <= 0:
             return
 
         conn.execute("BEGIN;")
-
-        conn.executemany(
-            "INSERT INTO raw_messages(recv_ts_ns, rank, sampler, payload_mp) "
-            "VALUES (?, ?, ?, ?);",
-            raw_rows,
-        )
 
         for writer in _PROJECTION_WRITERS:
             writer.insert_rows(conn, projection_rows[writer])
@@ -344,7 +307,7 @@ class SQLiteWriterSimple:
         self._prune_retained_rows(conn, projection_rows)
 
         conn.execute("COMMIT;")
-        self._written += len(raw_rows)
+        self._written += row_count
 
     def _prune_retained_rows(
         self,
@@ -375,14 +338,6 @@ class SQLiteWriterSimple:
 
             if writer is system_sql_writer:
                 self._prune_system_gpu_samples_to_retained_system_samples(conn)
-
-            sampler = getattr(writer, "SAMPLER_NAME", None)
-            if sampler is not None:
-                self._prune_raw_messages_for_sampler(
-                    conn,
-                    sampler=str(sampler),
-                    retention_rows=retention_rows,
-                )
 
     @staticmethod
     def _prune_table_by_identity(
@@ -435,34 +390,6 @@ class SQLiteWriterSimple:
             """
         )
 
-    @staticmethod
-    def _prune_raw_messages_for_sampler(
-        conn: sqlite3.Connection,
-        *,
-        sampler: str,
-        retention_rows: int,
-    ) -> None:
-        """Delete raw sampler blobs outside the retained per-rank window."""
-        conn.execute(
-            """
-            DELETE FROM raw_messages
-            WHERE id IN (
-                SELECT id FROM (
-                    SELECT
-                        id,
-                        ROW_NUMBER() OVER (
-                            PARTITION BY sampler, COALESCE(rank, 0)
-                            ORDER BY id DESC
-                        ) AS row_num
-                    FROM raw_messages
-                    WHERE sampler = ?
-                )
-                WHERE row_num > ?
-            );
-            """,
-            (sampler, int(retention_rows)),
-        )
-
     def _flush_once(self, conn: sqlite3.Connection) -> None:
         """
         Drain up to ``max_flush_items`` queued items and write them to SQLite.
@@ -481,12 +408,12 @@ class SQLiteWriterSimple:
             if not batch:
                 return
 
-            raw_rows, projection_rows = self._collect_flush_rows(batch)
-            if not raw_rows:
+            projection_rows = self._collect_projection_rows(batch)
+            if self._projection_row_count(projection_rows) <= 0:
                 return
 
             try:
-                self._write_flush_rows(conn, raw_rows, projection_rows)
+                self._write_projection_rows(conn, projection_rows)
             except Exception as exc:
                 try:
                     conn.execute("ROLLBACK;")
@@ -513,14 +440,13 @@ class SQLiteWriterSimple:
         Flow
         ----
         - Open and configure SQLite
-        - Initialize raw + projection schemas
+        - Initialize projection schemas
         - Sleep for ``flush_interval_sec``
         - Flush pending messages
         - On stop: perform one final best-effort flush
         """
         try:
             conn = self._connect()
-            self._init_schema(conn)
             for writer in _PROJECTION_WRITERS:
                 writer.init_schema(conn)
         except Exception as exc:

--- a/src/traceml_ai/aggregator/sqlite_writers/process.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/process.py
@@ -7,8 +7,8 @@
 """
 SQLite projection writer for ProcessSampler.
 
-This module projects TraceML ProcessSampler payloads into SQLite
-table while preserving the original sampler payload in `raw_messages`.
+This module projects TraceML ProcessSampler payloads into a query-friendly
+SQLite table.
 
 Design
 ------

--- a/src/traceml_ai/aggregator/sqlite_writers/stdout_stderr.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/stdout_stderr.py
@@ -2,8 +2,7 @@
 SQLite projection writer for StdoutStderrSampler.
 
 This module projects TraceML stdout/stderr sampler payloads into a simple,
-query-friendly SQLite table while preserving the original sampler payload in
-`raw_messages`.
+query-friendly SQLite table.
 
 Design
 ------

--- a/src/traceml_ai/aggregator/sqlite_writers/step_memory.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/step_memory.py
@@ -8,7 +8,7 @@
 SQLite projection writer for StepMemorySampler.
 
 This module projects TraceML StepMemorySampler payloads into a query-friendly
-SQLite table while preserving the original sampler payload in `raw_messages`.
+SQLite table.
 
 Design
 ------

--- a/src/traceml_ai/aggregator/sqlite_writers/step_time.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/step_time.py
@@ -8,7 +8,7 @@
 SQLite projection writer for StepTimeSampler.
 
 This module projects TraceML StepTimeSampler payloads into a query-friendly
-SQLite table while preserving the original sampler payload in `raw_messages`.
+SQLite table.
 
 Design
 ------

--- a/src/traceml_ai/aggregator/sqlite_writers/system.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/system.py
@@ -8,8 +8,7 @@
 SQLite projection writer for SystemSampler.
 
 This module projects TraceML SystemSampler payloads into query-friendly
-SQLite tables while preserving the original sampler payload in the main
-`raw_messages` table.
+SQLite tables.
 
 Storage units
 -------------

--- a/src/traceml_ai/aggregator/trace_aggregator.py
+++ b/src/traceml_ai/aggregator/trace_aggregator.py
@@ -254,15 +254,26 @@ class TraceMLAggregator:
                 and self._settings.db_path
                 and not get_final_summary_json_path(session_root).is_file()
             ):
-                generate_summary(
-                    str(self._settings.db_path),
-                    session_root=str(session_root),
-                    print_to_stdout=True,
-                    summary_window_rows=int(
-                        self._settings.summary_window_rows
-                    ),
-                    write_html=bool(self._settings.html_report),
-                )
+                try:
+                    generate_summary(
+                        str(self._settings.db_path),
+                        session_root=str(session_root),
+                        print_to_stdout=True,
+                        summary_window_rows=int(
+                            self._settings.summary_window_rows
+                        ),
+                        write_html=bool(self._settings.html_report),
+                    )
+                except Exception as summary_exc:
+                    # A summary-generation error is only fatal if it left no
+                    # artifact: the missing-file gate below makes that call.
+                    # A post-write render/print error (final_summary.json is
+                    # already on disk) is downgraded to a warning so it does
+                    # not fail an otherwise-successful run.
+                    self._logger.exception("[TraceML] generate_summary raised")
+                    warning_payload = self._add_generate_summary_warning(
+                        warning_payload, summary_exc
+                    )
 
             if (
                 self._started
@@ -289,7 +300,7 @@ class TraceMLAggregator:
                     "status": "error",
                     "completed_at": utc_now_iso(),
                     "error": str(exc),
-                    "finished_ranks": sorted(self._finished_ranks),
+                    "finished_ranks": self._finished_ranks_snapshot(),
                     "expected_world_size": self._expected_world_size,
                     "sqlite_finalize": finalize_payload,
                     "writer": self._sqlite_writer.stats(),
@@ -363,6 +374,41 @@ class TraceMLAggregator:
         warning_payload["sqlite_finalize"] = finalize_payload
         return warning_payload
 
+    @staticmethod
+    def _add_generate_summary_warning(
+        warning_payload: Optional[dict[str, Any]],
+        exc: Exception,
+    ) -> Optional[dict[str, Any]]:
+        """Record a nonfatal post-write summary-generation error.
+
+        Reached only when ``final_summary.json`` already exists (the
+        missing-file gate handles the fatal, no-artifact case), so a
+        render/print error after the write did not cost the artifact and must
+        not fail the run.
+        """
+        if warning_payload is None:
+            warning_payload = {
+                "status": "warning",
+                "completed_at": utc_now_iso(),
+                "message": (
+                    "Summary artifact was written, but summary generation "
+                    "raised after the write; continuing without failing the "
+                    "run."
+                ),
+            }
+        warning_payload["generate_summary_error"] = str(exc)
+        return warning_payload
+
+    def _finished_ranks_snapshot(self) -> List[int]:
+        """Return a sorted snapshot of finished global ranks (lock-safe).
+
+        ``_finished_ranks`` is mutated under ``_drain_lock`` by the drain
+        path; snapshotting under the same lock avoids a ``RuntimeError`` if a
+        late/zombie drain mutates the dict mid-iteration.
+        """
+        with self._drain_lock:
+            return sorted(self._finished_ranks)
+
     def _split_telemetry_payloads(self, msg: Any) -> List[Any]:
         """
         Consume control messages and return sampler telemetry payloads.
@@ -400,7 +446,10 @@ class TraceMLAggregator:
         """
         deadline = time.monotonic() + max(0.0, float(timeout_sec))
         quiet_sec = 0.5
-
+        # Back-compat: workers from older releases do not send a rank_finished
+        # marker, so _finished_ranks never reaches expected_world_size and this
+        # loop waits the full settle budget, then emits a nonfatal "missing
+        # ranks" warning. New workers short-circuit once all ranks report.
         while time.monotonic() < deadline:
             self._drain_tcp()
             if len(self._finished_ranks) >= self._expected_world_size:
@@ -434,7 +483,7 @@ class TraceMLAggregator:
                 "end-of-run finalization."
             ),
             "expected_world_size": self._expected_world_size,
-            "finished_ranks": sorted(self._finished_ranks),
+            "finished_ranks": self._finished_ranks_snapshot(),
             "missing_ranks": missing,
         }
         try:

--- a/src/traceml_ai/aggregator/trace_aggregator.py
+++ b/src/traceml_ai/aggregator/trace_aggregator.py
@@ -6,6 +6,7 @@
 
 """Out-of-process telemetry server and display driver host."""
 
+import logging
 import threading
 import time
 from pathlib import Path
@@ -37,6 +38,8 @@ _SQLITE_FINALIZE_BUDGET_FRACTION = 0.25
 _SQLITE_FINALIZE_BUDGET_MIN_SEC = 5.0
 _SQLITE_FINALIZE_BUDGET_MAX_SEC = 60.0
 _SQLITE_FINALIZE_TINY_FLOOR_SEC = 0.001
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _safe(logger: Any, label: str, fn: Callable[[], Any]) -> Any:
@@ -504,8 +507,12 @@ class TraceMLAggregator:
         try:
             path = Path(session_root).resolve() / "aggregator" / filename
             write_json_atomic(path, payload)
-        except Exception:
-            pass
+        except Exception as exc:
+            _LOGGER.warning(
+                "[TraceML] Failed to write finalization artifact '%s': %s",
+                filename,
+                exc,
+            )
 
     def _settle_telemetry(self, timeout_sec: float) -> bool:
         """

--- a/src/traceml_ai/aggregator/trace_aggregator.py
+++ b/src/traceml_ai/aggregator/trace_aggregator.py
@@ -489,6 +489,8 @@ class TraceMLAggregator:
         try:
             self._logger.warning("[TraceML] %s", warning["message"])
         except Exception:
+            # Best-effort warning emission: logging failures must not interrupt
+            # finalization or alter the warning payload returned to callers.
             pass
         return warning
 

--- a/src/traceml_ai/aggregator/trace_aggregator.py
+++ b/src/traceml_ai/aggregator/trace_aggregator.py
@@ -9,7 +9,7 @@
 import threading
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, Type
+from typing import Any, Callable, Dict, List, Optional, Type
 
 from traceml_ai.aggregator.display_drivers.base import BaseDisplayDriver
 from traceml_ai.aggregator.display_drivers.cli import CLIDisplayDriver
@@ -21,13 +21,22 @@ from traceml_ai.aggregator.sqlite_writer import (
 from traceml_ai.aggregator.summary_service import FinalSummaryService
 from traceml_ai.reporting.final import generate_summary
 from traceml_ai.runtime.settings import AggregatorEndpoint, TraceMLSettings
-from traceml_ai.sdk.protocol import get_final_summary_json_path
+from traceml_ai.sdk.protocol import get_final_summary_json_path, utc_now_iso
+from traceml_ai.telemetry.control import (
+    RankFinishedControl,
+    parse_rank_finished,
+)
 from traceml_ai.transport.tcp_transport import TCPConfig, TCPServer
+from traceml_ai.utils.atomic_io import write_json_atomic
 
 DASHBOARD_EXTRA_INSTALL_HINT = (
     "Dashboard mode requires optional dependencies. Install them with "
     "`pip install 'traceml-ai[dashboard]'`."
 )
+_SQLITE_FINALIZE_BUDGET_FRACTION = 0.25
+_SQLITE_FINALIZE_BUDGET_MIN_SEC = 5.0
+_SQLITE_FINALIZE_BUDGET_MAX_SEC = 60.0
+_SQLITE_FINALIZE_TINY_FLOOR_SEC = 0.001
 
 
 def _safe(logger: Any, label: str, fn: Callable[[], Any]) -> Any:
@@ -37,6 +46,10 @@ def _safe(logger: Any, label: str, fn: Callable[[], Any]) -> Any:
     except Exception:
         logger.exception(f"[TraceML] {label}")
         return None
+
+
+class TraceMLFinalizationError(RuntimeError):
+    """Raised when summary-mode end-of-run finalization cannot complete."""
 
 
 _DISPLAY_DRIVERS: Dict[str, Type[BaseDisplayDriver]] = {
@@ -81,6 +94,12 @@ class TraceMLAggregator:
         self._logger = logger
         self._stop_event = stop_event
         self._settings = settings
+        self._expected_world_size = max(
+            1, int(getattr(settings, "expected_world_size", 1) or 1)
+        )
+        self._finished_ranks: dict[int, RankFinishedControl] = {}
+        self._started = False
+        self._drain_lock = threading.Lock()
 
         # TCP server: aggregator listens for rank-local agents.
         self._tcp_server = TCPServer(
@@ -114,7 +133,7 @@ class TraceMLAggregator:
             logger=self._logger,
             session_root=session_root,
             db_path=str(db_path),
-            flush_history=self._sqlite_writer.flush_now,
+            flush_history=self._sqlite_writer.force_flush,
             settle_telemetry=self._settle_telemetry,
             summary_window_rows=int(settings.summary_window_rows),
             write_html=bool(settings.html_report),
@@ -153,6 +172,7 @@ class TraceMLAggregator:
 
         try:
             self._thread.start()
+            self._started = True
         except Exception:
             self._logger.exception("[TraceML] Aggregator thread start failed")
             raise
@@ -168,17 +188,28 @@ class TraceMLAggregator:
 
     def stop(self, timeout_sec: float) -> None:
         """
-        Stop the aggregator loop and release resources.
+        Stop the aggregator and deterministically finalize end-of-run artifacts.
 
         Notes
         -----
-        - The loop exits when ``stop_event`` is set by the process entrypoint.
-        - Cleanup is best-effort once shutdown begins.
-        - Final summary generation runs only when history is enabled and a
-          database path is configured.
+        End-of-run finalization keeps the TCP server open briefly so late
+        multi-node telemetry can arrive, closes SQLite before summary generation,
+        and treats a missing summary as an error in summary mode.
         """
+        deadline = time.monotonic() + max(0.0, float(timeout_sec))
+        session_root = Path(str(self._settings.logs_dir)).resolve() / str(
+            self._settings.session_id or "default"
+        )
+
+        def remaining() -> float:
+            return max(0.0, deadline - time.monotonic())
+
+        warning_payload: Optional[dict[str, Any]] = None
+        finalize_payload: Optional[dict[str, Any]] = None
+
+        self._stop_event.set()
         if self._thread.is_alive():
-            self._thread.join(timeout=float(timeout_sec))
+            self._thread.join(timeout=min(5.0, remaining()))
 
         if self._thread.is_alive():
             self._logger.error(
@@ -190,29 +221,40 @@ class TraceMLAggregator:
             "Display driver stop failed",
             self._display_driver.stop,
         )
-        _safe(
-            self._logger,
-            "TCPServer.stop failed",
-            self._tcp_server.stop,
-        )
-        _safe(
-            self._logger,
-            "SQLiteWriter.stop failed",
-            self._sqlite_writer.stop,
-        )
 
-        session_root = Path(str(self._settings.logs_dir)).resolve() / str(
-            self._settings.session_id or "default"
-        )
-        if (
-            self._settings.history_enabled
-            and self._settings.db_path
-            and not get_final_summary_json_path(session_root).is_file()
-        ):
+        try:
+            sqlite_finalize_budget = self._sqlite_finalize_budget(remaining())
+            settle_budget = max(0.0, remaining() - sqlite_finalize_budget)
+            if self._settings.history_enabled:
+                warning_payload = self._settle_end_of_run_telemetry(
+                    settle_budget
+                )
             _safe(
                 self._logger,
-                "Final summary failed",
-                lambda: generate_summary(
+                "TCPServer.stop failed",
+                self._tcp_server.stop,
+            )
+            finalize_result = self._sqlite_writer.finalize(
+                max(sqlite_finalize_budget, remaining())
+            )
+            finalize_payload = finalize_result.to_dict()
+            if not finalize_result.ok:
+                raise TraceMLFinalizationError(
+                    "SQLite history did not finalize cleanly: "
+                    f"{finalize_result.error or 'unknown error'}"
+                )
+            warning_payload = self._add_sqlite_finalize_warning(
+                warning_payload,
+                finalize_payload,
+            )
+
+            if (
+                self._started
+                and self._settings.history_enabled
+                and self._settings.db_path
+                and not get_final_summary_json_path(session_root).is_file()
+            ):
+                generate_summary(
                     str(self._settings.db_path),
                     session_root=str(session_root),
                     print_to_stdout=True,
@@ -220,8 +262,42 @@ class TraceMLAggregator:
                         self._settings.summary_window_rows
                     ),
                     write_html=bool(self._settings.html_report),
-                ),
+                )
+
+            if (
+                self._started
+                and self._settings.mode == "summary"
+                and self._settings.history_enabled
+                and not get_final_summary_json_path(session_root).is_file()
+            ):
+                raise TraceMLFinalizationError(
+                    "Summary mode finished without final_summary.json."
+                )
+
+            if warning_payload is not None:
+                self._write_finalization_artifact(
+                    session_root,
+                    "finalization_warning.json",
+                    warning_payload,
+                )
+
+        except Exception as exc:
+            self._write_finalization_artifact(
+                session_root,
+                "finalization_error.json",
+                {
+                    "status": "error",
+                    "completed_at": utc_now_iso(),
+                    "error": str(exc),
+                    "finished_ranks": sorted(self._finished_ranks),
+                    "expected_world_size": self._expected_world_size,
+                    "sqlite_finalize": finalize_payload,
+                    "writer": self._sqlite_writer.stats(),
+                },
             )
+            if self._settings.mode == "summary":
+                raise
+            self._logger.exception("[TraceML] Finalization failed")
 
     def _drain_tcp(self) -> None:
         """
@@ -230,11 +306,155 @@ class TraceMLAggregator:
         Each message is expected to be a telemetry row or batch compatible with
         ``SQLiteWriterSimple.ingest()``.
         """
-        for msg in self._tcp_server.poll():
-            try:
-                self._sqlite_writer.ingest(msg)
-            except Exception:
-                self._logger.exception("[TraceML] SQLiteWriter.ingest failed")
+        with self._drain_lock:
+            for msg in self._tcp_server.poll():
+                for payload in self._split_telemetry_payloads(msg):
+                    try:
+                        self._sqlite_writer.ingest(payload)
+                    except Exception:
+                        self._logger.exception(
+                            "[TraceML] SQLiteWriter.ingest failed"
+                        )
+
+    @staticmethod
+    def _sqlite_finalize_budget(timeout_sec: float) -> float:
+        """
+        Reserve part of the end-of-run timeout for SQLite close/checkpoint.
+
+        Large runs need most of the timeout for late rank telemetry, but SQLite
+        still needs a guaranteed slice so a missing rank marker cannot consume
+        the whole deadline and turn a clean writer close into a false timeout.
+        """
+        total = max(0.0, float(timeout_sec))
+        if total <= 0.0:
+            return 0.0
+        if total < _SQLITE_FINALIZE_BUDGET_MIN_SEC:
+            return max(
+                total * _SQLITE_FINALIZE_BUDGET_FRACTION,
+                min(_SQLITE_FINALIZE_TINY_FLOOR_SEC, total),
+            )
+        return min(
+            _SQLITE_FINALIZE_BUDGET_MAX_SEC,
+            max(
+                _SQLITE_FINALIZE_BUDGET_MIN_SEC,
+                total * _SQLITE_FINALIZE_BUDGET_FRACTION,
+            ),
+        )
+
+    @staticmethod
+    def _add_sqlite_finalize_warning(
+        warning_payload: Optional[dict[str, Any]],
+        finalize_payload: Optional[dict[str, Any]],
+    ) -> Optional[dict[str, Any]]:
+        """Attach nonfatal SQLite finalize warnings to the warning artifact."""
+        if not finalize_payload or finalize_payload.get("prune_ok", True):
+            return warning_payload
+
+        if warning_payload is None:
+            warning_payload = {
+                "status": "warning",
+                "completed_at": utc_now_iso(),
+                "message": (
+                    "SQLite final retention prune failed; summary generation "
+                    "continued because queued telemetry was written and "
+                    "SQLite checkpoint/close succeeded."
+                ),
+            }
+        warning_payload["sqlite_finalize"] = finalize_payload
+        return warning_payload
+
+    def _split_telemetry_payloads(self, msg: Any) -> List[Any]:
+        """
+        Consume control messages and return sampler telemetry payloads.
+
+        Rank-finished markers share the TCP transport with telemetry so workers
+        do not need a second control channel. They are consumed here and never
+        enter SQLite projection storage.
+        """
+        if isinstance(msg, list):
+            telemetry: List[Any] = []
+            for item in msg:
+                control = parse_rank_finished(item)
+                if control is not None:
+                    self._finished_ranks[control.global_rank] = control
+                else:
+                    telemetry.append(item)
+            return [telemetry] if telemetry else []
+
+        control = parse_rank_finished(msg)
+        if control is not None:
+            self._finished_ranks[control.global_rank] = control
+            return []
+        return [msg]
+
+    def _settle_end_of_run_telemetry(
+        self, timeout_sec: float
+    ) -> Optional[dict[str, Any]]:
+        """
+        Drain late telemetry before final SQLite close.
+
+        The aggregator keeps TCP open during this phase because worker ranks can
+        finish at slightly different times on multi-node jobs. Finalization
+        proceeds once all expected ranks sent a rank-finished marker or the
+        caller's deadline expires.
+        """
+        deadline = time.monotonic() + max(0.0, float(timeout_sec))
+        quiet_sec = 0.5
+
+        while time.monotonic() < deadline:
+            self._drain_tcp()
+            if len(self._finished_ranks) >= self._expected_world_size:
+                remaining = max(0.0, deadline - time.monotonic())
+                if not self._tcp_server.wait_for_data(
+                    timeout=min(quiet_sec, remaining)
+                ):
+                    self._drain_tcp()
+                    return None
+                continue
+
+            remaining = max(0.0, deadline - time.monotonic())
+            if remaining <= 0.0:
+                break
+            self._tcp_server.wait_for_data(timeout=min(quiet_sec, remaining))
+
+        self._drain_tcp()
+        if len(self._finished_ranks) >= self._expected_world_size:
+            return None
+
+        missing = [
+            rank
+            for rank in range(self._expected_world_size)
+            if rank not in self._finished_ranks
+        ]
+        warning = {
+            "status": "warning",
+            "completed_at": utc_now_iso(),
+            "message": (
+                "Timed out waiting for all ranks to report finished before "
+                "end-of-run finalization."
+            ),
+            "expected_world_size": self._expected_world_size,
+            "finished_ranks": sorted(self._finished_ranks),
+            "missing_ranks": missing,
+        }
+        try:
+            self._logger.warning("[TraceML] %s", warning["message"])
+        except Exception:
+            pass
+        return warning
+
+    @staticmethod
+    def _write_finalization_artifact(
+        session_root: Path,
+        filename: str,
+        payload: dict[str, Any],
+    ) -> None:
+        """Write a finalization diagnostic artifact under ``aggregator/``."""
+        try:
+            path = Path(session_root).resolve() / "aggregator" / filename
+            write_json_atomic(path, payload)
+        except Exception:
+            pass
 
     def _settle_telemetry(self, timeout_sec: float) -> bool:
         """
@@ -253,10 +473,10 @@ class TraceMLAggregator:
                 timeout=min(quiet_sec, remaining)
             ):
                 self._drain_tcp()
-                return bool(self._sqlite_writer.flush_now(remaining))
+                return bool(self._sqlite_writer.force_flush(remaining))
 
         self._drain_tcp()
-        return bool(self._sqlite_writer.flush_now(0.0))
+        return bool(self._sqlite_writer.force_flush(0.0))
 
     def _loop(self) -> None:
         """

--- a/src/traceml_ai/config/yaml_loader.py
+++ b/src/traceml_ai/config/yaml_loader.py
@@ -20,6 +20,8 @@ import warnings
 from pathlib import Path
 from typing import Any, Mapping
 
+from traceml_ai.runtime.settings import DEFAULT_FINALIZE_TIMEOUT_SEC
+
 _log = logging.getLogger(__name__)
 
 CONFIG_FILENAME = "traceml.yaml"
@@ -35,6 +37,7 @@ YAML_KEY_SCHEMA: dict[str, tuple[str, type]] = {
     "enable_logging": ("TRACEML_ENABLE_LOGGING", bool),
     "logs_dir": ("TRACEML_LOGS_DIR", str),
     "history_enabled": ("TRACEML_HISTORY_ENABLED", bool),
+    "finalize_timeout_sec": ("TRACEML_FINALIZE_TIMEOUT_SEC", float),
     "dashboard_port": ("TRACEML_DASHBOARD_PORT", int),
     "dashboard_auto_open": ("TRACEML_DASHBOARD_AUTO_OPEN", bool),
 }
@@ -46,6 +49,7 @@ BUILT_IN_DEFAULTS: dict[str, Any] = {
     "enable_logging": False,
     "logs_dir": "./logs",
     "history_enabled": True,
+    "finalize_timeout_sec": DEFAULT_FINALIZE_TIMEOUT_SEC,
     "dashboard_port": 8765,
     "dashboard_auto_open": True,
 }

--- a/src/traceml_ai/launcher/cli.py
+++ b/src/traceml_ai/launcher/cli.py
@@ -18,6 +18,7 @@ from traceml_ai.launcher.commands import (
     validate_launch_args,
 )
 from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
+from traceml_ai.runtime.settings import DEFAULT_FINALIZE_TIMEOUT_SEC
 
 
 def _add_launch_args(parser: argparse.ArgumentParser) -> None:
@@ -108,6 +109,16 @@ def _add_launch_args(parser: argparse.ArgumentParser) -> None:
             "Rows used per node/rank for final summaries. SQLite retains "
             "1.5x this value for alignment. Default: "
             f"{DEFAULT_SUMMARY_WINDOW_ROWS}."
+        ),
+    )
+    parser.add_argument(
+        "--finalize-timeout-sec",
+        type=float,
+        default=None,
+        help=(
+            "Maximum seconds TraceML waits at end of run to settle telemetry, "
+            "flush SQLite, checkpoint WAL, and write final summary artifacts. "
+            f"Default: {DEFAULT_FINALIZE_TIMEOUT_SEC:g}."
         ),
     )
     parser.add_argument(

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -41,6 +41,7 @@ from traceml_ai.launcher.process import (
 from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
 from traceml_ai.runtime.launch_context import LaunchContext
 from traceml_ai.runtime.session import get_session_id
+from traceml_ai.runtime.settings import DEFAULT_FINALIZE_TIMEOUT_SEC
 from traceml_ai.utils.msgpack_codec import Decoder as MsgpackDecoder
 
 DASHBOARD_EXTRA_INSTALL_HINT = (
@@ -101,6 +102,11 @@ def validate_launch_args(args: argparse.Namespace) -> None:
         raise SystemExit(
             "[TraceML] ERROR: --summary-window-rows must be greater than 0."
         )
+    finalize_timeout_sec = getattr(args, "finalize_timeout_sec", None)
+    if finalize_timeout_sec is not None and float(finalize_timeout_sec) <= 0.0:
+        raise SystemExit(
+            "[TraceML] ERROR: --finalize-timeout-sec must be greater than 0."
+        )
     trace_max_steps = getattr(args, "trace_max_steps", None)
     if trace_max_steps is not None and int(trace_max_steps) <= 0:
         raise SystemExit(
@@ -156,6 +162,7 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
         "enable_logging": args.enable_logging,
         "logs_dir": args.logs_dir,
         "history_enabled": (False if args.no_history else None),
+        "finalize_timeout_sec": args.finalize_timeout_sec,
         "dashboard_port": args.dashboard_port,
         "dashboard_auto_open": (
             False if args.no_dashboard_auto_open else None
@@ -167,6 +174,9 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
         parent_env=launcher_env,
         yaml_config=yaml_cfg,
         defaults=BUILT_IN_DEFAULTS,
+    )
+    cfg["finalize_timeout_sec"] = float(
+        cfg.get("finalize_timeout_sec") or DEFAULT_FINALIZE_TIMEOUT_SEC
     )
 
     # Cross-field validation after all sources are merged.
@@ -217,12 +227,18 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
     env["TRACEML_SUMMARY_WINDOW_ROWS"] = str(
         int(getattr(args, "summary_window_rows", DEFAULT_SUMMARY_WINDOW_ROWS))
     )
+    env["TRACEML_FINALIZE_TIMEOUT_SEC"] = str(
+        float(cfg["finalize_timeout_sec"])
+    )
     trace_max_steps = getattr(args, "trace_max_steps", None)
     env["TRACEML_TRACE_MAX_STEPS"] = (
         "" if trace_max_steps is None else str(int(trace_max_steps))
     )
     env["TRACEML_NNODES"] = str(torchrun_cfg.nnodes)
     env["TRACEML_NPROC_PER_NODE"] = str(torchrun_cfg.nproc_per_node)
+    env["TRACEML_EXPECTED_WORLD_SIZE"] = str(
+        int(torchrun_cfg.nnodes) * int(torchrun_cfg.nproc_per_node)
+    )
     env["TRACEML_NODE_RANK"] = str(torchrun_cfg.node_rank)
     env["TRACEML_MASTER_ADDR"] = torchrun_cfg.master_addr
     env["TRACEML_MASTER_PORT"] = str(torchrun_cfg.master_port)
@@ -263,6 +279,7 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
         nproc_per_node=torchrun_cfg.nproc_per_node,
         history_enabled=cfg["history_enabled"],
         summary_window_rows=int(env["TRACEML_SUMMARY_WINDOW_ROWS"]),
+        finalize_timeout_sec=float(env["TRACEML_FINALIZE_TIMEOUT_SEC"]),
         status="starting",
         launch_cwd=execution_cwd,
         aggregator_dir=aggregator_dir,
@@ -385,7 +402,11 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
                     file=sys.stderr,
                 )
                 terminate_process_group(
-                    agg_proc, timeout_sec=DEFAULT_SHUTDOWN_TIMEOUT_SEC
+                    agg_proc,
+                    timeout_sec=(
+                        float(env["TRACEML_FINALIZE_TIMEOUT_SEC"])
+                        + DEFAULT_SHUTDOWN_TIMEOUT_SEC
+                    ),
                 )
 
             final_status = "completed" if train_rc == 0 else "failed"
@@ -396,6 +417,23 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
                     db_path, session_root=session_root
                 ),
             )
+            if (
+                train_rc == 0
+                and owns_aggregator
+                and cfg["mode"] == "summary"
+                and cfg["history_enabled"]
+                and not (session_root / "final_summary.json").is_file()
+            ):
+                print(
+                    "[TraceML] ERROR: training finished successfully, but "
+                    "TraceML did not produce final_summary.json.",
+                    file=sys.stderr,
+                )
+                update_run_manifest(manifest_path, status="failed")
+                raise SystemExit(1)
+            if agg_proc is not None and agg_proc.returncode not in (0, None):
+                if train_rc == 0:
+                    raise SystemExit(int(agg_proc.returncode))
             raise SystemExit(train_rc)
 
         if agg_proc is not None and agg_proc.poll() is not None:

--- a/src/traceml_ai/launcher/manifest.py
+++ b/src/traceml_ai/launcher/manifest.py
@@ -110,6 +110,7 @@ def write_run_manifest(
     nproc_per_node: int,
     history_enabled: bool,
     summary_window_rows: int,
+    finalize_timeout_sec: float,
     status: str,
     launch_cwd: str,
     run: Optional[Dict[str, Any]] = None,
@@ -151,6 +152,7 @@ def write_run_manifest(
             "master_port": int(master_port),
             "history_enabled": bool(history_enabled),
             "summary_window_rows": int(summary_window_rows),
+            "finalize_timeout_sec": float(finalize_timeout_sec),
             "launch_cwd": str(Path(launch_cwd).resolve()),
         },
         "paths": {
@@ -208,8 +210,10 @@ def collect_existing_artifacts(
     """Return only launcher artifacts that currently exist on disk."""
     candidates = {
         "db": db_path,
-        "summary_card_json": Path(str(db_path) + ".summary_card.json"),
-        "summary_card_txt": Path(str(db_path) + ".summary_card.txt"),
+        "summary_card_json": Path(str(db_path) + "_summary_card.json"),
+        "summary_card_txt": Path(str(db_path) + "_summary_card.txt"),
+        "legacy_summary_card_json": Path(str(db_path) + ".summary_card.json"),
+        "legacy_summary_card_txt": Path(str(db_path) + ".summary_card.txt"),
     }
     if session_root is not None:
         candidates["code_manifest"] = (

--- a/src/traceml_ai/runtime/executor.py
+++ b/src/traceml_ai/runtime/executor.py
@@ -23,6 +23,7 @@ from traceml_ai.runtime.lifecycle import NoOpRuntime
 from traceml_ai.runtime.lifecycle import start_runtime as start_runtime_handle
 from traceml_ai.runtime.runtime import TraceMLRuntime
 from traceml_ai.runtime.settings import (
+    DEFAULT_FINALIZE_TIMEOUT_SEC,
     AggregatorTransportSettings,
     TraceMLSettings,
 )
@@ -204,6 +205,15 @@ def read_traceml_env() -> Dict[str, Any]:
                 str(DEFAULT_SUMMARY_WINDOW_ROWS),
             )
         ),
+        "finalize_timeout_sec": float(
+            os.environ.get(
+                "TRACEML_FINALIZE_TIMEOUT_SEC",
+                str(DEFAULT_FINALIZE_TIMEOUT_SEC),
+            )
+        ),
+        "expected_world_size": int(
+            os.environ.get("TRACEML_EXPECTED_WORLD_SIZE", "1")
+        ),
         "trace_max_steps": _parse_optional_positive_int(
             os.environ.get("TRACEML_TRACE_MAX_STEPS")
         ),
@@ -244,6 +254,10 @@ def build_runtime_settings(cfg: Dict[str, Any]) -> TraceMLSettings:
         logs_dir=str(cfg["logs_dir"]),
         session_id=str(cfg["session_id"]),
         summary_window_rows=int(cfg["summary_window_rows"]),
+        finalize_timeout_sec=float(
+            cfg.get("finalize_timeout_sec", DEFAULT_FINALIZE_TIMEOUT_SEC)
+        ),
+        expected_world_size=int(cfg.get("expected_world_size", 1)),
         trace_max_steps=cfg.get("trace_max_steps"),
         aggregator=AggregatorTransportSettings(
             connect_host=str(cfg["aggregator_host"]),

--- a/src/traceml_ai/runtime/lifecycle.py
+++ b/src/traceml_ai/runtime/lifecycle.py
@@ -16,7 +16,11 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from traceml_ai.loggers.error_log import get_error_logger, setup_error_logger
 from traceml_ai.runtime.runtime import TraceMLRuntime
-from traceml_ai.runtime.settings import AggregatorEndpoint, TraceMLSettings
+from traceml_ai.runtime.settings import (
+    DEFAULT_FINALIZE_TIMEOUT_SEC,
+    AggregatorEndpoint,
+    TraceMLSettings,
+)
 
 if TYPE_CHECKING:
     from traceml_ai.aggregator.trace_aggregator import TraceMLAggregator
@@ -52,7 +56,7 @@ class AggregatorHandle:
             session_id=str(self.settings.session_id),
         )
 
-    def stop(self, timeout_sec: float = 5.0) -> None:
+    def stop(self, timeout_sec: float = DEFAULT_FINALIZE_TIMEOUT_SEC) -> None:
         """Stop the aggregator once, flushing history and final summary."""
         if self._stopped:
             return
@@ -104,6 +108,12 @@ def _apply_settings_env(
     )
     os.environ["TRACEML_SUMMARY_WINDOW_ROWS"] = str(
         settings.summary_window_rows
+    )
+    os.environ["TRACEML_FINALIZE_TIMEOUT_SEC"] = str(
+        settings.finalize_timeout_sec
+    )
+    os.environ["TRACEML_EXPECTED_WORLD_SIZE"] = str(
+        settings.expected_world_size
     )
 
 

--- a/src/traceml_ai/runtime/runtime.py
+++ b/src/traceml_ai/runtime/runtime.py
@@ -22,6 +22,7 @@ from traceml_ai.runtime.state import (
 )
 from traceml_ai.runtime.stdout_stderr_capture import StreamCapture
 from traceml_ai.samplers.base_sampler import BaseSampler
+from traceml_ai.telemetry.control import build_rank_finished_payload
 from traceml_ai.transport.tcp_transport import TCPClient, TCPConfig
 
 from .settings import TraceMLSettings
@@ -209,6 +210,7 @@ class TraceMLRuntime:
 
         - Signals the sampler thread to stop
         - Joins the sampler thread
+        - Sends a rank-finished control message for aggregator finalization
         - Closes TCP client
         - Restores stdout/stderr (CLI mode only)
         """
@@ -223,6 +225,16 @@ class TraceMLRuntime:
             self._logger.error(
                 "[TraceML] WARNING: sampler thread did not terminate"
             )
+
+        self._publisher.publish(self._samplers)
+        self._publisher.send_control(
+            build_rank_finished_payload(
+                global_rank=self.identity.global_rank,
+                world_size=self.identity.world_size,
+                node_rank=self.identity.node_rank,
+                hostname=self.identity.hostname,
+            )
+        )
 
         # close client last
         self._publisher.close()

--- a/src/traceml_ai/runtime/sender.py
+++ b/src/traceml_ai/runtime/sender.py
@@ -138,6 +138,13 @@ class TelemetryPublisher:
         except Exception as exc:
             self._log_exception("TCPClient.send_batch failed", exc)
 
+    def send_control(self, payload: Dict[str, Any]) -> None:
+        """Send one internal control payload best-effort."""
+        try:
+            self._tcp_client.send(payload)
+        except Exception as exc:
+            self._log_exception("TCPClient.send control failed", exc)
+
     def close(self) -> None:
         """Close the underlying TCP client best-effort."""
         try:

--- a/src/traceml_ai/runtime/settings.py
+++ b/src/traceml_ai/runtime/settings.py
@@ -20,6 +20,8 @@ from typing import Optional
 
 from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
 
+DEFAULT_FINALIZE_TIMEOUT_SEC = 300.0
+
 
 @dataclass(frozen=True)
 class AggregatorEndpoint:
@@ -76,3 +78,5 @@ class TraceMLSettings:
     summary_window_rows: int = DEFAULT_SUMMARY_WINDOW_ROWS
     trace_max_steps: Optional[int] = None
     html_report: bool = False
+    finalize_timeout_sec: float = DEFAULT_FINALIZE_TIMEOUT_SEC
+    expected_world_size: int = 1

--- a/src/traceml_ai/telemetry/control.py
+++ b/src/traceml_ai/telemetry/control.py
@@ -1,0 +1,81 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal telemetry control messages.
+
+Control messages travel over the same TCP transport as sampler telemetry, but
+they are not sampler payloads and are never written to SQLite projection tables.
+They let the aggregator distinguish "workers are still sending late telemetry"
+from "all expected ranks have finished, so end-of-run finalization can begin".
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+CONTROL_KIND_FIELD = "_traceml_control"
+RANK_FINISHED = "rank_finished"
+
+
+@dataclass(frozen=True)
+class RankFinishedControl:
+    """Marker sent once by a runtime rank after its final telemetry publish."""
+
+    global_rank: int
+    world_size: int
+    node_rank: int
+    hostname: str
+    timestamp: float
+
+
+def build_rank_finished_payload(
+    *,
+    global_rank: int,
+    world_size: int,
+    node_rank: int,
+    hostname: str,
+    timestamp: Optional[float] = None,
+) -> dict[str, Any]:
+    """Return the wire payload for one rank-finished control message."""
+    return {
+        CONTROL_KIND_FIELD: RANK_FINISHED,
+        "global_rank": int(global_rank),
+        "world_size": int(world_size),
+        "node_rank": int(node_rank),
+        "hostname": str(hostname),
+        "timestamp": float(time.time() if timestamp is None else timestamp),
+    }
+
+
+def parse_rank_finished(
+    payload: Any,
+) -> Optional[RankFinishedControl]:
+    """Parse a rank-finished control payload, returning ``None`` otherwise."""
+    if not isinstance(payload, Mapping):
+        return None
+    if payload.get(CONTROL_KIND_FIELD) != RANK_FINISHED:
+        return None
+    try:
+        return RankFinishedControl(
+            global_rank=int(payload["global_rank"]),
+            world_size=int(payload.get("world_size", 1)),
+            node_rank=int(payload.get("node_rank", 0)),
+            hostname=str(payload.get("hostname", "")),
+            timestamp=float(payload.get("timestamp", 0.0)),
+        )
+    except Exception:
+        return None
+
+
+__all__ = [
+    "CONTROL_KIND_FIELD",
+    "RANK_FINISHED",
+    "RankFinishedControl",
+    "build_rank_finished_payload",
+    "parse_rank_finished",
+]

--- a/tests/aggregator/test_finalization.py
+++ b/tests/aggregator/test_finalization.py
@@ -1,0 +1,313 @@
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from traceml_ai.aggregator import aggregator_main, trace_aggregator
+from traceml_ai.aggregator.sqlite_writer import SQLiteFinalizeResult
+from traceml_ai.aggregator.trace_aggregator import (
+    TraceMLAggregator,
+    TraceMLFinalizationError,
+)
+from traceml_ai.runtime.settings import TraceMLSettings
+from traceml_ai.sdk.protocol import get_final_summary_json_path
+from traceml_ai.telemetry.control import build_rank_finished_payload
+
+
+class _Logger:
+    def error(self, *args, **kwargs):
+        return None
+
+    def warning(self, *args, **kwargs):
+        return None
+
+    def exception(self, *args, **kwargs):
+        return None
+
+
+class _StoppedThread:
+    def is_alive(self):
+        return False
+
+    def join(self, timeout=None):
+        return None
+
+
+class _Display:
+    def stop(self):
+        return None
+
+
+class _TCP:
+    def __init__(self, messages=None):
+        self._messages = list(messages or [])
+        self.stopped = False
+
+    def poll(self):
+        while self._messages:
+            yield self._messages.pop(0)
+
+    def wait_for_data(self, timeout):
+        return False
+
+    def stop(self):
+        self.stopped = True
+
+
+class _Writer:
+    def __init__(self, result):
+        self.result = result
+        self.ingested = []
+        self.finalize_timeouts = []
+
+    def ingest(self, payload):
+        self.ingested.append(payload)
+
+    def finalize(self, timeout_sec):
+        self.finalize_timeouts.append(timeout_sec)
+        return self.result
+
+    def stats(self):
+        return {"queue_size": 0, "last_error": None}
+
+
+def _ok_result():
+    return SQLiteFinalizeResult(
+        ok=True,
+        elapsed_sec=0.0,
+        enqueued=1,
+        written=1,
+        dropped=0,
+        queue_size=0,
+        checkpoint_ok=True,
+        error=None,
+    )
+
+
+def _make_aggregator(tmp_path: Path, *, writer: _Writer, tcp: _TCP):
+    agg = TraceMLAggregator.__new__(TraceMLAggregator)
+    agg._logger = _Logger()
+    agg._stop_event = threading.Event()
+    agg._settings = TraceMLSettings(
+        mode="summary",
+        logs_dir=str(tmp_path),
+        session_id="run",
+        history_enabled=True,
+        db_path=str(tmp_path / "run" / "aggregator" / "telemetry"),
+        expected_world_size=2,
+    )
+    agg._started = True
+    agg._expected_world_size = 2
+    agg._finished_ranks = {}
+    agg._drain_lock = threading.Lock()
+    agg._thread = _StoppedThread()
+    agg._display_driver = _Display()
+    agg._tcp_server = tcp
+    agg._sqlite_writer = writer
+    return agg
+
+
+def _write_fake_summary(tmp_path: Path):
+    path = get_final_summary_json_path(tmp_path / "run")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"schema_version": "test"}),
+        encoding="utf-8",
+    )
+
+
+def test_split_telemetry_payloads_consumes_rank_finished_control(tmp_path):
+    writer = _Writer(_ok_result())
+    control = build_rank_finished_payload(
+        global_rank=1,
+        world_size=2,
+        node_rank=0,
+        hostname="worker",
+    )
+    agg = _make_aggregator(
+        tmp_path,
+        writer=writer,
+        tcp=_TCP(),
+    )
+
+    payloads = agg._split_telemetry_payloads(
+        [{"sampler": "SystemSampler"}, control]
+    )
+
+    assert payloads == [[{"sampler": "SystemSampler"}]]
+    assert sorted(agg._finished_ranks) == [1]
+
+
+def test_stop_writes_warning_when_rank_finished_markers_are_missing(
+    monkeypatch,
+    tmp_path,
+):
+    writer = _Writer(_ok_result())
+    control = build_rank_finished_payload(
+        global_rank=0,
+        world_size=2,
+        node_rank=0,
+        hostname="worker",
+    )
+    agg = _make_aggregator(
+        tmp_path,
+        writer=writer,
+        tcp=_TCP(messages=[control]),
+    )
+
+    monkeypatch.setattr(
+        trace_aggregator,
+        "generate_summary",
+        lambda *args, **kwargs: _write_fake_summary(tmp_path),
+    )
+
+    agg.stop(timeout_sec=0.01)
+
+    warning_path = (
+        tmp_path / "run" / "aggregator" / "finalization_warning.json"
+    )
+    warning = json.loads(warning_path.read_text(encoding="utf-8"))
+    assert warning["status"] == "warning"
+    assert warning["finished_ranks"] == [0]
+    assert warning["missing_ranks"] == [1]
+
+
+def test_stop_writes_error_and_raises_when_sqlite_finalize_fails(tmp_path):
+    writer = _Writer(
+        SQLiteFinalizeResult(
+            ok=False,
+            elapsed_sec=0.0,
+            enqueued=1,
+            written=0,
+            dropped=0,
+            queue_size=1,
+            checkpoint_ok=False,
+            error="boom",
+        )
+    )
+    control_messages = [
+        build_rank_finished_payload(
+            global_rank=rank,
+            world_size=2,
+            node_rank=0,
+            hostname="worker",
+        )
+        for rank in (0, 1)
+    ]
+    agg = _make_aggregator(
+        tmp_path,
+        writer=writer,
+        tcp=_TCP(messages=control_messages),
+    )
+
+    with pytest.raises(TraceMLFinalizationError):
+        agg.stop(timeout_sec=0.1)
+
+    error_path = tmp_path / "run" / "aggregator" / "finalization_error.json"
+    error = json.loads(error_path.read_text(encoding="utf-8"))
+    assert error["status"] == "error"
+    assert "SQLite history did not finalize" in error["error"]
+
+
+def test_stop_reserves_positive_sqlite_finalize_budget_when_ranks_missing(
+    monkeypatch,
+    tmp_path,
+):
+    class _SlowTCP(_TCP):
+        def wait_for_data(self, timeout):
+            time.sleep(float(timeout))
+            return False
+
+    writer = _Writer(_ok_result())
+    agg = _make_aggregator(
+        tmp_path,
+        writer=writer,
+        tcp=_SlowTCP(
+            messages=[
+                build_rank_finished_payload(
+                    global_rank=0,
+                    world_size=2,
+                    node_rank=0,
+                    hostname="worker",
+                )
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        trace_aggregator,
+        "generate_summary",
+        lambda *args, **kwargs: _write_fake_summary(tmp_path),
+    )
+
+    agg.stop(timeout_sec=0.02)
+
+    assert writer.finalize_timeouts
+    assert writer.finalize_timeouts[-1] > 0.0
+
+
+def test_drain_tcp_is_serialized(tmp_path):
+    class _ConcurrentDetectTCP:
+        def __init__(self):
+            self._lock = threading.Lock()
+            self._active = 0
+            self.max_active = 0
+
+        def poll(self):
+            with self._lock:
+                self._active += 1
+                self.max_active = max(self.max_active, self._active)
+            try:
+                time.sleep(0.02)
+                yield {"sampler": "UnknownSampler"}
+            finally:
+                with self._lock:
+                    self._active -= 1
+
+    writer = _Writer(_ok_result())
+    tcp = _ConcurrentDetectTCP()
+    agg = _make_aggregator(tmp_path, writer=writer, tcp=tcp)
+
+    threads = [
+        threading.Thread(target=agg._drain_tcp),
+        threading.Thread(target=agg._drain_tcp),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert tcp.max_active == 1
+
+
+def test_aggregator_main_does_not_swallow_keyboard_interrupt_during_stop(
+    monkeypatch,
+    tmp_path,
+):
+    class _Handle:
+        def stop(self, timeout_sec):
+            raise KeyboardInterrupt()
+
+    def fake_start_aggregator(settings, logger, stop_event):
+        stop_event.set()
+        return _Handle()
+
+    monkeypatch.setenv("TRACEML_LOGS_DIR", str(tmp_path))
+    monkeypatch.setenv("TRACEML_SESSION_ID", "run")
+    monkeypatch.setenv("TRACEML_UI_MODE", "summary")
+    monkeypatch.setenv("TRACEML_FINALIZE_TIMEOUT_SEC", "1")
+    monkeypatch.setattr(
+        aggregator_main, "setup_error_logger", lambda **kwargs: None
+    )
+    monkeypatch.setattr(
+        aggregator_main, "_install_signal_handlers", lambda event: None
+    )
+    monkeypatch.setattr(
+        aggregator_main,
+        "start_aggregator",
+        fake_start_aggregator,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        aggregator_main.main()

--- a/tests/aggregator/test_finalization.py
+++ b/tests/aggregator/test_finalization.py
@@ -311,3 +311,151 @@ def test_aggregator_main_does_not_swallow_keyboard_interrupt_during_stop(
 
     with pytest.raises(KeyboardInterrupt):
         aggregator_main.main()
+
+
+def _sys_payload(global_rank: int = 5) -> dict:
+    return {
+        "global_rank": global_rank,
+        "local_rank": 0,
+        "world_size": 2,
+        "local_world_size": 1,
+        "node_rank": global_rank,
+        "hostname": f"worker-{global_rank}",
+        "sampler": "SystemSampler",
+        "timestamp": 123.0,
+        "tables": {
+            "SystemTable": [
+                {
+                    "seq": 1,
+                    "ts": 123.0,
+                    "cpu": 42.0,
+                    "ram_used": 4_000.0,
+                    "ram_total": 16_000.0,
+                    "gpu_available": False,
+                    "gpu_count": 0,
+                    "gpus": [],
+                }
+            ]
+        },
+    }
+
+
+def test_sqlite_finalize_budget_clamp_regimes() -> None:
+    budget = TraceMLAggregator._sqlite_finalize_budget
+    assert budget(0.0) == 0.0
+    assert budget(-5.0) == 0.0
+    # total < MIN (5s): a fraction of total, floored at the tiny floor.
+    assert budget(4.0) == pytest.approx(1.0)
+    assert budget(2.0) == pytest.approx(0.5)
+    # total >= MIN: 25% clamped into [5, 60].
+    assert budget(16.0) == pytest.approx(5.0)  # 4.0 -> clamped up to MIN
+    assert budget(40.0) == pytest.approx(10.0)  # 25% lands in-range
+    assert budget(400.0) == pytest.approx(60.0)  # clamped down to MAX
+
+
+def test_split_telemetry_payloads_duplicate_rank_is_idempotent(tmp_path):
+    agg = _make_aggregator(tmp_path, writer=_Writer(_ok_result()), tcp=_TCP())
+    marker = build_rank_finished_payload(
+        global_rank=0, world_size=2, node_rank=0, hostname="worker"
+    )
+    agg._split_telemetry_payloads([marker, marker])
+    agg._split_telemetry_payloads(marker)
+    assert agg._finished_ranks_snapshot() == [0]
+
+
+def test_stop_writes_no_warning_when_all_ranks_finished(monkeypatch, tmp_path):
+    control_messages = [
+        build_rank_finished_payload(
+            global_rank=rank, world_size=2, node_rank=0, hostname="worker"
+        )
+        for rank in (0, 1)
+    ]
+    agg = _make_aggregator(
+        tmp_path,
+        writer=_Writer(_ok_result()),
+        tcp=_TCP(messages=control_messages),
+    )
+    monkeypatch.setattr(
+        trace_aggregator,
+        "generate_summary",
+        lambda *args, **kwargs: _write_fake_summary(tmp_path),
+    )
+
+    agg.stop(timeout_sec=0.5)
+
+    agg_dir = tmp_path / "run" / "aggregator"
+    assert not (agg_dir / "finalization_warning.json").exists()
+    assert not (agg_dir / "finalization_error.json").exists()
+    assert get_final_summary_json_path(tmp_path / "run").is_file()
+
+
+def test_stop_downgrades_post_write_summary_error_to_warning(
+    monkeypatch,
+    tmp_path,
+):
+    control_messages = [
+        build_rank_finished_payload(
+            global_rank=rank, world_size=2, node_rank=0, hostname="worker"
+        )
+        for rank in (0, 1)
+    ]
+    agg = _make_aggregator(
+        tmp_path,
+        writer=_Writer(_ok_result()),
+        tcp=_TCP(messages=control_messages),
+    )
+
+    def _summary_then_raise(*args, **kwargs):
+        _write_fake_summary(tmp_path)
+        raise RuntimeError("post-write render boom")
+
+    monkeypatch.setattr(
+        trace_aggregator, "generate_summary", _summary_then_raise
+    )
+
+    # The artifact is written before the raise, so stop() must NOT fail.
+    agg.stop(timeout_sec=0.5)
+
+    agg_dir = tmp_path / "run" / "aggregator"
+    assert get_final_summary_json_path(tmp_path / "run").is_file()
+    assert not (agg_dir / "finalization_error.json").exists()
+    warning = json.loads(
+        (agg_dir / "finalization_warning.json").read_text(encoding="utf-8")
+    )
+    assert "post-write render boom" in warning["generate_summary_error"]
+
+
+def test_stop_generates_summary_through_real_writer(tmp_path):
+    from traceml_ai.aggregator.sqlite_writer import (
+        SQLiteWriterConfig,
+        SQLiteWriterSimple,
+    )
+
+    db_path = tmp_path / "run" / "aggregator" / "telemetry"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    writer = SQLiteWriterSimple(
+        SQLiteWriterConfig(path=str(db_path), flush_interval_sec=0.01)
+    )
+    writer.start()
+    for _ in range(3):
+        writer.ingest(_sys_payload())
+    control_messages = [
+        build_rank_finished_payload(
+            global_rank=rank, world_size=2, node_rank=0, hostname="worker"
+        )
+        for rank in (0, 1)
+    ]
+    agg = _make_aggregator(
+        tmp_path, writer=writer, tcp=_TCP(messages=control_messages)
+    )
+
+    # Real finalize + real generate_summary (NOT monkeypatched): the literal
+    # inverse of #164 -- finalize cleanly, then the summary must appear.
+    agg.stop(timeout_sec=10.0)
+
+    assert get_final_summary_json_path(tmp_path / "run").is_file()
+    assert not Path(str(db_path) + "-wal").exists()
+    assert not Path(str(db_path) + "-shm").exists()
+    assert not (
+        tmp_path / "run" / "aggregator" / "finalization_error.json"
+    ).exists()

--- a/tests/config/test_yaml_loader.py
+++ b/tests/config/test_yaml_loader.py
@@ -73,6 +73,7 @@ def test_load_yaml_config_valid(tmp_path: Path) -> None:
         interval: 3.0
         logs_dir: ./runs
         history_enabled: true
+        finalize_timeout_sec: 120
         enable_logging: false
         """,
     )
@@ -81,6 +82,7 @@ def test_load_yaml_config_valid(tmp_path: Path) -> None:
     assert result["interval"] == 3.0
     assert result["logs_dir"] == "./runs"
     assert result["history_enabled"] is True
+    assert result["finalize_timeout_sec"] == 120.0
     assert result["enable_logging"] is False
 
 
@@ -211,9 +213,13 @@ def test_resolve_config_env_bool_coercion() -> None:
 
 def test_resolve_config_env_float_coercion() -> None:
     cli = _no_cli()
-    env = {"TRACEML_INTERVAL": "0.5"}
+    env = {
+        "TRACEML_INTERVAL": "0.5",
+        "TRACEML_FINALIZE_TIMEOUT_SEC": "42.5",
+    }
     result = resolve_config(cli, env, _no_yaml(), _defaults())
     assert result["interval"] == 0.5
+    assert result["finalize_timeout_sec"] == 42.5
 
 
 def test_resolve_config_history_disabled_via_cli() -> None:

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -37,6 +37,7 @@ from traceml_ai.runtime.executor import (
     run_user_script,
     write_user_error_log,
 )
+from traceml_ai.runtime.settings import DEFAULT_FINALIZE_TIMEOUT_SEC
 
 
 def test_extract_script_args_uses_separator_when_present(monkeypatch):
@@ -132,10 +133,14 @@ def test_run_user_script_restores_sys_argv_and_sys_path(tmp_path, monkeypatch):
 def test_read_traceml_env_parses_trace_max_steps(monkeypatch):
     monkeypatch.setenv("TRACEML_SCRIPT_PATH", "train.py")
     monkeypatch.setenv("TRACEML_TRACE_MAX_STEPS", "123")
+    monkeypatch.setenv("TRACEML_FINALIZE_TIMEOUT_SEC", "42.5")
+    monkeypatch.setenv("TRACEML_EXPECTED_WORLD_SIZE", "8")
 
     cfg = read_traceml_env()
 
     assert cfg["trace_max_steps"] == 123
+    assert cfg["finalize_timeout_sec"] == 42.5
+    assert cfg["expected_world_size"] == 8
 
 
 def test_build_runtime_settings_carries_trace_max_steps():
@@ -156,6 +161,8 @@ def test_build_runtime_settings_carries_trace_max_steps():
     )
 
     assert settings.trace_max_steps == 5
+    assert settings.finalize_timeout_sec == DEFAULT_FINALIZE_TIMEOUT_SEC
+    assert settings.expected_world_size == 1
 
 
 def test_write_user_error_log_records_error(tmp_path):

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -28,6 +28,7 @@ from traceml_ai.launcher.launch_config import (
     RunIdentity,
 )
 from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
+from traceml_ai.runtime.settings import DEFAULT_FINALIZE_TIMEOUT_SEC
 
 
 def test_build_parser_preserves_launch_commands() -> None:
@@ -56,6 +57,7 @@ def test_build_parser_preserves_launch_commands() -> None:
     assert args.run_name == ""
     assert args.session_id == ""
     assert args.summary_window_rows == DEFAULT_SUMMARY_WINDOW_ROWS
+    assert args.finalize_timeout_sec is None
     assert args.trace_max_steps is None
     assert args.args == ["--epochs", "1"]
 
@@ -100,6 +102,8 @@ def test_build_parser_accepts_multinode_launch_args() -> None:
             "29888",
             "--summary-window-rows",
             "2048",
+            "--finalize-timeout-sec",
+            "120",
             "--run-name",
             "multi_node_run",
         ]
@@ -114,6 +118,7 @@ def test_build_parser_accepts_multinode_launch_args() -> None:
     assert args.aggregator_bind_host == "0.0.0.0"
     assert args.aggregator_port == 29888
     assert args.summary_window_rows == 2048
+    assert args.finalize_timeout_sec == 120.0
     assert args.run_name == "multi_node_run"
 
 
@@ -296,6 +301,7 @@ def test_run_manifest_write_and_update_are_atomic(tmp_path) -> None:
         nproc_per_node=1,
         history_enabled=True,
         summary_window_rows=DEFAULT_SUMMARY_WINDOW_ROWS,
+        finalize_timeout_sec=DEFAULT_FINALIZE_TIMEOUT_SEC,
         status="starting",
         launch_cwd=str(tmp_path),
     )
@@ -317,6 +323,10 @@ def test_run_manifest_write_and_update_are_atomic(tmp_path) -> None:
     assert (
         payload["launch"]["summary_window_rows"] == DEFAULT_SUMMARY_WINDOW_ROWS
     )
+    assert (
+        payload["launch"]["finalize_timeout_sec"]
+        == DEFAULT_FINALIZE_TIMEOUT_SEC
+    )
     assert payload["paths"]["run_root"] == str(session_root.resolve())
     assert payload["artifacts"]["summary_card_json"] == "summary.json"
 
@@ -333,7 +343,7 @@ def test_collect_existing_artifacts_only_returns_existing_files(
     tmp_path,
 ) -> None:
     db_path = tmp_path / "telemetry"
-    summary_path = Path(str(db_path) + ".summary_card.txt")
+    summary_path = Path(str(db_path) + "_summary_card.txt")
     db_path.write_text("", encoding="utf-8")
     summary_path.write_text("summary", encoding="utf-8")
 

--- a/tests/telemetry/test_system_projection_identity.py
+++ b/tests/telemetry/test_system_projection_identity.py
@@ -300,3 +300,50 @@ def test_sqlite_writer_checkpoint_failure_is_fatal(tmp_path) -> None:
     assert not result.checkpoint_ok
     assert result.prune_ok
     assert "checkpoint boom" in str(result.error)
+
+
+def _system_payload_rank(global_rank: int) -> dict:
+    payload = _system_payload()
+    payload["global_rank"] = global_rank
+    payload["hostname"] = f"worker-{global_rank}"
+    return payload
+
+
+def test_sqlite_writer_finalize_drains_multi_rank_backlog(tmp_path) -> None:
+    # #164 was a MULTI-rank failure; the single-rank drain test above does not
+    # exercise interleaved per-rank backlog surviving the terminal drain.
+    db_path = tmp_path / "telemetry.db"
+    writer = SQLiteWriterSimple(
+        SQLiteWriterConfig(
+            path=str(db_path),
+            flush_interval_sec=60.0,
+            max_flush_items=1,
+        )
+    )
+    writer.start()
+    try:
+        for rank in (0, 1, 2, 3):
+            for _ in range(2):
+                writer.ingest(_system_payload_rank(rank))
+        result = writer.finalize(timeout_sec=2.0)
+    finally:
+        writer.finalize(timeout_sec=2.0)
+
+    assert result.ok
+    assert result.checkpoint_ok
+    assert result.queue_size == 0
+
+    conn = sqlite3.connect(db_path)
+    try:
+        per_rank = dict(
+            conn.execute(
+                "SELECT global_rank, COUNT(*) FROM system_samples "
+                "GROUP BY global_rank;"
+            ).fetchall()
+        )
+    finally:
+        conn.close()
+
+    assert per_rank == {0: 2, 1: 2, 2: 2, 3: 2}
+    assert not db_path.with_name(db_path.name + "-wal").exists()
+    assert not db_path.with_name(db_path.name + "-shm").exists()

--- a/tests/telemetry/test_system_projection_identity.py
+++ b/tests/telemetry/test_system_projection_identity.py
@@ -14,7 +14,6 @@ from traceml_ai.aggregator.sqlite_writer import (
 )
 from traceml_ai.aggregator.sqlite_writers import system as system_projection
 from traceml_ai.telemetry.envelope import normalize_telemetry_envelope
-from traceml_ai.utils.msgpack_codec import Decoder as MsgpackDecoder
 
 
 def _system_payload() -> dict:
@@ -72,28 +71,88 @@ def test_system_projection_stores_global_and_local_rank_identity() -> None:
     assert gpu_sample == (5, 1, 8, 4, 1, "worker-1", 0)
 
 
-def test_sqlite_writer_persists_canonical_raw_envelope(tmp_path) -> None:
+def _sqlite_table_names(conn: sqlite3.Connection) -> set[str]:
+    return {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table';"
+        )
+    }
+
+
+def _write_payload_through_sqlite_writer(db_path) -> None:
+    writer = SQLiteWriterSimple(
+        SQLiteWriterConfig(path=str(db_path), flush_interval_sec=0.01)
+    )
+    writer.start()
+    try:
+        writer.ingest(_system_payload())
+        assert writer.flush_now(timeout_sec=2.0)
+    finally:
+        writer.stop()
+
+
+def test_sqlite_writer_persists_projection_without_raw_table(tmp_path) -> None:
     db_path = tmp_path / "telemetry.db"
-    writer = SQLiteWriterSimple(SQLiteWriterConfig(path=str(db_path)))
+    _write_payload_through_sqlite_writer(db_path)
 
     conn = sqlite3.connect(db_path)
     try:
-        writer._init_schema(conn)
-        system_projection.init_schema(conn)
+        assert "raw_messages" not in _sqlite_table_names(conn)
+        sample = conn.execute(
+            """
+            SELECT global_rank, local_rank, world_size, local_world_size,
+                   node_rank, hostname, seq
+            FROM system_samples;
+            """
+        ).fetchone()
+        gpu_sample = conn.execute(
+            """
+            SELECT global_rank, local_rank, world_size, local_world_size,
+                   node_rank, hostname, gpu_idx
+            FROM system_gpu_samples;
+            """
+        ).fetchone()
+    finally:
+        conn.close()
 
-        raw_rows, projection_rows = writer._collect_flush_rows(
-            [_system_payload()]
+    assert sample == (5, 1, 8, 4, 1, "worker-1", 7)
+    assert gpu_sample == (5, 1, 8, 4, 1, "worker-1", 0)
+
+
+def test_sqlite_writer_leaves_existing_raw_table_untouched(tmp_path) -> None:
+    db_path = tmp_path / "telemetry.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE raw_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                payload_mp BLOB NOT NULL
+            );
+            """
         )
-        writer._write_flush_rows(conn, raw_rows, projection_rows)
+        conn.execute(
+            "INSERT INTO raw_messages(payload_mp) VALUES (?);",
+            (b"old-raw-payload",),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
-        payload_mp = conn.execute(
-            "SELECT payload_mp FROM raw_messages;"
+    _write_payload_through_sqlite_writer(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        assert "raw_messages" in _sqlite_table_names(conn)
+        raw_count = conn.execute(
+            "SELECT COUNT(*) FROM raw_messages;"
+        ).fetchone()[0]
+        projected_count = conn.execute(
+            "SELECT COUNT(*) FROM system_samples;"
         ).fetchone()[0]
     finally:
         conn.close()
 
-    payload = MsgpackDecoder().decode(payload_mp)
-    assert set(payload) == {"meta", "body"}
-    assert payload["meta"]["sampler"] == "SystemSampler"
-    assert payload["meta"]["global_rank"] == 5
-    assert payload["body"]["tables"]["SystemTable"][0]["seq"] == 7
+    assert raw_count == 1
+    assert projected_count == 1

--- a/tests/telemetry/test_system_projection_identity.py
+++ b/tests/telemetry/test_system_projection_identity.py
@@ -87,9 +87,9 @@ def _write_payload_through_sqlite_writer(db_path) -> None:
     writer.start()
     try:
         writer.ingest(_system_payload())
-        assert writer.flush_now(timeout_sec=2.0)
+        assert writer.force_flush(timeout_sec=2.0)
     finally:
-        writer.stop()
+        writer.finalize(timeout_sec=2.0)
 
 
 def test_sqlite_writer_persists_projection_without_raw_table(tmp_path) -> None:
@@ -156,3 +156,147 @@ def test_sqlite_writer_leaves_existing_raw_table_untouched(tmp_path) -> None:
 
     assert raw_count == 1
     assert projected_count == 1
+
+
+def test_sqlite_writer_finalize_drains_multiple_batches(tmp_path) -> None:
+    db_path = tmp_path / "telemetry.db"
+    writer = SQLiteWriterSimple(
+        SQLiteWriterConfig(
+            path=str(db_path),
+            flush_interval_sec=60.0,
+            max_flush_items=1,
+        )
+    )
+    writer.start()
+    try:
+        for _ in range(3):
+            writer.ingest(_system_payload())
+        result = writer.finalize(timeout_sec=2.0)
+    finally:
+        writer.finalize(timeout_sec=2.0)
+
+    assert result.ok
+    assert result.checkpoint_ok
+    assert result.queue_size == 0
+
+    conn = sqlite3.connect(db_path)
+    try:
+        projected_count = conn.execute(
+            "SELECT COUNT(*) FROM system_samples;"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert projected_count == 3
+    assert not db_path.with_name(db_path.name + "-wal").exists()
+    assert not db_path.with_name(db_path.name + "-shm").exists()
+
+
+def test_sqlite_writer_force_flush_keeps_writer_open(tmp_path) -> None:
+    db_path = tmp_path / "telemetry.db"
+    writer = SQLiteWriterSimple(
+        SQLiteWriterConfig(path=str(db_path), flush_interval_sec=60.0)
+    )
+    writer.start()
+    try:
+        writer.ingest(_system_payload())
+        assert writer.force_flush(timeout_sec=2.0)
+        assert not writer.stats()["last_error"]
+        writer.ingest(_system_payload())
+        result = writer.finalize(timeout_sec=2.0)
+    finally:
+        writer.finalize(timeout_sec=2.0)
+
+    assert result.ok
+
+    conn = sqlite3.connect(db_path)
+    try:
+        projected_count = conn.execute(
+            "SELECT COUNT(*) FROM system_samples;"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert projected_count == 2
+
+
+def test_sqlite_writer_finalize_timeout_reports_failure(monkeypatch, tmp_path):
+    db_path = tmp_path / "telemetry.db"
+    writer = SQLiteWriterSimple(SQLiteWriterConfig(path=str(db_path)))
+    writer._started = True
+    monkeypatch.setattr(writer._closed, "wait", lambda timeout: False)
+
+    result = writer.finalize(timeout_sec=0.01)
+
+    assert not result.ok
+    assert not result.checkpoint_ok
+    assert "Timed out" in str(result.error)
+
+
+def test_sqlite_writer_final_prune_failure_is_nonfatal(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "telemetry.db"
+    writer = SQLiteWriterSimple(
+        SQLiteWriterConfig(path=str(db_path), flush_interval_sec=60.0)
+    )
+    monkeypatch.setattr(
+        writer,
+        "_prune_all_retained_rows",
+        lambda conn: (_ for _ in ()).throw(RuntimeError("prune boom")),
+    )
+    writer.start()
+    try:
+        writer.ingest(_system_payload())
+        result = writer.finalize(timeout_sec=2.0)
+    finally:
+        writer.finalize(timeout_sec=2.0)
+
+    assert result.ok
+    assert result.checkpoint_ok
+    assert not result.prune_ok
+    assert "prune boom" in str(result.prune_error)
+    assert result.error is None
+    assert result.checkpoint_error is None
+
+
+def test_sqlite_writer_finalize_preserves_prune_and_checkpoint_errors(
+    tmp_path,
+) -> None:
+    writer = SQLiteWriterSimple(
+        SQLiteWriterConfig(path=str(tmp_path / "telemetry.db"))
+    )
+
+    result = writer._build_finalize_result(
+        elapsed_sec=1.0,
+        checkpoint_ok=False,
+        error="SQLite checkpoint/close failed: checkpoint boom",
+        prune_error="Final SQLite retention prune failed: prune boom",
+        checkpoint_error="SQLite checkpoint/close failed: checkpoint boom",
+    )
+
+    assert not result.ok
+    assert not result.checkpoint_ok
+    assert not result.prune_ok
+    assert "checkpoint boom" in str(result.error)
+    assert "checkpoint boom" in str(result.checkpoint_error)
+    assert "prune boom" in str(result.prune_error)
+
+
+def test_sqlite_writer_checkpoint_failure_is_fatal(tmp_path) -> None:
+    writer = SQLiteWriterSimple(
+        SQLiteWriterConfig(path=str(tmp_path / "telemetry.db"))
+    )
+
+    result = writer._build_finalize_result(
+        elapsed_sec=1.0,
+        checkpoint_ok=False,
+        error=None,
+        checkpoint_error="SQLite checkpoint/close failed: checkpoint boom",
+    )
+
+    assert not result.ok
+    assert not result.checkpoint_ok
+    assert result.prune_ok
+    assert "checkpoint boom" in str(result.error)


### PR DESCRIPTION
## What changed

Made TraceML history storage projection-only and made summary-mode shutdown
deterministic for large/multi-rank runs.

- Fresh SQLite history DBs no longer create or append `raw_messages` /
  `payload_mp` raw telemetry blobs.
- SQLite history now stores only structured projection tables used by live CLI,
  dashboard, final summary, HTML reports, and compare.
- Aggregator shutdown now settles late rank telemetry, finalizes SQLite,
  checkpoints/closes WAL, then generates final summary artifacts.
- Added `rank_finished` control messages so the aggregator can distinguish
  late telemetry from completed ranks without storing control payloads.
- Added `--finalize-timeout-sec`, `TRACEML_FINALIZE_TIMEOUT_SEC`, and
  `traceml.yaml: finalize_timeout_sec`.
- Summary mode now fails clearly if TraceML cannot finalize SQLite or produce
  `final_summary.json`.
- Final retention pruning is best-effort; checkpoint/close failure remains
  fatal for summary mode.

## Why

Long multi-rank runs could finish training successfully but lose
`final_summary.json`, `final_summary.txt`, and summary-card artifacts because
the SQLite writer had only a fixed short shutdown join. Large telemetry
backlogs could leave the writer thread alive and WAL sidecars uncheckpointed.

Raw telemetry blobs were also being stored in SQLite even though normal product
paths read projection tables, increasing shutdown pressure without helping
live UI, dashboard, final summary, HTML, or compare.

## How I tested

- [x] Tests added or updated
- [x] Existing tests run
- [x] Manual smoke test
- [ ] Not run; reason:

Targeted suites:

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/aggregator tests/telemetry tests/runtime tests/config -q
```

Result:

```text
151 passed
```

Full suite:

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider tests -q
```

Result:

```text
507 passed, 8 skipped
```

Manual summary smoke:

```bash
PYTHONPATH=src python -c 'from traceml_ai.launcher.cli import main; main()' \
  run examples/summary_logging_minimal.py \
  --mode=summary \
  --logs-dir /tmp/traceml-finalize-smoke-prod \
  --run-name finalize_smoke_prod \
  --finalize-timeout-sec 30 \
  --args --steps 1
```

Smoke checks confirmed:

```text
final_summary.json: present
final_summary.txt: present
aggregator/telemetry_summary_card.json: present
SQLite -wal sidecar: absent
SQLite -shm sidecar: absent
raw_messages table: absent
residual_ms: present
wait_ms: absent
```

Also ran:

```bash
git diff --check
```

Result: clean.

## Runtime impact

- [x] No training-path impact
- [x] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes:

This changes TraceML storage and aggregator finalization behavior, not the user
training loop. Runtime now sends one best-effort `rank_finished` control message
on shutdown after its final telemetry publish. Aggregator shutdown may wait up
to `finalize_timeout_sec` to settle late telemetry and close SQLite cleanly.

`history_enabled=false` still disables SQLite history and summary generation.
`enable_logging=false` still only controls the separate local msgpack logging
path.

Existing DBs are not migrated or dropped. Old `raw_messages` tables can remain
in reused DBs, but new runs do not append raw blob rows.

## Docs

- [x] Updated
- [ ] Not needed

Updated docs mention `--finalize-timeout-sec` / `TRACEML_FINALIZE_TIMEOUT_SEC`
and explain that larger multi-node runs may need a larger finalization budget
on slow filesystems or congested networks.

Touched docs include:

- `README.md`
- `docs/user_guide/quickstart.md`
- `docs/user_guide/distributed-training.md`
- `docs/user_guide/slurm.md`

## Extra context

The shutdown contract now follows a flush/finish-style sequence:

```text
settle late TCP telemetry
consume rank_finished markers
stop TCP
drain SQLite writer queue
run final retention prune best-effort
checkpoint WAL
close SQLite
generate final summary artifacts
```

Finalization diagnostics are written under `aggregator/` as
`finalization_warning.json` or `finalization_error.json` when needed. The
SQLite finalize result records queue counts, dropped rows, checkpoint status,
and separate prune/checkpoint errors for debugging.
