### PR TITLE
Abhinav/dual timers

### DIFF
--- a/src/traceml_ai/aggregator/sqlite_writers/step_time.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/step_time.py
@@ -228,6 +228,8 @@ def _normalize_events(events_raw: Any) -> Dict[str, Dict[str, Dict[str, Any]]]:
             "<device>": {
                 "is_gpu": bool | None,
                 "duration_ms": float | None,
+                "cpu_ms": float | None,
+                "gpu_ms": float | None,
                 "n_calls": int | None
             }
         }
@@ -259,6 +261,8 @@ def _normalize_events(events_raw: Any) -> Dict[str, Dict[str, Dict[str, Any]]]:
 
             is_gpu_raw = stats.get("is_gpu")
             duration_raw = stats.get("duration_ms")
+            cpu_raw = stats.get("cpu_ms")
+            gpu_raw = stats.get("gpu_ms")
             n_calls_raw = stats.get("n_calls")
 
             is_gpu = bool(is_gpu_raw) if isinstance(is_gpu_raw, bool) else None
@@ -267,6 +271,12 @@ def _normalize_events(events_raw: Any) -> Dict[str, Dict[str, Dict[str, Any]]]:
                 if isinstance(duration_raw, (int, float))
                 else None
             )
+            cpu_ms = (
+                float(cpu_raw) if isinstance(cpu_raw, (int, float)) else None
+            )
+            gpu_ms = (
+                float(gpu_raw) if isinstance(gpu_raw, (int, float)) else None
+            )
             n_calls = (
                 int(n_calls_raw) if isinstance(n_calls_raw, int) else None
             )
@@ -274,6 +284,8 @@ def _normalize_events(events_raw: Any) -> Dict[str, Dict[str, Dict[str, Any]]]:
             out[event_key][device_key] = {
                 "is_gpu": is_gpu,
                 "duration_ms": duration_ms,
+                "cpu_ms": cpu_ms,
+                "gpu_ms": gpu_ms,
                 "n_calls": n_calls,
             }
 

--- a/src/traceml_ai/samplers/schema/step_time_schema.py
+++ b/src/traceml_ai/samplers/schema/step_time_schema.py
@@ -22,15 +22,19 @@ Each record contains:
 Aggregation rules (produced by sampler)
 ---------------------------------------
 - Events are grouped by (event_name, device).
-- duration_ms is SUM'ed across repeated occurrences within a step
-  (e.g., gradient accumulation regions).
+- cpu_ms is SUM'ed across repeated occurrences within a step.
+- gpu_ms is SUM'ed across repeated GPU-timed occurrences within a step; it is
+  null when no GPU event timing was recorded.
+- duration_ms remains the compatibility/effective duration and is SUM'ed across
+  repeated occurrences within a step (e.g., gradient accumulation regions).
 - n_calls counts how many occurrences were aggregated.
 
 Clocks
 ------
-- CPU events use CPU wall-clock time.
-- GPU events use CUDA event (stream) time.
-- Both are stored in `duration_ms` and disambiguated by `is_gpu`.
+- CPU wall-clock time is always stored in `cpu_ms`.
+- GPU events use CUDA event (stream) time and are stored in nullable `gpu_ms`.
+- `duration_ms` preserves the legacy effective clock: GPU time when available,
+  otherwise CPU wall time. `is_gpu` identifies which clock backs `duration_ms`.
 
 Schema (per DB row)
 ------------------
@@ -43,6 +47,8 @@ Schema (per DB row)
             "<device>": {
                 "is_gpu": bool,
                 "duration_ms": float,
+                "cpu_ms": float,
+                "gpu_ms": float | null,
                 "n_calls": int
             },
             ...
@@ -56,7 +62,13 @@ from dataclasses import dataclass
 from typing import Any, Dict, Mapping
 
 # Type alias for readability and to keep the contract explicit.
-# events[event_name][device] = {"is_gpu": bool, "duration_ms": float, "n_calls": int}
+# events[event_name][device] = {
+#     "is_gpu": bool,
+#     "duration_ms": float,
+#     "cpu_ms": float,
+#     "gpu_ms": float | None,
+#     "n_calls": int,
+# }
 StepEventMap = Dict[str, Dict[str, Dict[str, Any]]]
 
 

