### PR TITLE
Version 0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ for batch in dataloader:
 traceml run train.py
 ```
 
+Or try the self-contained example first:
+
+```bash
+traceml run examples/quickstart.py --mode=summary
+```
+
 For DDP, FSDP, and multi-node runs, see
 [Distributed Training](docs/user_guide/distributed-training.md).
 
@@ -119,24 +125,53 @@ end-of-run budget with `--finalize-timeout-sec` or
 `TRACEML_FINALIZE_TIMEOUT_SEC` when running on slow filesystems or congested
 networks.
 
-Instead of guessing where step time and memory went, you get a compact
-diagnosis at the end of every run.
+Instead of guessing where training time went, you get an end-of-run verdict:
+what slowed the run down, which rank or phase is suspicious, and where to look
+next.
 
 Example TraceML output:
 
 ```text
 +----------------------------------------------------------------------------+
-|  Step Time                                                                 |
-|  - Diagnosis: INPUT STRAGGLER                                              |
-|  - Scope: compared over last 460 aligned steps across 4 global ranks       |
-|  - Stats: total 303.7ms | input 254.5ms | compute 259.5ms             |
-|  - Residual: 40.5ms                                                       |
-|  - Why: r0 input was slower than median global rank (254.5/3.8ms).         |
+|  TraceML Run Summary | duration 40.1s                                      |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  TraceML Verdict: INPUT STRAGGLER / CRITICAL                               |
+|  Why: Rank r0 dataloader was 254.5ms vs median rank r1 at 3.8ms.           |
+|  Next: Inspect dataloader, collate_fn, preprocessing, and storage on the   |
+|  slow rank.                                                                |
+|                                                                            |
+|  Section Status                                                            |
+|  Section       Status                  Severity                            |
+|  ------------------------------------------------                          |
+|  Step Time     INPUT STRAGGLER         CRITICAL                            |
+|  System        LOW GPU UTIL            INFO                                |
+|  Process       NORMAL                  INFO                                |
+|  Step Memory   BALANCED                INFO                                |
+|                                                                            |
+|  System Evidence                                                           |
+|  Metric          Median        Worst         Skew        Scope             |
+|  --------------------------------------------------------------------------|
+|  CPU Util        18.4%         71.2%         52.8pp      node=n1           |
+|  GPU Util        14.0%         0.0%          14.0pp      node=n0           |
+|  GPU Memory      6.20GB        8.90GB        43.5%       node=n1           |
+|  GPU Temp        42C           58C           16C         node=n1           |
+|                                                                            |
+|  Step Time Evidence                                                        |
+|  Phase           Median        Worst         Skew        Scope             |
+|  --------------------------------------------------------------------------|
+|  Total           303.7ms       304.1ms       0.1%        rank=r0 node=n0   |
+|  Dataloader      3.8ms         254.5ms       6597.4%     rank=r0 node=n0   |
+|  Compute         259.5ms       261.0ms       0.6%        rank=r2 node=n1   |
 +----------------------------------------------------------------------------+
 ```
 
 In this example, rank 0 is the slow input rank, which can hold back the aligned
 distributed step.
+
+Want to try a specific bottleneck? See [examples/](examples/) for
+self-contained demos covering dataloader bottlenecks, H2D timing, DDP rank
+stragglers, Lightning, Hugging Face, Ray, and tracker-friendly summary logging.
 
 For experiment trackers, call `traceml.summary()` near the end of your script
 to get a flat dict of diagnosis statuses and average metrics. Keep

--- a/docs/guides/pytorch-dataloader-bottleneck.md
+++ b/docs/guides/pytorch-dataloader-bottleneck.md
@@ -51,7 +51,7 @@ traceml view logs/<run_name>/final_summary.json
 
 ## What to look for
 
-Start with the `Step Time` section.
+Start with `TraceML Verdict`, then check the `Step Time Evidence` table.
 
 For DataLoader problems, the most relevant diagnoses are:
 
@@ -60,14 +60,19 @@ For DataLoader problems, the most relevant diagnoses are:
 - `INPUT STRAGGLER`: one rank has meaningfully more dataloader burden than a
   typical rank
 
-Example:
+Example excerpt:
 
 ```text
-Step Time
-- Diagnosis: INPUT STRAGGLER
-- Stats: total 303.7ms | input 254.5ms | compute 259.5ms
-- Residual: 40.5ms
-- Why: r0 input was slower than median global rank (254.5/3.8ms).
+TraceML Verdict: INPUT STRAGGLER / CRITICAL
+Why: Rank r0 dataloader was 254.5ms vs median rank r1 at 3.8ms.
+Next: Inspect dataloader, collate_fn, preprocessing, and storage on the slow rank.
+
+Step Time Evidence
+Phase           Median        Worst         Skew        Scope
+--------------------------------------------------------------------------
+Total           303.7ms       304.1ms       0.1%        rank=r0 node=n0
+Dataloader      3.8ms         254.5ms       6597.4%     rank=r0 node=n0
+Compute         259.5ms       261.0ms       0.6%        rank=r2 node=n1
 ```
 
 Read this as:

--- a/docs/user_guide/integrations/lightning.md
+++ b/docs/user_guide/integrations/lightning.md
@@ -8,6 +8,15 @@ memory drift.
 
 ## 1. Install
 
+If your environment already has either `lightning` or `pytorch-lightning`,
+installing TraceML is enough:
+
+```bash
+pip install traceml-ai
+```
+
+If you want TraceML to install the modern Lightning package for you:
+
 ```bash
 pip install "traceml-ai[lightning]"
 ```
@@ -15,6 +24,10 @@ pip install "traceml-ai[lightning]"
 ## 2. Add `TraceMLCallback`
 
 Initialize the Lightning integration once, then add `TraceMLCallback` to your Lightning `Trainer`. Everything else stays the same.
+
+Use one Lightning namespace consistently in your script. TraceML supports both
+`lightning.pytorch` and legacy `pytorch_lightning`, but your `Trainer` and
+`LightningModule` should come from the same namespace.
 
 ```python
 import lightning as L
@@ -33,6 +46,19 @@ trainer = L.Trainer(
 )
 
 trainer.fit(model, train_dataloaders=loader)
+```
+
+Legacy `pytorch_lightning` projects can keep their existing imports:
+
+```python
+import pytorch_lightning as pl
+from traceml_ai.integrations import lightning as traceml_lightning
+
+traceml_lightning.init()
+
+trainer = pl.Trainer(
+    callbacks=[traceml_lightning.TraceMLCallback()],
+)
 ```
 
 You do not need to add `traceml.trace_step(...)` manually. Lightning still owns

--- a/docs/user_guide/quickstart.md
+++ b/docs/user_guide/quickstart.md
@@ -75,11 +75,36 @@ For DDP, FSDP, and multi-node launches, see
 
 ```text
 +----------------------------------------------------------------------------+
