### PR TITLE
rename use gpu to record_gpu events

### DIFF
--- a/src/traceml_ai/instrumentation/patches/backward_auto_timer_patch.py
+++ b/src/traceml_ai/instrumentation/patches/backward_auto_timer_patch.py
@@ -36,7 +36,9 @@ def _traceml_tensor_backward(
     _set_depth(_depth() + 1)
     try:
         with timed_region(
-            "_traceml_internal:backward_time", scope="step", use_gpu=True
+            "_traceml_internal:backward_time",
+            scope="step",
+            record_gpu_events=True,
         ):
             return _ORIG_TENSOR_BACKWARD(self, *args, **kwargs)
     finally:
@@ -54,7 +56,9 @@ def _traceml_autograd_backward(*args: Any, **kwargs: Any) -> Any:
     _set_depth(_depth() + 1)
     try:
         with timed_region(
-            "_traceml_internal:backward_time", scope="step", use_gpu=True
+            "_traceml_internal:backward_time",
+            scope="step",
+            record_gpu_events=True,
         ):
             return _ORIG_AUTOGRAD_BACKWARD(*args, **kwargs)
     finally:

--- a/src/traceml_ai/instrumentation/patches/dataloader_patch.py
+++ b/src/traceml_ai/instrumentation/patches/dataloader_patch.py
@@ -13,7 +13,7 @@ def _traceml_dataloader_iter(self):
             with timed_region(
                 name="_traceml_internal:dataloader_next",
                 scope="step",
-                use_gpu=False,
+                record_gpu_events=False,
             ):
                 batch = next(it)
         except StopIteration:

--- a/src/traceml_ai/instrumentation/patches/forward_auto_timer_patch.py
+++ b/src/traceml_ai/instrumentation/patches/forward_auto_timer_patch.py
@@ -58,7 +58,9 @@ def _traceml_module_call(self: nn.Module, *args, **kwargs):
     _set_depth(_depth() + 1)
     try:
         with timed_region(
-            "_traceml_internal:forward_time", scope="step", use_gpu=True
+            "_traceml_internal:forward_time",
+            scope="step",
+            record_gpu_events=True,
         ):
             return _ORIG_MODULE_CALL(self, *args, **kwargs)
     finally:

--- a/src/traceml_ai/instrumentation/patches/h2d_auto_timer_patch.py
+++ b/src/traceml_ai/instrumentation/patches/h2d_auto_timer_patch.py
@@ -72,7 +72,7 @@ def _traceml_tensor_to(self: torch.Tensor, *args: Any, **kwargs: Any) -> Any:
     with timed_region(
         "_traceml_internal:h2d_time",
         scope="step",
-        use_gpu=True,
+        record_gpu_events=True,
     ):
         return _ORIG_TENSOR_TO(self, *args, **kwargs)
 

--- a/src/traceml_ai/integrations/lightning.py
+++ b/src/traceml_ai/integrations/lightning.py
@@ -221,7 +221,7 @@ class TraceMLCallback(_CallbackBase):
             with timed_region(
                 "_traceml_internal:forward_time",
                 scope=TimeScope.STEP,
-                use_gpu=True,
+                record_gpu_events=True,
             ):
                 return original_forward(*args, **kwargs)
 
@@ -311,7 +311,9 @@ class TraceMLCallback(_CallbackBase):
         if TRACEML_DISABLED:
             return
         self._traceml_step_ctx = timed_region(
-            "_traceml_internal:step_time", scope="step", use_gpu=False
+            "_traceml_internal:step_time",
+            scope="step",
+            record_gpu_events=False,
         )
         self._traceml_step_ctx.__enter__()
 

--- a/src/traceml_ai/sdk/instrumentation.py
+++ b/src/traceml_ai/sdk/instrumentation.py
@@ -155,7 +155,9 @@ def trace_step(model: nn.Module):
 
     try:
         with timed_region(
-            "_traceml_internal:step_time", scope="step", use_gpu=False
+            "_traceml_internal:step_time",
+            scope="step",
+            record_gpu_events=False,
         ):
             with (
                 forward_auto_timer(model),
@@ -192,7 +194,7 @@ def trace_step(model: nn.Module):
 def trace_time(
     name: str,
     scope: str = "global",
-    use_gpu: bool = True,
+    record_gpu_events: bool = True,
 ) -> Callable:
     """
     Decorator to time a function.
@@ -205,8 +207,8 @@ def trace_time(
         Semantic scope of this timing:
         - "step": attributed to the current training step
         - "global": not step-attributed
-    use_gpu:
-        If True, record CUDA timing when available.
+    record_gpu_events:
+        If True, record PyTorch CUDA stream events when available.
     """
     if _traceml_disabled():
         return lambda func: func
@@ -219,7 +221,11 @@ def trace_time(
     def decorator(func: Callable):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            with timed_region(name, scope=scope, use_gpu=use_gpu):
+            with timed_region(
+                name,
+                scope=scope,
+                record_gpu_events=record_gpu_events,
+            ):
                 return func(*args, **kwargs)
 
         return wrapper

--- a/src/traceml_ai/sdk/wrappers.py
+++ b/src/traceml_ai/sdk/wrappers.py
@@ -93,7 +93,7 @@ class _WrappedDataLoaderIterator:
         with timed_region(
             name="_traceml_internal:dataloader_next",
             scope=TimeScope.STEP,
-            use_gpu=False,
+            record_gpu_events=False,
         ):
             return next(self._iterator)
 
@@ -131,7 +131,7 @@ class _WrappedBackwardHandle:
         with timed_region(
             name="_traceml_internal:backward_time",
             scope=TimeScope.STEP,
-            use_gpu=True,
+            record_gpu_events=True,
         ):
             return self._loss.backward(*args, **kwargs)
 
@@ -192,7 +192,7 @@ def wrap_forward(model: nn.Module) -> nn.Module:
         with timed_region(
             name="_traceml_internal:forward_time",
             scope=TimeScope.STEP,
-            use_gpu=True,
+            record_gpu_events=True,
         ):
             return original_forward(*args, **kwargs)
 
@@ -249,7 +249,7 @@ def wrap_optimizer(optimizer: Any) -> Any:
         with timed_region(
             name="_traceml_internal:optimizer_step",
             scope=TimeScope.STEP,
-            use_gpu=True,
+            record_gpu_events=True,
         ):
             return step_fn(*args, **kwargs)
 
@@ -300,7 +300,7 @@ class _WrappedH2D:
         with timed_region(
             name="_traceml_internal:h2d_time",
             scope=TimeScope.STEP,
-            use_gpu=True,
+            record_gpu_events=True,
         ):
             return self._obj.to(*args, **kwargs)
 

--- a/src/traceml_ai/utils/timing.py
+++ b/src/traceml_ai/utils/timing.py
@@ -185,7 +185,7 @@ def flush_step_time_buffer(step: int) -> None:
 def timed_region(
     name: str,
     scope: TimeScope = TimeScope.STEP,
-    use_gpu: bool = True,
+    record_gpu_events: bool = True,
 ):
     """
     Context manager for timing arbitrary code regions.
@@ -195,6 +195,14 @@ def timed_region(
     - User code always runs
     - Timing is best-effort
     - User exceptions are never swallowed
+
+    Timing clocks
+    -------------
+    CPU wall time is always recorded. When ``record_gpu_events`` is true and
+    PyTorch CUDA is available, TraceML also records CUDA stream events and
+    resolves them later without synchronizing training. Timing events do not
+    currently include GPU backend metadata; CUDA and ROCm-specific labeling can
+    be added as a separate schema change when needed.
     """
     if TRACEML_DISABLED or not should_record_trace_events():
         yield
@@ -203,7 +211,7 @@ def timed_region(
     cpu_start = time.time()
 
     try:
-        if use_gpu and torch.cuda.is_available():
+        if record_gpu_events and torch.cuda.is_available():
             device = f"cuda:{torch.cuda.current_device()}"
             start_evt = get_cuda_event()
             end_evt = get_cuda_event()

--- a/tests/integrations/test_lightning.py
+++ b/tests/integrations/test_lightning.py
@@ -48,8 +48,8 @@ def test_lightning_forward_wrapper_times_only_forward(monkeypatch):
     calls = []
 
     @contextmanager
-    def fake_timed_region(name, scope, use_gpu=True):
-        calls.append((name, scope, use_gpu))
+    def fake_timed_region(name, scope, record_gpu_events=True):
+        calls.append((name, scope, record_gpu_events))
         yield
 
     monkeypatch.setattr(
@@ -89,8 +89,8 @@ def test_lightning_batch_start_does_not_open_forward_region(monkeypatch):
     calls = []
 
     @contextmanager
-    def fake_timed_region(name, scope, use_gpu=True):
-        calls.append((name, scope, use_gpu))
+    def fake_timed_region(name, scope, record_gpu_events=True):
+        calls.append((name, scope, record_gpu_events))
         yield
 
     class FakeMemoryTracker:

--- a/tests/sdk/test_init_and_wrappers.py
+++ b/tests/sdk/test_init_and_wrappers.py
@@ -420,8 +420,8 @@ def test_wrap_forward_times_model_instance(monkeypatch):
     calls = []
 
     @contextmanager
-    def fake_timed_region(name, scope, use_gpu):
-        calls.append((name, scope, use_gpu))
+    def fake_timed_region(name, scope, record_gpu_events):
+        calls.append((name, scope, record_gpu_events))
         yield
 
     monkeypatch.setattr(wrappers, "timed_region", fake_timed_region)
@@ -448,8 +448,8 @@ def test_wrap_backward_times_backward(monkeypatch):
     calls = []
 
     @contextmanager
-    def fake_timed_region(name, scope, use_gpu):
-        calls.append((name, scope, use_gpu))
+    def fake_timed_region(name, scope, record_gpu_events):
+        calls.append((name, scope, record_gpu_events))
         yield
 
     monkeypatch.setattr(wrappers, "timed_region", fake_timed_region)
@@ -481,8 +481,8 @@ def test_wrap_optimizer_preserves_identity_and_times_step(monkeypatch):
     calls = []
 
     @contextmanager
-    def fake_timed_region(name, scope, use_gpu):
-        calls.append((name, scope, use_gpu))
+    def fake_timed_region(name, scope, record_gpu_events):
+        calls.append((name, scope, record_gpu_events))
         yield
 
     monkeypatch.setattr(wrappers, "timed_region", fake_timed_region)

--- a/tests/test_h2d_timing.py
+++ b/tests/test_h2d_timing.py
@@ -167,7 +167,7 @@ class TestH2DAutoTimerPatch:
         tensor = torch.ones(4)
         recorded = []
 
-        def fake_timed_region(name, scope, use_gpu):
+        def fake_timed_region(name, scope, record_gpu_events):
             # Should never be reached when disabled
             recorded.append(name)
 
@@ -191,7 +191,7 @@ class TestH2DAutoTimerPatch:
         tensor = torch.ones(4)
         recorded = []
 
-        def fake_timed_region(name, scope, use_gpu):
+        def fake_timed_region(name, scope, record_gpu_events):
             recorded.append(name)
 
             @contextmanager
@@ -220,7 +220,7 @@ class TestH2DAutoTimerPatch:
         recorded = []
 
         @contextmanager
-        def fake_timed_region(name, scope, use_gpu):
+        def fake_timed_region(name, scope, record_gpu_events):
             recorded.append(name)
             yield
 
@@ -246,7 +246,7 @@ class TestH2DAutoTimerPatch:
         recorded = []
 
         @contextmanager
-        def fake_timed_region(name, scope, use_gpu):
+        def fake_timed_region(name, scope, record_gpu_events):
             recorded.append(name)
             yield
 
@@ -279,7 +279,7 @@ class TestH2DAutoTimerPatch:
         recorded = []
 
         @contextmanager
-        def fake_timed_region(name, scope, use_gpu):
+        def fake_timed_region(name, scope, record_gpu_events):
             recorded.append(name)
             yield
 
@@ -404,7 +404,7 @@ class TestWrapH2D:
         recorded = []
 
         @contextmanager
-        def fake_timed_region(name, scope, use_gpu):
+        def fake_timed_region(name, scope, record_gpu_events):
             recorded.append(name)
             yield
 


### PR DESCRIPTION
## What changed

Renamed TraceML timing's `use_gpu` flag to `record_gpu_events`.

- `timed_region(..., use_gpu=...)` is now
  `timed_region(..., record_gpu_events=...)`.
- `trace_time(..., use_gpu=...)` is now
  `trace_time(..., record_gpu_events=...)`.
- Existing timing behavior is unchanged: dataloader and step envelope timing
  still do not record GPU events, while forward/backward/H2D/manual optimizer
  timing still does.

## Why

`use_gpu` was ambiguous: timed regions always record CPU wall time, and the
flag only controls whether TraceML also records PyTorch CUDA stream events.
`record_gpu_events` describes the behavior more accurately and leaves room for
future backend metadata without changing the API name again.

## How I tested

- [x] Tests added or updated
- [x] Existing tests run
- [ ] Manual smoke test
- [ ] Not run; reason:

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/test_h2d_timing.py \
  tests/sdk/test_init_and_wrappers.py \
  tests/integrations/test_lightning.py \
  tests/runtime/test_trace_session_state.py -q
```

Result:

```text
68 passed, 1 warning
```

Also checked remaining `use_gpu` references:

```bash
rg -n "use_gpu" src tests docs examples README.md
```

Remaining matches are Ray configuration/examples only, not TraceML timing.

## Runtime impact

- [ ] No training-path impact
- [x] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes:

This is intended to be behavior-preserving, but it touches tracing call sites
and the exported `trace_time` decorator. The rename is strict:
`trace_time(use_gpu=...)` is no longer accepted.

## Docs

- [x] Updated
- [ ] Not needed

Updated the `timed_region` docstring to clarify that CPU wall time is always
recorded and `record_gpu_events=True` records PyTorch CUDA stream events when
available. No user docs needed for Ray/HF `use_gpu` settings because those are
unrelated framework config.

## Extra context

This PR intentionally does not change the step-time schema, sampler payloads,
dataloader timing behavior, diagnosis logic, or reporting output.