--- a/src/traceml_ai/samplers/step_time_sampler.py
+++ b/src/traceml_ai/samplers/step_time_sampler.py
@@ -63,6 +63,8 @@ class StepTimeSampler(BaseSampler):
         Build a single per-step payload containing all aggregated event timings.
         """
         sum_ms: Dict[Tuple[str, str, bool], float] = defaultdict(float)
+        sum_cpu_ms: Dict[Tuple[str, str, bool], float] = defaultdict(float)
+        sum_gpu_ms: Dict[Tuple[str, str, bool], float] = defaultdict(float)
         n_calls: Dict[Tuple[str, str, bool], int] = defaultdict(int)
 
         ts_max = 0.0
@@ -71,14 +73,15 @@ class StepTimeSampler(BaseSampler):
             ts_max = float(max(ts_max, float(evt.cpu_end)))
 
             is_gpu = evt.gpu_time_ms is not None
-            duration_ms = (
-                float(evt.gpu_time_ms)
-                if is_gpu
-                else float(self._cpu_duration_ms(evt))
-            )
+            cpu_ms = float(self._cpu_duration_ms(evt))
+            gpu_ms = float(evt.gpu_time_ms) if is_gpu else None
+            duration_ms = float(gpu_ms) if is_gpu else float(cpu_ms)
 
             key = (str(evt.name), str(evt.device), bool(is_gpu))
             sum_ms[key] += duration_ms
+            sum_cpu_ms[key] += cpu_ms
+            if gpu_ms is not None:
+                sum_gpu_ms[key] += gpu_ms
             n_calls[key] += 1
 
         events: Dict[str, Dict[str, Dict[str, Any]]] = defaultdict(dict)
@@ -86,6 +89,12 @@ class StepTimeSampler(BaseSampler):
             events[name][device] = {
                 "is_gpu": bool(is_gpu),
                 "duration_ms": float(total_ms),
+                "cpu_ms": float(sum_cpu_ms[(name, device, is_gpu)]),
+                "gpu_ms": (
+                    float(sum_gpu_ms[(name, device, is_gpu)])
+                    if is_gpu
+                    else None
+                ),
                 "n_calls": int(n_calls[(name, device, is_gpu)]),
             }
 

--- a/tests/aggregator/test_step_time_sqlite_writer.py
+++ b/tests/aggregator/test_step_time_sqlite_writer.py
@@ -1,0 +1,66 @@
+from traceml_ai.aggregator.sqlite_writers.step_time import _normalize_events
+
+
+def test_step_time_normalize_events_preserves_cpu_and_gpu_ms() -> None:
+    events = {
+        "_test_event": {
+            "cuda:0": {
+                "is_gpu": True,
+                "duration_ms": 9.0,
+                "cpu_ms": 3.0,
+                "gpu_ms": 9.0,
+                "n_calls": 2,
+                "extra": "drop me",
+            },
+            "cpu": {
+                "is_gpu": False,
+                "duration_ms": 4.0,
+                "cpu_ms": 4.0,
+                "gpu_ms": None,
+                "n_calls": 1,
+            },
+        }
+    }
+
+    normalized = _normalize_events(events)
+
+    assert normalized == {
+        "_test_event": {
+            "cuda:0": {
+                "is_gpu": True,
+                "duration_ms": 9.0,
+                "cpu_ms": 3.0,
+                "gpu_ms": 9.0,
+                "n_calls": 2,
+            },
+            "cpu": {
+                "is_gpu": False,
+                "duration_ms": 4.0,
+                "cpu_ms": 4.0,
+                "gpu_ms": None,
+                "n_calls": 1,
+            },
+        }
+    }
+
+
+def test_step_time_normalize_events_keeps_old_rows_valid() -> None:
+    normalized = _normalize_events(
+        {
+            "_old_event": {
+                "cpu": {
+                    "is_gpu": False,
+                    "duration_ms": 4.0,
+                    "n_calls": 1,
+                }
+            }
+        }
+    )
+
+    assert normalized["_old_event"]["cpu"] == {
+        "is_gpu": False,
+        "duration_ms": 4.0,
+        "cpu_ms": None,
+        "gpu_ms": None,
+        "n_calls": 1,
+    }

--- a/tests/runtime/test_step_time_sampler.py
+++ b/tests/runtime/test_step_time_sampler.py
@@ -1,0 +1,81 @@
+import pytest
+
+from traceml_ai.samplers.step_time_sampler import StepTimeSampler
+from traceml_ai.utils.timing import StepTimeBatch, TimeEvent
+
+
+def _payload_for(*events: TimeEvent):
+    sampler = StepTimeSampler()
+    _timestamp, payload = sampler._build_step_payload(
+        StepTimeBatch(step=1, events=list(events))
+    )
+    return payload
+
+
+def test_step_time_sampler_emits_cpu_clock_for_cpu_only_event() -> None:
+    payload = _payload_for(
+        TimeEvent(
+            name="_test_cpu",
+            device="cpu",
+            cpu_start=10.0,
+            cpu_end=10.025,
+        )
+    )
+
+    stats = payload["_test_cpu"]["cpu"]
+
+    assert stats["is_gpu"] is False
+    assert stats["duration_ms"] == pytest.approx(25.0)
+    assert stats["cpu_ms"] == pytest.approx(25.0)
+    assert stats["gpu_ms"] is None
+    assert stats["n_calls"] == 1
+
+
+def test_step_time_sampler_emits_cpu_and_gpu_clocks_for_gpu_event() -> None:
+    payload = _payload_for(
+        TimeEvent(
+            name="_test_gpu",
+            device="cuda:0",
+            cpu_start=20.0,
+            cpu_end=20.004,
+            gpu_time_ms=12.5,
+            resolved=True,
+        )
+    )
+
+    stats = payload["_test_gpu"]["cuda:0"]
+
+    assert stats["is_gpu"] is True
+    assert stats["duration_ms"] == pytest.approx(12.5)
+    assert stats["cpu_ms"] == pytest.approx(4.0)
+    assert stats["gpu_ms"] == pytest.approx(12.5)
+    assert stats["n_calls"] == 1
+
+
+def test_step_time_sampler_aggregates_repeated_event_clocks() -> None:
+    payload = _payload_for(
+        TimeEvent(
+            name="_test_gpu",
+            device="cuda:0",
+            cpu_start=1.0,
+            cpu_end=1.002,
+            gpu_time_ms=5.0,
+            resolved=True,
+        ),
+        TimeEvent(
+            name="_test_gpu",
+            device="cuda:0",
+            cpu_start=2.0,
+            cpu_end=2.003,
+            gpu_time_ms=7.0,
+            resolved=True,
+        ),
+    )
+
+    stats = payload["_test_gpu"]["cuda:0"]
+
+    assert stats["is_gpu"] is True
+    assert stats["duration_ms"] == pytest.approx(12.0)
+    assert stats["cpu_ms"] == pytest.approx(5.0)
+    assert stats["gpu_ms"] == pytest.approx(12.0)
+    assert stats["n_calls"] == 2


### PR DESCRIPTION
## What changed

Added explicit `cpu_ms` and nullable `gpu_ms` fields to Step Time event
payloads.

Existing fields remain unchanged:

- `duration_ms` is still the compatibility/effective duration.
- `is_gpu` still indicates whether `duration_ms` came from GPU event timing.
- `n_calls` is unchanged.

## Why

TraceML previously collapsed each timed region to a single duration too early.
Keeping both CPU wall time and GPU event time gives later diagnosis work the
raw evidence it needs, while preserving current reporting and diagnosis behavior
through `duration_ms`.

## How I tested

- [x] Tests added or updated
- [x] Existing tests run
- [ ] Manual smoke test
- [ ] Not run; reason:

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/runtime/test_step_time_sampler.py \
  tests/aggregator/test_step_time_sqlite_writer.py \
  tests/reporting/summary/test_step_time.py \
  tests/display/test_renderer_contracts.py -q
```

Result:

```text
13 passed, 1 warning
```

## Runtime impact

- [ ] No training-path impact
- [x] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes:

This changes the Step Time sampler payload and the SQLite-normalized
`events_json` shape by adding fields. Existing consumers continue to read
`duration_ms`, so summaries, renderers, reports, and diagnosis logic should be
behavior-preserving.

## Docs

- [x] Updated
- [ ] Not needed

Updated the Step Time event schema docstring to document `cpu_ms`, nullable
`gpu_ms`, and the compatibility role of `duration_ms`.

## Extra context

This PR does not enable GPU events for dataloader or step-envelope timing, and
does not change any bottleneck labels or calculations. It only preserves the
additional clock data for future diagnosis work.