-|  Step Time                                                                 |
-|  - Diagnosis: INPUT STRAGGLER                                              |
-|  - Stats: total 303.7ms | input 254.5ms | compute 259.5ms             |
-|  - Residual: 40.5ms                                                       |
-|  - Why: r0 input was slower than median global rank (254.5/3.8ms).         |
+|  TraceML Run Summary | duration 40.1s                                      |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  TraceML Verdict: INPUT STRAGGLER / CRITICAL                               |
+|  Why: Rank r0 dataloader was 254.5ms vs median rank r1 at 3.8ms.           |
+|  Next: Inspect dataloader, collate_fn, preprocessing, and storage on the   |
+|  slow rank.                                                                |
+|                                                                            |
+|  Section Status                                                            |
+|  Section       Status                  Severity                            |
+|  ------------------------------------------------                          |
+|  Step Time     INPUT STRAGGLER         CRITICAL                            |
+|  System        LOW GPU UTIL            INFO                                |
+|  Process       NORMAL                  INFO                                |
+|  Step Memory   BALANCED                INFO                                |
+|                                                                            |
+|  System Evidence                                                           |
+|  Metric          Median        Worst         Skew        Scope             |
+|  --------------------------------------------------------------------------|
+|  CPU Util        18.4%         71.2%         52.8pp      node=n1           |
+|  GPU Util        14.0%         0.0%          14.0pp      node=n0           |
+|  GPU Memory      6.20GB        8.90GB        43.5%       node=n1           |
+|  GPU Temp        42C           58C           16C         node=n1           |
+|                                                                            |
+|  Step Time Evidence                                                        |
+|  Phase           Median        Worst         Skew        Scope             |
+|  --------------------------------------------------------------------------|
+|  Total           303.7ms       304.1ms       0.1%        rank=r0 node=n0   |
+|  Dataloader      3.8ms         254.5ms       6597.4%     rank=r0 node=n0   |
+|  Compute         259.5ms       261.0ms       0.6%        rank=r2 node=n1   |
 +----------------------------------------------------------------------------+
 ```
 

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -53,6 +53,19 @@ unexplained-utilization fallback, not as root-cause proof by itself.
 By default, `traceml run train.py` prints a compact final summary and writes
 `final_summary.json` plus `final_summary.txt`.
 
+The text summary is intentionally verdict-first:
+
+- `TraceML Verdict`: the promoted performance diagnosis and severity
+- `Why`: the short evidence-backed reason
+- `Next`: the first action to try or inspect
+- `Section Status`: compact health/status across System, Process, Step Time,
+  and Step Memory
+- `System Evidence` and `Step Time Evidence`: the core numbers behind the
+  verdict
+
+Detailed section prose remains in the `system.card`, `process.card`,
+`step_time.card`, and `step_memory.card` fields inside `final_summary.json`.
+
 ### Shareable HTML report
 
 Add `--html-report` to `traceml run` (or `traceml watch`) to also write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "traceml-ai"
-version = "0.3.2"
+version = "0.3.3"
 
 description = "TraceML: Lightweight runtime bottleneck diagnostics for PyTorch training."
 authors = [{ name = "OptAI UG (haftungsbeschränkt)", email = "support@traceopt.ai" }]

--- a/src/traceml_ai/__init__.py
+++ b/src/traceml_ai/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 __all__ = [
     "__version__",

--- a/src/traceml_ai/integrations/huggingface.py
+++ b/src/traceml_ai/integrations/huggingface.py
@@ -89,8 +89,9 @@ class TraceMLTrainerCallback(TrainerCallback if HAS_TRANSFORMERS else object):
     def __init__(self) -> None:
         if not HAS_TRANSFORMERS:
             raise ImportError(
-                "TraceMLTrainerCallback requires 'transformers' to be "
-                "installed. Please run `pip install transformers`."
+                "TraceMLTrainerCallback requires the Hugging Face "
+                "integration. Install it with "
+                "`pip install 'traceml-ai[hf]'`."
             )
         super().__init__()
         self._step_cm = None
@@ -169,8 +170,8 @@ class TraceMLTrainer(Trainer if HAS_TRANSFORMERS else object):
     ):
         if not HAS_TRANSFORMERS:
             raise ImportError(
-                "TraceMLTrainer requires 'transformers' to be installed. "
-                "Please run `pip install transformers`."
+                "TraceMLTrainer requires the Hugging Face integration. "
+                "Install it with `pip install 'traceml-ai[hf]'`."
             )
 
         super().__init__(*args, **kwargs)

--- a/src/traceml_ai/integrations/lightning.py
+++ b/src/traceml_ai/integrations/lightning.py
@@ -1,6 +1,8 @@
 import functools
 import os
 import sys
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
 
 from traceml_ai.instrumentation.patches.h2d_auto_timer_patch import (
     h2d_auto_timer,
@@ -18,13 +20,83 @@ from traceml_ai.utils.timing import (
     timed_region,
 )
 
-try:
-    from lightning.pytorch.callbacks import Callback
+if TYPE_CHECKING:
+    from lightning.pytorch.callbacks import Callback as _CallbackBase
+else:
+    _CallbackBase = object
 
+
+def _dedupe_callback_bases(bases: tuple[type, ...]) -> tuple[type, ...]:
+    """Return callback bases without duplicates while preserving order."""
+    out: list[type] = []
+    for base in bases:
+        if any(base is existing for existing in out):
+            continue
+        out.append(base)
+    return tuple(out)
+
+
+def _build_callback_base(bases: tuple[type, ...]) -> Any:
+    """Build one runtime callback base from available namespace bases."""
+    unique_bases = _dedupe_callback_bases(bases)
+    if not unique_bases:
+        return SimpleNamespace(base=object, available=False)
+
+    if len(unique_bases) == 1:
+        return SimpleNamespace(base=unique_bases[0], available=True)
+
+    try:
+        base = type(
+            "_TraceMLLightningCallbackBase",
+            unique_bases,
+            {},
+        )
+    except TypeError:
+        # If the namespaces expose incompatible callback classes, prefer the
+        # legacy package because that is the namespace most likely to hit the
+        # mixed-import error this compatibility path fixes.
+        base = unique_bases[-1]
+
+    return SimpleNamespace(base=base, available=True)
+
+
+def _resolve_callback_base() -> Any:
+    """
+    Build a callback base accepted by either Lightning namespace.
+
+    ``lightning.pytorch`` and ``pytorch_lightning`` can be installed side by
+    side, but their ``Callback`` classes are not always identical. Inheriting
+    from every available callback base lets the same TraceML callback work with
+    whichever Trainer namespace the user already has.
+    """
+    bases: list[type] = []
+
+    try:
+        from lightning.pytorch.callbacks import Callback as LightningCallback
+
+        bases.append(LightningCallback)
+    except ImportError:
+        pass
+
+    try:
+        from pytorch_lightning.callbacks import (
+            Callback as PyTorchLightningCallback,
+        )
+
+        bases.append(PyTorchLightningCallback)
+    except ImportError:
+        pass
+
+    return _build_callback_base(tuple(bases))
+
+
+if not TYPE_CHECKING:
+    _callback_resolution = _resolve_callback_base()
+    _CallbackBase = _callback_resolution.base
+    IS_LIGHTNING_AVAILABLE = bool(_callback_resolution.available)
+else:
     IS_LIGHTNING_AVAILABLE = True
-except ImportError:
-    Callback = object
-    IS_LIGHTNING_AVAILABLE = False
+
 
 TRACEML_DISABLED = os.environ.get("TRACEML_DISABLED") == "1"
 _MISSING = object()
@@ -86,7 +158,7 @@ def _lightning_uses_cuda(trainer, pl_module) -> bool:
     return _device_is_cuda(module_device)
 
 
-class TraceMLCallback(Callback):
+class TraceMLCallback(_CallbackBase):
     """
     Official TraceML Callback for PyTorch Lightning.
 
@@ -99,7 +171,8 @@ class TraceMLCallback(Callback):
     def __init__(self):
         if not IS_LIGHTNING_AVAILABLE:
             raise ImportError(
-                "Install traceml[lightning] to use Lightning integration"
+                "Install either 'lightning' or 'pytorch-lightning' to use "
+                "TraceML's Lightning integration."
             )
         super().__init__()
         self._traceml_step_ctx = None

--- a/src/traceml_ai/integrations/ray.py
+++ b/src/traceml_ai/integrations/ray.py
@@ -96,7 +96,7 @@ def _require_ray() -> tuple[Any, Any]:
     except ImportError as exc:
         raise ImportError(
             "TraceML Ray integration requires Ray. Install it with "
-            "`pip install traceml-ai[ray]`."
+            "`pip install 'traceml-ai[ray]'`."
         ) from exc
     return ray, TorchTrainer
 

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -42,6 +42,12 @@ Sections:
 section diagnoses. It answers "why was training slow?" and is intentionally
 narrower than section-level health/resource diagnoses.
 
+`text` is a compact human-readable verdict report. It is presentation text for
+the CLI/TXT artifact, not a structured contract for downstream parsers. It
+starts with `TraceML Verdict`, `Why`, and `Next`, then shows compact section
+status plus System and Step Time evidence tables. Detailed section prose
+remains in each section-local `card` field.
+
 ## Primary Diagnosis Shape
 
 ```json
