### PR TITLE
Add data-loading bottleneck Colab notebook

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,9 @@
+# Notebooks
+
+Runnable, Colab-ready notebooks that demonstrate TraceML on real workloads.
+Each opens in Google Colab (a free T4 GPU is enough) and runs top to bottom in
+a few minutes.
+
+| Notebook | What it shows | Open |
+|---|---|---|
+| `data_loading_bottleneck.ipynb` | Diagnose and fix a data-loading (input-bound) bottleneck on a real ResNet-18 + Imagenette run: train twice, change only the DataLoader, and read the before/after wall-clock speedup and GPU utilization from TraceML | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/traceopt-ai/traceml/blob/main/notebooks/data_loading_bottleneck.ipynb) |

--- a/notebooks/data_loading_bottleneck.ipynb
+++ b/notebooks/data_loading_bottleneck.ipynb
@@ -1,0 +1,311 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/traceopt-ai/traceml/blob/main/notebooks/data_loading_bottleneck.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The Half-Idle GPU: find a data-loading bottleneck in your own training run\n",
+    "\n",
+    "Training jobs waste GPU time in a way nothing warns you about. The loss still descends, the run still finishes, and the GPU can sit half-idle the whole time, starved of data while the CPU decodes the next batch. This notebook lets you see that happen, and fix it, on your own hardware in a few minutes.\n",
+    "\n",
+    "You will train a small ResNet **twice**, changing only the data loading, and read three things off each run: how long it took (wall clock), how busy the GPU was, and TraceML's one-line verdict. Between the two runs you change three DataLoader arguments, and watch the GPU get fed.\n",
+    "\n",
+    "This is the runnable companion to the write-up [*The Half-Idle GPU*](https://medium.com/@apendyala/the-half-idle-gpu-40bbe394b834), where the same experiment on a 4-vCPU machine ran **1.8x faster** and flipped from input-bound to compute-bound. **How much you see here depends on your CPU cores.** A free Colab runtime has 2 vCPUs, so expect a real but smaller speedup with the GPU much better fed, and possibly still input-bound: two cores can only decode so fast. The final cell reads out the result for your specific hardware. That machine-dependence is the lesson, not a bug.\n",
+    "\n",
+    "**Before you start:** switch to a GPU runtime via *Runtime -> Change runtime type -> Hardware accelerator: GPU* (a free T4 is exactly what the case study used), then run the cells top to bottom.\n",
+    "\n",
+    "TraceML is open source: `pip install traceml-ai` (github.com/traceopt-ai/traceml)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Check the GPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!nvidia-smi -L\n",
+    "import torch\n",
+    "\n",
+    "print(\"CUDA available:\", torch.cuda.is_available())\n",
+    "assert (\n",
+    "    torch.cuda.is_available()\n",
+    "), \"No GPU. Runtime -> Change runtime type -> GPU, then rerun.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Install TraceML\n",
+    "torch and torchvision come preinstalled on Colab; we only add TraceML. We pass `--no-deps` so pip does not try to downgrade Colab's numpy (TraceML's runtime deps are already present on Colab). On a fresh environment that lacks them, drop `--no-deps`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q traceml-ai --no-deps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Get the data (full-resolution Imagenette, ~1.5 GB)\n",
+    "Full-resolution JPEGs are the point: decoding them is the heavy CPU cost that a single-worker loader cannot hide. (~1-2 min to download and extract.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if not os.path.isdir(\"imagenette2/train\"):\n",
+    "    !wget -q https://s3.amazonaws.com/fast-ai-imageclas/imagenette2.tgz\n",
+    "    !tar -xzf imagenette2.tgz\n",
+    "print(\"CPU cores:\", os.cpu_count())\n",
+    "print(\"train classes:\", len(os.listdir(\"imagenette2/train\")))\n",
+    "print(\"train images:\", sum(len(f) for _, _, f in os.walk(\"imagenette2/train\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. The training script\n",
+    "A standard ResNet-18 loop. The only TraceML additions are the two lines marked below: `traceml.init(...)` once, and a `with traceml.trace_step(model):` around the step. The `--profile` flag flips the data-loading settings and nothing else."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile train.py\n",
+    "import argparse, os\n",
+    "import torch, torch.nn as nn\n",
+    "import torchvision\n",
+    "import torchvision.transforms as T\n",
+    "from torch.utils.data import DataLoader\n",
+    "import traceml_ai as traceml\n",
+    "\n",
+    "MEAN = (0.485, 0.456, 0.406)\n",
+    "STD = (0.229, 0.224, 0.225)\n",
+    "\n",
+    "\n",
+    "def main():\n",
+    "    ap = argparse.ArgumentParser()\n",
+    "    ap.add_argument(\"--profile\", choices=[\"baseline\", \"optimized\"],\n",
+    "                    default=\"baseline\")\n",
+    "    ap.add_argument(\"--data-dir\", default=\"imagenette2\")\n",
+    "    ap.add_argument(\"--batch-size\", type=int, default=64)\n",
+    "    ap.add_argument(\"--max-steps\", type=int, default=300)\n",
+    "    args = ap.parse_args()\n",
+    "\n",
+    "    optimized = args.profile == \"optimized\"\n",
+    "    device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
+    "\n",
+    "    # ---- The ONLY thing that changes between the two profiles: data loading ----\n",
+    "    # Match workers to CPU cores so we do not oversubscribe (Colab free tier\n",
+    "    # has ~2 cores; more workers than cores thrash instead of overlapping).\n",
+    "    num_workers = min(4, os.cpu_count() or 2) if optimized else 0\n",
+    "    transform = T.Compose([\n",
+    "        T.RandomResizedCrop(224),\n",
+    "        T.RandomHorizontalFlip(),\n",
+    "        T.ToTensor(),\n",
+    "        T.Normalize(MEAN, STD),\n",
+    "    ])\n",
+    "    dataset = torchvision.datasets.ImageFolder(\n",
+    "        os.path.join(args.data_dir, \"train\"), transform=transform)\n",
+    "    loader = DataLoader(\n",
+    "        dataset,\n",
+    "        batch_size=args.batch_size,\n",
+    "        shuffle=True,\n",
+    "        num_workers=num_workers,\n",
+    "        pin_memory=optimized,                              # async H2D staging\n",
+    "        persistent_workers=(optimized and num_workers > 0),\n",
+    "        drop_last=True,\n",
+    "    )\n",
+    "    # AMP is OFF in both profiles on purpose: it would speed up compute and\n",
+    "    # confound a demo whose whole point is isolating the data-loading change.\n",
+    "\n",
+    "    model = torchvision.models.resnet18(\n",
+    "        weights=None, num_classes=len(dataset.classes)).to(device)\n",
+    "    criterion = nn.CrossEntropyLoss()\n",
+    "    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)\n",
+    "\n",
+    "    print(f\"[demo] profile={args.profile} device={device} \"\n",
+    "          f\"num_workers={num_workers} batch={args.batch_size} \"\n",
+    "          f\"max_steps={args.max_steps} amp=off\", flush=True)\n",
+    "\n",
+    "    traceml.init(mode=\"auto\")            # <-- TraceML line 1\n",
+    "\n",
+    "    model.train()\n",
+    "    step = 0\n",
+    "    while step < args.max_steps:\n",
+    "        for images, labels in loader:\n",
+    "            with traceml.trace_step(model):   # <-- TraceML line 2\n",
+    "                images = images.to(device, non_blocking=optimized)\n",
+    "                labels = labels.to(device, non_blocking=optimized)\n",
+    "                optimizer.zero_grad(set_to_none=True)\n",
+    "                loss = criterion(model(images), labels)\n",
+    "                loss.backward()\n",
+    "                optimizer.step()\n",
+    "            step += 1\n",
+    "            if step >= args.max_steps:\n",
+    "                break\n",
+    "\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    main()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Run 1 - baseline (`num_workers=0`)\n",
+    "The default, single-process data loading. 300 steps (the verdict needs at least ~50; use more for steadier numbers). Watch the end-of-run summary: it should say **INPUT-BOUND**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!traceml run --mode summary --logs-dir logs --run-name baseline train.py --args --profile baseline --data-dir imagenette2 --max-steps 300 --batch-size 64"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Run 2 - optimized (workers matched to CPU cores + pinned + persistent)\n",
+    "Same model, same data, same steps. Only the data loading changes (workers on, `pin_memory`, `persistent_workers`, non-blocking H2D). The GPU utilization should rise and the run should finish faster; if your machine has enough cores to fully hide the decode, the verdict flips to **COMPUTE-BOUND**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!traceml run --mode summary --logs-dir logs --run-name optimized train.py --args --profile optimized --data-dir imagenette2 --max-steps 300 --batch-size 64"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Before vs after\n",
+    "The numbers below come from the **wall clock** (how long each run actually took) plus GPU and CPU utilization, read straight from each run's summary. The cell interprets the result for your specific hardware."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "\n",
+    "def load(run):\n",
+    "    d = json.load(open(f\"logs/{run}/final_summary.json\"))\n",
+    "    g = d[\"system\"][\"global\"][\"average\"]\n",
+    "    return {\n",
+    "        \"wall_s\": round(d[\"duration_s\"], 1),\n",
+    "        \"verdict\": d[\"primary_diagnosis\"][\"status\"],\n",
+    "        \"gpu_util\": round(g[\"gpu_util_percent\"], 1),\n",
+    "        \"cpu_util\": round(g[\"cpu_percent\"], 1),\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "b, o = load(\"baseline\"), load(\"optimized\")\n",
+    "speedup = b[\"wall_s\"] / o[\"wall_s\"]\n",
+    "saved = (1 - o[\"wall_s\"] / b[\"wall_s\"]) * 100\n",
+    "\n",
+    "print(f\"{'metric':<20}{'baseline':>15}{'optimized':>15}\")\n",
+    "print(\"-\" * 50)\n",
+    "print(f\"{'wall clock (s)':<20}{b['wall_s']:>15}{o['wall_s']:>15}\")\n",
+    "print(f\"{'GPU util (%)':<20}{b['gpu_util']:>15}{o['gpu_util']:>15}\")\n",
+    "print(f\"{'CPU util (%)':<20}{b['cpu_util']:>15}{o['cpu_util']:>15}\")\n",
+    "print(f\"{'TraceML verdict':<20}{b['verdict']:>15}{o['verdict']:>15}\")\n",
+    "print(\"-\" * 50)\n",
+    "print(\n",
+    "    f\"\\nSpeedup (wall clock): {speedup:.2f}x  \"\n",
+    "    f\"({saved:.0f}% less GPU time for identical training)\\n\"\n",
+    ")\n",
+    "\n",
+    "if o[\"verdict\"] != \"INPUT-BOUND\":\n",
+    "    print(\n",
+    "        \"The fix flipped the bottleneck: your machine had enough CPU to hide\"\n",
+    "    )\n",
+    "    print(\"the decode, so the GPU is now the limit (COMPUTE-BOUND).\")\n",
+    "else:\n",
+    "    print(\n",
+    "        f\"Workers helped: GPU util {b['gpu_util']}% -> {o['gpu_util']}%, \"\n",
+    "        f\"{speedup:.2f}x faster.\"\n",
+    "    )\n",
+    "    print(f\"But the CPU is now the ceiling ({o['cpu_util']}% used) and still\")\n",
+    "    print(\"cannot fully feed the GPU, so it stays input-bound. With more CPU\")\n",
+    "    print(\"cores this flips to COMPUTE-BOUND (the case study ran on a 4-core\")\n",
+    "    print(\n",
+    "        \"box: 1.8x, fully compute-bound). That is the machine-dependence the\"\n",
+    "    )\n",
+    "    print(\"post is about, showing up live on your hardware.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What just happened\n",
+    "With `num_workers=0`, every batch of JPEGs is decoded in the training process while the GPU waits, then the GPU trains while the CPU waits. Turning on worker processes lets the decode happen in parallel, during time the GPU was going to spend computing anyway. The decode work did not get cheaper, it just stopped blocking the GPU.\n",
+    "\n",
+    "**It depends on your machine.** This fix needs spare CPU cores to absorb the decode. On the 4-core box in the case study, workers fully hid the decode and the run went from INPUT-BOUND to COMPUTE-BOUND (~1.8x). On a 2-core Colab CPU the win is smaller and the job may stay input-bound, because 2 cores can only decode so fast (watch the CPU utilization hit ~100%). More cores, or lighter decode, widen the gap. We set `num_workers` to your core count to avoid oversubscribing them.\n",
+    "\n",
+    "And it is not always the fix: on a job that is already compute-bound (try `resnet50` in the script), more workers buy nothing. Which of your jobs is which is exactly what the measurement tells you.\n",
+    "\n",
+    "Try it on your own model: add the two TraceML lines to your training loop and run it under `traceml run`. github.com/traceopt-ai/traceml"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## What

Adds `notebooks/`, a home for Colab-runnable demos, with the first one:
`data_loading_bottleneck.ipynb`. It walks through diagnosing and fixing a
data-loading (input-bound) bottleneck on a real ResNet-18 + Imagenette run:
train twice, change only the DataLoader, and read the before/after wall-clock
speedup and GPU utilization straight from TraceML. One-click "Open in Colab"
badge; runs on a free T4 in a few minutes.

Companion to the blog post *The Half-Idle GPU*.

## Why

TraceML's differentiator is the automatic verdict, and the fastest way to feel
it is to run one. This is the reproduce-it artifact for the case-study post and
a self-contained TraceML demo on a real workload.

## Note / question for review

This is the **first in-repo notebook**. The tooling is already set up for it
(black-jupyter + nbstripout are configured in pre-commit), but there is no
`notebooks/` directory yet. Happy to keep it as `notebooks/` (standard for
Colab demos), or convert it to a `.py` example under `examples/` if you would
rather keep the repo scripts-only. Your call.

Details:
- Outputs are stripped; the notebook is meant to be run in Colab.
- The Colab badge points to `main`, so it activates once this merges.
- ruff / isort are scoped to `src/ | dev/ | docs/`, so they do not lint `notebooks/`.
