### PR TITLE
lightining integrations legacy

### DIFF
--- a/docs/user_guide/integrations/lightning.md
+++ b/docs/user_guide/integrations/lightning.md
@@ -8,6 +8,15 @@ memory drift.
 
 ## 1. Install
 
+If your environment already has either `lightning` or `pytorch-lightning`,
+installing TraceML is enough:
+
+```bash
+pip install traceml-ai
+```
+
+If you want TraceML to install the modern Lightning package for you:
+
 ```bash
 pip install "traceml-ai[lightning]"
 ```
@@ -15,6 +24,10 @@ pip install "traceml-ai[lightning]"
 ## 2. Add `TraceMLCallback`
 
 Initialize the Lightning integration once, then add `TraceMLCallback` to your Lightning `Trainer`. Everything else stays the same.
+
+Use one Lightning namespace consistently in your script. TraceML supports both
+`lightning.pytorch` and legacy `pytorch_lightning`, but your `Trainer` and
+`LightningModule` should come from the same namespace.
 
 ```python
 import lightning as L
@@ -33,6 +46,19 @@ trainer = L.Trainer(
 )
 
 trainer.fit(model, train_dataloaders=loader)
+```
+
+Legacy `pytorch_lightning` projects can keep their existing imports:
+
+```python
+import pytorch_lightning as pl
+from traceml_ai.integrations import lightning as traceml_lightning
+
+traceml_lightning.init()
+
+trainer = pl.Trainer(
+    callbacks=[traceml_lightning.TraceMLCallback()],
+)
 ```
 
 You do not need to add `traceml.trace_step(...)` manually. Lightning still owns

--- a/src/traceml_ai/integrations/huggingface.py
+++ b/src/traceml_ai/integrations/huggingface.py
@@ -89,8 +89,9 @@ class TraceMLTrainerCallback(TrainerCallback if HAS_TRANSFORMERS else object):
     def __init__(self) -> None:
         if not HAS_TRANSFORMERS:
             raise ImportError(
-                "TraceMLTrainerCallback requires 'transformers' to be "
-                "installed. Please run `pip install transformers`."
+                "TraceMLTrainerCallback requires the Hugging Face "
+                "integration. Install it with "
+                "`pip install 'traceml-ai[hf]'`."
             )
         super().__init__()
         self._step_cm = None
@@ -169,8 +170,8 @@ class TraceMLTrainer(Trainer if HAS_TRANSFORMERS else object):
     ):
         if not HAS_TRANSFORMERS:
             raise ImportError(
-                "TraceMLTrainer requires 'transformers' to be installed. "
-                "Please run `pip install transformers`."
+                "TraceMLTrainer requires the Hugging Face integration. "
+                "Install it with `pip install 'traceml-ai[hf]'`."
             )
 
         super().__init__(*args, **kwargs)