@@ -242,6 +248,8 @@ Fallback evidence types are:
 - `metadata.global_ranks_seen` is all observed ranks.
 - `metadata.global_ranks_used` is the ranks included in `groups.rows` and the
   `global` comparison.
+- `card` is the section-local detailed text block used by section tooling and
+  retained in JSON even when top-level `text` uses the compact verdict report.
 
 `step_time` and `step_memory` use `common_steps` alignment. If a rank does not
 have the common step window, it can be counted in `global_ranks_seen` but not

--- a/src/traceml_ai/reporting/final.py
+++ b/src/traceml_ai/reporting/final.py
@@ -27,9 +27,9 @@ from traceml_ai.reporting.sections.process import ProcessSummarySection
 from traceml_ai.reporting.sections.step_memory import StepMemorySummarySection
 from traceml_ai.reporting.sections.step_time import StepTimeSummarySection
 from traceml_ai.reporting.sections.system import SystemSummarySection
+from traceml_ai.reporting.summaries.summary_formatting import bytes_to_gb
 from traceml_ai.reporting.summaries.summary_layout import (
     border,
-    indented_block,
     row,
     wrap_lines,
 )
@@ -43,6 +43,27 @@ from traceml_ai.utils.atomic_io import write_json_atomic, write_text_atomic
 
 SUMMARY_WIDTH = 78
 SUMMARY_INNER_TEXT_WIDTH = SUMMARY_WIDTH - 4
+
+_SYSTEM_EVIDENCE_METRICS = (
+    ("CPU Util", "cpu_percent"),
+    ("GPU Util", "gpu_util_percent"),
+    ("GPU Memory", "gpu_mem_bytes"),
+    ("GPU Temp", "gpu_temp_c"),
+)
+_STEP_TIME_EVIDENCE_METRICS = (
+    ("Total", "total_step_ms"),
+    ("Dataloader", "dataloader_ms"),
+    ("Compute", "compute_ms"),
+    ("Residual", "residual_ms"),
+    ("H2D", "h2d_ms"),
+)
+_SEVERITY_LABELS = {
+    "crit": "CRITICAL",
+    "critical": "CRITICAL",
+    "warn": "WARNING",
+    "warning": "WARNING",
+    "info": "INFO",
+}
 
 
 def _log_final_report_error(message: str, exc: Exception) -> None:
@@ -265,46 +286,383 @@ def _build_final_meta(
     }
 
 
