### PR TITLE
Fix TraceML initialization in Ray TorchTrainer when TRACEML_DISABLED=1

### DIFF
--- a/src/traceml_ai/integrations/ray.py
+++ b/src/traceml_ai/integrations/ray.py
@@ -314,6 +314,16 @@ class TraceMLTorchTrainer:
     def fit(self) -> Any:
         """Run Ray Train with TraceML telemetry enabled."""
         ray, TorchTrainer = _require_ray()
+
+        if os.environ.get("TRACEML_DISABLED") == "1":
+            trainer = TorchTrainer(
+                self._train_loop_per_worker,
+                train_loop_config=dict(self._train_loop_config),
+                **self._torch_trainer_kwargs,
+            )
+            return trainer.fit()
+
+
         config = _normalize_config(self._traceml_config)
 
         Actor = ray.remote(num_cpus=1)(_TraceMLAggregatorActor)


### PR DESCRIPTION
## What changed

This PR fixes an issue in `TraceMLTorchTrainer` where the `TRACEML_DISABLED=1` environment variable was being ignored. Previously, even when tracing was disabled, the `_TraceMLAggregatorActor` and worker wrappers were still being created. This PR ensures they are completely bypassed when the flag is set.

## Why

To ensure that when telemetry is explicitly disabled by the user, no TraceML-specific actors or wrappers are initialized.


## How I tested

- [ ] Tests added or updated
- [ ] Existing tests run
- [ ] Manual smoke test
- [x] Not run; reason: Relying on the automated CI/CD pipeline for this repository to verify the build and Ray training behavior.

## Runtime impact

- [ ] No training-path impact
- [x] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

**Notes:** When `TRACEML_DISABLED=1` is set, the trainer now immediately returns `trainer.fit()` using the unwrapped `train_loop_per_worker`, falling back completely to the standard Ray `TorchTrainer` behavior. The enabled Ray path stays entirely unchanged.

## Docs

- [ ] Updated
- [x] Not needed