--- a/src/traceml_ai/integrations/lightning.py
+++ b/src/traceml_ai/integrations/lightning.py
@@ -1,6 +1,8 @@
 import functools
 import os
 import sys
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
 
 from traceml_ai.instrumentation.patches.h2d_auto_timer_patch import (
     h2d_auto_timer,
@@ -18,13 +20,83 @@ from traceml_ai.utils.timing import (
     timed_region,
 )
 
-try:
-    from lightning.pytorch.callbacks import Callback
+if TYPE_CHECKING:
+    from lightning.pytorch.callbacks import Callback as _CallbackBase
+else:
+    _CallbackBase = object
 
+
+def _dedupe_callback_bases(bases: tuple[type, ...]) -> tuple[type, ...]:
+    """Return callback bases without duplicates while preserving order."""
+    out: list[type] = []
+    for base in bases:
+        if any(base is existing for existing in out):
+            continue
+        out.append(base)
+    return tuple(out)
+
+
+def _build_callback_base(bases: tuple[type, ...]) -> Any:
+    """Build one runtime callback base from available namespace bases."""
+    unique_bases = _dedupe_callback_bases(bases)
+    if not unique_bases:
+        return SimpleNamespace(base=object, available=False)
+
+    if len(unique_bases) == 1:
+        return SimpleNamespace(base=unique_bases[0], available=True)
+
+    try:
+        base = type(
+            "_TraceMLLightningCallbackBase",
+            unique_bases,
+            {},
+        )
+    except TypeError:
+        # If the namespaces expose incompatible callback classes, prefer the
+        # legacy package because that is the namespace most likely to hit the
+        # mixed-import error this compatibility path fixes.
+        base = unique_bases[-1]
+
+    return SimpleNamespace(base=base, available=True)
+
+
+def _resolve_callback_base() -> Any:
+    """
+    Build a callback base accepted by either Lightning namespace.
+
+    ``lightning.pytorch`` and ``pytorch_lightning`` can be installed side by
+    side, but their ``Callback`` classes are not always identical. Inheriting
+    from every available callback base lets the same TraceML callback work with
+    whichever Trainer namespace the user already has.
+    """
+    bases: list[type] = []
+
+    try:
+        from lightning.pytorch.callbacks import Callback as LightningCallback
+
+        bases.append(LightningCallback)
+    except ImportError:
+        pass
+
+    try:
+        from pytorch_lightning.callbacks import (
+            Callback as PyTorchLightningCallback,
+        )
+
+        bases.append(PyTorchLightningCallback)
+    except ImportError:
+        pass
+
+    return _build_callback_base(tuple(bases))
+
+
+if not TYPE_CHECKING:
+    _callback_resolution = _resolve_callback_base()
+    _CallbackBase = _callback_resolution.base
+    IS_LIGHTNING_AVAILABLE = bool(_callback_resolution.available)
+else:
     IS_LIGHTNING_AVAILABLE = True
-except ImportError:
-    Callback = object
-    IS_LIGHTNING_AVAILABLE = False
+
 
 TRACEML_DISABLED = os.environ.get("TRACEML_DISABLED") == "1"
 _MISSING = object()
@@ -86,7 +158,7 @@ def _lightning_uses_cuda(trainer, pl_module) -> bool:
     return _device_is_cuda(module_device)
 
 
-class TraceMLCallback(Callback):
+class TraceMLCallback(_CallbackBase):
     """
     Official TraceML Callback for PyTorch Lightning.
 
@@ -99,7 +171,8 @@ class TraceMLCallback(Callback):
     def __init__(self):
         if not IS_LIGHTNING_AVAILABLE:
             raise ImportError(
-                "Install traceml[lightning] to use Lightning integration"
+                "Install either 'lightning' or 'pytorch-lightning' to use "
+                "TraceML's Lightning integration."
             )
         super().__init__()
         self._traceml_step_ctx = None

--- a/src/traceml_ai/integrations/ray.py
+++ b/src/traceml_ai/integrations/ray.py
@@ -96,7 +96,7 @@ def _require_ray() -> tuple[Any, Any]:
     except ImportError as exc:
         raise ImportError(
             "TraceML Ray integration requires Ray. Install it with "
-            "`pip install traceml-ai[ray]`."
+            "`pip install 'traceml-ai[ray]'`."
         ) from exc
     return ray, TorchTrainer
 

--- a/tests/integrations/test_lightning.py
+++ b/tests/integrations/test_lightning.py
@@ -15,6 +15,34 @@ def _enable_callback_without_lightning(monkeypatch):
     )
 
 
+def test_lightning_callback_base_combines_distinct_namespaces() -> None:
+    class NewNamespaceCallback:
+        pass
+
+    class LegacyNamespaceCallback:
+        pass
+
+    resolved = lightning_integration._build_callback_base(
+        (NewNamespaceCallback, LegacyNamespaceCallback)
+    )
+
+    assert resolved.available is True
+    assert issubclass(resolved.base, NewNamespaceCallback)
+    assert issubclass(resolved.base, LegacyNamespaceCallback)
+
+
+def test_lightning_callback_base_dedupes_matching_namespaces() -> None:
+    class SharedCallback:
+        pass
+
+    resolved = lightning_integration._build_callback_base(
+        (SharedCallback, SharedCallback)
+    )
+
+    assert resolved.available is True
+    assert resolved.base is SharedCallback
+
+
 def test_lightning_forward_wrapper_times_only_forward(monkeypatch):
     _enable_callback_without_lightning(monkeypatch)
     calls = []


### PR DESCRIPTION
## What changed

Added compatibility support for both modern `lightning.pytorch` and legacy
`pytorch_lightning` callback namespaces in the TraceML Lightning integration.

Also updated integration install guidance for Lightning, Hugging Face, and Ray.

## Why

Some users still run projects on legacy `pytorch_lightning`, while newer
projects use `lightning.pytorch`. Their `Callback` base classes may differ when
both packages are present, which can cause TraceML's callback to be rejected by
the user's Trainer namespace.

This makes `TraceMLCallback` inherit from available Lightning callback bases so
it works with either namespace.

## How I tested

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider tests/integrations/test_lightning.py -q
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider tests/integrations -q
git diff --check main...HEAD
```

Results:

- `tests/integrations/test_lightning.py`: 4 passed
- `tests/integrations`: 10 passed, 7 skipped
- `git diff --check`: clean

- [x] Tests added or updated
- [x] Existing tests run
- [ ] Manual smoke test
- [ ] Not run; reason:

## Runtime impact

Scoped to optional integrations.

- [ ] No training-path impact
- [x] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes:

- Affects Lightning integration callback base resolution.
- Does not change samplers, transport, aggregator, or core tracing behavior.
- Hugging Face and Ray changes are install-message/docs cleanup only.

## Docs

- [x] Updated
- [ ] Not needed

## Extra context

TraceML now supports both `lightning.pytorch` and legacy `pytorch_lightning`,
but users should still keep their `Trainer` and `LightningModule` imports from
the same Lightning namespace.