-def _append_wrapped_card_lines(
-    lines: List[str],
-    card_text: str,
-    *,
-    section_title: str,
-    card_header_prefix: str,
-) -> None:
+def _diagnosis(section: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a section diagnosis mapping, if present."""
+    diagnosis = section.get("diagnosis") if isinstance(section, dict) else None
+    return dict(diagnosis) if isinstance(diagnosis, dict) else {}
+
+
+def _global_block(section: Dict[str, Any], block: str) -> Dict[str, Any]:
+    """Return one global rollup block from a section payload."""
+    global_summary = (
+        section.get("global") if isinstance(section, dict) else None
+    )
+    if not isinstance(global_summary, dict):
+        return {}
+    value = global_summary.get(block)
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _point_value(point: Any) -> Optional[float]:
+    """Return a numeric `{value, idx}` point value, if available."""
+    if not isinstance(point, dict):
+        return None
+    value = point.get("value")
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def _point_idx(point: Any) -> Optional[Any]:
+    """Return a `{value, idx}` point index, if available."""
+    if not isinstance(point, dict):
+        return None
+    return point.get("idx")
+
+
+def _average_value(section: Dict[str, Any], metric: str) -> Optional[float]:
+    """Return one average metric value from a section payload."""
+    value = _global_block(section, "average").get(metric)
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def _point(section: Dict[str, Any], block: str, metric: str) -> Dict[str, Any]:
+    """Return one median/worst point from a section payload."""
+    point = _global_block(section, block).get(metric)
+    return dict(point) if isinstance(point, dict) else {}
+
+
+def _status_label(value: Any, default: str = "NO DATA") -> str:
+    """Return an uppercase status label for compact terminal output."""
+    text = str(value or default).replace("_", " ").strip()
+    return " ".join(text.upper().split()) or default
+
+
+def _severity_label(value: Any) -> str:
+    """Return a normalized severity label for compact terminal output."""
+    text = str(value or "info").strip().lower()
+    return _SEVERITY_LABELS.get(text, text.upper() if text else "INFO")
+
+
+def _format_value(metric: str, value: Optional[float]) -> str:
+    """Format final-summary evidence values using compact CLI units."""
+    if value is None:
+        return "n/a"
+    if metric.endswith("_ms"):
+        return f"{value:.1f}ms"
+    if metric.endswith("_bytes"):
+        gb = bytes_to_gb(value)
+        return "n/a" if gb is None else f"{gb:.2f}GB"
+    if metric.endswith("_percent"):
+        return f"{value:.1f}%"
+    if metric.endswith("_c"):
+        return f"{value:.0f}C"
+    return f"{value:.1f}"
+
+
+def _format_share(value: Optional[float], total: Optional[float]) -> str:
+    """Format a share as a percent of total step time."""
+    if value is None or total is None or total <= 0.0:
+        return "n/a"
+    return f"{100.0 * value / total:.1f}%"
+
+
+def _format_skew(
+    metric: str,
+    median: Optional[float],
+    worst: Optional[float],
+) -> str:
     """
-    Append wrapped summary card lines into the final combined summary.
+    Format worst-vs-median skew for compact evidence tables.
+
+    Percentage-valued utilization rows use percentage-point skew. Temperature
+    uses an absolute Celsius skew. Other metrics use relative percent skew
+    when the median is positive. The value is intentionally unsigned because
+    the ``worst`` point already encodes the bad direction for that metric.
     """
-    for line in indented_block(card_text):
-        if line.startswith(card_header_prefix):
-            continue
-        if line == section_title:
-            continue
+    if median is None or worst is None:
+        return "n/a"
+    delta = abs(worst - median)
+    if metric.endswith("_percent"):
+        return f"{delta:.1f}pp"
+    if metric.endswith("_c"):
+        return f"{delta:.0f}C"
+    if median <= 0.0:
+        return "n/a"
+    return f"{100.0 * delta / median:.1f}%"
 
-        for wrapped in wrap_lines(line, SUMMARY_INNER_TEXT_WIDTH):
-            lines.append(row(wrapped, width=SUMMARY_WIDTH))
+
+def _clip(text: str, width: int) -> str:
+    """Clip text to a fixed table cell width without breaking layout."""
+    clean = str(text)
+    if len(clean) <= width:
+        return clean
+    if width <= 1:
+        return clean[:width]
+    return clean[: width - 1] + "."
 
 
-def _append_primary_diagnosis_lines(
+def _table_line(values: Sequence[Any], widths: Sequence[int]) -> str:
+    """Return one fixed-width table line for the compact text summary."""
+    cells = [
+        f"{_clip(str(value), width):<{width}}"
+        for value, width in zip(values, widths)
+    ]
+    return "  ".join(cells).rstrip()
+
+
+def _table_rule(widths: Sequence[int]) -> str:
+    """Return a separator matching a fixed-width table."""
+    return "-" * (sum(widths) + 2 * (len(widths) - 1))
+
+
+def _append_wrapped_text(lines: List[str], text: str) -> None:
+    """Append one potentially long logical line inside the summary border."""
+    for wrapped in wrap_lines(text, SUMMARY_INNER_TEXT_WIDTH):
+        lines.append(row(wrapped, width=SUMMARY_WIDTH))
+
+
+def _append_verdict_lines(
     lines: List[str],
     primary_diagnosis: Dict[str, Any],
 ) -> None:
-    """Append the top-level primary diagnosis block to final text."""
-    status = str(primary_diagnosis.get("status") or "NO DATA")
+    """Append the compact run-level verdict, why, and next-action lines."""
+    status = _status_label(primary_diagnosis.get("status"))
+    severity = _severity_label(primary_diagnosis.get("severity"))
     summary = str(primary_diagnosis.get("summary") or "")
     action = str(primary_diagnosis.get("action") or "")
-    block = [
-        "Primary Diagnosis",
-        f"- Diagnosis: {status}",
-    ]
+    _append_wrapped_text(lines, f"TraceML Verdict: {status} / {severity}")
     if summary:
-        block.append(f"- Why: {summary}")
+        _append_wrapped_text(lines, f"Why: {summary}")
     if action:
-        block.append(f"- Next: {action}")
+        _append_wrapped_text(lines, f"Next: {action}")
 
-    for line in block:
-        for wrapped in wrap_lines(line, SUMMARY_INNER_TEXT_WIDTH):
-            lines.append(row(wrapped, width=SUMMARY_WIDTH))
+
+def _append_section_status(
+    lines: List[str],
+    *,
+    system_summary: Dict[str, Any],
+    process_summary: Dict[str, Any],
+    step_time_summary: Dict[str, Any],
+    step_memory_summary: Dict[str, Any],
+) -> None:
+    """Append a compact status table for all section-local diagnoses."""
+    rows = (
+        ("Step Time", _diagnosis(step_time_summary)),
+        ("System", _diagnosis(system_summary)),
+        ("Process", _diagnosis(process_summary)),
+        ("Step Memory", _diagnosis(step_memory_summary)),
+    )
+    widths = (12, 22, 10)
+    lines.append(row("Section Status", width=SUMMARY_WIDTH))
+    lines.append(
+        row(
+            _table_line(("Section", "Status", "Severity"), widths),
+            width=SUMMARY_WIDTH,
+        )
+    )
+    lines.append(row(_table_rule(widths), width=SUMMARY_WIDTH))
+    for label, diagnosis in rows:
+        lines.append(
+            row(
+                _table_line(
+                    (
+                        label,
+                        _status_label(diagnosis.get("status")),
+                        _severity_label(diagnosis.get("severity")),
+                    ),
+                    widths,
+                ),
+                width=SUMMARY_WIDTH,
+            )
+        )
+
+
+def _is_multi_process(step_time_summary: Dict[str, Any]) -> bool:
+    """Return whether Step Time observed more than one global rank/process."""
+    value = _section_metadata(step_time_summary).get("global_ranks_used")
+    parsed = _safe_int(value, allow_zero=True)
+    return bool(parsed is not None and parsed > 1)
+
+
+def _row_identity(section: Dict[str, Any], idx: Any) -> Dict[str, Any]:
+    """Return a grouped-row identity for a median/worst point index."""
+    if idx is None:
+        return {}
+    rows = _section_group_rows(section)
+    row_data = rows.get(str(idx), {})
+    identity = row_data.get("identity") if isinstance(row_data, dict) else None
+    return dict(identity) if isinstance(identity, dict) else {}
+
+
+def _system_scope(system_summary: Dict[str, Any], idx: Any) -> str:
+    """Return node-level scope text for System evidence rows."""
+    identity = _row_identity(system_summary, idx)
+    node_rank = _safe_int(identity.get("node_rank"), allow_zero=True)
+    if node_rank is not None:
+        return f"node=n{node_rank}"
+    parsed = _safe_int(idx, allow_zero=True)
+    if parsed is not None:
+        return f"node=n{parsed}"
+    return "n/a" if idx is None else f"node={idx}"
+
+
+def _step_scope(step_time_summary: Dict[str, Any], idx: Any) -> str:
+    """Return rank/node scope text for Step Time evidence rows."""
+    identity = _row_identity(step_time_summary, idx)
+    rank = _safe_int(identity.get("global_rank"), allow_zero=True)
+    if rank is None:
+        rank = _safe_int(idx, allow_zero=True)
+    parts = []
+    if rank is not None:
+        parts.append(f"rank=r{rank}")
+    node_rank = _safe_int(identity.get("node_rank"), allow_zero=True)
+    if node_rank is not None:
+        parts.append(f"node=n{node_rank}")
+    if parts:
+        return " ".join(parts)
+    return "n/a" if idx is None else f"rank={idx}"
+
+
+def _append_system_evidence_single(
+    lines: List[str],
+    system_summary: Dict[str, Any],
+) -> None:
+    """Append average-only System evidence for single-process runs."""
+    widths = (16, 16)
+    lines.append(row("System Evidence", width=SUMMARY_WIDTH))
+    lines.append(
+        row(_table_line(("Metric", "Average"), widths), width=SUMMARY_WIDTH)
+    )
+    lines.append(row(_table_rule(widths), width=SUMMARY_WIDTH))
+    for label, metric in _SYSTEM_EVIDENCE_METRICS:
+        value = _average_value(system_summary, metric)
+        lines.append(
+            row(
+                _table_line(
+                    (label, _format_value(metric, value)),
+                    widths,
+                ),
+                width=SUMMARY_WIDTH,
+            )
+        )
+
+
+def _append_system_evidence_multi(
+    lines: List[str],
+    system_summary: Dict[str, Any],
+) -> None:
+    """Append median/worst System evidence for multi-process runs."""
+    widths = (14, 12, 12, 10, 18)
+    lines.append(row("System Evidence", width=SUMMARY_WIDTH))
+    lines.append(
+        row(
+            _table_line(
+                ("Metric", "Median", "Worst", "Skew", "Scope"),
+                widths,
+            ),
+            width=SUMMARY_WIDTH,
+        )
+    )
+    lines.append(row(_table_rule(widths), width=SUMMARY_WIDTH))
+    for label, metric in _SYSTEM_EVIDENCE_METRICS:
+        median = _point_value(_point(system_summary, "median", metric))
+        worst_point = _point(system_summary, "worst", metric)
+        worst = _point_value(worst_point)
+        lines.append(
+            row(
+                _table_line(
+                    (
+                        label,
+                        _format_value(metric, median),
+                        _format_value(metric, worst),
+                        _format_skew(metric, median, worst),
+                        _system_scope(system_summary, _point_idx(worst_point)),
+                    ),
+                    widths,
+                ),
+                width=SUMMARY_WIDTH,
+            )
+        )
+
+
+def _append_step_time_evidence_single(
+    lines: List[str],
+    step_time_summary: Dict[str, Any],
+) -> None:
+    """Append average/share Step Time evidence for single-process runs."""
+    widths = (16, 16, 12)
+    total = _average_value(step_time_summary, "total_step_ms")
+    lines.append(row("Step Time Evidence", width=SUMMARY_WIDTH))
+    lines.append(
+        row(
+            _table_line(("Phase", "Average", "Share"), widths),
+            width=SUMMARY_WIDTH,
+        )
+    )
+    lines.append(row(_table_rule(widths), width=SUMMARY_WIDTH))
+    for label, metric in _STEP_TIME_EVIDENCE_METRICS:
+        value = _average_value(step_time_summary, metric)
+        share = (
+            "100.0%"
+            if metric == "total_step_ms"
+            else _format_share(value, total)
+        )
+        lines.append(
+            row(
+                _table_line(
+                    (label, _format_value(metric, value), share),
+                    widths,
+                ),
+                width=SUMMARY_WIDTH,
+            )
+        )
+
+
+def _append_step_time_evidence_multi(
+    lines: List[str],
+    step_time_summary: Dict[str, Any],
+) -> None:
+    """Append median/worst Step Time evidence for multi-process runs."""
+    widths = (14, 12, 12, 10, 18)
+    lines.append(row("Step Time Evidence", width=SUMMARY_WIDTH))
+    lines.append(
+        row(
+            _table_line(("Phase", "Median", "Worst", "Skew", "Scope"), widths),
+            width=SUMMARY_WIDTH,
+        )
+    )
+    lines.append(row(_table_rule(widths), width=SUMMARY_WIDTH))
+    for label, metric in _STEP_TIME_EVIDENCE_METRICS:
+        median = _point_value(_point(step_time_summary, "median", metric))
+        worst_point = _point(step_time_summary, "worst", metric)
+        worst = _point_value(worst_point)
+        lines.append(
+            row(
+                _table_line(
+                    (
+                        label,
+                        _format_value(metric, median),
+                        _format_value(metric, worst),
+                        _format_skew(metric, median, worst),
+                        _step_scope(
+                            step_time_summary,
+                            _point_idx(worst_point),
+                        ),
+                    ),
+                    widths,
+                ),
+                width=SUMMARY_WIDTH,
+            )
+        )
 
 
 def _build_final_summary_text_from_sections(
@@ -316,7 +674,12 @@ def _build_final_summary_text_from_sections(
     step_memory_summary: Dict[str, Any],
 ) -> str:
     """
-    Build the single printed end-of-run summary from per-domain sections.
+    Build the compact printed end-of-run summary from per-domain sections.
+
+    Section-local ``card`` strings stay in the JSON payload for detailed
+    inspection. The top-level text is intentionally verdict-first and lossy:
+    it shows the primary finding plus the minimum evidence needed to orient
+    the next debugging step.
     """
     duration_s = _summary_duration_s(
         step_time_summary,
@@ -339,63 +702,42 @@ def _build_final_summary_text_from_sections(
         row(width=SUMMARY_WIDTH),
     ]
 
-    _append_primary_diagnosis_lines(lines, primary_diagnosis)
+    _append_verdict_lines(lines, primary_diagnosis)
 
     lines.extend(
         [
             row(width=SUMMARY_WIDTH),
-            row("System", width=SUMMARY_WIDTH),
         ]
     )
-
-    _append_wrapped_card_lines(
+    _append_section_status(
         lines,
-        system_summary.get("card", ""),
-        section_title="System",
-        card_header_prefix="TraceML System Summary",
+        system_summary=system_summary,
+        process_summary=process_summary,
+        step_time_summary=step_time_summary,
+        step_memory_summary=step_memory_summary,
     )
+
+    multi_process = _is_multi_process(step_time_summary)
 
     lines.extend(
         [
             row(width=SUMMARY_WIDTH),
-            row("Process", width=SUMMARY_WIDTH),
         ]
     )
-
-    _append_wrapped_card_lines(
-        lines,
-        process_summary.get("card", ""),
-        section_title="Process",
-        card_header_prefix="TraceML Process Summary",
-    )
+    if multi_process:
+        _append_system_evidence_multi(lines, system_summary)
+    else:
+        _append_system_evidence_single(lines, system_summary)
 
     lines.extend(
         [
             row(width=SUMMARY_WIDTH),
-            row("Step Time", width=SUMMARY_WIDTH),
         ]
     )
-
-    _append_wrapped_card_lines(
-        lines,
-        step_time_summary.get("card", ""),
-        section_title="Step Time",
-        card_header_prefix="TraceML Step Timing Summary",
-    )
-
-    lines.extend(
-        [
-            row(width=SUMMARY_WIDTH),
-            row("Step Memory", width=SUMMARY_WIDTH),
-        ]
-    )
-
-    _append_wrapped_card_lines(
-        lines,
-        step_memory_summary.get("card", ""),
-        section_title="Step Memory",
-        card_header_prefix="TraceML Step Memory Summary",
-    )
+    if multi_process:
+        _append_step_time_evidence_multi(lines, step_time_summary)
+    else:
+        _append_step_time_evidence_single(lines, step_time_summary)
 
     lines.append(border(width=SUMMARY_WIDTH))
     return "\n".join(lines)

--- a/tests/integrations/test_lightning.py
+++ b/tests/integrations/test_lightning.py
@@ -15,6 +15,34 @@ def _enable_callback_without_lightning(monkeypatch):
     )
 
 
+def test_lightning_callback_base_combines_distinct_namespaces() -> None:
+    class NewNamespaceCallback:
+        pass
+
+    class LegacyNamespaceCallback:
+        pass
+
+    resolved = lightning_integration._build_callback_base(
+        (NewNamespaceCallback, LegacyNamespaceCallback)
+    )
+
+    assert resolved.available is True
+    assert issubclass(resolved.base, NewNamespaceCallback)
+    assert issubclass(resolved.base, LegacyNamespaceCallback)
+
+
+def test_lightning_callback_base_dedupes_matching_namespaces() -> None:
+    class SharedCallback:
+        pass
+
+    resolved = lightning_integration._build_callback_base(
+        (SharedCallback, SharedCallback)
+    )
+
+    assert resolved.available is True
+    assert resolved.base is SharedCallback
+
+
 def test_lightning_forward_wrapper_times_only_forward(monkeypatch):
     _enable_callback_without_lightning(monkeypatch)
     calls = []

--- a/tests/reporting/summary/test_final.py
+++ b/tests/reporting/summary/test_final.py
@@ -38,8 +38,71 @@ class _BrokenSection:
         raise RuntimeError("section failed")
 
 
+@dataclass(frozen=True)
+class _PayloadSection:
+    name: str
+    payload: dict
+
+    def build(self, db_path: str) -> SummaryResult:
+        return SummaryResult(
+            section=self.name,
+            payload=self.payload,
+            text=str(self.payload.get("card", "")),
+        )
+
+
 def _generator(*sections) -> FinalReportGenerator:
     return FinalReportGenerator(sections=sections)
+
+
+def _diagnosis(
+    kind: str,
+    status: str,
+    *,
+    severity: str = "info",
+    summary: str = "summary",
+    action: str = "action",
+    phase: str | None = None,
+) -> dict:
+    return {
+        "kind": kind,
+        "status": status,
+        "severity": severity,
+        "summary": summary,
+        "action": action,
+        "phase": phase,
+    }
+
+
+def _payload(
+    *,
+    metadata: dict,
+    diagnosis: dict,
+    global_summary: dict | None = None,
+    groups: dict | None = None,
+    card: str = "ORIGINAL SECTION CARD",
+) -> dict:
+    return {
+        "metadata": metadata,
+        "diagnosis": diagnosis,
+        "issues": [diagnosis],
+        "global": global_summary or {},
+        "groups": groups or {"by": "global_rank", "rows": {}},
+        "units": {},
+        "card": card,
+    }
+
+
+def _point(value: float, idx: int) -> dict:
+    return {"value": value, "idx": str(idx)}
+
+
+def _status_payload(status: str) -> dict:
+    return _payload(
+        metadata={},
+        diagnosis=_diagnosis(status, status),
+        card=f"{status} SECTION CARD",
+    )
 
 
 def test_final_report_generator_preserves_summary_schema_and_order():
@@ -78,9 +141,10 @@ def test_final_report_generator_preserves_summary_schema_and_order():
         "INSUFFICIENT_STEP_TIME_DATA"
     )
     assert "TraceML Run Summary | duration 10.0s" in payload["text"]
-    assert "Primary Diagnosis" in payload["text"]
-    assert "System" in payload["text"]
-    assert "Step Memory" in payload["text"]
+    assert "TraceML Verdict:" in payload["text"]
+    assert "Section Status" in payload["text"]
+    assert "System Evidence" in payload["text"]
+    assert "Step Time Evidence" in payload["text"]
 
 
 def test_final_report_generator_fails_open_for_one_section():
@@ -107,6 +171,168 @@ def test_final_report_generator_fails_open_for_one_section():
         "INSUFFICIENT_STEP_TIME_DATA"
     )
     assert "Process" in payload["text"]
+
+
+def test_final_text_uses_single_process_average_layout():
+    step_diag = _diagnosis(
+        "INPUT_BOUND",
+        "INPUT-BOUND",
+        severity="crit",
+        action="Increase workers, prefetch, or storage throughput.",
+    )
+    step_time = _payload(
+        metadata={"global_ranks_used": 1},
+        diagnosis=step_diag,
+        global_summary={
+            "window": {"steps_analyzed": 60},
+            "average": {
+                "total_step_ms": 139.1,
+                "dataloader_ms": 130.8,
+                "compute_ms": 6.9,
+                "residual_ms": 1.3,
+                "h2d_ms": 0.2,
+            },
+        },
+        card="STEP TIME ORIGINAL CARD",
+    )
+    system = _payload(
+        metadata={"mode": "single_node", "gpus_observed": 1},
+        diagnosis=_diagnosis("LOW_GPU_UTILIZATION", "LOW GPU UTIL"),
+        global_summary={
+            "average": {
+                "cpu_percent": 18.4,
+                "gpu_util_percent": 0.0,
+                "gpu_mem_bytes": 570_000_000.0,
+                "gpu_temp_c": 30.0,
+            }
+        },
+        groups={"by": "node_rank", "rows": {}},
+        card="SYSTEM ORIGINAL CARD",
+    )
+
+    payload = build_summary_payload(
+        "fake.db",
+        generator=_generator(
+            _PayloadSection("system", system),
+            _PayloadSection("process", _status_payload("NORMAL")),
+            _PayloadSection("step_time", step_time),
+            _PayloadSection("step_memory", _status_payload("BALANCED")),
+        ),
+    )
+
+    text = payload["text"]
+    assert "TraceML Verdict: INPUT-BOUND / CRITICAL" in text
+    assert "Why: Input loading took 130.8ms of a 139.1ms average step." in text
+    assert "Next: Increase workers, prefetch, or storage throughput." in text
+    assert "System Evidence" in text
+    assert "Metric            Average" in text
+    assert "Step Time Evidence" in text
+    assert "Phase             Average           Share" in text
+    assert "Dataloader        130.8ms           94.0%" in text
+    assert "Median" not in text
+    assert "Worst" not in text
+    assert "Skew" not in text
+    assert "rank=r" not in text
+    assert "node=n" not in text
+    assert payload["step_time"]["card"] == "STEP TIME ORIGINAL CARD"
+    assert payload["system"]["card"] == "SYSTEM ORIGINAL CARD"
+
+
+def test_final_text_uses_multi_process_comparison_layout():
+    step_diag = _diagnosis(
+        "INPUT_STRAGGLER",
+        "INPUT STRAGGLER",
+        severity="crit",
+        phase="dataloader",
+        action=(
+            "Inspect dataloader, collate_fn, preprocessing, and storage "
+            "on the slow rank."
+        ),
+    )
+    step_time = _payload(
+        metadata={"global_ranks_used": 2},
+        diagnosis=step_diag,
+        global_summary={
+            "window": {"steps_analyzed": 60},
+            "median": {
+                "total_step_ms": _point(303.7, 1),
+                "dataloader_ms": _point(3.8, 1),
+                "compute_ms": _point(259.5, 1),
+                "residual_ms": _point(40.5, 1),
+                "h2d_ms": _point(0.2, 1),
+            },
+            "worst": {
+                "total_step_ms": _point(304.1, 0),
+                "dataloader_ms": _point(254.5, 0),
+                "compute_ms": _point(261.0, 0),
+                "residual_ms": _point(42.1, 0),
+                "h2d_ms": _point(0.4, 0),
+            },
+        },
+        groups={
+            "by": "global_rank",
+            "rows": {
+                "0": {
+                    "identity": {"global_rank": 0, "node_rank": 0},
+                    "metrics": {},
+                },
+                "1": {
+                    "identity": {"global_rank": 1, "node_rank": 1},
+                    "metrics": {},
+                },
+            },
+        },
+    )
+    system = _payload(
+        metadata={"mode": "multi_node", "nodes_observed": 2},
+        diagnosis=_diagnosis("LOW_GPU_UTILIZATION", "LOW GPU UTIL"),
+        global_summary={
+            "median": {
+                "cpu_percent": _point(18.4, 0),
+                "gpu_util_percent": _point(14.0, 0),
+                "gpu_mem_bytes": _point(6_200_000_000.0, 0),
+                "gpu_temp_c": _point(42.0, 0),
+            },
+            "worst": {
+                "cpu_percent": _point(71.2, 1),
+                "gpu_util_percent": _point(0.0, 0),
+                "gpu_mem_bytes": _point(8_900_000_000.0, 1),
+                "gpu_temp_c": _point(58.0, 1),
+            },
+        },
+        groups={
+            "by": "node_rank",
+            "rows": {
+                "0": {"identity": {"node_rank": 0}, "metrics": {}},
+                "1": {"identity": {"node_rank": 1}, "metrics": {}},
+            },
+        },
+    )
+
+    payload = build_summary_payload(
+        "fake.db",
+        generator=_generator(
+            _PayloadSection("system", system),
+            _PayloadSection("process", _status_payload("NORMAL")),
+            _PayloadSection("step_time", step_time),
+            _PayloadSection("step_memory", _status_payload("BALANCED")),
+        ),
+    )
+
+    text = payload["text"]
+    assert "TraceML Verdict: INPUT STRAGGLER / CRITICAL" in text
+    assert "Rank r0 dataloader was 254.5ms vs median rank r1 at 3.8ms." in text
+    assert (
+        "Metric          Median        Worst         Skew        Scope" in text
+    )
+    assert "GPU Util        14.0%         0.0%          14.0pp" in text
+    assert "node=n1" in text
+    assert (
+        "Phase           Median        Worst         Skew        Scope" in text
+    )
+    assert "Dataloader      3.8ms         254.5ms       6597.4%" in text
+    assert "rank=r0 node=n0" in text
+    assert "Average" not in text
 
 
 def test_reporting_final_is_the_summary_orchestration_owner():

--- a/tests/reporting/summary/test_fixtures.py
+++ b/tests/reporting/summary/test_fixtures.py
@@ -872,5 +872,5 @@ def test_final_summary_fixture_schema_contains_all_sections(
         assert "- Next:" not in payload[key]["card"]
     assert payload["system"]["diagnosis"]["status"] == "NORMAL"
     assert "NO GPU" not in payload["system"]["card"]
-    assert "Primary Diagnosis" in payload["text"]
-    assert "- Next:" in payload["text"]
+    assert "TraceML Verdict:" in payload["text"]
+    assert "Next:" in payload["text"]

--- a/tests/runtime/test_final_summary_smoke.py
+++ b/tests/runtime/test_final_summary_smoke.py
@@ -1,0 +1,146 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+
+SRC_DIR = Path(__file__).resolve().parents[2] / "src"
+RUN_NAME = "smoke-test"
+FINALIZE_TIMEOUT_SEC = 60.0
+SUBPROCESS_TIMEOUT_SEC = 240
+
+TRAIN_SCRIPT = """\
+import torch
+from torch import nn
+
+import traceml_ai as traceml
+
+
+class TinyMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(32, 64), nn.GELU(), nn.Linear(64, 4)
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+def main():
+    torch.manual_seed(0)
+    traceml.init()
+
+    model = TinyMLP()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    criterion = nn.CrossEntropyLoss()
+
+    for _ in range(80):
+        x = torch.randn(16, 32)
+        y = torch.randint(0, 4, (16,))
+        with traceml.trace_step(model):
+            optimizer.zero_grad(set_to_none=True)
+            criterion(model(x), y).backward()
+            optimizer.step()
+
+    traceml.summary(print_text=False)
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+
+def _free_tcp_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Aggregator uses socket.SO_REUSEPORT, unavailable on Windows.",
+)
+def test_final_summary_json_smoke(tmp_path):
+    script_path = tmp_path / "smoke_train.py"
+    script_path.write_text(TRAIN_SCRIPT, encoding="utf-8")
+
+    logs_dir = tmp_path / "logs"
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(SRC_DIR), env.get("PYTHONPATH", "")) if part
+    )
+
+    # Warm bytecode/import caches so the aggregator binds within the launcher's
+    # fixed 15s readiness window. On a cold checkout the first import compiles
+    # .pyc for the whole stack, which can otherwise blow the startup budget.
+    subprocess.run(
+        [sys.executable, "-c", "import traceml_ai.aggregator.aggregator_main"],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=SUBPROCESS_TIMEOUT_SEC,
+    )
+
+    cmd = [
+        sys.executable,
+        "-c",
+        "from traceml_ai.launcher.cli import main; main()",
+        "run",
+        str(script_path),
+        "--mode=summary",
+        "--run-name",
+        RUN_NAME,
+        "--logs-dir",
+        str(logs_dir),
+        "--aggregator-port",
+        str(_free_tcp_port()),
+        "--finalize-timeout-sec",
+        str(FINALIZE_TIMEOUT_SEC),
+    ]
+
+    result = subprocess.run(
+        cmd,
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=SUBPROCESS_TIMEOUT_SEC,
+    )
+
+    assert result.returncode == 0, (
+        f"traceml run exited with {result.returncode}\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+    session_root = logs_dir / RUN_NAME
+    assert (session_root / "final_summary.json").is_file()
+    assert (session_root / "final_summary.txt").is_file()
+
+    payload = json.loads(
+        (session_root / "final_summary.json").read_text(encoding="utf-8")
+    )
+    required = (
+        "schema_version",
+        "system",
+        "process",
+        "step_time",
+        "step_memory",
+    )
+    for key in required:
+        assert key in payload, f"final_summary.json missing key: {key!r}"


### PR DESCRIPTION
## What changed

Compared with `main`, the current `version_0.3.3` branch updates two
user-facing areas:

- Makes the default end-of-run `final_summary.txt` /
  top-level `final_summary.json["text"]` verdict-first and compact.
- Adds explicit support for both modern `lightning.pytorch` and legacy
  `pytorch_lightning` Trainer namespaces in the TraceML Lightning callback.
- Updates integration install guidance and error messages for Lightning,
  Hugging Face, and Ray extras.
- Updates README and user docs to show the new final-summary output shape and
  the self-contained quickstart example.

The structured final-summary JSON contract stays at `schema_version: 1.5`.
Section-local `system.card`, `process.card`, `step_time.card`, and
`step_memory.card` fields remain available for detailed section prose.

## Why

The old final summary pasted full section cards into the top-level text, which
made users search through prose before finding the actual verdict, evidence,
and next action. The new text starts with the diagnosis, explains why, gives a
next step, and then shows compact evidence tables.

The Lightning change fixes a real integration footgun: users with
`pytorch_lightning` could pass `TraceMLCallback()` to a legacy
`pl.Trainer(...)` and hit callback type validation errors because TraceML only
inherited from the modern Lightning callback base. The callback now resolves
available callback bases at import time and can be accepted by either namespace.

## How I tested

- [x] Tests added or updated
- [x] Existing tests run
- [x] Manual smoke test
- [ ] Not run; reason:

Lightning integration tests:

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/integrations/test_lightning.py -q
```

Result:

```text
4 passed
```

Summary/reporting tests:

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/reporting/summary -q
```

Result:

```text
53 passed
```

HTML/reporting regression tests:

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/reporting/html -q
```

Result:

```text
62 passed
```

Manual CLI smoke:

```bash
PYTHONPATH=src python -c 'from traceml_ai.launcher.cli import main; main()' \
  run examples/summary_logging_minimal.py \
  --mode=summary \
  --logs-dir /tmp/traceml-compact-summary-smoke \
  --run-name compact_summary_smoke \
  --finalize-timeout-sec 30 \
  --args --steps 1
```

Smoke confirmed:

```text
schema_version=1.5
top-level text contains TraceML Verdict
top-level text contains System Evidence
top-level text contains Step Time Evidence
all four section card fields remain present
```

Also ran:

```bash
git diff --check main --
```

Result: clean.

Note: `ruff` was not available in this local environment as either `ruff` or
`python -m ruff`, so I could not run it here.

## Runtime impact

- [ ] No training-path impact
- [x] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes:

The final-summary work is presentation-only: it changes top-level human text,
not diagnostics, telemetry, samplers, transport, section payloads, or HTML
rendering.

The Lightning integration change affects framework callback compatibility. It
does not change the traced Lightning regions themselves, but it changes the
callback base class resolution so the same `TraceMLCallback` can work with
either installed Lightning namespace.

Code that needs stable machine-readable data should use structured JSON fields
rather than parsing top-level `text`.

## Docs

- [x] Updated
- [ ] Not needed

Updated:

- `README.md`
- `docs/user_guide/quickstart.md`
- `docs/user_guide/reading-output.md`
- `docs/guides/pytorch-dataloader-bottleneck.md`
- `docs/user_guide/integrations/lightning.md`
- `src/traceml_ai/reporting/SCHEMA.md`

## Extra context

Example compact final-summary shape:

```text
TraceML Verdict: INPUT STRAGGLER / CRITICAL
Why: Rank r0 dataloader was 254.5ms vs median rank r1 at 3.8ms.
Next: Inspect dataloader, collate_fn, preprocessing, and storage on the slow rank.

Section Status
Section       Status                  Severity
------------------------------------------------
Step Time     INPUT STRAGGLER         CRITICAL
System        LOW GPU UTIL            INFO
Process       NORMAL                  INFO
Step Memory   BALANCED                INFO

Step Time Evidence
Phase           Median        Worst         Skew        Scope
--------------------------------------------------------------------------
Total           303.7ms       304.1ms       0.1%        rank=r0 node=n0
Dataloader      3.8ms         254.5ms       6597.4%     rank=r0 node=n0
Compute         259.5ms       261.0ms       0.6%        rank=r2 node=n1
```

Tracked diff versus `main`:

```text
README.md
docs/guides/pytorch-dataloader-bottleneck.md
docs/user_guide/integrations/lightning.md
docs/user_guide/quickstart.md
docs/user_guide/reading-output.md
src/traceml_ai/integrations/huggingface.py
src/traceml_ai/integrations/lightning.py
src/traceml_ai/integrations/ray.py
src/traceml_ai/reporting/SCHEMA.md
src/traceml_ai/reporting/final.py
tests/integrations/test_lightning.py
tests/reporting/summary/test_final.py
tests/reporting/summary/test_fixtures.py
```
