### PR TITLE
Next version: 0.3.5

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+tone_instructions: >-
+  TraceML instruments PyTorch training in-process. Flag anything that could
+  block the training thread, raise instead of degrading, or swallow a user
+  exception. Be direct and specific; skip generic praise.
+
+reviews:
+  profile: chill
+  high_level_summary: true
+  poem: false
+
+  path_filters:
+    - "!uv.lock"
+    - "!docs/assets/**"
+    - "!**/*.ipynb"
+
+  path_instructions:
+    - path: "src/**/*.py"
+      instructions: |
+        This is instrumentation code that runs inside a user's training loop.
+        Check that:
+        - Any code that touches torch internals or I/O is wrapped in
+          try/except, reports via sys.stderr with a "[TraceML]" prefix, and
+          never blocks or raises into the user's training process.
+        - Changes to the wire format or the final_summary schema keep
+          backward compatibility or come with a migration note.
+
+  tools:
+    ruff:
+      enabled: true
+    shellcheck:
+      enabled: true
+    markdownlint:
+      enabled: true
+    gitleaks:
+      enabled: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+
+chat:
+  auto_reply: true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "TraceML",
+  "image": "mcr.microsoft.com/devcontainers/python:3.10",
+  "postCreateCommand": "pip install -e '.[dev,torch]' && pre-commit install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff"
+      ]
+    }
+  }
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.DS_Store
+Thumbs.db
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.tox
+.venv
+__pycache__
+*.py[cod]
+*.egg-info
+build
+dist
+logs
+site

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,10 @@ For code extension points, see
 - Run basic training loops to verify no regressions
 - Performance-sensitive changes should include a short explanation
 
+CodeRabbit reviews every pull request automatically and leaves inline comments.
+Treat it like a first-pass reviewer: worth reading, not a blocker. A maintainer
+still reviews and merges every PR.
+
 ---
 
 ## What We Are Not Looking For (Yet)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,14 @@ Requirements:
 - PyTorch 2.5+ for Torch-backed examples and tests
 - CUDA enabled GPU for GPU/distributed changes. Many docs, reporting, CLI, and CPU smoke-test changes can be developed without a GPU.
 
+### Develop in a container
+
+If you use VS Code with the Dev Containers extension (or GitHub Codespaces),
+open the repository in the provided dev container. It installs an editable
+`.[dev,torch]` build and enables the pre-commit hooks for you, so the
+environment matches what CI expects. The container is CPU-only; GPU work still
+needs a local CUDA setup.
+
 ---
 
 ## Open tasks for first contributors

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN python -m pip install --no-cache-dir --timeout 120 ".[torch]" \
+    && rm -rf build src/traceml_ai.egg-info
+
+CMD ["traceml", "run", "examples/diagnosis/dataloader_bottleneck_demo.py", "--mode=summary", "--args", "--scenario", "slow"]

--- a/README.md
+++ b/README.md
@@ -371,8 +371,8 @@ when you need operator- or kernel-level detail.
 - Run-to-run comparison from `final_summary.json`
 - Custom PyTorch loops, Hugging Face, PyTorch Lightning, and Ray Train
 
-FSDP support means timing collection and rank-skew surfacing; explicit FSDP
-collective attribution is on the roadmap.
+Validated on single-process and DDP. Runs on FSDP; under-reports due to
+collective masking.
 
 **On the roadmap:**
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ For the live browser dashboard:
 pip install traceml-ai
 ```
 
+Or install with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv pip install traceml-ai
+```
+
+For a uv-managed project, add TraceML to the project's dependencies instead:
+
+```bash
+uv add traceml-ai
+```
+
+Extras use the same syntax with pip and uv. For example:
+
+```bash
+pip install "traceml-ai[dashboard]"
+uv add "traceml-ai[dashboard]"
+uv add "traceml-ai[torch]"
+```
+
+To try TraceML immediately in an environment managed by uv, install the
+`torch` extra required by the example:
+
+```bash
+uv pip install "traceml-ai[torch]"
+traceml run examples/quickstart.py
+```
+
 Using Hugging Face Trainer, PyTorch Lightning, Ray Train, W&B, or MLflow?
 Start with the native integration path in
 [Use With Your Stack](docs/user_guide/integrations.md).

--- a/README.md
+++ b/README.md
@@ -131,6 +131,40 @@ traceml run train.py --mode=summary
 For DDP, FSDP, Slurm, and multi-node runs, see
 [Distributed Training](docs/user_guide/distributed-training.md).
 
+### Or launch your script directly
+
+Prefer to launch training yourself with `python` or `torchrun`? Start the
+TraceML aggregator once with `traceml serve`, then run your script directly.
+`traceml.init(...)` connects to the aggregator over TCP:
+
+```bash
+# terminal 1: start the TraceML aggregator
+traceml serve --aggregator-host 127.0.0.1 --aggregator-port 29765
+
+# terminal 2: run your script directly
+python train.py
+```
+
+For torchrun and multi-node, bind the aggregator so workers on other nodes can
+reach it:
+
+```bash
+# on the aggregator node (--nnodes x --nproc-per-node = total workers, so the
+# aggregator waits for every rank before finalizing)
+traceml serve --aggregator-bind-host 0.0.0.0 --aggregator-host <node0-ip> \
+  --aggregator-port 29765 --nnodes <N> --nproc-per-node <M>
+
+# on each training node: point workers at node 0's aggregator, then launch
+TRACEML_AGGREGATOR_HOST=<node0-ip> TRACEML_AGGREGATOR_PORT=29765 \
+  torchrun ... train.py
+```
+
+`traceml.init(...)` takes runtime settings as arguments (for example
+`traceml.init(mode="auto", logs_dir="logs", aggregator_port=29765)`), and falls
+back to `TRACEML_*` environment variables and `traceml.yaml`. The aggregator
+endpoint is configured with `traceml serve` flags. See
+[Public API](docs/user_guide/public-api.md#direct-launch-with-traceml-serve).
+
 ---
 
 ## Example Diagnosis

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 
 [![PyPI version](https://img.shields.io/pypi/v/traceml-ai.svg)](https://pypi.org/project/traceml-ai/)
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/traceml-ai?period=total&units=INTERNATIONAL_SYSTEM&left_color=grey&right_color=blue&left_text=downloads)](https://pepy.tech/projects/traceml-ai)
 [![CI](https://github.com/traceopt-ai/traceml/actions/workflows/ci.yml/badge.svg)](https://github.com/traceopt-ai/traceml/actions/workflows/ci.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -46,26 +46,6 @@ TraceML produces actionable diagnostics with under 1% overhead in current benchm
 
 ## Quickstart
 
-### Try it in Docker
-
-Build the image from the repository checkout, then run the default CPU demo:
-
-```bash
-docker build -t traceml-demo .
-docker run --rm traceml-demo
-```
-
-The image installs TraceML from the checkout with PyTorch support and runs the
-slow DataLoader diagnosis demo in summary mode. The final report should identify
-the run as input-bound; no external dataset or GPU is required.
-
-If the host has the NVIDIA Container Toolkit configured and the installed
-PyTorch build supports CUDA, the same demo can optionally access the GPU:
-
-```bash
-docker run --rm --gpus all traceml-demo
-```
-
 ### 1. Install TraceML
 
 For the live browser dashboard:
@@ -184,6 +164,26 @@ TRACEML_AGGREGATOR_HOST=<node0-ip> TRACEML_AGGREGATOR_PORT=29765 \
 back to `TRACEML_*` environment variables and `traceml.yaml`. The aggregator
 endpoint is configured with `traceml serve` flags. See
 [Public API](docs/user_guide/public-api.md#direct-launch-with-traceml-serve).
+
+### Try it in Docker
+
+Build the image from the repository checkout, then run the default CPU demo:
+
+```bash
+docker build -t traceml-demo .
+docker run --rm traceml-demo
+```
+
+The image installs TraceML from the checkout with PyTorch support and runs the
+slow DataLoader diagnosis demo in summary mode. The final report should identify
+the run as input-bound; no external dataset or GPU is required.
+
+If the host has the NVIDIA Container Toolkit configured and the installed
+PyTorch build supports CUDA, the same demo can optionally access the GPU:
+
+```bash
+docker run --rm --gpus all traceml-demo
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ TraceML produces actionable diagnostics with under 1% overhead in current benchm
 
 ## Quickstart
 
+### Try it in Docker
+
+Build the image from the repository checkout, then run the default CPU demo:
+
+```bash
+docker build -t traceml-demo .
+docker run --rm traceml-demo
+```
+
+The image installs TraceML from the checkout with PyTorch support and runs the
+slow DataLoader diagnosis demo in summary mode. The final report should identify
+the run as input-bound; no external dataset or GPU is required.
+
+If the host has the NVIDIA Container Toolkit configured and the installed
+PyTorch build supports CUDA, the same demo can optionally access the GPU:
+
+```bash
+docker run --rm --gpus all traceml-demo
+```
+
 ### 1. Install TraceML
 
 For the live browser dashboard:

--- a/docs/developer_guide/architecture.md
+++ b/docs/developer_guide/architecture.md
@@ -104,7 +104,7 @@ Architectural risks and known structural debt. Day-to-day bugs live in the issue
 | Step / trace_step | A training iteration; `with trace_step(model)` marks the boundary that phase timing is computed against. |
 | Residual (residual_proxy) | Residual step time, `max(0, step - h2d - forward - backward - optimizer)`. |
 | INPUT_BOUND / COMPUTE_BOUND | Input wait dominates iteration time, or compute dominates the traced step. |
-| INPUT_STRAGGLER / COMPUTE_STRAGGLER / H2D_STRAGGLER / RESIDUAL_STRAGGLER / STRAGGLER | One rank is slower than typical after accounting for backward waiting; the label names the dominant timing difference, or `STRAGGLER` when mixed. |
+| INPUT_STRAGGLER / COMPUTE_STRAGGLER / H2D_STRAGGLER / STRAGGLER | Visible rank skew exists; the label names the culprit's material input, DDP-forward, or H2D excess, or `STRAGGLER` when the skew is sync-bound or unattributed. |
 | RESIDUAL_HEAVY | A large window-wide share of step time is unattributed residual time. |
 | HIGH_PRESSURE / IMBALANCE | GPU memory is near capacity, or uneven across ranks. |
 | CREEP_EARLY / CREEP_CONFIRMED | Direction-confirmed GPU-memory growth across the run, early or confirmed. |

--- a/docs/developer_guide/architecture.md
+++ b/docs/developer_guide/architecture.md
@@ -103,7 +103,7 @@ Architectural risks and known structural debt. Day-to-day bugs live in the issue
 | Phase | A timed part of a step: input wait, H2D, forward, backward, or optimizer. |
 | Step / trace_step | A training iteration; `with trace_step(model)` marks the boundary that phase timing is computed against. |
 | Residual (residual_proxy) | Residual step time, `max(0, step - h2d - forward - backward - optimizer)`. |
-| INPUT_BOUND / COMPUTE_BOUND | The step is dominated by input wait or compute. |
+| INPUT_BOUND / COMPUTE_BOUND | Input wait dominates iteration time, or compute dominates the traced step. |
 | INPUT_STRAGGLER / COMPUTE_STRAGGLER / H2D_STRAGGLER / RESIDUAL_STRAGGLER / STRAGGLER | One rank is slower than typical after accounting for backward waiting; the label names the dominant timing difference, or `STRAGGLER` when mixed. |
 | RESIDUAL_HEAVY | A large window-wide share of step time is unattributed residual time. |
 | HIGH_PRESSURE / IMBALANCE | GPU memory is near capacity, or uneven across ranks. |

--- a/docs/developer_guide/architecture.md
+++ b/docs/developer_guide/architecture.md
@@ -103,7 +103,7 @@ Architectural risks and known structural debt. Day-to-day bugs live in the issue
 | Phase | A timed part of a step: input wait, H2D, forward, backward, or optimizer. |
 | Step / trace_step | A training iteration; `with trace_step(model)` marks the boundary that phase timing is computed against. |
 | Residual (residual_proxy) | Residual step time, `max(0, step - h2d - forward - backward - optimizer)`. |
-| INPUT_BOUND / COMPUTE_BOUND | Input wait dominates iteration time, or compute dominates the traced step. |
+| INPUT_BOUND / COMPUTE_BOUND | Input wait is material, or compute reaches 90% of typical selected-clock iteration time. |
 | INPUT_STRAGGLER / COMPUTE_STRAGGLER / H2D_STRAGGLER / STRAGGLER | Visible rank skew exists; the label names the culprit's material input, DDP-forward, or H2D excess, or `STRAGGLER` when the skew is sync-bound or unattributed. |
 | RESIDUAL_HEAVY | A large window-wide share of step time is unattributed residual time. |
 | HIGH_PRESSURE / IMBALANCE | GPU memory is near capacity, or uneven across ranks. |

--- a/docs/developer_guide/rank-straggler-policy.md
+++ b/docs/developer_guide/rank-straggler-policy.md
@@ -1,0 +1,122 @@
+# Rank Straggler Policy
+
+This page documents how TraceML decides that one rank in a distributed job is a
+straggler, which rank it blames, and how confident it is. It is the developer
+reference behind the Step Time rank-straggler diagnoses. For the user-facing
+walkthrough of a slow rank, see
+[Diagnosing a slow rank in DDP](../guides/ddp-slow-training-rank-straggler.md).
+
+The implementation lives in `src/traceml_ai/diagnostics/` (rule evaluation and
+culprit/victim context) and `src/traceml_ai/reporting/primary_diagnosis.py`
+(evidence assembly). The canonical policy summary is
+`src/traceml_ai/diagnostics/DIAGNOSIS.md` (Step Time section); this page expands
+on it.
+
+## Diagnosis kinds
+
+Rank-straggler diagnoses describe skew *across ranks* in a single analyzed
+window, as opposed to the single-rank bottleneck kinds (`INPUT_BOUND`,
+`COMPUTE_BOUND`, `RESIDUAL_HEAVY`).
+
+| Kind | Meaning |
+|---|---|
+| `STRAGGLER` | Visible rank skew exists, but input wait, H2D, and forward do not explain the likely culprit. |
+| `INPUT_STRAGGLER` | The culprit rank has materially higher selected-clock input wait than the victim. |
+| `COMPUTE_STRAGGLER` | DDP / default strategy only: the culprit rank has materially higher forward time than the victim. |
+| `H2D_STRAGGLER` | The culprit rank has materially higher host-to-device transfer time than the victim. |
+
+## Selected clock and eligibility
+
+Step Time diagnosis analyzes one *selected clock* for the window. It uses GPU
+event timing when every rank and step has GPU timing for the step envelope,
+input wait, and traced phase events; otherwise it falls back to explicit
+`cpu_ms` timing. All rank-straggler comparisons below are in that selected
+clock.
+
+TraceML first picks one visible synchronization phase per rank:
+
+```text
+visible_r = backward_r              # DDP / default
+visible_r = forward_r + backward_r  # FSDP
+```
+
+Only ranks with a measured visible-phase anchor and a measured step envelope are
+eligible:
+
+```text
+DDP / default: backward_r > 0 and step_time_r > 0
+FSDP:          forward_r > 0 and backward_r > 0 and step_time_r > 0
+```
+
+If fewer than two ranks are eligible, TraceML does not report a rank straggler.
+Missing visible instrumentation makes the rule abstain rather than treat a
+zero as a fast rank. Component values of `input_wait == 0` and `h2d == 0` are
+still valid measurements and are kept.
+
+## Culprit and victim selection
+
+- The **culprit** is the rank with the minimum visible value. It is the rank
+  that most likely arrived late at the synchronization phase and therefore
+  waited least in it.
+- The **victim** is the upper actual median rank by visible value. Using the
+  upper median rather than the maximum keeps the reference rank representative
+  of the group instead of a single outlier.
+
+## Straggler score
+
+The score normalizes the visible gap between victim and culprit by the victim's
+own selected-clock iteration cost:
+
+```text
+denom = input_wait_victim + step_time_victim
+score = (visible_victim - visible_culprit) / denom
+```
+
+If `score < 0.10`, TraceML does not report a rank straggler. The gap is treated
+as normal run-to-run variation rather than a real straggler.
+
+## Attribution
+
+Once the score clears the threshold, TraceML compares the culprit directly with
+the victim to explain the visible wait:
+
+```text
+input_excess   = input_wait_culprit - input_wait_victim
+h2d_excess     = h2d_culprit - h2d_victim
+forward_excess = forward_culprit - forward_victim   # DDP / default only
+```
+
+The largest material positive excess selects the kind: `INPUT_STRAGGLER`,
+`H2D_STRAGGLER`, or (DDP / default only) `COMPUTE_STRAGGLER`. DDP / default
+compute attribution requires measured forward time on both the culprit and the
+victim. If no excess explains the visible wait cost, the diagnosis stays
+`STRAGGLER` with a sync-or-unattributed component. That residual can cover
+validation, checkpointing, logging, framework orchestration, CPU stalls, or
+unobserved transfer stalls inside the timed step. It is not direct NCCL,
+all-reduce, or synchronization timing.
+
+## Training strategy context
+
+When runtime environment metadata is available, Step Time diagnosis receives an
+advisory training strategy such as `ddp` or `fsdp`. This context only chooses
+attribution behavior; it is not a public Step Time metric. Missing or
+unrecognized strategy metadata defaults to `ddp` to preserve the DDP / default
+visible-backward straggler behavior.
+
+- DDP / default stays eligible for critical rank-straggler diagnoses once
+  thresholds and confidence gates are met.
+- FSDP diagnoses are capped at warning, because collective masking can make
+  cross-rank attribution under-confident.
+
+## Confidence gates
+
+Shared Step Time diagnosis needs at least 2 steps to emit warning-only
+diagnoses, and at least 20 steps before a critical diagnosis is allowed. The
+live CLI table, dashboard, and final summary use the same gates and the same
+global-rank window loader; they differ only by the selected timing window size.
+
+## See also
+
+- [Diagnosing a slow rank in DDP](../guides/ddp-slow-training-rank-straggler.md)
+- [Reading Output](../user_guide/reading-output.md)
+- `src/traceml_ai/diagnostics/DIAGNOSIS.md` (canonical Step Time policy)

--- a/docs/developer_guide/rank-straggler-policy.md
+++ b/docs/developer_guide/rank-straggler-policy.md
@@ -20,7 +20,7 @@ window, as opposed to the single-rank bottleneck kinds (`INPUT_BOUND`,
 
 | Kind | Meaning |
 |---|---|
-| `STRAGGLER` | Visible rank skew exists, but input wait, H2D, and forward do not explain the likely culprit. |
+| `STRAGGLER` | Visible rank skew exists, but no measured component explains enough of the visible wait to name a cause. |
 | `INPUT_STRAGGLER` | The culprit rank has materially higher selected-clock input wait than the victim. |
 | `COMPUTE_STRAGGLER` | DDP / default strategy only: the culprit rank has materially higher forward time than the victim. |
 | `H2D_STRAGGLER` | The culprit rank has materially higher host-to-device transfer time than the victim. |
@@ -72,8 +72,10 @@ denom = input_wait_victim + step_time_victim
 score = (visible_victim - visible_culprit) / denom
 ```
 
-If `score < 0.10`, TraceML does not report a rank straggler. The gap is treated
-as normal run-to-run variation rather than a real straggler.
+If `score < 0.10`, TraceML does not report a rank straggler. At 10% it emits a
+warning; at 20% it emits critical severity when the existing confidence gates
+permit it. The gap below 10% is treated as normal run-to-run variation rather
+than a real straggler.
 
 ## Attribution
 
@@ -86,14 +88,25 @@ h2d_excess     = h2d_culprit - h2d_victim
 forward_excess = forward_culprit - forward_victim   # DDP / default only
 ```
 
-The largest material positive excess selects the kind: `INPUT_STRAGGLER`,
-`H2D_STRAGGLER`, or (DDP / default only) `COMPUTE_STRAGGLER`. DDP / default
-compute attribution requires measured forward time on both the culprit and the
-victim. If no excess explains the visible wait cost, the diagnosis stays
-`STRAGGLER` with a sync-or-unattributed component. That residual can cover
-validation, checkpointing, logging, framework orchestration, CPU stalls, or
-unobserved transfer stalls inside the timed step. It is not direct NCCL,
-all-reduce, or synchronization timing.
+Each excess is converted into bounded cause coverage of the visible wait:
+
+```text
+cause_coverage = min(1, component_excess / visible_cost)
+```
+
+The component with the highest coverage names `INPUT_STRAGGLER`,
+`H2D_STRAGGLER`, or (DDP / default only) `COMPUTE_STRAGGLER` only when its
+coverage reaches 80%. DDP / default compute attribution requires measured
+forward time on both the culprit and victim. Otherwise the diagnosis stays
+`STRAGGLER` with a sync-or-unattributed component. The issue evidence includes
+both `component_excesses_ms` and `component_coverage`, keyed by `input`,
+`h2d`, and `compute`.
+
+Cause coverage chooses the diagnosis label. The straggler score above remains
+the sole source of warning or critical severity. Generic residual attribution
+can cover validation, checkpointing, logging, framework orchestration, CPU
+stalls, or unobserved transfer stalls inside the timed step. It is not direct
+NCCL, all-reduce, or synchronization timing.
 
 ## Training strategy context
 

--- a/docs/guides/ddp-slow-training-rank-straggler.md
+++ b/docs/guides/ddp-slow-training-rank-straggler.md
@@ -1,11 +1,11 @@
 # Debug slow DDP training and rank stragglers
 
 Use this guide when PyTorch DDP training is slow, uneven, or controlled by one
-slow rank.
+culprit rank.
 
-TraceML compares worst-rank and median-rank timing in distributed runs. It can
-surface input stragglers, compute stragglers, mixed stragglers, and residual-heavy
-windows.
+TraceML looks for visible rank skew in distributed runs, identifies a culprit
+rank and a victim/reference rank, then attributes material culprit excess to
+input, H2D, DDP forward compute, or sync/unattributed work.
 
 For whole-run triage, start with
 [Find why PyTorch training is slow](slow-pytorch-training.md). This page stays
@@ -92,56 +92,56 @@ Start with the Step Time diagnosis.
 | Diagnosis | Meaning |
 |---|---|
 | `INPUT STRAGGLER` | one rank spends much longer waiting for input than peer ranks |
-| `COMPUTE STRAGGLER` | one rank has meaningfully more observed forward/backward/optimizer time; in FSDP this may include collective wait |
-| `H2D STRAGGLER` | one rank has meaningfully more host-to-device transfer burden than a typical rank |
-| `RESIDUAL STRAGGLER` | one rank has meaningfully more rank-local residual `residual_proxy` than a typical rank |
-| `STRAGGLER` | one rank is slower, but input wait, compute, H2D, and residual signals are mixed |
+| `COMPUTE STRAGGLER` | in DDP, the culprit rank has materially more forward-time burden than the victim rank |
+| `H2D STRAGGLER` | the culprit rank has meaningfully more host-to-device transfer burden than the victim rank |
+| `STRAGGLER` | visible rank skew exists, but input wait, H2D, and DDP forward do not explain it |
 | `INPUT-BOUND` | input work is broad, not just one bad rank |
 | `RESIDUAL-HEAVY` | meaningful residual time is not attributed to input wait, H2D, forward, backward, or optimizer work |
 
-For rank-local stragglers, TraceML first accounts for time a rank may spend
-waiting during backward because another rank arrived late. It then compares
-ranks and labels the largest timing difference among input wait, compute, H2D,
-and residual. The largest difference must be at least `1.25x` the next-largest
-difference.
+For rank stragglers, TraceML first looks for visible wait cost: in DDP this is
+the gap between the upper-median backward time and the rank with the smallest
+backward time. The smallest-backward rank is the likely culprit because it
+arrived late and waited least. TraceML then compares that culprit with the
+victim rank to see whether input wait, H2D, or DDP forward time explains the
+cost.
 
 Then inspect:
 
-- `Worst Rank`
-- worst vs median timing
+- culprit rank
+- victim/reference rank
+- visible rank skew
 - `Input Wait`
 - `Forward`
 - `Backward`
 - `Optimizer Step`
 - `Residual`
 
-## How to triage the worst rank
+## How to triage the culprit rank
 
-If the diagnosis is `INPUT STRAGGLER`, inspect input loading on the worst rank:
+If the diagnosis is `INPUT STRAGGLER`, inspect input loading on the culprit
+rank:
 
 - uneven shards or batch construction
 - rank-local preprocessing jitter
 - slow storage path on one host
 - custom collation or tokenization on one rank
 
-If the diagnosis is `COMPUTE STRAGGLER`, inspect observed compute-phase work on
-the worst rank:
+If the diagnosis is `COMPUTE STRAGGLER`, inspect DDP forward work on the
+culprit rank:
 
 - uneven input shapes
 - rank-local branching
-- extra forward, backward, or optimizer work
+- extra forward work
 - framework hooks or callbacks that run on one rank
 
 If the diagnosis is `H2D STRAGGLER`, inspect host-to-device transfer on the
-worst rank: batch shapes, transfer placement, pinned memory, and transfer
+culprit rank: batch shapes, transfer placement, pinned memory, and transfer
 jitter.
 
-If the diagnosis is `RESIDUAL STRAGGLER`, inspect rank-local host-side work on the
-worst rank: logging, checkpointing, validation, callbacks, CPU stalls, or
-unobserved transfer work.
-
-If the diagnosis is `STRAGGLER`, reduce the problem one phase at a time. Start
-with the largest timing gap on the slow rank.
+If the diagnosis is `STRAGGLER`, inspect synchronization, collectives, and
+unattributed work around the culprit rank. Explicit collective timing is not
+available yet, so this is the honest fallback when input, H2D, and DDP forward
+do not explain the visible wait cost.
 
 If the diagnosis is `RESIDUAL-HEAVY`, remember that TraceML reports residual
 time as a derived bucket. It is not direct NCCL or all-reduce timing. Inspect logging,
@@ -154,12 +154,11 @@ TraceML supports single-node multi-GPU DDP and FSDP in the current public docs.
 Multi-node DDP summary reports are supported. Multi-node FSDP uses the same
 distributed launch path as DDP, but should be validated in your environment.
 
-TraceML's clean-step rank attribution is calibrated for DDP-style backward
-synchronization. In FSDP, forward time can include parameter all-gather wait
-caused by another rank arriving late. Use this guide for FSDP rank-skew
-symptoms, but treat `COMPUTE STRAGGLER` as observed compute-phase skew, not
-proof of rank-local model compute. TraceML does not yet report explicit FSDP
-all-gather or reduce-scatter timing.
+TraceML uses backward as the visible rank-skew phase for DDP/default strategy.
+For FSDP, it uses forward + backward because sharding communication can appear
+in both phases. FSDP rank stragglers can still be attributed to input wait or
+H2D, but TraceML does not emit `COMPUTE STRAGGLER` from the FSDP rank-skew
+rule without explicit all-gather or reduce-scatter timing.
 
 ## Compare a fix
 
@@ -170,8 +169,8 @@ the old and new summaries:
 traceml compare old_run/final_summary.json new_run/final_summary.json
 ```
 
-Look for changes in total step time, worst-rank skew, input time, compute time,
-residual time, and diagnosis.
+Look for changes in total step time, visible rank skew, input time, compute
+time, residual time, and diagnosis.
 
 ## Related
 

--- a/docs/guides/low-gpu-utilization-pytorch.md
+++ b/docs/guides/low-gpu-utilization-pytorch.md
@@ -32,12 +32,11 @@ After confirming low or moderate GPU utilization, read the Step Time diagnosis.
 | Step Time diagnosis | What to do |
 |---|---|
 | `INPUT-BOUND` | Inspect input loading, preprocessing, collation, and storage. |
-| `INPUT STRAGGLER` | Inspect the slow input rank. |
-| `H2D STRAGGLER` | Inspect host-to-device transfer on the worst rank. |
-| `RESIDUAL STRAGGLER` | Inspect rank-local host-side work on the worst rank. |
+| `INPUT STRAGGLER` | Inspect input loading on the culprit rank. |
+| `H2D STRAGGLER` | Inspect host-to-device transfer on the culprit rank. |
 | `RESIDUAL-HEAVY` | Inspect work outside traced phases, such as logging, checkpointing, validation, CPU stalls, framework orchestration, or unobserved transfers. |
 | `COMPUTE-BOUND` | Inspect forward, backward, and optimizer time before changing the DataLoader. |
-| `COMPUTE STRAGGLER` or `STRAGGLER` | Inspect rank skew and the called-out worst rank. |
+| `COMPUTE STRAGGLER` or `STRAGGLER` | Inspect visible rank skew and the culprit rank. |
 | `BALANCED` | Compare against a known good run or use a heavier profiler for lower-level detail. |
 
 Low GPU utilization plus `INPUT-BOUND` is a strong signal to start with the
@@ -68,7 +67,7 @@ If residual time is high:
 If one rank is worse than the others:
 
 - use the [DDP rank straggler guide](ddp-slow-training-rank-straggler.md)
-- compare the worst rank with the median rank
+- compare the culprit rank with the victim/reference rank
 
 ## Compare a fix
 

--- a/docs/guides/pytorch-input-pipeline-bottleneck.md
+++ b/docs/guides/pytorch-input-pipeline-bottleneck.md
@@ -56,7 +56,7 @@ Start with `TraceML Verdict`, then check the `Step Time Evidence` table.
 
 For input pipeline problems, the most relevant diagnoses are:
 
-- `INPUT-BOUND`: input wait is taking a large share of the typical step
+- `INPUT-BOUND`: input wait is taking a large share of iteration time
 - `INPUT STRAGGLER`: one rank has meaningfully more input-wait burden than a
   typical rank
 

--- a/docs/guides/slow-pytorch-training.md
+++ b/docs/guides/slow-pytorch-training.md
@@ -41,7 +41,7 @@ diagnosis or symptom.
 
 ## Quick interpretation
 
-`INPUT-BOUND` means input wait is taking a large share of the typical step.
+`INPUT-BOUND` means input wait is taking a large share of iteration time.
 Confirm the input path before tuning model compute.
 
 `LOW_GPU_UTILIZATION` and `MODERATE_GPU_UTILIZATION` are system-level symptoms.

--- a/docs/guides/slow-pytorch-training.md
+++ b/docs/guides/slow-pytorch-training.md
@@ -34,7 +34,7 @@ diagnosis or symptom.
 |---|---|
 | Step Time says `INPUT-BOUND` | [Find Input Pipeline Bottlenecks](pytorch-input-pipeline-bottleneck.md) |
 | System says `LOW_GPU_UTILIZATION` or `MODERATE_GPU_UTILIZATION` | [Debug Low GPU Utilization](low-gpu-utilization-pytorch.md) |
-| Step Time says `INPUT STRAGGLER`, `COMPUTE STRAGGLER`, `H2D STRAGGLER`, `RESIDUAL STRAGGLER`, or `STRAGGLER` | [Debug DDP Rank Stragglers](ddp-slow-training-rank-straggler.md) |
+| Step Time says `INPUT STRAGGLER`, `COMPUTE STRAGGLER`, `H2D STRAGGLER`, or `STRAGGLER` | [Debug DDP Rank Stragglers](ddp-slow-training-rank-straggler.md) |
 | Step Memory says `MEMORY CREEP` or `MEMORY RISING` | [Find PyTorch Memory Creep](pytorch-memory-creep.md) |
 | A recent change made the run slower | [Compare Runs](../user_guide/compare.md) |
 | Step Time says `COMPUTE-BOUND` or `RESIDUAL-HEAVY` | [How to Read TraceML Output](../user_guide/reading-output.md) |
@@ -48,9 +48,9 @@ Confirm the input path before tuning model compute.
 They say the GPU was not fully busy, not why it was not fully busy. Pair them
 with Step Time.
 
-`INPUT STRAGGLER`, `COMPUTE STRAGGLER`, `H2D STRAGGLER`,
-`RESIDUAL STRAGGLER`, and `STRAGGLER` are distributed rank-skew signals.
-Inspect the called-out worst rank and compare it with the median rank.
+`INPUT STRAGGLER`, `COMPUTE STRAGGLER`, `H2D STRAGGLER`, and `STRAGGLER` are
+distributed rank-skew signals. Inspect the culprit rank and compare it with the
+victim/reference rank.
 
 `MEMORY CREEP` and `MEMORY RISING` are step-memory trend signals. Inspect
 retained tensors, caches, and per-step state that may stay alive.

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -371,9 +371,10 @@ See:
 
 It means one rank is slower in the input path than the typical rank.
 
-In distributed runs, TraceML accounts for time another rank may spend waiting
-during backward. `INPUT STRAGGLER` means input-wait excess on the slowest rank
-dominates compute, H2D, and residual differences by at least `1.25x`.
+In distributed runs, TraceML first finds visible wait cost. In DDP/default
+strategy that signal comes from backward time; in FSDP it comes from forward +
+backward time. `INPUT STRAGGLER` means the likely culprit rank has material
+input-wait excess compared with the victim rank.
 
 Common causes:
 
@@ -389,19 +390,19 @@ See:
 
 ## What does `COMPUTE STRAGGLER` mean?
 
-It means one rank spends more time in observed compute phases than the typical
-rank.
+It means the likely culprit rank spends materially more time in DDP forward
+compute than the victim rank.
 
-TraceML accounts for backward time that can be explained by another rank
-arriving late. It uses `COMPUTE STRAGGLER` when compute-time excess dominates
-input wait, H2D, and residual differences by at least `1.25x`; otherwise the
-mixed case remains `STRAGGLER`.
+TraceML emits `COMPUTE STRAGGLER` from the rank-skew rule for DDP/default
+strategy only. For FSDP, forward and backward can include sharding
+communication, so unexplained rank skew remains `STRAGGLER` unless input wait
+or H2D explains it.
 
 Common causes:
 
 - uneven shapes or data
 - rank-local branching or extra work
-- compute imbalance in forward, backward, or optimizer
+- compute imbalance in forward
 
 See:
 

--- a/docs/user_guide/integrations.md
+++ b/docs/user_guide/integrations.md
@@ -10,4 +10,5 @@ job already runs.
 | Hugging Face Trainer | `TraceMLTrainerCallback` | [Hugging Face](integrations/huggingface.md) |
 | PyTorch Lightning | `traceml_ai.integrations.lightning.init()` + `TraceMLCallback` | [PyTorch Lightning](integrations/lightning.md) |
 | Ray Train | `TraceMLTorchTrainer` | [Ray Train](integrations/ray.md) |
+| DeepSpeed | `traceml.trace_step(...)` | [DeepSpeed](integrations/deepspeed.md) |
 | W&B / MLflow | `traceml.summary()` | [W&B / MLflow](integrations/wandb-mlflow.md) |

--- a/docs/user_guide/integrations/deepspeed.md
+++ b/docs/user_guide/integrations/deepspeed.md
@@ -1,0 +1,137 @@
+# DeepSpeed
+
+Use TraceML with DeepSpeed to find training bottlenecks without changing how
+your DeepSpeed job runs.
+
+DeepSpeed leaves the training loop to you: you call `model_engine(...)`,
+`model_engine.backward(loss)`, and `model_engine.step()` yourself. So the
+integration is the same recipe used for plain PyTorch, DDP, and FSDP — wrap
+each step with `traceml.trace_step(...)`. There is no DeepSpeed-specific
+callback or wrapper to install.
+
+## 1. Install
+
+TraceML does not depend on DeepSpeed. Install DeepSpeed yourself:
+
+```bash
+pip install "traceml-ai[deepspeed]"
+```
+
+or follow the [DeepSpeed getting-started guide](https://www.deepspeed.ai/getting-started/).
+DeepSpeed requires a CUDA GPU.
+
+## 2. Wrap The Step
+
+Call `traceml.init(mode="auto")` once, then wrap each DeepSpeed step with
+`traceml.trace_step(...)`. Pass `model_engine.module` (the unwrapped model),
+exactly like `model.module` for DDP and `base_model` for FSDP.
+
+```python
+import traceml_ai as traceml
+
+# ... deepspeed.initialize(...) returns model_engine ...
+
+traceml.init(mode="auto")
+
+for batch_x, batch_y in loader:
+    with traceml.trace_step(model_engine.module):
+        batch_x = batch_x.to(model_engine.device, non_blocking=True)
+        batch_y = batch_y.to(model_engine.device, non_blocking=True)
+
+        logits = model_engine(batch_x)      # forward
+        loss = criterion(logits, batch_y)
+
+        model_engine.backward(loss)         # backward
+        model_engine.step()                 # optimizer step
+```
+
+`traceml.init(mode="auto")` installs TraceML's process-wide auto-timers, so it
+records DataLoader fetch timing (when you iterate a real PyTorch `DataLoader`,
+as above), host-to-device (H2D) copies, forward, backward, optimizer, and step
+timing, plus GPU and process memory, and writes an end-of-run summary.
+Forward is timed on `model_engine.module`; backward is captured because
+`model_engine.backward(loss)` reaches `torch.Tensor.backward()`;
+optimizer time is captured from the underlying torch optimizer step inside
+`model_engine.step()`. You do not need to add anything else per step.
+
+## 3. Launch The Run
+
+DeepSpeed reads `RANK` / `LOCAL_RANK` / `WORLD_SIZE` from the environment, and
+`traceml run` launches your script through torchrun, so the two work together
+directly.
+
+Single GPU:
+
+```bash
+traceml run train.py --mode=summary
+```
+
+Single-node multi-GPU (e.g. 4 GPUs):
+
+```bash
+traceml run train.py --nproc-per-node=4 --mode=summary
+```
+
+For multi-node launch commands, see
+[Distributed Training](../distributed-training.md).
+
+## Limitations
+
+- **No explicit NCCL / collective timing.** With ZeRO, gradient reduce-scatter
+  runs during the backward pass and parameter all-gather runs inside the
+  optimizer step. That communication overlaps the phases TraceML measures, so
+  its cost is folded into backward / optimizer / step time and reported as
+  residual/proxy timing rather than as a separate collective number.
+- **Optimizer timing is "where available".** TraceML times the underlying torch
+  optimizer step reached inside `model_engine.step()`. DeepSpeed's own work
+  around that step (loss scaling, gradient clipping, ZeRO partitioning) is
+  outside the traced phases and shows up as residual.
+- **Gradient accumulation.** The example config uses
+  `gradient_accumulation_steps: 1`, so each `trace_step` brackets one optimizer
+  step. With accumulation greater than 1, `model_engine.step()` runs the
+  optimizer only on boundary micro-steps, so backward is timed every step while
+  optimizer time appears only on those boundaries, and TraceML's step count
+  follows micro-steps rather than optimizer steps.
+
+## Troubleshooting
+
+### Multi-GPU run only shows one rank
+
+Make sure you launched through TraceML with `--nproc-per-node`, not plain
+`python`:
+
+```bash
+traceml run train.py --nproc-per-node=4
+```
+
+### I want a baseline without TraceML
+
+Run the same script with TraceML disabled:
+
+```bash
+traceml run train.py --disable-traceml
+```
+
+This launches your script natively through `torchrun` without TraceML telemetry.
+
+## Full Example
+
+A runnable example and a minimal ZeRO stage-2 config live in the repo:
+
+- `examples/integrations/deepspeed_minimal.py`
+- `examples/integrations/deepspeed_config_minimal.json`
+
+Run it with:
+
+```bash
+traceml run examples/integrations/deepspeed_minimal.py --mode=summary
+```
+
+The example exits cleanly when DeepSpeed or a CUDA GPU is unavailable.
+
+## Next Steps
+
+- [How to Read Output](../reading-output.md)
+- [Distributed Training](../distributed-training.md)
+- [Quickstart](../quickstart.md)
+- [Open an issue](https://github.com/traceopt-ai/traceml/issues)

--- a/docs/user_guide/integrations/ray.md
+++ b/docs/user_guide/integrations/ray.md
@@ -203,7 +203,7 @@ TraceMLRayConfig(
     patch_h2d=None,
     logs_dir="./logs",
     session_id="",
-    sampler_interval_sec=1.0,
+    sampler_interval_sec=2.0,
     bind_host="0.0.0.0",
     port=0,
 )
@@ -212,6 +212,10 @@ TraceMLRayConfig(
 The default ``mode="summary"`` is recommended for Ray because distributed worker
 logs are noisy. Use ``mode="cli"`` only when you specifically want live terminal
 rendering from the aggregator actor.
+
+``sampler_interval_sec`` defaults to ``2.0`` seconds. It controls worker sampling
+and the aggregator actor's live UI refresh; incoming TCP telemetry is drained as
+soon as it arrives.
 
 ``init_mode`` is passed to ``traceml.init(mode="auto")`` inside each Ray
 worker. The Ray Data ``wrap_dataloader_fetch(...)`` pattern above works with

--- a/docs/user_guide/public-api.md
+++ b/docs/user_guide/public-api.md
@@ -68,6 +68,7 @@ traceml run <script> --mode=summary  # final summary JSON/text only
 traceml run <script> --mode=cli      # explicit live terminal view
 traceml run <script> --mode=dashboard # live browser view
 traceml watch <script>               # zero-code system/process view
+traceml serve                        # standalone aggregator for direct launch
 ```
 
 Live `cli` and `dashboard` modes are intended for single-node runs. Multi-node
@@ -78,6 +79,102 @@ TraceML no longer ships layer-level/deep profiling. Use PyTorch Profiler,
 Nsight, or another operator-level profiler when you need that detail.
 
 See `traceml --help` for the full set of options.
+
+## Direct launch with `traceml serve`
+
+`traceml run` starts the aggregator and your script together. If you would
+rather launch training yourself with `python` or `torchrun`, run the aggregator
+as a standalone process and call `traceml.init(...)` inside your script.
+
+`traceml serve` owns only the aggregator. It binds a host/port, prints the
+reachable endpoint, blocks until SIGINT/SIGTERM, shuts down cleanly, and writes
+the final summary on exit. It never launches or wraps your training script.
+
+```bash
+# terminal 1: start the aggregator
+traceml serve --aggregator-host 127.0.0.1 --aggregator-port 29765
+
+# terminal 2: run your script directly
+python train.py
+```
+
+For torchrun and multi-node, bind the aggregator so workers on other nodes can
+connect:
+
+```bash
+# aggregator node: --nnodes x --nproc-per-node = total workers, so the
+# aggregator waits for every rank before finalizing (and warns about ranks
+# that never report)
+traceml serve --aggregator-bind-host 0.0.0.0 --aggregator-host <node0-ip> \
+  --aggregator-port 29765 --nnodes <N> --nproc-per-node <M>
+
+# each training node: workers read the aggregator endpoint from the
+# environment, so set it before torchrun
+TRACEML_AGGREGATOR_HOST=<node0-ip> TRACEML_AGGREGATOR_PORT=29765 \
+  torchrun ... train.py
+```
+
+Workers resolve the aggregator host from `TRACEML_AGGREGATOR_HOST` (default
+`127.0.0.1`), so on multi-node it must be set on every non-aggregator node or
+those workers cannot reach node 0.
+
+`traceml serve` flags:
+
+| Flag | Meaning |
+|---|---|
+| `--aggregator-host` | Address workers connect to. Default `127.0.0.1`. |
+| `--aggregator-bind-host` | Address the aggregator binds to. Use `0.0.0.0` for multi-node. Default `127.0.0.1`. |
+| `--aggregator-port` | Aggregator TCP port. Default `29765`. |
+| `--nnodes` / `--nproc-per-node` | Total ranks = product. The aggregator waits for all of them before finalizing and warns about missing ranks. Falls back to `TRACEML_EXPECTED_WORLD_SIZE`, else 1. |
+| `--mode` | Display mode: `summary` (default), `cli`, or `dashboard`. |
+| `--logs-dir` | Directory for session logs. |
+| `--run-name` / `--session-id` | Run identity. Workers must use the same value for shared artifacts. |
+
+### Configuration in the direct-launch path
+
+In the direct `python` path you cannot pass `traceml run` flags, so runtime
+settings are resolved with this precedence:
+
+1. explicit `traceml.init(...)` arguments
+2. `TRACEML_*` environment variables
+3. `traceml.yaml`
+4. built-in defaults
+
+```python
+traceml.init(
+    mode="auto",          # instrumentation mode
+    ui_mode="summary",    # display/telemetry mode
+    logs_dir="logs",
+    session_id="my_run",
+    aggregator_host="127.0.0.1",
+    aggregator_port=29765,
+)
+```
+
+The aggregator endpoint (`aggregator_host`, `aggregator_port`) is a launch
+setting, not read from `traceml.yaml`. If the aggregator is not reachable,
+`traceml.init(...)` retries for a short bounded period and then raises a clear
+error. Use `traceml.init(disabled=True)` (or `TRACEML_DISABLED=1`) to run with
+tracing fully disabled as a no-op.
+
+### Matching display modes across processes
+
+`traceml run` configures one display mode for the whole run. In the direct-launch
+path the aggregator and the worker are launched separately, so their display
+modes are set independently: `traceml serve --mode` for the aggregator, and
+`ui_mode` (via `traceml.init(ui_mode=...)` or `TRACEML_UI_MODE`) for the worker.
+
+For the live `cli` STDOUT/STDERR panel to show your script's output, set both to
+`cli` so the worker mirrors its stdout to the aggregator:
+
+```bash
+traceml serve --mode cli --run-name demo --aggregator-port 29765
+TRACEML_UI_MODE=cli TRACEML_SESSION_ID=demo python train.py
+```
+
+If the modes differ (for example a `cli` aggregator with a worker left on the
+default `summary`), telemetry, diagnosis, and the final summary are unaffected;
+only worker stdout mirroring into the live panel is skipped.
 
 ## Summary APIs
 

--- a/docs/user_guide/quickstart.md
+++ b/docs/user_guide/quickstart.md
@@ -100,6 +100,43 @@ tables.)
 For DDP, FSDP, and multi-node launches, see
 [Distributed Training](distributed-training.md).
 
+### Alternative: launch your script directly
+
+If you would rather launch training yourself with `python` or `torchrun`, start
+the TraceML aggregator once, then run your script directly. `traceml.init(...)`
+connects to the running aggregator:
+
+```bash
+# terminal 1
+traceml serve --aggregator-host 127.0.0.1 --aggregator-port 29765
+
+# terminal 2
+python train.py
+```
+
+For torchrun and multi-node, bind the aggregator so other nodes can connect:
+
+```bash
+# aggregator node: --nnodes x --nproc-per-node = total workers, so the
+# aggregator waits for every rank before finalizing
+traceml serve --aggregator-bind-host 0.0.0.0 --aggregator-host <node0-ip> \
+  --aggregator-port 29765 --nnodes <N> --nproc-per-node <M>
+
+# each training node: point workers at node 0's aggregator, then launch
+TRACEML_AGGREGATOR_HOST=<node0-ip> TRACEML_AGGREGATOR_PORT=29765 \
+  torchrun ... train.py
+```
+
+In the direct-launch path you cannot pass `traceml run` flags, so runtime
+settings come from `traceml.init(...)` arguments, then `TRACEML_*` environment
+variables, then `traceml.yaml`, then built-in defaults. The aggregator endpoint
+is set with `traceml serve` flags. If the aggregator is not reachable,
+`traceml.init(...)` prints one warning and continues without tracing (a no-op),
+so instrumentation never crashes your training run. Pass
+`traceml.init(on_missing_aggregator="raise")` to fail hard instead, or
+`traceml.init(disabled=True)` to silence it entirely. See
+[Public API](public-api.md#direct-launch-with-traceml-serve).
+
 ## 4. Read Your Diagnosis
 
 ```text

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -162,6 +162,8 @@ What to do next:
 Meaning:
 
 - input wait is taking a large share of iteration time
+- TraceML uses the median per-rank input share, so one unusually slow rank
+  does not hide a broad input bottleneck
 
 Common causes:
 
@@ -190,6 +192,7 @@ What to do next:
 Meaning:
 
 - model compute dominates the typical step
+- this is informational when no material input or residual overhead is visible
 
 In practice this means most step time is going into:
 
@@ -365,6 +368,11 @@ In TraceML:
 - `compute = forward + backward + optimizer`
 - `residual = step_time - h2d - compute`
 - `total_step = input_wait + step_time`
+
+TraceML evaluates residual as the median per-rank share of selected-clock
+iteration time (`input_wait + step_time`). Input and residual findings warn at
+10% and are critical at 20%; rank skew is supporting evidence rather than a
+gate that hides a typical bottleneck.
 
 This is residual unattributed time inside the traced step, not direct
 collective, NCCL, or all-reduce timing.

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -135,7 +135,7 @@ It is based on:
 - optimizer time
 - step time
 - residual / overhead
-- worst-rank vs median-rank differences in distributed runs
+- culprit/victim visible rank skew in distributed runs
 
 ### `BALANCED`
 
@@ -227,10 +227,12 @@ Meaning:
 
 TraceML uses this idea:
 
-- account for backward time that can be explained by another rank arriving late
-- compare the slowest rank to the typical rank
-- blame input wait when its worst-rank excess over peer median dominates the
-  other timing differences by at least `1.25x`
+- detect visible wait cost from backward in DDP/default, or forward + backward
+  in FSDP
+- identify the likely culprit as the rank that waited least in the visible
+  phase
+- blame input wait when the culprit has material input-wait excess compared
+  with the victim rank
 
 In simpler words:
 
@@ -246,13 +248,14 @@ Common causes:
 What to look at:
 
 - `Input Wait`
-- worst rank
+- culprit rank
+- victim/reference rank
 - skew (%)
 - diagnosis evidence
 
 What to do next:
 
-- inspect input loading on the worst rank
+- inspect input loading on the culprit rank
 - compare batch preparation across ranks
 - check for host-side interference or noisy neighbors
 
@@ -262,23 +265,21 @@ What to do next:
 
 Meaning:
 
-- one rank has meaningfully more observed compute-phase burden than a typical
-  rank
+- in DDP/default strategy, the likely culprit rank has materially more forward
+  time than the victim rank
 
-For FSDP, observed forward time may include parameter all-gather wait, so this
-is not proof of pure rank-local model compute.
+FSDP does not emit `COMPUTE STRAGGLER` from the rank-skew rule for now because
+forward and backward can include sharding communication.
 
 TraceML uses this idea:
 
-- account for backward time that can be explained by another rank arriving late
-- compare the worst rank's compute time to peer median
-- blame compute when compute-time excess dominates input wait, H2D, and
-  residual differences by at least `1.25x`
+- detect visible wait cost from backward in DDP/default strategy
+- compare the culprit rank's forward time with the victim rank
+- blame compute when the forward excess is material
 
 In simpler words:
 
-- one rank is spending more time in the observed forward, backward, or optimizer
-  phases than the others
+- one rank is spending more time in forward work than the victim rank
 
 Common causes:
 
@@ -289,17 +290,15 @@ Common causes:
 What to look at:
 
 - `Forward`
-- `Backward`
-- `Optimizer Step`
-- worst rank
+- culprit rank
+- victim/reference rank
 - skew (%)
 - diagnosis note
 
 What to do next:
 
-- inspect the called-out compute phase on the worst rank
+- inspect the called-out forward phase on the culprit rank
 - compare input shapes and rank-local logic
-- inspect imbalance in backward or optimizer time
 
 ---
 
@@ -310,7 +309,7 @@ Meaning:
 - one rank spends meaningfully more time in host-to-device transfer than a
   typical rank
 
-TraceML reports this when H2D is the largest timing difference on the slow
+TraceML reports this when H2D is the largest material excess on the culprit
 rank.
 
 Common causes:
@@ -321,30 +320,8 @@ Common causes:
 
 What to do next:
 
-- inspect batch shapes and transfer placement on the worst rank
+- inspect batch shapes and transfer placement on the culprit rank
 - compare CPU-to-GPU copy timing across ranks
-
----
-
-### `RESIDUAL STRAGGLER`
-
-Meaning:
-
-- one rank has meaningfully more rank-local residual `residual_proxy` than a
-  typical rank
-
-This is rank-local residual excess. It differs from `RESIDUAL-HEAVY`, which
-describes a window-wide residual time share.
-
-Common causes:
-
-- rank-local logging, checkpointing, validation, callbacks, CPU stalls, or
-  unobserved transfer work inside the timed step
-
-What to do next:
-
-- inspect host-side work on the worst rank
-- compare callbacks and per-rank side effects
 
 ---
 
@@ -352,15 +329,15 @@ What to do next:
 
 Meaning:
 
-- one rank is slower, but no single timing category clearly dominates
+- visible rank skew exists, but input wait, H2D, and DDP forward do not explain
+  the likely culprit
 
 In the current policy, this is used when:
 
 - the rank difference is large enough to matter
-- the largest worst-rank excess among input wait, compute, H2D, and residual
-  is less than `1.25x` the next-largest excess
+- the culprit's input wait, H2D, and DDP forward excesses are not material
 
-This is a mixed unevenness case.
+This is sync-bound or unattributed rank skew.
 
 Common causes:
 
@@ -371,7 +348,7 @@ Common causes:
 What to do next:
 
 - inspect input wait, H2D, compute, and residual signals
-- inspect the worst rank and the largest uneven phases
+- inspect sync, collective, and unattributed work around the culprit rank
 - reduce complexity by isolating one issue at a time
 
 ---
@@ -730,9 +707,9 @@ It gives:
 
 This card shows:
 
-- median vs worst step breakdown
-- gap
-- worst rank
+- median/reference vs rank breakdown
+- visible rank skew
+- culprit rank when a rank straggler is diagnosed
 - residual time
 - dominant split
 
@@ -764,11 +741,10 @@ Use these as context cards:
 |---|---|
 | `INPUT-BOUND` | inspect input loading, preprocessing, and storage |
 | `COMPUTE-BOUND` | inspect forward/backward/optimizer cost |
-| `INPUT STRAGGLER` | inspect input path on the worst rank |
-| `COMPUTE STRAGGLER` | inspect observed compute-phase skew on the worst rank |
-| `H2D STRAGGLER` | inspect host-to-device transfer on the worst rank |
-| `RESIDUAL STRAGGLER` | inspect rank-local host-side work on the worst rank |
-| `STRAGGLER` | inspect mixed rank unevenness |
+| `INPUT STRAGGLER` | inspect input path on the culprit rank |
+| `COMPUTE STRAGGLER` | inspect DDP forward work on the culprit rank |
+| `H2D STRAGGLER` | inspect host-to-device transfer on the culprit rank |
+| `STRAGGLER` | inspect sync, collective, or unattributed work around the culprit rank |
 | `RESIDUAL-HEAVY` | inspect logging, checkpointing, validation, CPU stalls, and unobserved transfer paths |
 | `MEMORY RISING` | inspect retained state and watch the next window |
 | `MEMORY CREEP` | inspect retained tensors and growing caches |
@@ -824,8 +800,8 @@ Always read:
 If you are in a hurry:
 
 1. read the diagnosis
-2. identify the worst rank if shown
-3. compare worst vs median
+2. identify the culprit rank if shown
+3. compare culprit vs victim/reference rank
 4. look at residual time or memory trend
 5. take the suggested next action
 

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -175,7 +175,7 @@ Common causes:
 What to look at:
 
 - `Input Wait`
-- its share of the step
+- its share of iteration time
 - whether the issue is broad or rank-specific
 
 What to do next:
@@ -184,6 +184,30 @@ What to do next:
 - reduce preprocessing cost
 - improve storage throughput
 - inspect batch construction
+
+---
+
+### `H2D-BOUND`
+
+Meaning:
+
+- host-to-device transfer is taking a large share of typical iteration time
+- TraceML uses the median per-rank H2D share, so one unusually slow rank does
+  not hide a broad transfer bottleneck
+- this diagnosis requires GPU-selected timing; CPU host-call duration is not
+  treated as transfer cost
+
+TraceML reports a warning at 10% of iteration time and critical severity at
+20%.
+
+What to do next:
+
+- use pinned host memory where appropriate
+- inspect batch transfer placement and non-blocking copies
+- reduce transferred batch size or unnecessary host-to-device copies
+
+`H2D-BOUND` describes broad transfer cost. `H2D STRAGGLER` instead describes
+one rank with excess transfer time.
 
 ---
 
@@ -748,6 +772,7 @@ Use these as context cards:
 | Diagnosis | Good next step |
 |---|---|
 | `INPUT-BOUND` | inspect input loading, preprocessing, and storage |
+| `H2D-BOUND` | inspect pinned memory, batch transfer, and host-to-device copies |
 | `COMPUTE-BOUND` | inspect forward/backward/optimizer cost |
 | `INPUT STRAGGLER` | inspect input path on the culprit rank |
 | `COMPUTE STRAGGLER` | inspect DDP forward work on the culprit rank |

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -161,7 +161,7 @@ What to do next:
 
 Meaning:
 
-- input wait is taking a large share of the typical step
+- input wait is taking a large share of iteration time
 
 Common causes:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,7 @@ These are the main user-facing examples.
 | `ray/lightning_text_classifier.py` | Ray Train + Lightning text classifier | CPU / CUDA | Uses Ray Data, `TraceMLCallback`, and optional input/H2D demo knobs |
 | `integrations/huggingface_trainer_minimal.py` | Minimal Hugging Face `TraceMLTrainer` example | CPU / CUDA | No model download required |
 | `integrations/lightning_minimal.py` | Minimal Lightning integration init + `TraceMLCallback` example | CPU / CUDA | No dataset download required |
+| `integrations/deepspeed_minimal.py` | Minimal DeepSpeed loop wrapped with `traceml.trace_step(...)` | CUDA | Requires `deepspeed`; exits cleanly without it |
 
 If you only try one example first, use:
 
@@ -135,6 +136,13 @@ Single-node DDP:
 traceml run examples/distributed/ddp_minimal.py --nproc-per-node=4
 ```
 
+DeepSpeed (single or multi-GPU; requires `deepspeed` + a CUDA GPU):
+
+```bash
+traceml run examples/integrations/deepspeed_minimal.py --mode=summary
+traceml run examples/integrations/deepspeed_minimal.py --nproc-per-node=2 --mode=summary
+```
+
 Multi-node on Slurm:
 
 ```bash
@@ -201,6 +209,7 @@ Use:
 - `integrations/huggingface_trainer_minimal.py` if you use Hugging Face `Trainer`
 - `integrations/lightning_minimal.py` if you use PyTorch Lightning
 - `ray/torchtrainer_minimal.py` if you use Ray Train
+- `integrations/deepspeed_minimal.py` if you use DeepSpeed
 
 Use the diagnosis demos when you want to see:
 

--- a/examples/integrations/deepspeed_config_minimal.json
+++ b/examples/integrations/deepspeed_config_minimal.json
@@ -1,0 +1,13 @@
+{
+    "train_micro_batch_size_per_gpu": 256,
+    "gradient_accumulation_steps": 1,
+    "optimizer": {
+        "type": "Adam",
+        "params": {
+            "lr": 1e-3
+        }
+    },
+    "zero_optimization": {
+        "stage": 2
+    }
+}

--- a/examples/integrations/deepspeed_minimal.py
+++ b/examples/integrations/deepspeed_minimal.py
@@ -1,0 +1,161 @@
+import os
+import sys
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, DistributedSampler, TensorDataset
+
+import traceml_ai as traceml
+
+SEED = 42
+INPUT_DIM = 1024
+HIDDEN_DIM = 2048
+NUM_CLASSES = 10
+NUM_SAMPLES = 100000
+BATCH_SIZE = 256
+EPOCHS = 2
+
+CONFIG_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "deepspeed_config_minimal.json",
+)
+
+
+class TinyMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(INPUT_DIM, HIDDEN_DIM),
+            nn.GELU(),
+            nn.Linear(HIDDEN_DIM, HIDDEN_DIM),
+            nn.GELU(),
+            nn.Linear(HIDDEN_DIM, NUM_CLASSES),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+def set_seed(seed: int) -> None:
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def prepare_data(rank: int, world_size: int):
+    x = torch.randn(NUM_SAMPLES, INPUT_DIM)
+    y = torch.randint(0, NUM_CLASSES, (NUM_SAMPLES,))
+    dataset = TensorDataset(x, y)
+
+    sampler = DistributedSampler(
+        dataset,
+        num_replicas=world_size,
+        rank=rank,
+        shuffle=True,
+    )
+
+    # batch_size must match train_micro_batch_size_per_gpu in the config.
+    loader = DataLoader(
+        dataset,
+        batch_size=BATCH_SIZE,
+        sampler=sampler,
+        pin_memory=True,
+        drop_last=True,
+    )
+
+    return loader, sampler
+
+
+def main() -> None:
+    try:
+        import deepspeed
+    except ImportError:
+        print(
+            "This example requires DeepSpeed. Install it with:\n"
+            '  pip install "traceml-ai[deepspeed]"\n'
+            "or follow https://www.deepspeed.ai/getting-started/. "
+            "DeepSpeed also requires a CUDA GPU."
+        )
+        sys.exit(0)
+
+    if not torch.cuda.is_available():
+        print(
+            "DeepSpeed requires a CUDA GPU; none is available, so this "
+            "minimal example has nothing to run. Exiting cleanly."
+        )
+        sys.exit(0)
+
+    rank = int(os.environ.get("RANK", 0))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+
+    # deepspeed.init_distributed() replaces torch.distributed's
+    # init_process_group. It reads RANK/LOCAL_RANK/WORLD_SIZE from the
+    # torchrun environment, which is how `traceml run` launches this script.
+    deepspeed.init_distributed()
+
+    set_seed(SEED + rank)
+
+    model = TinyMLP()
+    train_loader, train_sampler = prepare_data(rank, world_size)
+
+    # DeepSpeed builds the optimizer from the "optimizer" block in the config
+    # and returns (engine, optimizer, dataloader, lr_scheduler).
+    model_engine, _, _, _ = deepspeed.initialize(
+        model=model,
+        model_parameters=model.parameters(),
+        config=CONFIG_PATH,
+    )
+
+    # Enable TraceML auto instrumentation (dataloader, forward, backward,
+    # optimizer, and H2D timing) for this process.
+    traceml.init(mode="auto")
+
+    criterion = nn.CrossEntropyLoss()
+    device = model_engine.device
+
+    model_engine.train()
+    global_step = 0
+
+    for epoch in range(EPOCHS):
+        train_sampler.set_epoch(epoch)
+        running_loss = torch.zeros((), device=device)
+
+        for batch_x, batch_y in train_loader:
+            # Wrap the DeepSpeed step. Pass model_engine.module (the unwrapped
+            # model) so TraceML's forward timer targets your model, exactly
+            # like model.module for DDP and base_model for FSDP.
+            with traceml.trace_step(model_engine.module):
+                batch_x = batch_x.to(device, non_blocking=True)
+                batch_y = batch_y.to(device, non_blocking=True)
+
+                logits = model_engine(batch_x)
+                loss = criterion(logits, batch_y)
+
+                model_engine.backward(loss)
+                model_engine.step()
+
+            # Keep loss logging OUTSIDE trace_step so it never inflates the
+            # measured step, and accumulate on-device so there is no per-step
+            # device-to-host sync (only when we actually print), mirroring the
+            # quickstart example.
+            running_loss += loss.detach()
+            global_step += 1
+
+            if rank == 0 and global_step % 50 == 0:
+                print(
+                    f"Epoch {epoch + 1} | Step {global_step} | "
+                    f"loss: {float(running_loss) / 50:.4f}"
+                )
+                running_loss.zero_()
+
+    if rank == 0:
+        print("Done.")
+
+    # Match the DDP / FSDP examples: tear down the process group that
+    # deepspeed.init_distributed() set up.
+    if torch.distributed.is_initialized():
+        torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,5 +95,6 @@ nav:
       - Public API: user_guide/public-api.md
   - Developer Guide:
       - Architecture: developer_guide/architecture.md
+      - Rank Straggler Policy: developer_guide/rank-straggler-policy.md
       - Extending TraceML: developer_guide/extending.md
       - Contributing: developer_guide/contributing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
           - Hugging Face: user_guide/integrations/huggingface.md
           - PyTorch Lightning: user_guide/integrations/lightning.md
           - Ray Train: user_guide/integrations/ray.md
+          - DeepSpeed: user_guide/integrations/deepspeed.md
           - W&B / MLflow: user_guide/integrations/wandb-mlflow.md
       - FAQ: user_guide/faq.md
       - Compare Runs: user_guide/compare.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,10 @@ ray = [
     "ray[train]>=2.0.0",
 ]
 
+deepspeed = [
+    "deepspeed>=0.10.0",
+]
+
 docs = [
     "mkdocs>=1.6",
     "mkdocs-material>=9.5",

--- a/src/traceml_ai/aggregator/aggregator_main.py
+++ b/src/traceml_ai/aggregator/aggregator_main.py
@@ -40,6 +40,7 @@ from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
 from traceml_ai.runtime.lifecycle import start_aggregator
 from traceml_ai.runtime.settings import (
     DEFAULT_FINALIZE_TIMEOUT_SEC,
+    DEFAULT_INTERVAL_SEC,
     AggregatorTransportSettings,
     TraceMLSettings,
 )
@@ -110,7 +111,9 @@ def read_traceml_env() -> dict[str, Any]:
     return {
         "mode": ui_mode,
         "profile": os.environ.get("TRACEML_PROFILE", "run"),
-        "interval": float(os.environ.get("TRACEML_INTERVAL", "1.0")),
+        "interval": float(
+            os.environ.get("TRACEML_INTERVAL", str(DEFAULT_INTERVAL_SEC))
+        ),
         "enable_logging": os.environ.get("TRACEML_ENABLE_LOGGING", "0") == "1",
         "logs_dir": os.environ.get("TRACEML_LOGS_DIR", "./logs"),
         "aggregator_host": os.environ.get(

--- a/src/traceml_ai/aggregator/aggregator_main.py
+++ b/src/traceml_ai/aggregator/aggregator_main.py
@@ -30,6 +30,7 @@ import signal
 import sys
 import threading
 import traceback
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -166,29 +167,43 @@ def _install_signal_handlers(stop_event: threading.Event) -> None:
     signal.signal(signal.SIGTERM, _handler)
 
 
-def main() -> None:
+def run_aggregator(
+    settings: TraceMLSettings,
+    *,
+    logger: Optional[Any] = None,
+) -> int:
     """
-    Aggregator process entrypoint.
+    Own one aggregator lifecycle until a shutdown signal, then exit cleanly.
 
-    Execution flow
-    --------------
-    1. Initialize logging
-    2. Read configuration from environment variables
-    3. Create the session directory and settings
-    4. Start the aggregator
-    5. Wait for a shutdown request
-    6. Stop the aggregator and report any fatal errors
+    This is the single aggregator-owning entry point shared by the standalone
+    aggregator process (started by ``traceml run``) and the ``traceml serve``
+    command. It:
+
+    - starts only the aggregator (never a user training script)
+    - prints the reachable endpoint
+    - blocks until SIGINT/SIGTERM
+    - shuts down cleanly, preserving final-summary behavior
+    - logs fatal aggregator errors to ``aggregator_error.log``
+
+    Returns a process exit code (0 on clean shutdown, 1 on fatal error).
     """
-    setup_error_logger(is_aggregator=True)
-    logger = get_error_logger("TraceMLAggregatorMain")
-
-    cfg = read_traceml_env()
-
-    session_id = str(cfg["session_id"] or "default")
-    session_root = Path(str(cfg["logs_dir"])).resolve() / session_id
+    session_id = str(settings.session_id or "default")
+    session_root = Path(str(settings.logs_dir)).resolve() / session_id
     session_dir = session_root / "aggregator"
     session_dir.mkdir(parents=True, exist_ok=True)
     db_path = session_dir / "telemetry"
+    settings = replace(settings, session_id=session_id, db_path=str(db_path))
+
+    # The shared error logger resolves its directory from TRACEML_LOGS_DIR and
+    # TRACEML_SESSION_ID. The `traceml run` launcher sets these before spawning
+    # the aggregator subprocess; the `traceml serve` path runs in-process and
+    # does not, so mirror them from the resolved settings before logging setup.
+    os.environ["TRACEML_LOGS_DIR"] = str(settings.logs_dir)
+    os.environ["TRACEML_SESSION_ID"] = session_id
+
+    if logger is None:
+        setup_error_logger(is_aggregator=True)
+        logger = get_error_logger("TraceMLAggregatorMain")
 
     stop_event = threading.Event()
     _install_signal_handlers(stop_event)
@@ -197,34 +212,24 @@ def main() -> None:
     err: Optional[BaseException] = None
 
     try:
-        settings = TraceMLSettings(
-            mode=str(cfg["mode"]),
-            profile=str(cfg["profile"]),
-            render_interval_sec=float(cfg["interval"]),
-            enable_logging=bool(cfg["enable_logging"]),
-            logs_dir=str(cfg["logs_dir"]),
-            dashboard_port=int(cfg["dashboard_port"]),
-            dashboard_auto_open=bool(cfg["dashboard_auto_open"]),
-            session_id=session_id,
-            history_enabled=bool(cfg["history_enabled"]),
-            summary_window_rows=int(cfg["summary_window_rows"]),
-            html_report=bool(cfg["html_report"]),
-            finalize_timeout_sec=float(cfg["finalize_timeout_sec"]),
-            expected_world_size=int(cfg["expected_world_size"]),
-            aggregator=AggregatorTransportSettings(
-                connect_host=str(cfg["aggregator_host"]),
-                bind_host=str(cfg["aggregator_bind_host"]),
-                port=int(cfg["aggregator_port"]),
-            ),
-            db_path=str(db_path),
-        )
-
         logger.info("[TraceML] Starting aggregator")
         handle = start_aggregator(
             settings,
             logger=logger,
             stop_event=stop_event,
         )
+
+        endpoint = handle.endpoint
+        print(
+            "[TraceML] Aggregator ready on "
+            f"{settings.aggregator.bind_host}:{endpoint.port} "
+            f"(workers connect to {endpoint.host}:{endpoint.port}, "
+            f"session={endpoint.session_id}, ui={settings.mode}). "
+            "Press Ctrl+C to stop.",
+            file=sys.stderr,
+            flush=True,
+        )
+
         stop_event.wait()
 
     except BaseException as exc:
@@ -234,7 +239,7 @@ def main() -> None:
         if handle is not None:
             try:
                 logger.info("[TraceML] Stopping aggregator")
-                handle.stop(timeout_sec=float(cfg["finalize_timeout_sec"]))
+                handle.stop(timeout_sec=float(settings.finalize_timeout_sec))
             except Exception as stop_exc:
                 if err is None:
                     err = stop_exc
@@ -270,10 +275,47 @@ def main() -> None:
                 file=sys.stderr,
             )
             sys.stderr.flush()
-            raise SystemExit(1)
+            return 1
 
     print("\n[TraceML] Aggregator stopped.", file=sys.stderr, flush=True)
-    raise SystemExit(0)
+    return 0
+
+
+def main() -> None:
+    """
+    Standalone aggregator process entrypoint.
+
+    Reads configuration from the ``TRACEML_*`` environment variables set by the
+    ``traceml run`` launcher, builds settings, and delegates the lifecycle to
+    :func:`run_aggregator`.
+    """
+    setup_error_logger(is_aggregator=True)
+    logger = get_error_logger("TraceMLAggregatorMain")
+
+    cfg = read_traceml_env()
+
+    settings = TraceMLSettings(
+        mode=str(cfg["mode"]),
+        profile=str(cfg["profile"]),
+        render_interval_sec=float(cfg["interval"]),
+        enable_logging=bool(cfg["enable_logging"]),
+        logs_dir=str(cfg["logs_dir"]),
+        dashboard_port=int(cfg["dashboard_port"]),
+        dashboard_auto_open=bool(cfg["dashboard_auto_open"]),
+        session_id=str(cfg["session_id"] or "default"),
+        history_enabled=bool(cfg["history_enabled"]),
+        summary_window_rows=int(cfg["summary_window_rows"]),
+        html_report=bool(cfg["html_report"]),
+        finalize_timeout_sec=float(cfg["finalize_timeout_sec"]),
+        expected_world_size=int(cfg["expected_world_size"]),
+        aggregator=AggregatorTransportSettings(
+            connect_host=str(cfg["aggregator_host"]),
+            bind_host=str(cfg["aggregator_bind_host"]),
+            port=int(cfg["aggregator_port"]),
+        ),
+    )
+
+    raise SystemExit(run_aggregator(settings, logger=logger))
 
 
 if __name__ == "__main__":

--- a/src/traceml_ai/aggregator/sqlite_writer.py
+++ b/src/traceml_ai/aggregator/sqlite_writer.py
@@ -16,6 +16,9 @@ from typing import Any, Dict, Iterator, Optional
 
 from traceml_ai.aggregator.sqlite_writers import process as process_sql_writer
 from traceml_ai.aggregator.sqlite_writers import (
+    runtime_environment as runtime_environment_sql_writer,
+)
+from traceml_ai.aggregator.sqlite_writers import (
     stdout_stderr as stdout_stderr_sql_writer,
 )
 from traceml_ai.aggregator.sqlite_writers import (
@@ -36,6 +39,7 @@ from traceml_ai.telemetry.envelope import (
 )
 
 _PROJECTION_WRITERS = [
+    runtime_environment_sql_writer,
     system_sql_writer,
     process_sql_writer,
     step_time_sql_writer,

--- a/src/traceml_ai/aggregator/sqlite_writers/runtime_environment.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/runtime_environment.py
@@ -1,0 +1,209 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SQLite projection writer for RuntimeEnvironmentSampler.
+
+The runtime environment table stores one small rank-scoped context row, such as
+topology and observed training strategy. It is sampler body data, not TCP
+envelope metadata, and is intentionally excluded from retention pruning.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from traceml_ai.telemetry.envelope import TelemetryEnvelope, TelemetryMeta
+
+SAMPLER_NAME = "RuntimeEnvironmentSampler"
+TABLE_NAME = "RuntimeEnvironmentTable"
+
+
+def _optional_float(value: Any) -> Optional[float]:
+    """Best-effort float coercion for runtime environment rows."""
+    try:
+        return float(value) if value is not None else None
+    except Exception:
+        return None
+
+
+def _optional_int(value: Any) -> Optional[int]:
+    """Best-effort integer coercion for runtime environment rows."""
+    try:
+        return int(value) if value is not None else None
+    except Exception:
+        return None
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    """Best-effort string coercion for runtime environment rows."""
+    if value is None:
+        return None
+    try:
+        return str(value)
+    except Exception:
+        return None
+
+
+def _optional_bool_int(value: Any) -> Optional[int]:
+    """Return booleans as 1/0 while preserving unknown as NULL."""
+    if value is True:
+        return 1
+    if value is False:
+        return 0
+    return None
+
+
+@dataclass(frozen=True)
+class RuntimeEnvironmentPayloadIdentity:
+    """Distributed identity stored with runtime environment telemetry."""
+
+    rank: Optional[int]
+    global_rank: Optional[int]
+    local_rank: Optional[int]
+    world_size: Optional[int]
+    local_world_size: Optional[int]
+    node_rank: Optional[int]
+    hostname: Optional[str]
+    pid: Optional[int]
+
+
+def _payload_identity(
+    meta: TelemetryMeta,
+) -> RuntimeEnvironmentPayloadIdentity:
+    """Return storage identity for one RuntimeEnvironmentSampler payload."""
+    return RuntimeEnvironmentPayloadIdentity(
+        rank=_optional_int(meta.rank),
+        global_rank=_optional_int(meta.global_rank),
+        local_rank=_optional_int(meta.local_rank),
+        world_size=_optional_int(meta.world_size),
+        local_world_size=_optional_int(meta.local_world_size),
+        node_rank=_optional_int(meta.node_rank),
+        hostname=_optional_str(meta.hostname),
+        pid=_optional_int(meta.pid),
+    )
+
+
+def accepts_sampler(sampler: Optional[str]) -> bool:
+    """Return True if this projection writer handles the given sampler."""
+    return sampler == SAMPLER_NAME
+
+
+def init_schema(conn: sqlite3.Connection) -> None:
+    """Create the query-friendly runtime environment table."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS runtime_environment (
+            id                         INTEGER PRIMARY KEY AUTOINCREMENT,
+            recv_ts_ns                 INTEGER NOT NULL,
+            rank                       INTEGER,
+            global_rank                INTEGER,
+            local_rank                 INTEGER,
+            world_size                 INTEGER,
+            local_world_size           INTEGER,
+            node_rank                  INTEGER,
+            hostname                   TEXT,
+            pid                        INTEGER,
+            sample_ts_s                REAL,
+            seq                        INTEGER,
+            topology                   TEXT,
+            distributed_initialized    INTEGER,
+            distributed_backend        TEXT,
+            training_strategy          TEXT,
+            strategy_source            TEXT,
+            strategy_confidence        TEXT
+        );
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_runtime_environment_global_rank
+        ON runtime_environment(global_rank, id);
+        """
+    )
+
+
+def build_rows(
+    envelope: TelemetryEnvelope,
+    recv_ts_ns: int,
+) -> Dict[str, list[tuple]]:
+    """Build SQLite rows from one decoded RuntimeEnvironmentSampler payload."""
+    out: Dict[str, list[tuple]] = {"runtime_environment": []}
+
+    sampler = envelope.meta.sampler
+    if not accepts_sampler(sampler):
+        return out
+
+    identity = _payload_identity(envelope.meta)
+    tables = envelope.tables
+    if not isinstance(tables, dict):
+        return out
+
+    rows = tables.get(TABLE_NAME)
+    if not isinstance(rows, list):
+        return out
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+
+        out["runtime_environment"].append(
+            (
+                recv_ts_ns,
+                identity.rank,
+                identity.global_rank,
+                identity.local_rank,
+                identity.world_size,
+                identity.local_world_size,
+                identity.node_rank,
+                identity.hostname,
+                identity.pid,
+                _optional_float(row.get("ts")),
+                _optional_int(row.get("seq")),
+                _optional_str(row.get("topology")),
+                _optional_bool_int(row.get("distributed_initialized")),
+                _optional_str(row.get("distributed_backend")),
+                _optional_str(row.get("training_strategy")),
+                _optional_str(row.get("strategy_source")),
+                _optional_str(row.get("strategy_confidence")),
+            )
+        )
+
+    return out
+
+
+def insert_rows(
+    conn: sqlite3.Connection,
+    rows_by_table: Dict[str, list[tuple]],
+) -> None:
+    """Insert runtime environment projection rows into SQLite."""
+    rows = rows_by_table.get("runtime_environment", [])
+    if rows:
+        conn.executemany(
+            """
+            INSERT INTO runtime_environment(
+                recv_ts_ns,
+                rank,
+                global_rank,
+                local_rank,
+                world_size,
+                local_world_size,
+                node_rank,
+                hostname,
+                pid,
+                sample_ts_s,
+                seq,
+                topology,
+                distributed_initialized,
+                distributed_backend,
+                training_strategy,
+                strategy_source,
+                strategy_confidence
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """,
+            rows,
+        )

--- a/src/traceml_ai/api.py
+++ b/src/traceml_ai/api.py
@@ -98,8 +98,26 @@ def init(
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
     patch_h2d: Optional[bool] = None,
+    disabled: Optional[bool] = None,
+    ui_mode: Optional[str] = None,
+    interval: Optional[float] = None,
+    logs_dir: Optional[str] = None,
+    enable_logging: Optional[bool] = None,
+    session_id: Optional[str] = None,
+    aggregator_host: Optional[str] = None,
+    aggregator_port: Optional[int] = None,
+    connect_timeout_sec: float = 10.0,
+    connect_retry_interval_sec: float = 0.25,
+    on_missing_aggregator: Optional[str] = None,
 ) -> TraceMLInitConfig:
-    """Initialize TraceML instrumentation for this process."""
+    """Initialize TraceML and start its runtime for this process.
+
+    ``on_missing_aggregator`` controls what happens when the aggregator is
+    unreachable (or the runtime fails to start): ``'warn'`` (default) emits one
+    stderr warning and continues as a no-op so tracing never crashes training;
+    ``'raise'`` fails hard. Defaults to ``TRACEML_ON_MISSING_AGGREGATOR`` then
+    ``'warn'``.
+    """
     from traceml_ai.sdk.initial import init as _init
 
     return _init(
@@ -108,6 +126,17 @@ def init(
         patch_forward=patch_forward,
         patch_backward=patch_backward,
         patch_h2d=patch_h2d,
+        disabled=disabled,
+        ui_mode=ui_mode,
+        interval=interval,
+        logs_dir=logs_dir,
+        enable_logging=enable_logging,
+        session_id=session_id,
+        aggregator_host=aggregator_host,
+        aggregator_port=aggregator_port,
+        connect_timeout_sec=connect_timeout_sec,
+        connect_retry_interval_sec=connect_retry_interval_sec,
+        on_missing_aggregator=on_missing_aggregator,
     )
 
 
@@ -118,6 +147,16 @@ def start(
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
     patch_h2d: Optional[bool] = None,
+    disabled: Optional[bool] = None,
+    ui_mode: Optional[str] = None,
+    interval: Optional[float] = None,
+    logs_dir: Optional[str] = None,
+    enable_logging: Optional[bool] = None,
+    session_id: Optional[str] = None,
+    aggregator_host: Optional[str] = None,
+    aggregator_port: Optional[int] = None,
+    connect_timeout_sec: float = 10.0,
+    connect_retry_interval_sec: float = 0.25,
 ) -> TraceMLInitConfig:
     """Alias for `traceml.init(...)`."""
     from traceml_ai.sdk.initial import start as _start
@@ -128,6 +167,16 @@ def start(
         patch_forward=patch_forward,
         patch_backward=patch_backward,
         patch_h2d=patch_h2d,
+        disabled=disabled,
+        ui_mode=ui_mode,
+        interval=interval,
+        logs_dir=logs_dir,
+        enable_logging=enable_logging,
+        session_id=session_id,
+        aggregator_host=aggregator_host,
+        aggregator_port=aggregator_port,
+        connect_timeout_sec=connect_timeout_sec,
+        connect_retry_interval_sec=connect_retry_interval_sec,
     )
 
 

--- a/src/traceml_ai/config/yaml_loader.py
+++ b/src/traceml_ai/config/yaml_loader.py
@@ -20,7 +20,10 @@ import warnings
 from pathlib import Path
 from typing import Any, Mapping
 
-from traceml_ai.runtime.settings import DEFAULT_FINALIZE_TIMEOUT_SEC
+from traceml_ai.runtime.settings import (
+    DEFAULT_FINALIZE_TIMEOUT_SEC,
+    DEFAULT_INTERVAL_SEC,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -33,6 +36,8 @@ _MAX_WALK_LEVELS = 10
 # To add a setting: add here, add to BUILT_IN_DEFAULTS, add default=None in cli.py.
 YAML_KEY_SCHEMA: dict[str, tuple[str, type]] = {
     "mode": ("TRACEML_UI_MODE", str),
+    # This is the one public cadence control: sampler frequency on workers and
+    # UI refresh frequency on the aggregator. TCP ingestion remains event-driven.
     "interval": ("TRACEML_INTERVAL", float),
     "enable_logging": ("TRACEML_ENABLE_LOGGING", bool),
     "logs_dir": ("TRACEML_LOGS_DIR", str),
@@ -46,7 +51,7 @@ YAML_KEY_SCHEMA: dict[str, tuple[str, type]] = {
 # The launcher promotes mode to "summary" for multi-node runs.
 BUILT_IN_DEFAULTS: dict[str, Any] = {
     "mode": "dashboard",
-    "interval": 2.0,
+    "interval": DEFAULT_INTERVAL_SEC,
     "enable_logging": False,
     "logs_dir": "./logs",
     "history_enabled": True,

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -70,7 +70,7 @@ Training-step timing.
 - `COMPUTE_STRAGGLER`: one rank has materially higher clean compute time.
 - `H2D_STRAGGLER`: one rank has materially higher host-to-device transfer time.
 - `RESIDUAL_STRAGGLER`: one rank has materially higher residual `residual_proxy`.
-- `INPUT_BOUND`: selected-clock input wait dominates the typical step.
+- `INPUT_BOUND`: selected-clock input wait dominates iteration time.
 - `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical step.
 - `RESIDUAL_HEAVY`: unattributed residual time is a material share of the step.
 
@@ -84,14 +84,16 @@ The compatibility `dataloader_ms` field remains CPU dataloader fetch time, and
 `total_step_ms` remains CPU dataloader fetch plus CPU step envelope timing.
 These compatibility fields are not selected-clock phase-share denominators.
 `duration_ms` stays stored compatibility timing and is not used for Step Time
-display or diagnosis. In the final text report, selected-clock phase shares
-are divided by `step_time_ms`; CPU compatibility rows are labeled separately.
+display or diagnosis. In the final text report, most selected-clock phase
+shares are divided by `step_time_ms`; CPU compatibility rows are labeled
+separately.
 
-`INPUT_BOUND` uses selected-clock `input_wait_ms / step_time_ms`. This compares
-pre-step input wait with the traced step envelope, not end-to-end wall time, so
-the ratio can exceed 100%. Live diagnosis warns at 25% and is critical at 35%.
-Summary diagnosis is more conservative because it covers a larger final window:
-it warns at 30% and is critical at 40%.
+`INPUT_BOUND` uses selected-clock
+`input_wait_ms / iteration_time_ms`, where
+`iteration_time_ms = input_wait_ms + step_time_ms`. This compares pre-step
+input wait with the full selected-clock iteration time while leaving
+`step_time_ms` as the traced step envelope. Live and summary diagnosis both
+warn at 10% and are critical at 20%.
 
 `RESIDUAL_HEAVY` is not a communication diagnosis. `residual_ms` is residual
 unattributed step time averaged from per-step clamped residuals:
@@ -100,6 +102,7 @@ unattributed step time averaged from per-step clamped residuals:
 compute_ms = forward_ms + backward_ms + optimizer_ms
 known_step_ms = h2d_ms + compute_ms
 traced_step_ms = selected step envelope timing
+iteration_time_ms = selected input_wait_ms + selected traced_step_ms
 residual_ms = average(max(0, traced_step_ms - known_step_ms))
 total_step_ms = CPU dataloader_ms + CPU step envelope timing
 ```

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -113,6 +113,17 @@ contrast, `H2D_STRAGGLER` identifies one rank's excess H2D time.
 `COMPUTE_BOUND` remains an informational finding when compute dominates the
 traced step and no material input, H2D, or residual overhead is visible.
 
+Step Time uses `DiagnosticIssue.score` as normalized iteration impact for
+`INPUT_BOUND`, `H2D_BOUND`, `RESIDUAL_HEAVY`, and all rank-straggler findings.
+Typical findings use the median per-rank share above; stragglers use the
+culprit/victim score below. `COMPUTE_BOUND` has no score because its
+informational 85% gate remains compute divided by step time.
+
+When several Step Time findings qualify, TraceML orders them by severity, then
+score. A rank straggler wins only an exact severity-and-score tie with a
+typical finding; ties within the same scope preserve rule order. The primary
+diagnosis is always the first ordered issue.
+
 Shared Step Time diagnosis needs at least 2 steps to emit warning-only
 bottleneck diagnoses. Critical diagnoses are allowed once the window has at
 least 20 steps. Live and summary use the same diagnosis gates; they differ by

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -101,6 +101,12 @@ bottleneck diagnoses. Critical diagnoses are allowed once the window has at
 least 20 steps. Live and summary use the same diagnosis gates; they differ by
 the selected timing window size.
 
+When runtime environment metadata is available, Step Time diagnosis also
+receives an advisory training strategy such as `ddp` or `fsdp`. This context is
+used only to choose diagnosis attribution behavior; it is not a public Step
+Time metric. Missing or unrecognized strategy metadata defaults to `ddp` to
+preserve the current straggler behavior.
+
 `RESIDUAL_HEAVY` is not a communication diagnosis. `residual_ms` is residual
 unattributed step time averaged from per-step clamped residuals:
 

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -78,7 +78,8 @@ Step-time diagnosis uses one selected clock for the analyzed window. It uses
 GPU event timing when every rank/step has GPU timing for the step envelope,
 input wait, and traced phase events present in the window. Otherwise it uses
 explicit `cpu_ms` timing. The live CLI Step Time table, dashboard, and final
-summary use this same selected-clock window for diagnosis-facing timing.
+summary use the same global-rank SQLite loader and selected-clock window
+builder for diagnosis-facing timing; they differ only by row window sizing.
 Summary JSON exposes selected-clock `input_wait_ms` and `step_time_ms`.
 The compatibility `dataloader_ms` field remains CPU dataloader fetch time, and
 `total_step_ms` remains CPU dataloader fetch plus CPU step envelope timing.

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -74,6 +74,8 @@ Training-step timing.
 - `H2D_STRAGGLER`: the culprit rank has materially higher host-to-device
   transfer time than the victim rank.
 - `INPUT_BOUND`: selected-clock input wait is a material typical iteration cost.
+- `H2D_BOUND`: selected-clock GPU H2D transfer is a material typical iteration
+  cost.
 - `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical step;
   this is informational when no material overhead is visible.
 - `RESIDUAL_HEAVY`: unattributed residual time is a material typical iteration
@@ -90,9 +92,9 @@ The compatibility `dataloader_ms` field remains CPU dataloader fetch time, and
 `total_step_ms` remains CPU dataloader fetch plus CPU step envelope timing.
 These compatibility fields are not selected-clock phase-share denominators.
 `duration_ms` stays stored compatibility timing and is not used for Step Time
-display or diagnosis. In the final text report, most selected-clock phase
-shares are divided by `step_time_ms`; CPU compatibility rows are labeled
-separately.
+display or diagnosis. In the final text report, selected-clock phase shares
+are divided by `input_wait_ms + step_time_ms`; CPU compatibility rows are
+labeled separately.
 
 Typical overhead diagnoses use selected-clock per-rank iteration shares:
 
@@ -102,11 +104,14 @@ component_share_r = component_r / iteration_r
 typical_component_share = median(component_share_r across ranks)
 ```
 
-`INPUT_BOUND` uses `input_wait` and `RESIDUAL_HEAVY` uses residual as the
-component. Both warn at 10% and are critical at 20%. Cross-rank skew remains
-evidence in the finding, but does not suppress a bottleneck affecting typical
-ranks. `COMPUTE_BOUND` remains an informational finding when compute dominates
-the traced step and no material input or residual overhead is visible.
+`INPUT_BOUND` uses `input_wait`, `H2D_BOUND` uses H2D transfer, and
+`RESIDUAL_HEAVY` uses residual as the component. They warn at 10% and are
+critical at 20%. `H2D_BOUND` requires GPU-selected timing, so asynchronous CPU
+host-call duration is not reported as transfer cost. Cross-rank skew remains
+evidence in a typical-bottleneck finding, but does not suppress one. In
+contrast, `H2D_STRAGGLER` identifies one rank's excess H2D time.
+`COMPUTE_BOUND` remains an informational finding when compute dominates the
+traced step and no material input, H2D, or residual overhead is visible.
 
 Shared Step Time diagnosis needs at least 2 steps to emit warning-only
 bottleneck diagnoses. Critical diagnoses are allowed once the window has at

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -63,7 +63,7 @@ Traced process pressure.
 Training-step timing.
 
 - `NO_DATA`: no usable step-time data.
-- `WARMUP`: some data exists, but not enough for a stable diagnosis.
+- `WARMUP`: some data exists, but not enough for diagnosis.
 - `BALANCED`: no clear timing bottleneck or rank straggler.
 - `STRAGGLER`: one rank has a mixed clean-step straggler signal.
 - `INPUT_STRAGGLER`: one rank has materially higher selected-clock input wait.
@@ -94,6 +94,11 @@ separately.
 input wait with the full selected-clock iteration time while leaving
 `step_time_ms` as the traced step envelope. Live and summary diagnosis both
 warn at 10% and are critical at 20%.
+
+Shared Step Time diagnosis needs at least 2 steps to emit warning-only
+bottleneck diagnoses. Critical diagnoses are allowed once the window has at
+least 20 steps. Higher-level summary policies may still require a larger
+aligned window before calling shared Step Time diagnosis.
 
 `RESIDUAL_HEAVY` is not a communication diagnosis. `residual_ms` is residual
 unattributed step time averaged from per-step clamped residuals:

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -65,11 +65,14 @@ Training-step timing.
 - `NO_DATA`: no usable step-time data.
 - `WARMUP`: some data exists, but not enough for diagnosis.
 - `BALANCED`: no clear timing bottleneck or rank straggler.
-- `STRAGGLER`: one rank has a mixed clean-step straggler signal.
-- `INPUT_STRAGGLER`: one rank has materially higher selected-clock input wait.
-- `COMPUTE_STRAGGLER`: one rank has materially higher clean compute time.
-- `H2D_STRAGGLER`: one rank has materially higher host-to-device transfer time.
-- `RESIDUAL_STRAGGLER`: one rank has materially higher residual `residual_proxy`.
+- `STRAGGLER`: visible rank skew exists, but input wait, H2D, and DDP forward
+  do not explain the likely culprit.
+- `INPUT_STRAGGLER`: the culprit rank has materially higher selected-clock
+  input wait than the victim rank.
+- `COMPUTE_STRAGGLER`: in DDP/default strategy, the culprit rank has
+  materially higher forward time than the victim rank.
+- `H2D_STRAGGLER`: the culprit rank has materially higher host-to-device
+  transfer time than the victim rank.
 - `INPUT_BOUND`: selected-clock input wait dominates iteration time.
 - `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical step.
 - `RESIDUAL_HEAVY`: unattributed residual time is a material share of the step.
@@ -105,10 +108,10 @@ When runtime environment metadata is available, Step Time diagnosis also
 receives an advisory training strategy such as `ddp` or `fsdp`. This context is
 used only to choose diagnosis attribution behavior; it is not a public Step
 Time metric. Missing or unrecognized strategy metadata defaults to `ddp` to
-preserve the current straggler behavior. DDP remains eligible for critical
-Step Time diagnoses once thresholds and confidence gates are met. FSDP Step
-Time diagnoses are capped at warning because collective masking can make
-attribution under-confident.
+preserve the DDP/default visible-backward straggler behavior. DDP remains
+eligible for critical Step Time diagnoses once thresholds and confidence gates
+are met. FSDP Step Time diagnoses are capped at warning because collective
+masking can make attribution under-confident.
 
 `RESIDUAL_HEAVY` is not a communication diagnosis. `residual_ms` is residual
 unattributed step time averaged from per-step clamped residuals:
@@ -122,22 +125,52 @@ residual_ms = average(max(0, traced_step_ms - known_step_ms))
 total_step_ms = CPU dataloader_ms + CPU step envelope timing
 ```
 
-Rank-local stragglers use clean-step evidence. TraceML first discounts backward
-time that can be explained by another rank's non-backward work:
+Rank stragglers use culprit/victim evidence from selected-clock timing. TraceML
+first chooses one visible synchronization phase:
 
 ```text
-residual_r = residual_proxy_r
-non_bwd_r = input_wait_r + h2d_r + forward_r + optimizer_r + residual_r
-clean_bwd_r = max(0, backward_r - max(0, max(non_bwd) - non_bwd_r))
-clean_compute_r = forward_r + clean_bwd_r + optimizer_r
-clean_step_r = input_wait_r + h2d_r + clean_compute_r + residual_r
-score = (max(clean_step) - median(clean_step)) / median(actual_step)
+visible_r = backward_r              # DDP/default
+visible_r = forward_r + backward_r  # FSDP
 ```
 
-If `score < 0.10`, TraceML does not report a rank-local straggler. Otherwise it
-blames the largest worst-rank excess over peer median among input wait, clean
-compute, H2D, and residual. The largest excess must dominate the next-largest
-excess by `1.25x`; otherwise the diagnosis stays mixed `STRAGGLER`.
+Only ranks with measured visible-phase anchors and a measured step envelope are
+eligible:
+
+```text
+DDP/default: backward_r > 0 and step_time_r > 0
+FSDP:        forward_r > 0 and backward_r > 0 and step_time_r > 0
+```
+
+If fewer than two ranks are eligible, TraceML does not report a rank straggler.
+Missing visible instrumentation causes this rule to abstain instead of treating
+zero as a fast rank. `input_wait == 0` and `h2d == 0` remain valid component
+values.
+
+The culprit rank is the rank with the minimum visible value. This is the rank
+that likely arrived late and therefore waited least in the visible phase. The
+victim rank is the upper actual median rank by visible value.
+
+```text
+denom = input_wait_victim + step_time_victim
+score = (visible_victim - visible_culprit) / denom
+```
+
+If `score < 0.10`, TraceML does not report a rank straggler. Otherwise it
+compares the culprit directly with the victim:
+
+```text
+input_excess = input_wait_culprit - input_wait_victim
+h2d_excess = h2d_culprit - h2d_victim
+forward_excess = forward_culprit - forward_victim  # DDP/default only
+```
+
+DDP/default compute attribution requires measured forward time on both the
+culprit and victim ranks.
+
+The largest material positive excess becomes `INPUT_STRAGGLER`,
+`H2D_STRAGGLER`, or, for DDP/default only, `COMPUTE_STRAGGLER`. If no such
+excess explains the visible wait cost, the diagnosis stays `STRAGGLER` with a
+sync-or-unattributed component.
 
 It can include validation, checkpointing, logging, framework orchestration, CPU
 stalls, unobserved transfer stalls, or other work inside the timed step but

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -169,8 +169,9 @@ denom = input_wait_victim + step_time_victim
 score = (visible_victim - visible_culprit) / denom
 ```
 
-If `score < 0.10`, TraceML does not report a rank straggler. Otherwise it
-compares the culprit directly with the victim:
+If `score < 0.10`, TraceML does not report a rank straggler. At 10% it reports
+a warning; at 20% it reports critical severity when the existing confidence
+gates permit it. Otherwise it compares the culprit directly with the victim:
 
 ```text
 input_excess = input_wait_culprit - input_wait_victim
@@ -179,12 +180,17 @@ forward_excess = forward_culprit - forward_victim  # DDP/default only
 ```
 
 DDP/default compute attribution requires measured forward time on both the
-culprit and victim ranks.
+culprit and victim ranks. A component names the cause only when it covers at
+least 80% of visible wait cost:
 
-The largest material positive excess becomes `INPUT_STRAGGLER`,
-`H2D_STRAGGLER`, or, for DDP/default only, `COMPUTE_STRAGGLER`. If no such
-excess explains the visible wait cost, the diagnosis stays `STRAGGLER` with a
-sync-or-unattributed component.
+```text
+component_coverage = min(1, component_excess / visible_cost)
+```
+
+The highest qualifying coverage becomes `INPUT_STRAGGLER`, `H2D_STRAGGLER`,
+or, for DDP/default only, `COMPUTE_STRAGGLER`. Otherwise the diagnosis stays
+`STRAGGLER` with a sync-or-unattributed component and coverage evidence.
+Coverage chooses the label; the score alone chooses severity.
 
 It can include validation, checkpointing, logging, framework orchestration, CPU
 stalls, unobserved transfer stalls, or other work inside the timed step but

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -105,7 +105,10 @@ When runtime environment metadata is available, Step Time diagnosis also
 receives an advisory training strategy such as `ddp` or `fsdp`. This context is
 used only to choose diagnosis attribution behavior; it is not a public Step
 Time metric. Missing or unrecognized strategy metadata defaults to `ddp` to
-preserve the current straggler behavior.
+preserve the current straggler behavior. DDP remains eligible for critical
+Step Time diagnoses once thresholds and confidence gates are met. FSDP Step
+Time diagnoses are capped at warning because collective masking can make
+attribution under-confident.
 
 `RESIDUAL_HEAVY` is not a communication diagnosis. `residual_ms` is residual
 unattributed step time averaged from per-step clamped residuals:

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -73,9 +73,11 @@ Training-step timing.
   materially higher forward time than the victim rank.
 - `H2D_STRAGGLER`: the culprit rank has materially higher host-to-device
   transfer time than the victim rank.
-- `INPUT_BOUND`: selected-clock input wait dominates iteration time.
-- `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical step.
-- `RESIDUAL_HEAVY`: unattributed residual time is a material share of the step.
+- `INPUT_BOUND`: selected-clock input wait is a material typical iteration cost.
+- `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical step;
+  this is informational when no material overhead is visible.
+- `RESIDUAL_HEAVY`: unattributed residual time is a material typical iteration
+  cost.
 
 Step-time diagnosis uses one selected clock for the analyzed window. It uses
 GPU event timing when every rank/step has GPU timing for the step envelope,
@@ -92,12 +94,19 @@ display or diagnosis. In the final text report, most selected-clock phase
 shares are divided by `step_time_ms`; CPU compatibility rows are labeled
 separately.
 
-`INPUT_BOUND` uses selected-clock
-`input_wait_ms / iteration_time_ms`, where
-`iteration_time_ms = input_wait_ms + step_time_ms`. This compares pre-step
-input wait with the full selected-clock iteration time while leaving
-`step_time_ms` as the traced step envelope. Live and summary diagnosis both
-warn at 10% and are critical at 20%.
+Typical overhead diagnoses use selected-clock per-rank iteration shares:
+
+```text
+iteration_r = input_wait_r + step_time_r
+component_share_r = component_r / iteration_r
+typical_component_share = median(component_share_r across ranks)
+```
+
+`INPUT_BOUND` uses `input_wait` and `RESIDUAL_HEAVY` uses residual as the
+component. Both warn at 10% and are critical at 20%. Cross-rank skew remains
+evidence in the finding, but does not suppress a bottleneck affecting typical
+ranks. `COMPUTE_BOUND` remains an informational finding when compute dominates
+the traced step and no material input or residual overhead is visible.
 
 Shared Step Time diagnosis needs at least 2 steps to emit warning-only
 bottleneck diagnoses. Critical diagnoses are allowed once the window has at

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -97,8 +97,8 @@ warn at 10% and are critical at 20%.
 
 Shared Step Time diagnosis needs at least 2 steps to emit warning-only
 bottleneck diagnoses. Critical diagnoses are allowed once the window has at
-least 20 steps. Higher-level summary policies may still require a larger
-aligned window before calling shared Step Time diagnosis.
+least 20 steps. Live and summary use the same diagnosis gates; they differ by
+the selected timing window size.
 
 `RESIDUAL_HEAVY` is not a communication diagnosis. `residual_ms` is residual
 unattributed step time averaged from per-step clamped residuals:

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -111,14 +111,16 @@ critical at 20%. `H2D_BOUND` requires GPU-selected timing, so asynchronous CPU
 host-call duration is not reported as transfer cost. Cross-rank skew remains
 evidence in a typical-bottleneck finding, but does not suppress one. In
 contrast, `H2D_STRAGGLER` identifies one rank's excess H2D time.
-`COMPUTE_BOUND` remains an informational finding when compute dominates the
-traced step and no material input, H2D, or residual overhead is visible.
+`COMPUTE_BOUND` remains an informational finding when the median per-rank
+compute share reaches 90% of selected-clock iteration time and no material
+input, H2D, or residual overhead is visible. Built-in live and summary policies
+use this same threshold; their analyzed window sizes differ.
 
 Step Time uses `DiagnosticIssue.score` as normalized iteration impact for
 `INPUT_BOUND`, `H2D_BOUND`, `RESIDUAL_HEAVY`, and all rank-straggler findings.
 Typical findings use the median per-rank share above; stragglers use the
 culprit/victim score below. `COMPUTE_BOUND` has no score because its
-informational 85% gate remains compute divided by step time.
+informational context is excluded from impact-based primary ordering.
 
 When several Step Time findings qualify, TraceML orders them by severity, then
 score. A rank straggler wins only an exact severity-and-score tie with a

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -94,7 +94,8 @@ These compatibility fields are not selected-clock phase-share denominators.
 `duration_ms` stays stored compatibility timing and is not used for Step Time
 display or diagnosis. In the final text report, selected-clock phase shares
 are divided by `input_wait_ms + step_time_ms`; CPU compatibility rows are
-labeled separately.
+labeled separately. These report-table shares are observational and do not
+replace the median per-rank diagnosis score.
 
 Typical overhead diagnoses use selected-clock per-rank iteration shares:
 
@@ -123,6 +124,10 @@ When several Step Time findings qualify, TraceML orders them by severity, then
 score. A rank straggler wins only an exact severity-and-score tie with a
 typical finding; ties within the same scope preserve rule order. The primary
 diagnosis is always the first ordered issue.
+
+The Step Time summary card reuses the selected issue summary for its reason
+text. It does not recompute phase shares or rank-straggler attribution from
+display rollups.
 
 Shared Step Time diagnosis needs at least 2 steps to emit warning-only
 bottleneck diagnoses. Critical diagnoses are allowed once the window has at

--- a/src/traceml_ai/diagnostics/common.py
+++ b/src/traceml_ai/diagnostics/common.py
@@ -108,25 +108,6 @@ def severity_rank(severity: Severity) -> int:
     return {"crit": 2, "warn": 1, "info": 0}.get(severity, 0)
 
 
-def sort_issues(
-    issues: Sequence[DiagnosticIssue],
-) -> Tuple[DiagnosticIssue, ...]:
-    """
-    Return issues sorted by severity, score, and attribution breadth.
-    """
-    return tuple(
-        sorted(
-            issues,
-            key=lambda item: (
-                severity_rank(item.severity),
-                float(item.score or 0.0),
-                len(item.ranks),
-            ),
-            reverse=True,
-        )
-    )
-
-
 def validate_confidence(confidence: Optional[float]) -> None:
     """
     Validate an optional confidence value.
@@ -223,7 +204,6 @@ __all__ = [
     "DiagnosticResult",
     "DiagnosticRule",
     "severity_rank",
-    "sort_issues",
     "validate_confidence",
     "diagnosis_to_issue",
     "ensure_primary_issue",

--- a/src/traceml_ai/diagnostics/model_diagnostics.py
+++ b/src/traceml_ai/diagnostics/model_diagnostics.py
@@ -100,6 +100,7 @@ def build_model_diagnostics_payload(
     ] = None,
     step_time_per_rank_timing: Optional[Dict[int, Dict[str, float]]] = None,
     step_time_diagnosis_clock: str = "cpu",
+    step_time_training_strategy: str = "ddp",
     step_memory_metrics: Sequence[StepMemoryCombinedMetric],
     step_memory_status_message: Optional[str] = None,
     gpu_total_bytes: Optional[float] = None,
@@ -117,6 +118,7 @@ def build_model_diagnostics_payload(
         step_time_diagnosis_metrics=tuple(step_time_diagnosis_metrics or ()),
         step_time_per_rank_timing=dict(step_time_per_rank_timing or {}),
         step_time_diagnosis_clock=str(step_time_diagnosis_clock or "cpu"),
+        step_time_training_strategy=str(step_time_training_strategy or "ddp"),
         step_memory_metrics=step_memory_metrics,
         step_memory_status_message=step_memory_status_message,
         gpu_total_bytes=gpu_total_bytes,
@@ -157,6 +159,7 @@ def _build_step_time_item(
         context.step_time_diagnosis_metrics,
         per_rank_timing=context.step_time_per_rank_timing,
         diagnosis_clock=context.step_time_diagnosis_clock,
+        training_strategy=context.step_time_training_strategy,
     )
     return ModelDiagnosisItem(
         source="step_time",

--- a/src/traceml_ai/diagnostics/registry.py
+++ b/src/traceml_ai/diagnostics/registry.py
@@ -35,6 +35,7 @@ class ModelDiagnosticContext:
         default_factory=dict
     )
     step_time_diagnosis_clock: str = "cpu"
+    step_time_training_strategy: str = "ddp"
     step_memory_status_message: Optional[str] = None
     gpu_total_bytes: Optional[float] = None
 

--- a/src/traceml_ai/diagnostics/step_time/adapters.py
+++ b/src/traceml_ai/diagnostics/step_time/adapters.py
@@ -24,17 +24,22 @@ DEFAULT_SUMMARY_DIAG_CONFIG = SUMMARY_STEP_TIME_POLICY
 
 @dataclass(frozen=True)
 class StepTimeDiagnosisInput:
-    """Canonical Step Time window consumed by final-summary diagnosis."""
+    """Canonical Step Time window and advisory context for summary diagnosis."""
 
     window: StepTimeWindow
     policy: StepTimeDiagnosisPolicy = DEFAULT_SUMMARY_DIAG_CONFIG
+    training_strategy: str = "ddp"
 
 
 def diagnose_step_time_summary(
     data: StepTimeDiagnosisInput,
 ) -> DiagnosticResult[StepDiagnosis]:
     """Run final-summary Step Time diagnosis from the canonical window."""
-    return diagnose_step_time_window(data.window, policy=data.policy)
+    return diagnose_step_time_window(
+        data.window,
+        policy=data.policy,
+        training_strategy=data.training_strategy,
+    )
 
 
 __all__ = [

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -324,8 +324,8 @@ def _apply_trend_note(
             input_wait_metric=input_wait_metric,
             residual_share=residual_share,
             input_bound_share=input_bound_share,
-            residual_warn_threshold=thresholds.residual_share_warn,
-            input_warn_threshold=thresholds.input_share_warn,
+            residual_warn_threshold=thresholds.overhead_share_warn,
+            input_warn_threshold=thresholds.overhead_share_warn,
             cfg=DEFAULT_STEP_TREND_HEURISTICS,
         )
         if not trend_note:

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -24,6 +24,7 @@ from ..common import (
 )
 from .context import (
     build_step_time_context,
+    compute_rank_values_from_components,
     metric_median_total,
     metric_skew,
     metric_total,
@@ -44,7 +45,6 @@ DiagnosisKind = Literal[
     "INPUT_STRAGGLER",
     "COMPUTE_STRAGGLER",
     "H2D_STRAGGLER",
-    "RESIDUAL_STRAGGLER",
     "INPUT_BOUND",
     "COMPUTE_BOUND",
     "RESIDUAL_HEAVY",
@@ -58,7 +58,6 @@ _STATUS_BY_KIND: dict[DiagnosisKind, str] = {
     "INPUT_STRAGGLER": "INPUT STRAGGLER",
     "COMPUTE_STRAGGLER": "COMPUTE STRAGGLER",
     "H2D_STRAGGLER": "H2D STRAGGLER",
-    "RESIDUAL_STRAGGLER": "RESIDUAL STRAGGLER",
     "INPUT_BOUND": "INPUT-BOUND",
     "COMPUTE_BOUND": "COMPUTE-BOUND",
     "RESIDUAL_HEAVY": "RESIDUAL-HEAVY",
@@ -69,7 +68,6 @@ _PRIMARY_KIND_PRIORITY: dict[str, int] = {
     "INPUT_STRAGGLER": 40,
     "COMPUTE_STRAGGLER": 40,
     "H2D_STRAGGLER": 40,
-    "RESIDUAL_STRAGGLER": 40,
     "INPUT_BOUND": 30,
     "RESIDUAL_HEAVY": 20,
     "COMPUTE_BOUND": 10,
@@ -428,7 +426,6 @@ def build_step_diagnosis_result(
         "INPUT_STRAGGLER",
         "COMPUTE_STRAGGLER",
         "H2D_STRAGGLER",
-        "RESIDUAL_STRAGGLER",
     }:
         worst_rank = primary_issue.ranks[0] if primary_issue.ranks else None
         primary = _mk_diag(
@@ -514,20 +511,9 @@ def build_step_diagnosis_result(
             ),
         )
 
-    fwd_rank_values = context.rank_values.get("forward", {})
-    bwd_rank_values = context.rank_values.get("backward", {})
-    opt_rank_values = context.rank_values.get("optimizer_step", {})
-    compute_rank_values = context.clean_rank_values.get("clean_compute", {})
-    if not compute_rank_values:
-        compute_rank_values = {}
-        for rank in sorted(
-            set(fwd_rank_values) | set(bwd_rank_values) | set(opt_rank_values)
-        ):
-            compute_rank_values[int(rank)] = (
-                non_negative_finite(fwd_rank_values.get(rank, 0.0))
-                + non_negative_finite(bwd_rank_values.get(rank, 0.0))
-                + non_negative_finite(opt_rank_values.get(rank, 0.0))
-            )
+    compute_rank_values = compute_rank_values_from_components(
+        context.rank_values
+    )
     (
         compute_median_ms,
         compute_worst_ms,
@@ -555,7 +541,7 @@ def build_step_diagnosis_result(
         "forward": _metric_attribution_entry(
             metric=context.forward_metric,
             metric_key="forward",
-            rank_values=fwd_rank_values,
+            rank_values=context.rank_values.get("forward", {}),
             step_total=context.step_total,
             single_rank=context.single_rank,
             phase="forward",
@@ -563,7 +549,7 @@ def build_step_diagnosis_result(
         "backward": _metric_attribution_entry(
             metric=context.backward_metric,
             metric_key="backward",
-            rank_values=bwd_rank_values,
+            rank_values=context.rank_values.get("backward", {}),
             step_total=context.step_total,
             single_rank=context.single_rank,
             phase="backward",
@@ -571,7 +557,7 @@ def build_step_diagnosis_result(
         "optimizer_step": _metric_attribution_entry(
             metric=context.optimizer_metric,
             metric_key="optimizer_step",
-            rank_values=opt_rank_values,
+            rank_values=context.rank_values.get("optimizer_step", {}),
             step_total=context.step_total,
             single_rank=context.single_rank,
             phase="optimizer",
@@ -594,7 +580,7 @@ def build_step_diagnosis_result(
         ),
         "compute": {
             "metric": "compute",
-            "phase": "clean_compute",
+            "phase": "compute",
             "median_total_ms": compute_median_ms,
             "worst_total_ms": compute_worst_ms,
             "worst_rank": compute_worst_rank,

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -343,6 +343,7 @@ def build_step_diagnosis_result(
     *,
     per_rank_timing: Optional[Dict[int, Dict[str, float]]] = None,
     diagnosis_clock: str = "cpu",
+    training_strategy: str = "ddp",
 ) -> DiagnosticResult[StepDiagnosis]:
     """
     Build a rich step-time diagnosis result from one analyzed window.
@@ -406,6 +407,7 @@ def build_step_diagnosis_result(
         thresholds=thresholds,
         per_rank_timing=per_rank_timing,
         diagnosis_clock=diagnosis_clock,
+        training_strategy=training_strategy,
     )
     raw_issues = run_step_time_rules(context)
     issue_list = list(raw_issues)
@@ -611,6 +613,7 @@ def build_step_diagnosis(
     *,
     per_rank_timing: Optional[Dict[int, Dict[str, float]]] = None,
     diagnosis_clock: str = "cpu",
+    training_strategy: str = "ddp",
 ) -> StepDiagnosis:
     """
     Build one primary diagnosis from step-combined metrics.
@@ -623,6 +626,7 @@ def build_step_diagnosis(
         thresholds=thresholds,
         per_rank_timing=per_rank_timing,
         diagnosis_clock=diagnosis_clock,
+        training_strategy=training_strategy,
     ).primary
     if not isinstance(primary, StepDiagnosis):
         raise TypeError(

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -411,6 +411,10 @@ def build_step_diagnosis_result(
     )
     raw_issues = run_step_time_rules(context)
     issue_list = list(raw_issues)
+    if context.training_strategy == "fsdp":
+        issue_list = [
+            _cap_issue_severity(issue, "warn") for issue in issue_list
+        ]
     if steps_used < thresholds.min_steps_for_confident_diag:
         issue_list = [
             _cap_issue_severity(issue, "warn") for issue in issue_list

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -19,7 +19,6 @@ from ..common import (
     DiagnosticResult,
     Severity,
     severity_rank,
-    sort_issues,
     validate_confidence,
 )
 from .context import (
@@ -65,16 +64,14 @@ _STATUS_BY_KIND: dict[DiagnosisKind, str] = {
     "RESIDUAL_HEAVY": "RESIDUAL-HEAVY",
 }
 
-_PRIMARY_KIND_PRIORITY: dict[str, int] = {
-    "STRAGGLER": 50,
-    "INPUT_STRAGGLER": 40,
-    "COMPUTE_STRAGGLER": 40,
-    "H2D_STRAGGLER": 40,
-    "INPUT_BOUND": 30,
-    "H2D_BOUND": 30,
-    "RESIDUAL_HEAVY": 20,
-    "COMPUTE_BOUND": 10,
-}
+_RANK_STRAGGLER_KINDS = frozenset(
+    {
+        "STRAGGLER",
+        "INPUT_STRAGGLER",
+        "COMPUTE_STRAGGLER",
+        "H2D_STRAGGLER",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -175,11 +172,15 @@ def _severity(value: float, crit_threshold: float) -> Severity:
     return "crit" if non_negative_finite(value) >= crit_threshold else "warn"
 
 
-def _primary_issue_rank(issue: DiagnosticIssue) -> int:
-    """
-    Rank contributor issues for primary-diagnosis selection.
-    """
-    return _PRIMARY_KIND_PRIORITY.get(issue.kind, 0)
+def _step_time_issue_sort_key(
+    issue: DiagnosticIssue,
+) -> tuple[int, float, int]:
+    """Order Step Time findings by severity, impact, then rank-local scope."""
+    return (
+        severity_rank(issue.severity),
+        non_negative_finite(issue.score or 0.0),
+        int(issue.kind in _RANK_STRAGGLER_KINDS),
+    )
 
 
 def _cap_issue_severity(
@@ -282,25 +283,6 @@ def _metric_attribution_entry(
         ),
         "top_ranks": _top_rank_entries(rank_values),
     }
-
-
-def _select_primary_issue(
-    issues: Sequence[DiagnosticIssue],
-) -> Optional[DiagnosticIssue]:
-    """
-    Return the strongest atomic issue candidate.
-    """
-    if not issues:
-        return None
-    ranked = sorted(
-        issues,
-        key=lambda issue: (
-            _primary_issue_rank(issue),
-            float(issue.score or 0.0),
-        ),
-        reverse=True,
-    )
-    return ranked[0]
 
 
 def _apply_trend_note(
@@ -421,8 +403,10 @@ def build_step_diagnosis_result(
             _cap_issue_severity(issue, "warn") for issue in issue_list
         ]
 
-    issues = sort_issues(issue_list)
-    primary_issue = _select_primary_issue(issues)
+    issues = tuple(
+        sorted(issue_list, key=_step_time_issue_sort_key, reverse=True)
+    )
+    primary_issue = issues[0] if issues else None
 
     if primary_issue is not None and primary_issue.kind in {
         "STRAGGLER",

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -46,6 +46,7 @@ DiagnosisKind = Literal[
     "COMPUTE_STRAGGLER",
     "H2D_STRAGGLER",
     "INPUT_BOUND",
+    "H2D_BOUND",
     "COMPUTE_BOUND",
     "RESIDUAL_HEAVY",
 ]
@@ -59,6 +60,7 @@ _STATUS_BY_KIND: dict[DiagnosisKind, str] = {
     "COMPUTE_STRAGGLER": "COMPUTE STRAGGLER",
     "H2D_STRAGGLER": "H2D STRAGGLER",
     "INPUT_BOUND": "INPUT-BOUND",
+    "H2D_BOUND": "H2D-BOUND",
     "COMPUTE_BOUND": "COMPUTE-BOUND",
     "RESIDUAL_HEAVY": "RESIDUAL-HEAVY",
 }
@@ -69,6 +71,7 @@ _PRIMARY_KIND_PRIORITY: dict[str, int] = {
     "COMPUTE_STRAGGLER": 40,
     "H2D_STRAGGLER": 40,
     "INPUT_BOUND": 30,
+    "H2D_BOUND": 30,
     "RESIDUAL_HEAVY": 20,
     "COMPUTE_BOUND": 10,
 }
@@ -445,6 +448,17 @@ def build_step_diagnosis_result(
             steps_used=context.steps_used,
             worst_rank=(
                 None if context.single_rank else context.input_bound_worst_rank
+            ),
+        )
+    elif primary_issue is not None and primary_issue.kind == "H2D_BOUND":
+        primary = _mk_diag(
+            kind="H2D_BOUND",
+            severity=primary_issue.severity,
+            reason=primary_issue.summary,
+            action=primary_issue.action,
+            steps_used=context.steps_used,
+            worst_rank=(
+                primary_issue.ranks[0] if primary_issue.ranks else None
             ),
         )
     elif primary_issue is not None and primary_issue.kind == "RESIDUAL_HEAVY":

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -18,6 +18,7 @@ from ..common import (
     DiagnosticIssue,
     DiagnosticResult,
     Severity,
+    severity_rank,
     sort_issues,
     validate_confidence,
 )
@@ -124,7 +125,7 @@ def build_step_warmup_diagnosis(
 
     ``NO_DATA`` is reserved for missing or unusable timing data. ``WARMUP``
     means TraceML has timing samples, but fewer than the configured minimum for
-    a stable summary diagnosis.
+    diagnosis.
     """
     low = max(0, int(steps_used))
     high = max(low, int(max_steps_used if max_steps_used is not None else low))
@@ -135,8 +136,8 @@ def build_step_warmup_diagnosis(
         kind="WARMUP",
         severity="info",
         reason=(
-            f"Only {available} {suffix} per rank available; summary "
-            f"diagnosis requires {required}."
+            f"Only {available} {suffix} per rank available; diagnosis "
+            f"requires {required}."
         ),
         action="Use a longer run for a stable timing diagnosis.",
         steps_used=low,
@@ -178,6 +179,18 @@ def _primary_issue_rank(issue: DiagnosticIssue) -> int:
     Rank contributor issues for primary-diagnosis selection.
     """
     return _PRIMARY_KIND_PRIORITY.get(issue.kind, 0)
+
+
+def _cap_issue_severity(
+    issue: DiagnosticIssue,
+    severity: Severity,
+) -> DiagnosticIssue:
+    """
+    Return an issue whose severity is no stronger than `severity`.
+    """
+    if severity_rank(issue.severity) <= severity_rank(severity):
+        return issue
+    return replace(issue, severity=severity)
 
 
 def _top_rank_entries(
@@ -379,10 +392,10 @@ def build_step_diagnosis_result(
         )
         return DiagnosticResult(primary=primary)
 
-    if steps_used < thresholds.min_steps_for_confident_diag:
+    if steps_used < thresholds.min_steps_for_warning_diag:
         result = build_step_warmup_diagnosis(
             steps_used=steps_used,
-            required_steps=thresholds.min_steps_for_confident_diag,
+            required_steps=thresholds.min_steps_for_warning_diag,
         )
         return DiagnosticResult(
             primary=replace(result.primary, worst_rank=overall_worst_rank)
@@ -396,6 +409,10 @@ def build_step_diagnosis_result(
     )
     raw_issues = run_step_time_rules(context)
     issue_list = list(raw_issues)
+    if steps_used < thresholds.min_steps_for_confident_diag:
+        issue_list = [
+            _cap_issue_severity(issue, "warn") for issue in issue_list
+        ]
 
     issues = sort_issues(issue_list)
     primary_issue = _select_primary_issue(issues)

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -94,6 +94,7 @@ class StepTimeAnalysisContext:
     diagnosis_clock: str
     input_wait_total: float
     input_bound_step_total: float
+    iteration_time_total: float
 
     largest_compute: Optional[ComputeSignal]
 
@@ -594,6 +595,7 @@ def build_step_time_context(
     input_bound_step_total = (
         input_step_worst if single_rank else input_step_median
     )
+    iteration_time_total = input_wait_total + input_bound_step_total
     input_bound_skew = (
         0.0
         if single_rank or input_wait_median <= 0.0
@@ -628,7 +630,7 @@ def build_step_time_context(
         compute_total=compute_total_value,
         residual_share=share(residual_total, step_total),
         compute_share=share(compute_total_value, step_total),
-        input_bound_share=share(input_wait_total, input_bound_step_total),
+        input_bound_share=share(input_wait_total, iteration_time_total),
         input_bound_skew=input_bound_skew,
         compute_skew=compute_skew_value,
         input_bound_worst_rank=input_wait_worst_rank,
@@ -637,6 +639,7 @@ def build_step_time_context(
         ),
         input_wait_total=input_wait_total,
         input_bound_step_total=input_bound_step_total,
+        iteration_time_total=iteration_time_total,
         largest_compute=largest_compute,
         rank_values=rank_values,
         clean_rank_values=clean_rank_values,

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, Optional, Sequence
 
 from traceml_ai.renderers.step_time.schema import StepCombinedTimeMetric
+from traceml_ai.utils.training_strategy import normalize_training_strategy
 
 if TYPE_CHECKING:
     from .policy import DiagnosisThresholds
@@ -65,12 +66,16 @@ class StepTimeAnalysisContext:
     """
     Normalized step-time analysis state shared by all step-time diagnosis
     rules.
+
+    `training_strategy` is advisory run context from runtime metadata. It is
+    not a public metric; rules may use it to choose attribution logic.
     """
 
     thresholds: "DiagnosisThresholds"
     single_rank: bool
     steps_used: int
     overall_worst_rank: Optional[int]
+    training_strategy: str
 
     step_metric: StepCombinedTimeMetric
     input_wait_metric: Optional[StepCombinedTimeMetric]
@@ -490,6 +495,7 @@ def build_step_time_context(
     thresholds: "DiagnosisThresholds",
     per_rank_timing: Optional[Dict[int, Dict[str, float]]] = None,
     diagnosis_clock: str = "cpu",
+    training_strategy: str = "ddp",
 ) -> StepTimeAnalysisContext:
     """
     Build one normalized context shared by all step-time diagnosis rules.
@@ -618,6 +624,7 @@ def build_step_time_context(
         single_rank=single_rank,
         steps_used=steps_used,
         overall_worst_rank=overall_worst_rank,
+        training_strategy=normalize_training_strategy(training_strategy),
         step_metric=step_metric,
         input_wait_metric=input_wait_metric,
         h2d_metric=h2d_metric,
@@ -660,6 +667,7 @@ __all__ = [
     "metric_worst_rank",
     "metric_worst_total",
     "non_negative_finite",
+    "normalize_training_strategy",
     "rank_values_from_metric",
     "share",
 ]

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -63,7 +63,8 @@ class _RankStragglerEvidence:
 
     The score is visible wait cost paid by the victim rank, normalized by that
     victim's selected-clock iteration time. Component attribution compares the
-    culprit's own input/H2D/forward values against the victim rank.
+    culprit's own input/H2D/forward values against the victim rank and names a
+    cause only when it covers enough of the visible cost.
     """
 
     kind: str
@@ -80,6 +81,7 @@ class _RankStragglerEvidence:
     visible_cost_ms: float
     iteration_time_ms: float
     component_excesses_ms: Dict[str, float]
+    component_coverage: Dict[str, float]
 
 
 @dataclass(frozen=True)
@@ -319,6 +321,7 @@ def _build_rank_straggler_evidence(
     *,
     per_rank_timing: Dict[int, Dict[str, float]],
     score_threshold: float,
+    cause_coverage_threshold: float,
     training_strategy: str,
 ) -> Optional[_RankStragglerEvidence]:
     """
@@ -328,8 +331,8 @@ def _build_rank_straggler_evidence(
     forward + backward because FSDP can communicate on both sides of module
     execution. Only ranks with measured visible-phase anchors and a measured
     step envelope are eligible. Component attribution compares the culprit rank
-    directly to the victim rank and only emits a subtype for material positive
-    excess.
+    directly to the victim rank and emits a subtype only when one component
+    explains enough of the visible cost.
     """
     if len(per_rank_timing) <= 1:
         return None
@@ -404,6 +407,10 @@ def _build_rank_straggler_evidence(
         "h2d": h2d_excess,
         "compute": forward_excess,
     }
+    component_coverage = {
+        component: min(1.0, excess / pair.cost_ms)
+        for component, excess in component_excesses.items()
+    }
     components = {
         "input": ("INPUT_STRAGGLER", "INPUT STRAGGLER", "input_wait", "input"),
         "h2d": ("H2D_STRAGGLER", "H2D STRAGGLER", "h2d", "h2d"),
@@ -415,14 +422,16 @@ def _build_rank_straggler_evidence(
         ),
     }
     ordered = sorted(
-        component_excesses.items(),
+        component_coverage.items(),
         key=lambda item: (
             -item[1],
             ("input", "h2d", "compute").index(item[0]),
         ),
     )
-    top_component, top_excess = ordered[0]
-    if top_excess > 0.0 and (top_excess / iteration_time) >= threshold:
+    top_component, top_coverage = ordered[0]
+    if top_coverage > 0.0 and top_coverage >= non_negative_finite(
+        cause_coverage_threshold
+    ):
         kind, status, metric, phase = components[top_component]
         component = top_component
     else:
@@ -449,6 +458,7 @@ def _build_rank_straggler_evidence(
         visible_cost_ms=pair.cost_ms,
         iteration_time_ms=iteration_time,
         component_excesses_ms=component_excesses,
+        component_coverage=component_coverage,
     )
 
 
@@ -677,6 +687,7 @@ def build_step_time_context(
     rank_straggler = _build_rank_straggler_evidence(
         per_rank_timing=local_per_rank_timing,
         score_threshold=thresholds.straggler_score_warn,
+        cause_coverage_threshold=thresholds.straggler_cause_coverage_min,
         training_strategy=training_strategy,
     )
     compute_rank_values = compute_rank_values_from_components(rank_values)

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -39,10 +39,31 @@ class ComputeSignal:
 
 
 @dataclass(frozen=True)
-class _CleanStragglerEvidence:
+class _RankStragglerPair:
     """
-    Rank-local straggler evidence after discounting backward delay that can be
-    explained by non-backward rank skew.
+    Culprit/victim pair for visible distributed rank skew.
+
+    The culprit is the rank with the smallest visible synchronization phase:
+    it likely arrived late and therefore waited least. The victim is the upper
+    actual median rank by that same visible phase, representing a real rank
+    that paid typical waiting cost.
+    """
+
+    culprit_rank: int
+    victim_rank: int
+    culprit_value_ms: float
+    victim_value_ms: float
+    cost_ms: float
+
+
+@dataclass(frozen=True)
+class _RankStragglerEvidence:
+    """
+    Culprit-first rank straggler evidence.
+
+    The score is visible wait cost paid by the victim rank, normalized by that
+    victim's selected-clock iteration time. Component attribution compares the
+    culprit's own input/H2D/forward values against the victim rank.
     """
 
     kind: str
@@ -51,13 +72,13 @@ class _CleanStragglerEvidence:
     metric: str
     phase: str
     score: float
-    worst_rank: Optional[int]
-    clean_step_median_ms: float
-    clean_step_worst_ms: float
-    clean_step_slack_ms: float
-    typical_step_ms: float
-    top_excess_ms: float
-    second_excess_ms: float
+    culprit_rank: int
+    victim_rank: int
+    visible_metric: str
+    visible_culprit_ms: float
+    visible_victim_ms: float
+    visible_cost_ms: float
+    iteration_time_ms: float
     component_excesses_ms: Dict[str, float]
 
 
@@ -104,8 +125,7 @@ class StepTimeAnalysisContext:
     largest_compute: Optional[ComputeSignal]
 
     rank_values: Dict[str, Dict[int, float]]
-    clean_rank_values: Dict[str, Dict[int, float]]
-    clean_straggler: Optional[_CleanStragglerEvidence]
+    rank_straggler: Optional[_RankStragglerEvidence]
 
 
 def non_negative_finite(value: float) -> float:
@@ -249,180 +269,184 @@ def metric_excess(metric: Optional[StepCombinedTimeMetric]) -> float:
     return max(0.0, metric_worst_total(metric) - metric_median_total(metric))
 
 
-def _clean_rank_timings(
-    per_rank_timing: Dict[int, Dict[str, float]],
-) -> Dict[str, Dict[int, float]]:
+def _rank_straggler_pair(
+    visible_values: Dict[int, float],
+) -> Optional[_RankStragglerPair]:
     """
-    Return clean rank-local timings used for straggler diagnosis.
+    Return the culprit and victim ranks for visible synchronization skew.
 
-    The policy discounts backward time that can be explained by another rank's
-    non-backward work in the same averaged/aligned window:
-
-        residual_r = current residual_proxy_r
-        non_bwd_r = INPUT_WAIT_r + H2D_r + FWD_r + OPT_r + RESIDUAL_r
-        clean_bwd_r = max(0, BWD_r - max(0, max(non_bwd) - non_bwd_r))
-        clean_compute_r = FWD_r + clean_bwd_r + OPT_r
-        clean_step_r = INPUT_WAIT_r + H2D_r + clean_compute_r + RESIDUAL_r
-        score = (max(clean_step) - median(clean_step)) / median(actual_step)
+    The culprit is the rank with the smallest visible phase. The victim is the
+    upper actual median rank by that same phase. Both are real observed ranks,
+    which keeps two-rank and even-world-size comparisons easy to explain.
     """
-    if not per_rank_timing:
-        return {}
-
-    ranks = sorted(int(rank) for rank in per_rank_timing)
-    non_bwd = {
-        rank: (
-            non_negative_finite(per_rank_timing[rank].get("input_wait", 0.0))
-            + non_negative_finite(per_rank_timing[rank].get("h2d", 0.0))
-            + non_negative_finite(per_rank_timing[rank].get("forward", 0.0))
-            + non_negative_finite(
-                per_rank_timing[rank].get("optimizer_step", 0.0)
-            )
-            + non_negative_finite(
-                per_rank_timing[rank].get("residual_proxy", 0.0)
-            )
-        )
-        for rank in ranks
-    }
-    non_bwd_max = max(non_bwd.values()) if non_bwd else 0.0
-
-    out = {
-        "input_wait": {},
-        "h2d": {},
-        "forward": {},
-        "backward": {},
-        "optimizer_step": {},
-        "residual_proxy": {},
-        "total_step": {},
-        "non_backward": {},
-        "clean_backward": {},
-        "clean_compute": {},
-        "clean_step": {},
-    }
-    for rank in ranks:
-        values = per_rank_timing[rank]
-        input_wait = non_negative_finite(values.get("input_wait", 0.0))
-        h2d = non_negative_finite(values.get("h2d", 0.0))
-        forward = non_negative_finite(values.get("forward", 0.0))
-        backward = non_negative_finite(values.get("backward", 0.0))
-        optimizer = non_negative_finite(values.get("optimizer_step", 0.0))
-        residual = non_negative_finite(values.get("residual_proxy", 0.0))
-        total_step = non_negative_finite(values.get("total_step", 0.0))
-
-        explained_bwd_delay = max(0.0, non_bwd_max - non_bwd[rank])
-        clean_backward = max(0.0, backward - explained_bwd_delay)
-        clean_compute = forward + clean_backward + optimizer
-        clean_step = input_wait + h2d + clean_compute + residual
-
-        out["input_wait"][rank] = input_wait
-        out["h2d"][rank] = h2d
-        out["forward"][rank] = forward
-        out["backward"][rank] = backward
-        out["optimizer_step"][rank] = optimizer
-        out["residual_proxy"][rank] = residual
-        out["total_step"][rank] = total_step
-        out["non_backward"][rank] = non_bwd[rank]
-        out["clean_backward"][rank] = clean_backward
-        out["clean_compute"][rank] = clean_compute
-        out["clean_step"][rank] = clean_step
-
-    return out
-
-
-def _clean_straggler_evidence(
-    *,
-    clean_rank_values: Dict[str, Dict[int, float]],
-    score_threshold: float,
-    dominance_tolerance: float,
-) -> Optional[_CleanStragglerEvidence]:
-    """Return rank-local clean-step straggler evidence, if material."""
-    clean_steps = clean_rank_values.get("clean_step", {})
-    actual_steps = clean_rank_values.get("total_step", {})
-    if len(clean_steps) <= 1 or not actual_steps:
+    if len(visible_values) <= 1:
         return None
 
-    median_clean, worst_clean, worst_rank, clean_slack = _rank_stats(
-        clean_steps
+    clean = {
+        int(rank): non_negative_finite(value)
+        for rank, value in visible_values.items()
+    }
+    ordered = sorted(clean, key=lambda rank: (clean[rank], int(rank)))
+    if len(ordered) <= 1:
+        return None
+
+    culprit_rank = int(ordered[0])
+    victim_rank = int(ordered[len(ordered) // 2])
+    culprit_value = clean[culprit_rank]
+    victim_value = clean[victim_rank]
+    return _RankStragglerPair(
+        culprit_rank=culprit_rank,
+        victim_rank=victim_rank,
+        culprit_value_ms=culprit_value,
+        victim_value_ms=victim_value,
+        cost_ms=max(0.0, victim_value - culprit_value),
     )
-    typical_step = _median(tuple(actual_steps.values()))
-    if typical_step <= 0.0:
+
+
+def _rank_metric_value(
+    per_rank_timing: Dict[int, Dict[str, float]],
+    rank: int,
+    metric: str,
+) -> float:
+    """Return a safe metric value for one rank."""
+    return non_negative_finite(
+        per_rank_timing.get(int(rank), {}).get(str(metric), 0.0)
+    )
+
+
+def _build_rank_straggler_evidence(
+    *,
+    per_rank_timing: Dict[int, Dict[str, float]],
+    score_threshold: float,
+    training_strategy: str,
+) -> Optional[_RankStragglerEvidence]:
+    """
+    Build culprit/victim rank straggler evidence for distributed runs.
+
+    DDP/default uses backward as the visible synchronization phase. FSDP uses
+    forward + backward because FSDP can communicate on both sides of module
+    execution. Only ranks with measured visible-phase anchors and a measured
+    step envelope are eligible. Component attribution compares the culprit rank
+    directly to the victim rank and only emits a subtype for material positive
+    excess.
+    """
+    if len(per_rank_timing) <= 1:
         return None
 
-    score = clean_slack / typical_step
-    if score < non_negative_finite(score_threshold):
-        return None
-    if worst_rank is None:
+    strategy = normalize_training_strategy(training_strategy)
+    visible_metric = "forward_backward" if strategy == "fsdp" else "backward"
+    eligible_ranks = []
+    for rank in sorted(int(rank) for rank in per_rank_timing):
+        forward = _rank_metric_value(per_rank_timing, rank, "forward")
+        backward = _rank_metric_value(per_rank_timing, rank, "backward")
+        step_time = _rank_metric_value(per_rank_timing, rank, "step_time")
+        if step_time <= 0.0 or backward <= 0.0:
+            continue
+        if strategy == "fsdp" and forward <= 0.0:
+            continue
+        eligible_ranks.append(rank)
+    if len(eligible_ranks) <= 1:
         return None
 
+    visible_values = {
+        int(rank): (
+            _rank_metric_value(per_rank_timing, rank, "forward")
+            + _rank_metric_value(per_rank_timing, rank, "backward")
+            if strategy == "fsdp"
+            else _rank_metric_value(per_rank_timing, rank, "backward")
+        )
+        for rank in eligible_ranks
+    }
+    pair = _rank_straggler_pair(visible_values)
+    if pair is None:
+        return None
+
+    culprit = pair.culprit_rank
+    victim = pair.victim_rank
+    iteration_time = _rank_metric_value(
+        per_rank_timing, victim, "input_wait"
+    ) + _rank_metric_value(per_rank_timing, victim, "step_time")
+
+    score = pair.cost_ms / iteration_time
+    threshold = non_negative_finite(score_threshold)
+    if score < threshold:
+        return None
+
+    input_excess = max(
+        0.0,
+        _rank_metric_value(per_rank_timing, culprit, "input_wait")
+        - _rank_metric_value(per_rank_timing, victim, "input_wait"),
+    )
+    h2d_excess = max(
+        0.0,
+        _rank_metric_value(per_rank_timing, culprit, "h2d")
+        - _rank_metric_value(per_rank_timing, victim, "h2d"),
+    )
+    if strategy == "fsdp":
+        # FSDP interleaves collectives with forward/backward, so without
+        # explicit collective timing this rule should not emit compute
+        # stragglers from forward excess.
+        forward_excess = 0.0
+    else:
+        culprit_forward = _rank_metric_value(
+            per_rank_timing, culprit, "forward"
+        )
+        victim_forward = _rank_metric_value(per_rank_timing, victim, "forward")
+        forward_excess = (
+            max(0.0, culprit_forward - victim_forward)
+            if culprit_forward > 0.0 and victim_forward > 0.0
+            else 0.0
+        )
+
+    component_excesses = {
+        "input": input_excess,
+        "h2d": h2d_excess,
+        "compute": forward_excess,
+    }
     components = {
-        "input": (
-            "INPUT_STRAGGLER",
-            "INPUT STRAGGLER",
-            "input_wait",
-            "input",
-        ),
+        "input": ("INPUT_STRAGGLER", "INPUT STRAGGLER", "input_wait", "input"),
+        "h2d": ("H2D_STRAGGLER", "H2D STRAGGLER", "h2d", "h2d"),
         "compute": (
             "COMPUTE_STRAGGLER",
             "COMPUTE STRAGGLER",
-            "compute",
-            "compute",
+            "forward",
+            "forward",
         ),
-        "h2d": ("H2D_STRAGGLER", "H2D STRAGGLER", "h2d", "h2d"),
-        "residual": (
-            "RESIDUAL_STRAGGLER",
-            "RESIDUAL STRAGGLER",
-            "residual_proxy",
-            "residual",
-        ),
-    }
-    source_by_component = {
-        "input": clean_rank_values.get("input_wait", {}),
-        "compute": clean_rank_values.get("clean_compute", {}),
-        "h2d": clean_rank_values.get("h2d", {}),
-        "residual": clean_rank_values.get("residual_proxy", {}),
-    }
-    component_excesses = {
-        name: max(
-            0.0,
-            non_negative_finite(values.get(worst_rank, 0.0))
-            - _median(tuple(values.values())),
-        )
-        for name, values in source_by_component.items()
     }
     ordered = sorted(
         component_excesses.items(),
-        key=lambda item: (item[1], item[0]),
-        reverse=True,
+        key=lambda item: (
+            -item[1],
+            ("input", "h2d", "compute").index(item[0]),
+        ),
     )
     top_component, top_excess = ordered[0]
-    second_excess = ordered[1][1] if len(ordered) > 1 else 0.0
-
-    tolerance = max(1.0, non_negative_finite(dominance_tolerance))
-    if top_excess <= 0.0 or top_excess < tolerance * second_excess:
+    if top_excess > 0.0 and (top_excess / iteration_time) >= threshold:
+        kind, status, metric, phase = components[top_component]
+        component = top_component
+    else:
         kind, status, metric, phase = (
             "STRAGGLER",
             "STRAGGLER",
-            "step_time",
-            "mixed",
+            visible_metric,
+            "sync",
         )
-        component = "mixed"
-    else:
-        kind, status, metric, phase = components[top_component]
-        component = top_component
+        component = "sync_or_unattributed"
 
-    return _CleanStragglerEvidence(
+    return _RankStragglerEvidence(
         kind=kind,
         status=status,
         component=component,
         metric=metric,
         phase=phase,
         score=score,
-        worst_rank=worst_rank,
-        clean_step_median_ms=median_clean,
-        clean_step_worst_ms=worst_clean,
-        clean_step_slack_ms=clean_slack,
-        typical_step_ms=typical_step,
-        top_excess_ms=top_excess,
-        second_excess_ms=second_excess,
+        culprit_rank=culprit,
+        victim_rank=victim,
+        visible_metric=visible_metric,
+        visible_culprit_ms=pair.culprit_value_ms,
+        visible_victim_ms=pair.victim_value_ms,
+        visible_cost_ms=pair.cost_ms,
+        iteration_time_ms=iteration_time,
         component_excesses_ms=component_excesses,
     )
 
@@ -487,6 +511,25 @@ def rank_values_from_metric(
         return {}
 
     return {int(rank): metric_worst_total(metric)}
+
+
+def compute_rank_values_from_components(
+    rank_values: Dict[str, Dict[int, float]],
+) -> Dict[int, float]:
+    """
+    Return rank -> forward + backward + optimizer_step from rank-value maps.
+    """
+    forward = rank_values.get("forward", {})
+    backward = rank_values.get("backward", {})
+    optimizer = rank_values.get("optimizer_step", {})
+    out: Dict[int, float] = {}
+    for rank in sorted(set(forward) | set(backward) | set(optimizer)):
+        out[int(rank)] = (
+            non_negative_finite(forward.get(rank, 0.0))
+            + non_negative_finite(backward.get(rank, 0.0))
+            + non_negative_finite(optimizer.get(rank, 0.0))
+        )
+    return out
 
 
 def build_step_time_context(
@@ -607,14 +650,13 @@ def build_step_time_context(
         if single_rank or input_wait_median <= 0.0
         else input_slack / input_wait_median
     )
-    clean_rank_values = _clean_rank_timings(local_per_rank_timing)
-    clean_straggler = _clean_straggler_evidence(
-        clean_rank_values=clean_rank_values,
+    rank_straggler = _build_rank_straggler_evidence(
+        per_rank_timing=local_per_rank_timing,
         score_threshold=thresholds.straggler_score_warn,
-        dominance_tolerance=thresholds.straggler_dominance_tolerance,
+        training_strategy=training_strategy,
     )
-    clean_compute_values = clean_rank_values.get("clean_compute", {})
-    _compute_median, _, _, _compute_slack = _rank_stats(clean_compute_values)
+    compute_rank_values = compute_rank_values_from_components(rank_values)
+    _compute_median, _, _, _compute_slack = _rank_stats(compute_rank_values)
     compute_skew_value = (
         (_compute_slack / _compute_median) if _compute_median > 0.0 else 0.0
     )
@@ -649,8 +691,7 @@ def build_step_time_context(
         iteration_time_total=iteration_time_total,
         largest_compute=largest_compute,
         rank_values=rank_values,
-        clean_rank_values=clean_rank_values,
-        clean_straggler=clean_straggler,
+        rank_straggler=rank_straggler,
     )
 
 
@@ -659,6 +700,7 @@ __all__ = [
     "StepTimeAnalysisContext",
     "build_step_time_context",
     "compute_total",
+    "compute_rank_values_from_components",
     "largest_compute_phase",
     "metric_median_total",
     "metric_excess",

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -532,6 +532,29 @@ def compute_rank_values_from_components(
     return out
 
 
+def _median_iteration_component_share(
+    per_rank_timing: Dict[int, Dict[str, float]],
+    component: str,
+) -> float:
+    """Return the median selected-clock iteration share for one component."""
+    shares = []
+    for values in per_rank_timing.values():
+        if not {
+            "input_wait",
+            "step_time",
+            component,
+        }.issubset(values):
+            continue
+        iteration = non_negative_finite(
+            values["input_wait"]
+        ) + non_negative_finite(values["step_time"])
+        if iteration > 0.0:
+            shares.append(
+                share(non_negative_finite(values[component]), iteration)
+            )
+    return _median(shares)
+
+
 def build_step_time_context(
     *,
     metrics: Sequence[StepCombinedTimeMetric],
@@ -677,9 +700,15 @@ def build_step_time_context(
         step_total=step_total,
         residual_total=residual_total,
         compute_total=compute_total_value,
-        residual_share=share(residual_total, step_total),
+        residual_share=_median_iteration_component_share(
+            local_per_rank_timing,
+            "residual_proxy",
+        ),
         compute_share=share(compute_total_value, step_total),
-        input_bound_share=share(input_wait_total, iteration_time_total),
+        input_bound_share=_median_iteration_component_share(
+            local_per_rank_timing,
+            "input_wait",
+        ),
         input_bound_skew=input_bound_skew,
         compute_skew=compute_skew_value,
         input_bound_worst_rank=input_wait_worst_rank,

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -113,6 +113,7 @@ class StepTimeAnalysisContext:
     residual_share: float
     compute_share: float
     input_bound_share: float
+    h2d_share: float
 
     input_bound_skew: float
     compute_skew: float
@@ -708,6 +709,10 @@ def build_step_time_context(
         input_bound_share=_median_iteration_component_share(
             local_per_rank_timing,
             "input_wait",
+        ),
+        h2d_share=_median_iteration_component_share(
+            local_per_rank_timing,
+            "h2d",
         ),
         input_bound_skew=input_bound_skew,
         compute_skew=compute_skew_value,

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -622,6 +622,13 @@ def build_step_time_context(
         int(rank): {str(k): non_negative_finite(v) for k, v in values.items()}
         for rank, values in (per_rank_timing or {}).items()
     }
+    for values in local_per_rank_timing.values():
+        if {"forward", "backward", "optimizer_step"}.issubset(values):
+            values["compute"] = (
+                values["forward"]
+                + values["backward"]
+                + values["optimizer_step"]
+            )
     if local_per_rank_timing:
         rank_values = {
             "input_wait": {
@@ -716,7 +723,10 @@ def build_step_time_context(
             local_per_rank_timing,
             "residual_proxy",
         ),
-        compute_share=share(compute_total_value, step_total),
+        compute_share=_median_iteration_component_share(
+            local_per_rank_timing,
+            "compute",
+        ),
         input_bound_share=_median_iteration_component_share(
             local_per_rank_timing,
             "input_wait",

--- a/src/traceml_ai/diagnostics/step_time/formatters.py
+++ b/src/traceml_ai/diagnostics/step_time/formatters.py
@@ -23,6 +23,8 @@ def _styled_status(diagnosis: StepDiagnosis) -> str:
         style = "bold bright_black"
     elif diagnosis.kind == "INPUT_BOUND":
         style = "bold yellow"
+    elif diagnosis.kind == "H2D_BOUND":
+        style = "bold red" if diagnosis.severity == "crit" else "bold yellow"
     elif diagnosis.kind in {
         "INPUT_STRAGGLER",
         "COMPUTE_STRAGGLER",

--- a/src/traceml_ai/diagnostics/step_time/formatters.py
+++ b/src/traceml_ai/diagnostics/step_time/formatters.py
@@ -27,7 +27,6 @@ def _styled_status(diagnosis: StepDiagnosis) -> str:
         "INPUT_STRAGGLER",
         "COMPUTE_STRAGGLER",
         "H2D_STRAGGLER",
-        "RESIDUAL_STRAGGLER",
         "STRAGGLER",
         "RESIDUAL_HEAVY",
     }:

--- a/src/traceml_ai/diagnostics/step_time/formatters.py
+++ b/src/traceml_ai/diagnostics/step_time/formatters.py
@@ -21,7 +21,7 @@ def _styled_status(diagnosis: StepDiagnosis) -> str:
         style = "bold green"
     elif diagnosis.kind in {"NO_DATA", "WARMUP"}:
         style = "bold bright_black"
-    elif diagnosis.kind in {"INPUT_BOUND", "COMPUTE_BOUND"}:
+    elif diagnosis.kind == "INPUT_BOUND":
         style = "bold yellow"
     elif diagnosis.kind in {
         "INPUT_STRAGGLER",

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -17,6 +17,10 @@ class DiagnosisThresholds:
     where ``iteration_time_ms = input_wait_ms + step_time_ms``. This keeps the
     traced step envelope stable while measuring input wait against the full
     selected-clock iteration time.
+
+    ``min_steps_for_warning_diag`` is the minimum window size for warning-only
+    bottleneck diagnoses. ``min_steps_for_confident_diag`` is the minimum window
+    size for critical diagnoses.
     """
 
     straggler_score_warn: float = 0.10
@@ -35,6 +39,7 @@ class DiagnosisThresholds:
     compute_bound_share_warn: float = 0.85
     compute_bound_share_crit: float = 0.92
 
+    min_steps_for_warning_diag: int = 2
     min_steps_for_confident_diag: int = 20
 
 

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -14,10 +14,11 @@ class DiagnosisThresholds:
     the same rules and produce the same diagnosis vocabulary. Live and summary
     differ by the selected timing window, not by extra diagnosis gates.
 
-    INPUT_BOUND uses selected-clock ``input_wait_ms / iteration_time_ms``,
-    where ``iteration_time_ms = input_wait_ms + step_time_ms``. This keeps the
-    traced step envelope stable while measuring input wait against the full
-    selected-clock iteration time.
+    Typical overhead diagnoses use selected-clock per-rank iteration shares.
+    The context takes the median of those shares across ranks, where
+    ``iteration_time_ms = input_wait_ms + step_time_ms``. The shared overhead
+    thresholds are the future configuration surface for input, residual, and
+    H2D policies.
 
     ``min_steps_for_warning_diag`` is the minimum window size for warning-only
     bottleneck diagnoses. ``min_steps_for_confident_diag`` is the minimum window
@@ -27,17 +28,10 @@ class DiagnosisThresholds:
     straggler_score_warn: float = 0.10
     straggler_score_crit: float = 0.20
 
-    input_share_warn: float = 0.10
-    input_share_crit: float = 0.20
-
-    residual_share_warn: float = 0.15
-    residual_share_crit: float = 0.25
-
-    input_bound_max_skew: float = 0.06
-    compute_bound_max_skew: float = 0.06
+    overhead_share_warn: float = 0.10
+    overhead_share_crit: float = 0.20
 
     compute_bound_share_warn: float = 0.85
-    compute_bound_share_crit: float = 0.92
 
     min_steps_for_warning_diag: int = 2
     min_steps_for_confident_diag: int = 20
@@ -63,14 +57,9 @@ SUMMARY_STEP_TIME_POLICY = StepTimeDiagnosisPolicy(
     thresholds=DiagnosisThresholds(
         straggler_score_warn=0.10,
         straggler_score_crit=0.20,
-        input_share_warn=0.10,
-        input_share_crit=0.20,
-        residual_share_warn=0.18,
-        residual_share_crit=0.28,
-        input_bound_max_skew=0.05,
-        compute_bound_max_skew=0.05,
+        overhead_share_warn=0.10,
+        overhead_share_crit=0.20,
         compute_bound_share_warn=0.88,
-        compute_bound_share_crit=0.94,
         min_steps_for_confident_diag=20,
     ),
 )

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -13,19 +13,18 @@ class DiagnosisThresholds:
     Live and summary policies may choose different values, but they still run
     the same rules and produce the same diagnosis vocabulary.
 
-    INPUT_BOUND uses selected-clock ``input_wait_ms / step_time_ms``. This is
-    a pre-step wait compared with the traced step envelope, not an end-to-end
-    wall-time share, so values can exceed 1.0. Summary thresholds are slightly
-    more conservative than live thresholds because the final report should call
-    only durable bottlenecks across a larger window.
+    INPUT_BOUND uses selected-clock ``input_wait_ms / iteration_time_ms``,
+    where ``iteration_time_ms = input_wait_ms + step_time_ms``. This keeps the
+    traced step envelope stable while measuring input wait against the full
+    selected-clock iteration time.
     """
 
     straggler_score_warn: float = 0.10
     straggler_score_crit: float = 0.20
     straggler_dominance_tolerance: float = 1.25
 
-    input_share_warn: float = 0.25
-    input_share_crit: float = 0.35
+    input_share_warn: float = 0.10
+    input_share_crit: float = 0.20
 
     residual_share_warn: float = 0.15
     residual_share_crit: float = 0.25
@@ -61,8 +60,8 @@ SUMMARY_STEP_TIME_POLICY = StepTimeDiagnosisPolicy(
     thresholds=DiagnosisThresholds(
         straggler_score_warn=0.10,
         straggler_score_crit=0.18,
-        input_share_warn=0.30,
-        input_share_crit=0.40,
+        input_share_warn=0.10,
+        input_share_crit=0.20,
         residual_share_warn=0.18,
         residual_share_crit=0.28,
         input_bound_max_skew=0.05,

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -22,11 +22,13 @@ class DiagnosisThresholds:
 
     ``min_steps_for_warning_diag`` is the minimum window size for warning-only
     bottleneck diagnoses. ``min_steps_for_confident_diag`` is the minimum window
-    size for critical diagnoses.
+    size for critical diagnoses. ``straggler_cause_coverage_min`` is the future
+    configuration surface for naming a rank-straggler cause.
     """
 
     straggler_score_warn: float = 0.10
     straggler_score_crit: float = 0.20
+    straggler_cause_coverage_min: float = 0.80
 
     overhead_share_warn: float = 0.10
     overhead_share_crit: float = 0.20

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -26,7 +26,6 @@ class DiagnosisThresholds:
 
     straggler_score_warn: float = 0.10
     straggler_score_crit: float = 0.20
-    straggler_dominance_tolerance: float = 1.25
 
     input_share_warn: float = 0.10
     input_share_crit: float = 0.20

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -11,7 +11,8 @@ class DiagnosisThresholds:
     Thresholds used by the shared step-time rules.
 
     Live and summary policies may choose different values, but they still run
-    the same rules and produce the same diagnosis vocabulary.
+    the same rules and produce the same diagnosis vocabulary. Live and summary
+    differ by the selected timing window, not by extra diagnosis gates.
 
     INPUT_BOUND uses selected-clock ``input_wait_ms / iteration_time_ms``,
     where ``iteration_time_ms = input_wait_ms + step_time_ms``. This keeps the
@@ -45,26 +46,24 @@ class DiagnosisThresholds:
 
 @dataclass(frozen=True)
 class StepTimeDiagnosisPolicy:
-    """Named threshold set for one step-time diagnosis window type."""
+    """Named threshold set for shared Step Time diagnosis."""
 
     name: str
     thresholds: DiagnosisThresholds = field(
         default_factory=DiagnosisThresholds
     )
-    min_steps_for_diag: int = 20
 
 
 LIVE_STEP_TIME_POLICY = StepTimeDiagnosisPolicy(
     name="live",
     thresholds=DiagnosisThresholds(),
-    min_steps_for_diag=20,
 )
 
 SUMMARY_STEP_TIME_POLICY = StepTimeDiagnosisPolicy(
     name="summary",
     thresholds=DiagnosisThresholds(
         straggler_score_warn=0.10,
-        straggler_score_crit=0.18,
+        straggler_score_crit=0.20,
         input_share_warn=0.10,
         input_share_crit=0.20,
         residual_share_warn=0.18,
@@ -75,7 +74,6 @@ SUMMARY_STEP_TIME_POLICY = StepTimeDiagnosisPolicy(
         compute_bound_share_crit=0.94,
         min_steps_for_confident_diag=20,
     ),
-    min_steps_for_diag=50,
 )
 
 DEFAULT_THRESHOLDS = LIVE_STEP_TIME_POLICY.thresholds

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -10,15 +10,16 @@ class DiagnosisThresholds:
     """
     Thresholds used by the shared step-time rules.
 
-    Live and summary policies may choose different values, but they still run
-    the same rules and produce the same diagnosis vocabulary. Live and summary
-    differ by the selected timing window, not by extra diagnosis gates.
+    Built-in live and summary policies share these values and differ only by
+    their selected timing windows. Explicit callers may still supply a custom
+    policy.
 
     Typical overhead diagnoses use selected-clock per-rank iteration shares.
     The context takes the median of those shares across ranks, where
     ``iteration_time_ms = input_wait_ms + step_time_ms``. The shared overhead
     thresholds are the future configuration surface for input, residual, and
-    H2D policies.
+    H2D policies. Compute-bound uses the same denominator and a separate
+    informational dominance threshold.
 
     ``min_steps_for_warning_diag`` is the minimum window size for warning-only
     bottleneck diagnoses. ``min_steps_for_confident_diag`` is the minimum window
@@ -33,7 +34,7 @@ class DiagnosisThresholds:
     overhead_share_warn: float = 0.10
     overhead_share_crit: float = 0.20
 
-    compute_bound_share_warn: float = 0.85
+    compute_bound_share_warn: float = 0.90
 
     min_steps_for_warning_diag: int = 2
     min_steps_for_confident_diag: int = 20
@@ -49,24 +50,17 @@ class StepTimeDiagnosisPolicy:
     )
 
 
+DEFAULT_THRESHOLDS = DiagnosisThresholds()
+
 LIVE_STEP_TIME_POLICY = StepTimeDiagnosisPolicy(
     name="live",
-    thresholds=DiagnosisThresholds(),
+    thresholds=DEFAULT_THRESHOLDS,
 )
 
 SUMMARY_STEP_TIME_POLICY = StepTimeDiagnosisPolicy(
     name="summary",
-    thresholds=DiagnosisThresholds(
-        straggler_score_warn=0.10,
-        straggler_score_crit=0.20,
-        overhead_share_warn=0.10,
-        overhead_share_crit=0.20,
-        compute_bound_share_warn=0.88,
-        min_steps_for_confident_diag=20,
-    ),
+    thresholds=DEFAULT_THRESHOLDS,
 )
-
-DEFAULT_THRESHOLDS = LIVE_STEP_TIME_POLICY.thresholds
 
 
 __all__ = [

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -12,7 +12,13 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Sequence, Tuple
 
 from ..common import DiagnosticIssue, DiagnosticRule
-from .context import StepTimeAnalysisContext, non_negative_finite
+from .context import (
+    StepTimeAnalysisContext,
+    metric_skew,
+    metric_total,
+    metric_worst_rank,
+    non_negative_finite,
+)
 
 
 def _severity(value: float, crit_threshold: float) -> str:
@@ -204,6 +210,56 @@ class InputBoundRule(_BaseStepTimeRule):
 
 
 @dataclass(frozen=True)
+class H2DBoundRule(_BaseStepTimeRule):
+    """Detect broad H2D transfer cost from GPU-selected timing."""
+
+    name: str = "h2d_bound"
+
+    def evaluate(
+        self,
+        context: StepTimeAnalysisContext,
+    ) -> Optional[DiagnosticIssue]:
+        if context.diagnosis_clock != "gpu":
+            return None
+        if context.h2d_share < context.thresholds.overhead_share_warn:
+            return None
+        worst_rank = metric_worst_rank(context.h2d_metric)
+
+        return self._issue(
+            kind="H2D_BOUND",
+            status="H2D-BOUND",
+            severity=_severity(
+                context.h2d_share,
+                context.thresholds.overhead_share_crit,
+            ),
+            summary=(
+                f"H2D transfer is {_pct(context.h2d_share)} of the "
+                "typical GPU iteration time."
+            ),
+            action=(
+                "Inspect pinned memory, batch transfer, and host-to-device "
+                "copies."
+            ),
+            metric="h2d",
+            phase="h2d",
+            share_pct=context.h2d_share,
+            skew_pct=metric_skew(
+                context.h2d_metric,
+                single_rank=context.single_rank,
+            ),
+            ranks=(worst_rank,) if worst_rank is not None else (),
+            evidence={
+                "h2d_ms": metric_total(
+                    context.h2d_metric,
+                    single_rank=context.single_rank,
+                ),
+                "h2d_share": context.h2d_share,
+                "diagnosis_clock": context.diagnosis_clock,
+            },
+        )
+
+
+@dataclass(frozen=True)
 class ResidualHeavyRule(_BaseStepTimeRule):
     """
     Detect windows dominated by residual time rather than traced local work.
@@ -256,6 +312,11 @@ class ComputeBoundRule(_BaseStepTimeRule):
             return None
         if context.input_bound_share >= context.thresholds.overhead_share_warn:
             return None
+        if (
+            context.diagnosis_clock == "gpu"
+            and context.h2d_share >= context.thresholds.overhead_share_warn
+        ):
+            return None
         if context.residual_share >= context.thresholds.overhead_share_warn:
             return None
 
@@ -283,6 +344,7 @@ DEFAULT_STEP_TIME_RULES: Tuple[
 ] = (
     RankStragglerRule(),
     InputBoundRule(),
+    H2DBoundRule(),
     ResidualHeavyRule(),
     ComputeBoundRule(),
 )
@@ -309,6 +371,7 @@ def run_step_time_rules(
 __all__ = [
     "DEFAULT_STEP_TIME_RULES",
     "ComputeBoundRule",
+    "H2DBoundRule",
     "InputBoundRule",
     "RankStragglerRule",
     "ResidualHeavyRule",

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -117,16 +117,15 @@ class RankStragglerRule(_BaseStepTimeRule):
             "h2d": "H2D",
             "sync_or_unattributed": "sync or unattributed work",
         }.get(evidence.component, evidence.component)
+        cause_coverage = non_negative_finite(
+            evidence.component_coverage.get(evidence.component, 0.0)
+        )
         if evidence.kind == "STRAGGLER":
-            explanation = (
-                "no input or H2D excess explains it"
-                if context.training_strategy == "fsdp"
-                else "no input, H2D, or DDP-forward excess explains it"
-            )
             summary = (
                 f"{_rank_str(rank)} appears to be the culprit rank "
-                f"(~{_pct(evidence.score)} victim wait cost); "
-                f"{explanation}."
+                f"(~{_pct(evidence.score)} impact); no measured component "
+                f"explains {_pct(context.thresholds.straggler_cause_coverage_min)} "
+                "of visible wait cost."
             )
             action = (
                 "Inspect synchronization, collectives, and unattributed work "
@@ -135,7 +134,8 @@ class RankStragglerRule(_BaseStepTimeRule):
         else:
             summary = (
                 f"{_rank_str(rank)} has excess {component_label} burden "
-                f"explaining ~{_pct(evidence.score)} victim wait cost."
+                f"(~{_pct(evidence.score)} impact; "
+                f"~{_pct(cause_coverage)} of visible wait cost)."
             )
             action = f"Inspect {component_label} on {_rank_str(rank)}."
 
@@ -163,6 +163,7 @@ class RankStragglerRule(_BaseStepTimeRule):
                 "visible_cost_ms": evidence.visible_cost_ms,
                 "iteration_time_ms": evidence.iteration_time_ms,
                 "component_excesses_ms": evidence.component_excesses_ms,
+                "component_coverage": evidence.component_coverage,
             },
         )
 

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -173,12 +173,7 @@ class InputBoundRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
-        if context.input_bound_share < context.thresholds.input_share_warn:
-            return None
-
-        if not context.single_rank and (
-            context.input_bound_skew > context.thresholds.input_bound_max_skew
-        ):
+        if context.input_bound_share < context.thresholds.overhead_share_warn:
             return None
 
         return self._issue(
@@ -186,7 +181,7 @@ class InputBoundRule(_BaseStepTimeRule):
             status="INPUT-BOUND",
             severity=_severity(
                 context.input_bound_share,
-                context.thresholds.input_share_crit,
+                context.thresholds.overhead_share_crit,
             ),
             summary=(
                 f"Input wait is {_pct(context.input_bound_share)} of the "
@@ -220,7 +215,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
-        if context.residual_share < context.thresholds.residual_share_warn:
+        if context.residual_share < context.thresholds.overhead_share_warn:
             return None
 
         return self._issue(
@@ -228,7 +223,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
             status="RESIDUAL-HEAVY",
             severity=_severity(
                 context.residual_share,
-                context.thresholds.residual_share_crit,
+                context.thresholds.overhead_share_crit,
             ),
             summary=(
                 f"Residual time is {_pct(context.residual_share)} of the "
@@ -248,7 +243,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
 @dataclass(frozen=True)
 class ComputeBoundRule(_BaseStepTimeRule):
     """
-    Detect windows dominated by compute without a strong cross-rank straggler.
+    Report dominant compute as informational context.
     """
 
     name: str = "compute_bound"
@@ -257,17 +252,11 @@ class ComputeBoundRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
-        if context.rank_straggler is not None:
-            return None
         if context.compute_share < context.thresholds.compute_bound_share_warn:
             return None
-        if context.input_bound_share >= context.thresholds.input_share_warn:
+        if context.input_bound_share >= context.thresholds.overhead_share_warn:
             return None
-        if context.residual_share >= context.thresholds.residual_share_warn:
-            return None
-        if not context.single_rank and (
-            context.compute_skew > context.thresholds.compute_bound_max_skew
-        ):
+        if context.residual_share >= context.thresholds.overhead_share_warn:
             return None
 
         label = (
@@ -278,10 +267,7 @@ class ComputeBoundRule(_BaseStepTimeRule):
         return self._issue(
             kind="COMPUTE_BOUND",
             status="COMPUTE-BOUND",
-            severity=_severity(
-                context.compute_share,
-                context.thresholds.compute_bound_share_crit,
-            ),
+            severity="info",
             summary=f"Compute-bound; {label.lower()} is the largest phase.",
             action="Optimize model compute or reduce step cost.",
             metric="compute",

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -186,7 +186,7 @@ class InputBoundRule(_BaseStepTimeRule):
             ),
             summary=(
                 f"Input wait is {_pct(context.input_bound_share)} of the "
-                f"typical {context.diagnosis_clock} step."
+                f"typical {context.diagnosis_clock} iteration time."
             ),
             action="Increase workers, prefetch, or storage throughput.",
             metric="input_wait",
@@ -197,6 +197,7 @@ class InputBoundRule(_BaseStepTimeRule):
             evidence={
                 "input_wait_ms": context.input_wait_total,
                 "step_time_ms": context.input_bound_step_total,
+                "iteration_time_ms": context.iteration_time_total,
                 "input_bound_share": context.input_bound_share,
                 "diagnosis_clock": context.diagnosis_clock,
             },

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -60,7 +60,7 @@ class _BaseStepTimeRule(DiagnosticRule[StepTimeAnalysisContext]):
         ranks: Sequence[Optional[int]] = (),
         evidence: Optional[Dict[str, Any]] = None,
     ) -> DiagnosticIssue:
-        clean_ranks: Tuple[int, ...] = tuple(
+        issue_ranks: Tuple[int, ...] = tuple(
             int(rank) for rank in ranks if rank is not None
         )
         return DiagnosticIssue(
@@ -80,18 +80,18 @@ class _BaseStepTimeRule(DiagnosticRule[StepTimeAnalysisContext]):
             skew_pct=(
                 non_negative_finite(skew_pct) if skew_pct is not None else None
             ),
-            ranks=clean_ranks,
+            ranks=issue_ranks,
             evidence=evidence or {},
         )
 
 
 @dataclass(frozen=True)
-class CleanStragglerRule(_BaseStepTimeRule):
+class RankStragglerRule(_BaseStepTimeRule):
     """
-    Detect rank-local clean-step stragglers and classify the dominant cause.
+    Detect visible rank stragglers and classify the likely culprit cause.
     """
 
-    name: str = "clean_straggler"
+    name: str = "rank_straggler"
 
     def evaluate(
         self,
@@ -100,29 +100,36 @@ class CleanStragglerRule(_BaseStepTimeRule):
         if context.single_rank:
             return None
 
-        evidence = context.clean_straggler
+        evidence = context.rank_straggler
         if evidence is None:
             return None
 
-        rank = evidence.worst_rank
+        rank = evidence.culprit_rank
         component_label = {
             "input": "input wait",
-            "compute": "clean compute",
+            "compute": "forward compute",
             "h2d": "H2D",
-            "residual": "residual",
-            "mixed": "multiple components",
+            "sync_or_unattributed": "sync or unattributed work",
         }.get(evidence.component, evidence.component)
         if evidence.kind == "STRAGGLER":
-            summary = (
-                f"{_rank_str(rank)} is slower after backward-delay discount "
-                f"(~{_pct(evidence.score)} of a typical step); no component "
-                "dominates."
+            explanation = (
+                "no input or H2D excess explains it"
+                if context.training_strategy == "fsdp"
+                else "no input, H2D, or DDP-forward excess explains it"
             )
-            action = "Inspect input, H2D, compute, and residual time on the slow rank."
+            summary = (
+                f"{_rank_str(rank)} appears to be the culprit rank "
+                f"(~{_pct(evidence.score)} victim wait cost); "
+                f"{explanation}."
+            )
+            action = (
+                "Inspect synchronization, collectives, and unattributed work "
+                f"around {_rank_str(rank)}."
+            )
         else:
             summary = (
                 f"{_rank_str(rank)} has excess {component_label} burden "
-                f"(~{_pct(evidence.score)} of a typical step)."
+                f"explaining ~{_pct(evidence.score)} victim wait cost."
             )
             action = f"Inspect {component_label} on {_rank_str(rank)}."
 
@@ -138,20 +145,17 @@ class CleanStragglerRule(_BaseStepTimeRule):
             metric=evidence.metric,
             phase=evidence.phase,
             score=evidence.score,
-            skew_pct=(
-                evidence.clean_step_slack_ms / evidence.clean_step_median_ms
-                if evidence.clean_step_median_ms > 0.0
-                else 0.0
-            ),
+            skew_pct=evidence.score,
             ranks=(rank,),
             evidence={
                 "component": evidence.component,
-                "clean_step_median_ms": evidence.clean_step_median_ms,
-                "clean_step_worst_ms": evidence.clean_step_worst_ms,
-                "clean_step_slack_ms": evidence.clean_step_slack_ms,
-                "typical_step_ms": evidence.typical_step_ms,
-                "top_excess_ms": evidence.top_excess_ms,
-                "second_excess_ms": evidence.second_excess_ms,
+                "culprit_rank": evidence.culprit_rank,
+                "victim_rank": evidence.victim_rank,
+                "visible_metric": evidence.visible_metric,
+                "visible_culprit_ms": evidence.visible_culprit_ms,
+                "visible_victim_ms": evidence.visible_victim_ms,
+                "visible_cost_ms": evidence.visible_cost_ms,
+                "iteration_time_ms": evidence.iteration_time_ms,
                 "component_excesses_ms": evidence.component_excesses_ms,
             },
         )
@@ -253,7 +257,7 @@ class ComputeBoundRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
-        if context.clean_straggler is not None:
+        if context.rank_straggler is not None:
             return None
         if context.compute_share < context.thresholds.compute_bound_share_warn:
             return None
@@ -291,7 +295,7 @@ class ComputeBoundRule(_BaseStepTimeRule):
 DEFAULT_STEP_TIME_RULES: Tuple[
     DiagnosticRule[StepTimeAnalysisContext], ...
 ] = (
-    CleanStragglerRule(),
+    RankStragglerRule(),
     InputBoundRule(),
     ResidualHeavyRule(),
     ComputeBoundRule(),
@@ -318,9 +322,9 @@ def run_step_time_rules(
 
 __all__ = [
     "DEFAULT_STEP_TIME_RULES",
-    "CleanStragglerRule",
     "ComputeBoundRule",
     "InputBoundRule",
+    "RankStragglerRule",
     "ResidualHeavyRule",
     "run_step_time_rules",
 ]

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -197,6 +197,7 @@ class InputBoundRule(_BaseStepTimeRule):
             action="Increase workers, prefetch, or storage throughput.",
             metric="input_wait",
             phase="input",
+            score=context.input_bound_share,
             share_pct=context.input_bound_share,
             skew_pct=context.input_bound_skew,
             ranks=(context.input_bound_worst_rank,),
@@ -243,6 +244,7 @@ class H2DBoundRule(_BaseStepTimeRule):
             ),
             metric="h2d",
             phase="h2d",
+            score=context.h2d_share,
             share_pct=context.h2d_share,
             skew_pct=metric_skew(
                 context.h2d_metric,
@@ -292,6 +294,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
             ),
             metric="residual_proxy",
             phase="residual",
+            score=context.residual_share,
             share_pct=context.residual_share,
             ranks=(context.overall_worst_rank,),
         )

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -122,9 +122,11 @@ class RankStragglerRule(_BaseStepTimeRule):
         )
         if evidence.kind == "STRAGGLER":
             summary = (
-                f"{_rank_str(rank)} appears to be the culprit rank "
+                f"{_rank_str(rank)} is slower than victim "
+                f"{_rank_str(evidence.victim_rank)} "
                 f"(~{_pct(evidence.score)} impact); no measured component "
-                f"explains {_pct(context.thresholds.straggler_cause_coverage_min)} "
+                "explains "
+                f"{_pct(context.thresholds.straggler_cause_coverage_min)} "
                 "of visible wait cost."
             )
             action = (
@@ -134,6 +136,7 @@ class RankStragglerRule(_BaseStepTimeRule):
         else:
             summary = (
                 f"{_rank_str(rank)} has excess {component_label} burden "
+                f"relative to victim {_rank_str(evidence.victim_rank)} "
                 f"(~{_pct(evidence.score)} impact; "
                 f"~{_pct(cause_coverage)} of visible wait cost)."
             )
@@ -286,7 +289,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
             ),
             summary=(
                 f"Residual time is {_pct(context.residual_share)} of the "
-                "typical step."
+                f"typical {context.diagnosis_clock} iteration time."
             ),
             action=(
                 "Inspect work outside traced phases, CPU stalls, logging, "

--- a/src/traceml_ai/diagnostics/step_time/trend.py
+++ b/src/traceml_ai/diagnostics/step_time/trend.py
@@ -124,10 +124,7 @@ def build_step_trend_note(
                 f"{step_state} ({format_trend_pct(step_tr, deadband_pct=cfg.deadband_pct)})."
             )
 
-        if (
-            diagnosis_kind in {"RESIDUAL_HEAVY", "RESIDUAL_STRAGGLER"}
-            and residual_state
-        ):
+        if diagnosis_kind == "RESIDUAL_HEAVY" and residual_state:
             return (
                 "Trend: residual time is "
                 f"{residual_state} ({format_trend_pct(residual_tr, deadband_pct=cfg.deadband_pct)})."

--- a/src/traceml_ai/instrumentation/patches/backward_auto_timer_patch.py
+++ b/src/traceml_ai/instrumentation/patches/backward_auto_timer_patch.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import torch
 
+from traceml_ai.runtime.arming import is_tracing_armed
 from traceml_ai.utils.timing import timed_region
 
 _BACKWARD_TLS = threading.local()
@@ -26,7 +27,7 @@ def _set_depth(v: int) -> None:
 def _traceml_tensor_backward(
     self: torch.Tensor, *args: Any, **kwargs: Any
 ) -> Any:
-    if not _enabled():
+    if not is_tracing_armed() or not _enabled():
         return _ORIG_TENSOR_BACKWARD(self, *args, **kwargs)
 
     # Optional: only time the OUTERMOST backward call (avoid double timing)
@@ -46,7 +47,7 @@ def _traceml_tensor_backward(
 
 
 def _traceml_autograd_backward(*args: Any, **kwargs: Any) -> Any:
-    if not _enabled():
+    if not is_tracing_armed() or not _enabled():
         return _ORIG_AUTOGRAD_BACKWARD(*args, **kwargs)
 
     # Optional: only time the OUTERMOST backward call (avoid double timing)

--- a/src/traceml_ai/instrumentation/patches/dataloader_patch.py
+++ b/src/traceml_ai/instrumentation/patches/dataloader_patch.py
@@ -1,5 +1,6 @@
 from torch.utils.data import DataLoader
 
+from traceml_ai.runtime.arming import is_tracing_armed
 from traceml_ai.utils.timing import timed_region
 
 _ORIG_DATALOADER_ITER = DataLoader.__iter__
@@ -7,6 +8,10 @@ _ORIG_DATALOADER_ITER = DataLoader.__iter__
 
 def _traceml_dataloader_iter(self):
     it = _ORIG_DATALOADER_ITER(self)
+
+    if not is_tracing_armed():
+        yield from it
+        return
 
     while True:
         try:

--- a/src/traceml_ai/instrumentation/patches/forward_auto_timer_patch.py
+++ b/src/traceml_ai/instrumentation/patches/forward_auto_timer_patch.py
@@ -2,6 +2,7 @@ import threading
 
 import torch.nn as nn
 
+from traceml_ai.runtime.arming import is_tracing_armed
 from traceml_ai.utils.timing import timed_region
 
 _TLS = threading.local()
@@ -48,7 +49,7 @@ def _collect_forward_target_ids(model: nn.Module | None) -> set[int]:
 
 
 def _traceml_module_call(self: nn.Module, *args, **kwargs):
-    if not _enabled() or not _is_target(self):
+    if not is_tracing_armed() or not _enabled() or not _is_target(self):
         return _ORIG_MODULE_CALL(self, *args, **kwargs)
 
     # Only time the OUTERMOST forward to avoid submodule spam

--- a/src/traceml_ai/instrumentation/patches/h2d_auto_timer_patch.py
+++ b/src/traceml_ai/instrumentation/patches/h2d_auto_timer_patch.py
@@ -46,6 +46,7 @@ from typing import Any
 import torch
 
 from traceml_ai.instrumentation.h2d import should_time_h2d
+from traceml_ai.runtime.arming import is_tracing_armed
 from traceml_ai.utils.timing import timed_region
 
 _H2D_TLS = threading.local()
@@ -63,7 +64,7 @@ def _enabled() -> bool:
 
 
 def _traceml_tensor_to(self: torch.Tensor, *args: Any, **kwargs: Any) -> Any:
-    if not _enabled():
+    if not is_tracing_armed() or not _enabled():
         return _ORIG_TENSOR_TO(self, *args, **kwargs)
 
     if not should_time_h2d(self, args, kwargs):

--- a/src/traceml_ai/integrations/lightning.py
+++ b/src/traceml_ai/integrations/lightning.py
@@ -98,8 +98,12 @@ else:
     IS_LIGHTNING_AVAILABLE = True
 
 
-TRACEML_DISABLED = os.environ.get("TRACEML_DISABLED") == "1"
 _MISSING = object()
+
+
+def _traceml_disabled() -> bool:
+    """Read the TraceML kill switch dynamically."""
+    return os.environ.get("TRACEML_DISABLED") == "1"
 
 
 def init():
@@ -199,6 +203,8 @@ class TraceMLCallback(_CallbackBase):
         setattr(self, ctx_attr, None)
 
     def setup(self, trainer, pl_module, stage=None):
+        if _traceml_disabled():
+            return
         self._wrap_forward(trainer, pl_module)
         self._wrap_batch_to_device(trainer, pl_module)
 
@@ -215,7 +221,7 @@ class TraceMLCallback(_CallbackBase):
 
         @functools.wraps(original_forward)
         def wrapped_forward(*args, **kwargs):
-            if TRACEML_DISABLED or not getattr(trainer, "training", False):
+            if _traceml_disabled() or not getattr(trainer, "training", False):
                 return original_forward(*args, **kwargs)
 
             with timed_region(
@@ -248,7 +254,7 @@ class TraceMLCallback(_CallbackBase):
 
         def wrapped_batch_to_device(batch, *args, **kwargs):
             if (
-                TRACEML_DISABLED
+                _traceml_disabled()
                 or not getattr(trainer, "training", True)
                 or not _lightning_uses_cuda(trainer, pl_module)
             ):
@@ -308,7 +314,7 @@ class TraceMLCallback(_CallbackBase):
 
     def on_train_batch_start(self, trainer, pl_module, batch, batch_idx):
         # Start overall step timing
-        if TRACEML_DISABLED:
+        if _traceml_disabled():
             return
         self._traceml_step_ctx = timed_region(
             "_traceml_internal:step_time",
@@ -330,7 +336,7 @@ class TraceMLCallback(_CallbackBase):
             self._mem_tracker = None
 
     def on_before_backward(self, trainer, pl_module, loss):
-        if TRACEML_DISABLED:
+        if _traceml_disabled():
             return
         # Start backward timing
         self._backward_ctx = timed_region(
@@ -339,13 +345,13 @@ class TraceMLCallback(_CallbackBase):
         self._backward_ctx.__enter__()
 
     def on_after_backward(self, trainer, pl_module):
-        if TRACEML_DISABLED:
+        if _traceml_disabled():
             return
         # End backward timing
         self._close_context("_backward_ctx")
 
     def on_before_optimizer_step(self, trainer, pl_module, optimizer):
-        if TRACEML_DISABLED:
+        if _traceml_disabled():
             return
         self._opt_step_occurred = True
 
@@ -356,7 +362,7 @@ class TraceMLCallback(_CallbackBase):
         self._optimizer_ctx.__enter__()
 
     def on_before_zero_grad(self, trainer, pl_module, optimizer):
-        if TRACEML_DISABLED:
+        if _traceml_disabled():
             return
         # End optimizer step timing (zero_grad happens after step)
         self._close_context("_optimizer_ctx")
@@ -364,7 +370,7 @@ class TraceMLCallback(_CallbackBase):
     def on_train_batch_end(
         self, trainer, pl_module, outputs, batch, batch_idx
     ):
-        if TRACEML_DISABLED:
+        if _traceml_disabled():
             return
         # Safety: end any active context managers (edge cases)
         for ctx_attr in (

--- a/src/traceml_ai/integrations/ray.py
+++ b/src/traceml_ai/integrations/ray.py
@@ -24,6 +24,7 @@ from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
 from traceml_ai.runtime.lifecycle import RuntimeHandle, start_aggregator
 from traceml_ai.runtime.lifecycle import start_runtime as start_runtime_handle
 from traceml_ai.runtime.settings import (
+    DEFAULT_INTERVAL_SEC,
     AggregatorEndpoint,
     AggregatorTransportSettings,
     TraceMLSettings,
@@ -60,7 +61,8 @@ class TraceMLRayConfig:
         Optional explicit TraceML session id. If omitted, a unique Ray session
         id is generated for each ``fit()`` call.
     sampler_interval_sec:
-        Background sampler cadence in seconds.
+        Background sampler cadence in seconds. The aggregator actor uses the
+        same value for its live UI refresh cadence; TCP ingestion is immediate.
     summary_window_rows:
         Number of recent history rows used by final summary generation.
     bind_host:
@@ -81,7 +83,7 @@ class TraceMLRayConfig:
     patch_h2d: Optional[bool] = None
     logs_dir: str = "./logs"
     session_id: str = ""
-    sampler_interval_sec: float = 1.0
+    sampler_interval_sec: float = DEFAULT_INTERVAL_SEC
     summary_window_rows: int = DEFAULT_SUMMARY_WINDOW_ROWS
     bind_host: str = "0.0.0.0"
     port: int = 0
@@ -135,7 +137,7 @@ def _build_aggregator_settings(
     return TraceMLSettings(
         mode=str(config.mode),
         profile=str(config.profile),
-        sampler_interval_sec=float(config.sampler_interval_sec),
+        render_interval_sec=float(config.sampler_interval_sec),
         logs_dir=str(config.logs_dir),
         session_id=str(config.session_id),
         summary_window_rows=int(config.summary_window_rows),

--- a/src/traceml_ai/launcher/cli.py
+++ b/src/traceml_ai/launcher/cli.py
@@ -195,6 +195,8 @@ def _add_launch_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--disable-traceml",
+        "--disable_traceml",
+        dest="disable_traceml",
         action="store_const",
         const=True,
         default=None,

--- a/src/traceml_ai/launcher/cli.py
+++ b/src/traceml_ai/launcher/cli.py
@@ -13,6 +13,7 @@ import argparse
 from traceml_ai.launcher.commands import (
     run_compare,
     run_inspect,
+    run_serve,
     run_view,
     run_with_tracing,
     validate_launch_args,
@@ -245,6 +246,97 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_launch_args(run_parser)
 
+    serve_parser = sub.add_parser(
+        "serve",
+        help=(
+            "Start the TraceML aggregator standalone. Use with scripts "
+            "launched directly via `python` or `torchrun` that call "
+            "traceml.init(...)."
+        ),
+    )
+    serve_parser.add_argument(
+        "--mode",
+        type=str,
+        default=None,
+        choices=["cli", "dashboard", "summary"],
+        help="TraceML display mode for the aggregator. Default: summary.",
+    )
+    serve_parser.add_argument(
+        "--logs-dir",
+        type=str,
+        default=None,
+        help="Directory for TraceML session logs.",
+    )
+    serve_parser.add_argument(
+        "--run-name",
+        type=str,
+        default="",
+        help=(
+            "Human-readable TraceML run name. Determines the output folder "
+            "under --logs-dir. Workers must use the same run name."
+        ),
+    )
+    serve_parser.add_argument(
+        "--session-id",
+        type=str,
+        default="",
+        help="Backward-compatible alias for --run-name.",
+    )
+    serve_parser.add_argument(
+        "--nnodes",
+        type=int,
+        default=None,
+        help=(
+            "Total nodes in the training job. With --nproc-per-node, sets the "
+            "expected worker count so the aggregator waits for ALL ranks "
+            "before finalizing (and warns about ranks that never report). "
+            "Without it the aggregator finalizes after the first rank."
+        ),
+    )
+    serve_parser.add_argument(
+        "--nproc-per-node",
+        type=int,
+        default=None,
+        help="Workers per node. Multiplied by --nnodes for the rank count.",
+    )
+    serve_parser.add_argument(
+        "--interval",
+        type=float,
+        default=None,
+        help="Aggregator render/polling interval in seconds.",
+    )
+    serve_parser.add_argument(
+        "--enable-logging",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Enable TraceML logging output.",
+    )
+    serve_parser.add_argument(
+        "--aggregator-host",
+        type=str,
+        default=None,
+        help=(
+            "Address workers use to connect to this aggregator. Defaults to "
+            "127.0.0.1. Set to node 0's reachable address for multi-node."
+        ),
+    )
+    serve_parser.add_argument(
+        "--aggregator-bind-host",
+        type=str,
+        default=None,
+        help=(
+            "Address the aggregator binds to. Defaults to 127.0.0.1. Use "
+            "0.0.0.0 when workers on other nodes must connect."
+        ),
+    )
+    serve_parser.add_argument(
+        "--aggregator-port",
+        type=int,
+        default=29765,
+        help="TraceML aggregator port.",
+    )
+
     compare_parser = sub.add_parser(
         "compare",
         help="Compare two TraceML final summary JSON files.",
@@ -309,6 +401,8 @@ def main() -> None:
         run_with_tracing(args, profile="watch")
     elif args.command == "run":
         run_with_tracing(args, profile="run")
+    elif args.command == "serve":
+        run_serve(args)
     elif args.command == "compare":
         run_compare(args)
     elif args.command == "view":

--- a/src/traceml_ai/launcher/cli.py
+++ b/src/traceml_ai/launcher/cli.py
@@ -19,7 +19,10 @@ from traceml_ai.launcher.commands import (
     validate_launch_args,
 )
 from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
-from traceml_ai.runtime.settings import DEFAULT_FINALIZE_TIMEOUT_SEC
+from traceml_ai.runtime.settings import (
+    DEFAULT_FINALIZE_TIMEOUT_SEC,
+    DEFAULT_INTERVAL_SEC,
+)
 
 
 def _add_launch_args(parser: argparse.ArgumentParser) -> None:
@@ -45,7 +48,11 @@ def _add_launch_args(parser: argparse.ArgumentParser) -> None:
         "--interval",
         type=float,
         default=None,
-        help="Polling interval in seconds.",
+        help=(
+            "Worker sampler interval and live UI refresh interval in seconds "
+            f"(default: {DEFAULT_INTERVAL_SEC:g}). TCP ingestion is "
+            "event-driven."
+        ),
     )
     parser.add_argument(
         "--enable-logging",

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -577,6 +577,122 @@ def run_with_tracing(args: argparse.Namespace, profile: str) -> None:
     launch_process(script_path=script_path, args=args)
 
 
+def _resolve_serve_settings(args: argparse.Namespace):
+    """Resolve aggregator settings for ``traceml serve``.
+
+    UI/telemetry settings route through the shared config resolver
+    (CLI > env > traceml.yaml > default), the same resolver the launcher uses.
+    Aggregator host/bind-host/port come from serve's own flags, and run
+    identity reuses the launcher's ``RunIdentity``.
+    """
+    from traceml_ai.config.yaml_loader import (
+        BUILT_IN_DEFAULTS,
+        find_config_file,
+        load_yaml_config,
+        resolve_config,
+    )
+    from traceml_ai.runtime.settings import (
+        AggregatorTransportSettings,
+        TraceMLSettings,
+    )
+
+    config_path = find_config_file(Path.cwd())
+    try:
+        yaml_cfg = (
+            load_yaml_config(config_path) if config_path is not None else {}
+        )
+    except (ValueError, OSError) as exc:
+        raise SystemExit(f"[TraceML] ERROR: {exc}")
+
+    cli_overrides = {
+        "mode": args.mode,
+        "interval": args.interval,
+        "enable_logging": args.enable_logging,
+        "logs_dir": args.logs_dir,
+    }
+    cfg = resolve_config(
+        cli_overrides=cli_overrides,
+        parent_env=os.environ,
+        yaml_config=yaml_cfg,
+        defaults=BUILT_IN_DEFAULTS,
+    )
+
+    run_identity = RunIdentity.from_args(
+        args,
+        generated_session_id=get_session_id(),
+        require_explicit=False,
+    )
+
+    connect_host = str(getattr(args, "aggregator_host", None) or "127.0.0.1")
+    bind_host = str(getattr(args, "aggregator_bind_host", None) or "127.0.0.1")
+    port = int(getattr(args, "aggregator_port", 29765))
+
+    # Expected worker count so the aggregator waits for ALL ranks before
+    # finalizing (and warns about ranks that never report). Prefer explicit
+    # --nnodes x --nproc-per-node, else TRACEML_EXPECTED_WORLD_SIZE (matching
+    # the `traceml run` launcher), else 1. Without this the finalize gate
+    # treats the first finished rank as "all done" on multi-rank jobs.
+    nnodes = getattr(args, "nnodes", None)
+    nproc = getattr(args, "nproc_per_node", None)
+    if nnodes and nproc:
+        expected_world_size = int(nnodes) * int(nproc)
+    else:
+        env_ws = os.environ.get("TRACEML_EXPECTED_WORLD_SIZE")
+        try:
+            expected_world_size = int(env_ws) if env_ws else 1
+        except ValueError:
+            expected_world_size = 1
+    expected_world_size = max(1, expected_world_size)
+
+    return TraceMLSettings(
+        mode=str(cfg["mode"]),
+        expected_world_size=expected_world_size,
+        render_interval_sec=float(cfg["interval"]),
+        enable_logging=bool(cfg["enable_logging"]),
+        logs_dir=str(cfg["logs_dir"]),
+        history_enabled=bool(cfg["history_enabled"]),
+        dashboard_port=int(cfg["dashboard_port"]),
+        dashboard_auto_open=bool(cfg["dashboard_auto_open"]),
+        finalize_timeout_sec=float(cfg["finalize_timeout_sec"]),
+        session_id=run_identity.session_id,
+        aggregator=AggregatorTransportSettings(
+            connect_host=connect_host,
+            bind_host=bind_host,
+            port=port,
+        ),
+    )
+
+
+def run_serve(args: argparse.Namespace) -> None:
+    """Run the TraceML aggregator standalone in the foreground.
+
+    Starts only the aggregator; it never launches or wraps a user training
+    script. Reuses ``aggregator_main.run_aggregator`` so it binds host/port,
+    prints the reachable endpoint, blocks until SIGINT/SIGTERM, shuts down
+    cleanly, and preserves final-summary behavior.
+    """
+    if getattr(args, "mode", None) == "dashboard":
+        missing = [
+            package
+            for package in ("nicegui", "plotly")
+            if importlib.util.find_spec(package) is None
+        ]
+        if missing:
+            raise SystemExit(
+                "[TraceML] ERROR: "
+                f"{DASHBOARD_EXTRA_INSTALL_HINT} Missing: {', '.join(missing)}."
+            )
+
+    try:
+        settings = _resolve_serve_settings(args)
+    except ValueError as exc:
+        raise SystemExit(f"[TraceML] ERROR: {exc}") from exc
+
+    from traceml_ai.aggregator.aggregator_main import run_aggregator
+
+    raise SystemExit(run_aggregator(settings))
+
+
 def run_inspect(args: argparse.Namespace) -> None:
     """Decode and print binary msgpack logs for debugging."""
     path = Path(args.file)

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -680,7 +680,8 @@ def run_serve(args: argparse.Namespace) -> None:
         if missing:
             raise SystemExit(
                 "[TraceML] ERROR: "
-                f"{DASHBOARD_EXTRA_INSTALL_HINT} Missing: {', '.join(missing)}."
+                f"{DASHBOARD_DEPENDENCY_INSTALL_HINT} "
+                f"Missing: {', '.join(missing)}."
             )
 
     try:

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -22,6 +22,7 @@ from typing import Any, Mapping, Optional
 from traceml_ai.launcher.launch_config import (
     DistributedLaunchConfig,
     RunIdentity,
+    TorchrunLaunchConfig,
 )
 from traceml_ai.launcher.manifest import (
     collect_existing_artifacts,
@@ -163,10 +164,72 @@ def resolve_existing_script_path(script_path: str) -> str:
     return str(path.resolve())
 
 
+def _disable_traceml_requested(
+    args: argparse.Namespace, environ: Mapping[str, str]
+) -> bool:
+    """Return True when the CLI or parent environment requests native launch."""
+    return bool(getattr(args, "disable_traceml", False)) or (
+        environ.get("TRACEML_DISABLED") == "1"
+    )
+
+
+def _disabled_native_env(environ: Mapping[str, str]) -> dict[str, str]:
+    """Copy the user environment while removing stale TraceML settings."""
+    env = {
+        key: value
+        for key, value in environ.items()
+        if not key.startswith("TRACEML_")
+    }
+    env["TRACEML_DISABLED"] = "1"
+    return env
+
+
+def _launch_disabled_process(
+    *,
+    script_path: str,
+    args: argparse.Namespace,
+    torchrun_cfg: Any,
+    launch_context: LaunchContext,
+) -> None:
+    """Launch the target script natively with TraceML disabled."""
+    print(
+        "[TraceML] TraceML is disabled via --disable-traceml. "
+        "Running natively."
+    )
+    train_cmd = [
+        *torchrun_cfg.to_command(),
+        str(script_path),
+        *(args.args or []),
+    ]
+    env = _disabled_native_env(os.environ)
+
+    train_proc: Optional[subprocess.Popen] = None
+    install_shutdown_handlers(lambda: (train_proc,), manifest_path=None)
+    train_proc = start_training_process(
+        train_cmd=train_cmd,
+        env=env,
+        cwd=launch_context.launch_cwd,
+        capture_stderr=False,
+    )
+    train_proc.wait()
+    raise SystemExit(train_proc.returncode)
+
+
 def validate_launch_args(args: argparse.Namespace) -> None:
     """Validate cross-argument constraints for TraceML launch commands."""
+    if _disable_traceml_requested(args, os.environ):
+        try:
+            TorchrunLaunchConfig.from_args(args)
+        except ValueError as exc:
+            raise SystemExit(f"[TraceML] ERROR: {exc}") from exc
+        return
+
     try:
         launch_cfg = DistributedLaunchConfig.from_args(args)
+    except ValueError as exc:
+        raise SystemExit(f"[TraceML] ERROR: {exc}") from exc
+
+    try:
         RunIdentity.from_args(
             args,
             generated_session_id="validation_placeholder",
@@ -209,14 +272,26 @@ def validate_launch_args(args: argparse.Namespace) -> None:
 
 def launch_process(script_path: str, args: argparse.Namespace) -> None:
     """Launch the TraceML aggregator and target training process."""
+    launch_context = LaunchContext.capture()
+
+    if _disable_traceml_requested(args, os.environ):
+        torchrun_cfg = TorchrunLaunchConfig.from_args(args)
+        _launch_disabled_process(
+            script_path=script_path,
+            args=args,
+            torchrun_cfg=torchrun_cfg,
+            launch_context=launch_context,
+        )
+
+    launch_cfg = DistributedLaunchConfig.from_args(args)
+    torchrun_cfg = launch_cfg.torchrun
+
     from traceml_ai.config.yaml_loader import (
         BUILT_IN_DEFAULTS,
         find_config_file,
         load_yaml_config,
         resolve_config,
     )
-
-    launch_context = LaunchContext.capture()
 
     config_path = find_config_file(Path(launch_context.launch_cwd))
     try:
@@ -236,8 +311,6 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
             "TRACEML_UI_MODE": os.environ["TRACEML_MODE"],
         }
 
-    launch_cfg = DistributedLaunchConfig.from_args(args)
-    torchrun_cfg = launch_cfg.torchrun
     aggregator_cfg = launch_cfg.aggregator
     launch_defaults = _launch_defaults_for_topology(
         BUILT_IN_DEFAULTS,
@@ -292,9 +365,7 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
     env = os.environ.copy()
     env["PYTHONUNBUFFERED"] = "1"
 
-    env["TRACEML_DISABLED"] = (
-        "1" if getattr(args, "disable_traceml", False) else "0"
-    )
+    env["TRACEML_DISABLED"] = "0"
     capture_stderr = _stderr_capture_enabled(args, launcher_env)
     env["TRACEML_CAPTURE_STDERR"] = "1" if capture_stderr else "0"
     env["TRACEML_PROFILE"] = getattr(args, "profile", "watch")
@@ -386,44 +457,6 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
     traceml_root = Path(__file__).resolve().parents[1]
     runner_path = str(traceml_root / "runtime" / "executor.py")
     script_args = args.args or []
-
-    if env["TRACEML_DISABLED"] == "1":
-        print(
-            "[TraceML] TraceML is disabled via --disable-traceml. Running natively."
-        )
-        if getattr(args, "html_report", False):
-            print(
-                "[TraceML] --html-report ignored: TraceML is disabled.",
-                file=sys.stderr,
-            )
-        train_cmd = [
-            *torchrun_cfg.to_command(),
-            str(script_path),
-            *script_args,
-        ]
-        train_proc = start_training_process(
-            train_cmd=train_cmd,
-            env=env,
-            cwd=execution_cwd,
-            capture_stderr=capture_stderr,
-        )
-        stderr_capture = (
-            start_stderr_tail_capture(train_proc) if capture_stderr else None
-        )
-        install_shutdown_handlers(
-            lambda: (train_proc, None), manifest_path=manifest_path
-        )
-        train_proc.wait()
-        _finish_stderr_capture(stderr_capture, session_root)
-        final_status = "completed" if train_proc.returncode == 0 else "failed"
-        update_run_manifest(
-            manifest_path,
-            status=final_status,
-            artifacts=collect_existing_artifacts(
-                db_path, session_root=session_root
-            ),
-        )
-        raise SystemExit(train_proc.returncode)
 
     train_cmd = [
         *torchrun_cfg.to_command(),

--- a/src/traceml_ai/launcher/process.py
+++ b/src/traceml_ai/launcher/process.py
@@ -287,7 +287,7 @@ def start_training_process(
     capture_stderr: bool = False,
 ) -> subprocess.Popen:
     """Start the user training process in a separate process group."""
-    print("[TraceML] Launching TraceML executor:", " ".join(train_cmd))
+    print("[TraceML] Launching training process:", " ".join(train_cmd))
     popen_kwargs = {}
     if capture_stderr:
         popen_kwargs["stderr"] = subprocess.PIPE

--- a/src/traceml_ai/renderers/model_diagnostics/renderer.py
+++ b/src/traceml_ai/renderers/model_diagnostics/renderer.py
@@ -67,6 +67,7 @@ class ModelDiagnosticsRenderer(BaseRenderer):
                 step_time_diagnosis_metrics=step_time.diagnosis_metrics,
                 step_time_per_rank_timing=step_time.per_rank_timing,
                 step_time_diagnosis_clock=step_time.diagnosis_clock,
+                step_time_training_strategy=step_time.training_strategy,
                 step_memory_metrics=step_memory.metrics,
                 step_memory_status_message=step_memory.status_message,
                 gpu_total_bytes=None,

--- a/src/traceml_ai/renderers/step_time/compute.py
+++ b/src/traceml_ai/renderers/step_time/compute.py
@@ -13,7 +13,12 @@ STEP_TIME_TABLE = "step_time_samples"
 
 
 class StepCombinedComputer:
-    """Compute selected-clock Step Time diagnosis payloads from SQLite."""
+    """
+    Compute selected-clock Step Time diagnosis payloads from SQLite.
+
+    Live payloads use global-rank ids from SQLite while preserving the existing
+    rank-shaped output contract for CLI/dashboard consumers.
+    """
 
     def __init__(
         self,
@@ -125,16 +130,17 @@ class StepCombinedComputer:
 
     def _load_ranks(self, conn: sqlite3.Connection) -> List[int]:
         """
-        Load available ranks from the step-time table.
+        Load available global ranks from the step-time table.
 
-        Returns only non-null ranks, optionally filtered by `rank_filter`.
+        Returns ids as `rank` values to preserve the existing live payload
+        contract, optionally filtered by `rank_filter`.
         """
         rows = conn.execute(
             f"""
-            SELECT DISTINCT rank
+            SELECT DISTINCT global_rank AS rank
             FROM {self.table}
-            WHERE rank IS NOT NULL
-            ORDER BY rank ASC;
+            WHERE global_rank IS NOT NULL
+            ORDER BY global_rank ASC;
             """
         ).fetchall()
 
@@ -174,7 +180,7 @@ class StepCombinedComputer:
                     FROM (
                         SELECT step, events_json
                         FROM {self.table}
-                        WHERE rank = ?
+                        WHERE global_rank = ?
                         ORDER BY step DESC, id DESC
                         LIMIT ?
                     )

--- a/src/traceml_ai/renderers/step_time/compute.py
+++ b/src/traceml_ai/renderers/step_time/compute.py
@@ -1,13 +1,10 @@
-import json
 import sqlite3
 import time
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Dict, Optional, Sequence
 
 from traceml_ai.loggers.error_log import get_error_logger
 from traceml_ai.renderers.step_time.schema import StepCombinedTimeResult
-from traceml_ai.utils.step_time_window import (
-    build_step_time_window_from_events,
-)
+from traceml_ai.utils.step_time_sqlite import load_step_time_window_from_sqlite
 
 STEP_TIME_TABLE = "step_time_samples"
 
@@ -16,8 +13,9 @@ class StepCombinedComputer:
     """
     Compute selected-clock Step Time diagnosis payloads from SQLite.
 
-    Live payloads use global-rank ids from SQLite while preserving the existing
-    rank-shaped output contract for CLI/dashboard consumers.
+    Live delegates global-rank SQLite loading to the shared Step Time window
+    loader, then adds CLI/dashboard-specific stale handling and status text.
+    The output remains rank-shaped for existing UI and diagnosis consumers.
     """
 
     def __init__(
@@ -79,23 +77,28 @@ class StepCombinedComputer:
         self,
         conn: sqlite3.Connection,
     ) -> StepCombinedTimeResult:
-        ranks = self._load_ranks(conn)
+        loaded = load_step_time_window_from_sqlite(
+            conn,
+            max_rows=self.window_size,
+            lookback_factor=self.lookback_factor,
+            table=self.table,
+            rank_filter=(
+                tuple(self.rank_filter)
+                if self.rank_filter is not None
+                else None
+            ),
+        )
+        ranks = loaded.global_ranks
         if not ranks:
             return StepCombinedTimeResult(
                 status_message="No ranks available",
             )
 
-        per_rank_steps = self._load_last_steps(conn, ranks)
-        if not per_rank_steps:
+        window = loaded.window
+        if window.coverage.ranks_present <= 0:
             return StepCombinedTimeResult(
                 status_message="No StepTime data available",
             )
-
-        window = build_step_time_window_from_events(
-            per_rank_steps,
-            max_rows=self.window_size,
-            expected_ranks=ranks,
-        )
         if not window.metrics:
             return StepCombinedTimeResult(
                 status_message="No common step window yet",
@@ -127,100 +130,6 @@ class StepCombinedComputer:
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
         return conn
-
-    def _load_ranks(self, conn: sqlite3.Connection) -> List[int]:
-        """
-        Load available global ranks from the step-time table.
-
-        Returns ids as `rank` values to preserve the existing live payload
-        contract, optionally filtered by `rank_filter`.
-        """
-        rows = conn.execute(
-            f"""
-            SELECT DISTINCT global_rank AS rank
-            FROM {self.table}
-            WHERE global_rank IS NOT NULL
-            ORDER BY global_rank ASC;
-            """
-        ).fetchall()
-
-        ranks = [int(r["rank"]) for r in rows if r["rank"] is not None]
-        if self.rank_filter is not None:
-            ranks = [r for r in ranks if r in self.rank_filter]
-        return ranks
-
-    def _load_last_steps(
-        self,
-        conn: sqlite3.Connection,
-        ranks: List[int],
-    ) -> Dict[int, Dict[int, Dict[str, Any]]]:
-        """
-        Load a bounded recent step map per rank.
-
-        To avoid scanning the full table, this method only reads a recent
-        suffix per rank. The lookback is intentionally larger than the final
-        window size so the common-step suffix has room to form even when some
-        ranks are slightly ahead/behind.
-
-        Returns
-        -------
-        dict[int, dict[int, dict]]
-            rank -> step -> events_payload
-        """
-        out: Dict[int, Dict[int, Dict[str, Any]]] = {}
-        lookback = max(
-            self.window_size * self.lookback_factor, self.window_size
-        )
-
-        for rank in ranks:
-            try:
-                rows = conn.execute(
-                    f"""
-                    SELECT step, events_json
-                    FROM (
-                        SELECT step, events_json
-                        FROM {self.table}
-                        WHERE global_rank = ?
-                        ORDER BY step DESC, id DESC
-                        LIMIT ?
-                    )
-                    ORDER BY step ASC;
-                    """,
-                    (int(rank), int(lookback)),
-                ).fetchall()
-
-                if not rows:
-                    continue
-
-                step_map: Dict[int, Dict[str, Any]] = {}
-                for row in rows:
-                    step_raw = row["step"]
-                    if step_raw is None:
-                        continue
-
-                    step = int(step_raw)
-                    # If duplicates somehow exist, keep the latest from the DESC/limit
-                    # selection; the final ORDER BY ASC preserves chronological order.
-                    if step in step_map:
-                        continue
-
-                    events_json = row["events_json"]
-                    try:
-                        parsed = json.loads(events_json) if events_json else {}
-                    except Exception:
-                        parsed = {}
-
-                    step_map[step] = parsed if isinstance(parsed, dict) else {}
-
-                if step_map:
-                    out[int(rank)] = step_map
-
-            except Exception:
-                self.logger.exception(
-                    "Failed loading step data for rank=%s", rank
-                )
-
-        return out
 
     # ------------------------------------------------------------------
     # Stale handling

--- a/src/traceml_ai/renderers/step_time/compute.py
+++ b/src/traceml_ai/renderers/step_time/compute.py
@@ -113,6 +113,7 @@ class StepCombinedComputer:
             status_message=status,
             per_rank_timing=window.per_rank_timing,
             diagnosis_clock=window.clock,
+            training_strategy=loaded.training_strategy,
             diagnosis_metrics=window.metrics,
         )
 
@@ -146,6 +147,7 @@ class StepCombinedComputer:
                     status_message=msg,
                     per_rank_timing=self._last_ok.per_rank_timing,
                     diagnosis_clock=self._last_ok.diagnosis_clock,
+                    training_strategy=self._last_ok.training_strategy,
                     diagnosis_metrics=self._last_ok.diagnosis_metrics,
                 )
         return StepCombinedTimeResult(

--- a/src/traceml_ai/renderers/step_time/renderer.py
+++ b/src/traceml_ai/renderers/step_time/renderer.py
@@ -92,6 +92,7 @@ class StepCombinedRenderer(BaseRenderer):
             thresholds=LIVE_STEP_TIME_POLICY.thresholds,
             per_rank_timing=payload.per_rank_timing,
             diagnosis_clock=payload.diagnosis_clock,
+            training_strategy=payload.training_strategy,
         )
         diag_text = format_cli_diagnosis(diag)
         metrics = _table_metrics(payload.diagnosis_metrics)

--- a/src/traceml_ai/renderers/step_time/schema.py
+++ b/src/traceml_ai/renderers/step_time/schema.py
@@ -45,6 +45,7 @@ class StepCombinedTimeResult:
     status_message: str = "OK"
     per_rank_timing: Dict[int, Dict[str, float]] = field(default_factory=dict)
     diagnosis_clock: str = "cpu"
+    training_strategy: str = "ddp"
     diagnosis_metrics: List[StepCombinedTimeMetric] = field(
         default_factory=list
     )

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -89,6 +89,9 @@ Selection policy:
   Live and summary use the same global-rank Step Time SQLite window loader;
   summary uses a larger selected-clock window, but not a separate Step Time
   diagnosis gate.
+- Step Time diagnosis may consume advisory runtime training strategy context
+  when available. This does not add a public summary metric; missing or
+  unrecognized strategy metadata defaults to `ddp`.
 
 High temperature, memory pressure, memory creep, high RSS, high CPU, and other
 resource-health findings are not promoted into `primary_diagnosis` in schema

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -75,8 +75,8 @@ Selection policy:
 
 - `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`, `H2D_STRAGGLER`, and `STRAGGLER`
   use rank-comparison evidence and are promoted from `step_time.diagnosis`.
-- `RESIDUAL_HEAVY`, `INPUT_BOUND`, and `COMPUTE_BOUND` use phase-share evidence
-  and are promoted from `step_time.diagnosis`.
+- `RESIDUAL_HEAVY`, `INPUT_BOUND`, `H2D_BOUND`, and `COMPUTE_BOUND` use
+  phase-share evidence and are promoted from `step_time.diagnosis`.
 - `LOW_GPU_UTILIZATION_UNEXPLAINED` appears only when Step Time is `BALANCED`
   and System reports `LOW_GPU_UTILIZATION` or `MODERATE_GPU_UTILIZATION`.
 - `NO_CLEAR_PERFORMANCE_BOTTLENECK` appears when Step Time is `BALANCED` and
@@ -115,18 +115,17 @@ Primary diagnosis evidence uses a small union:
   "residual_ms": 39.6,
   "shares": {
     "input_wait_pct": 33.3,
-    "h2d_pct": 0.3,
-    "compute_pct": 75.0,
-    "residual_pct": 24.8
+    "h2d_pct": 0.2,
+    "compute_pct": 50.0,
+    "residual_pct": 16.5
   },
   "gpu_util_avg_percent": 37.8
 }
 ```
 
-`phase_share` is used for `INPUT_BOUND`, `RESIDUAL_HEAVY`, and `COMPUTE_BOUND`.
-Values come from `step_time.global.average`. For `INPUT_BOUND`,
-`input_wait_pct` uses `iteration_time_ms = input_wait_ms + step_time_ms`;
-other phase-share percentages use `step_time_ms`.
+`phase_share` is used for `INPUT_BOUND`, `H2D_BOUND`, `RESIDUAL_HEAVY`, and
+`COMPUTE_BOUND`. Values come from `step_time.global.average`. All phase-share
+percentages use `iteration_time_ms = input_wait_ms + step_time_ms`.
 
 ```json
 {
@@ -329,9 +328,8 @@ The public `dataloader_ms` key is kept for compatibility and represents CPU
 dataloader fetch wall time.
 The public `total_step_ms` key is also CPU-clocked for compatibility; it is
 not the denominator for selected-clock phase shares. The final text report
-uses selected-clock `step_time_ms` for most phase shares and labels CPU
-compatibility rows separately. `INPUT_BOUND` input-wait share uses derived
-`iteration_time_ms = input_wait_ms + step_time_ms`.
+uses derived `iteration_time_ms = input_wait_ms + step_time_ms` for every
+selected-clock phase share and labels CPU compatibility rows separately.
 
 `residual_ms` is residual unattributed step time. It is averaged from
 per-step clamped residuals, not recomputed from already-averaged phase totals:

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -84,6 +84,8 @@ Selection policy:
   GPU utilization is not low/moderate.
 - `INSUFFICIENT_STEP_TIME_DATA` appears when Step Time is `NO_DATA` or
   `WARMUP`.
+- Step Time may emit warning-only bottleneck diagnoses before its confident
+  threshold; critical Step Time diagnoses require the confident window size.
 
 High temperature, memory pressure, memory creep, high RSS, high CPU, and other
 resource-health findings are not promoted into `primary_diagnosis` in schema

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -86,7 +86,8 @@ Selection policy:
   `WARMUP`.
 - Step Time may emit warning-only bottleneck diagnoses before its confident
   threshold; critical Step Time diagnoses require the confident window size.
-  Summary uses a larger selected-clock window, but not a separate Step Time
+  Live and summary use the same global-rank Step Time SQLite window loader;
+  summary uses a larger selected-clock window, but not a separate Step Time
   diagnosis gate.
 
 High temperature, memory pressure, memory creep, high RSS, high CPU, and other

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -249,6 +249,9 @@ Fallback evidence types are:
 - `status` is the user-facing display label.
 - `summary` is the short explanation. Older `reason` fields should be treated
   as pre-`1.4` input, not the current final-summary contract.
+- `score` is an optional section-specific ranking signal. In Step Time, scored
+  typical bottlenecks use median per-rank iteration impact and stragglers use
+  visible wait cost divided by victim iteration time.
 - Section-specific details such as `scope`, `samples_used`, `steps_used`,
   `note`, and `confidence` belong in `evidence`.
 - `groups.rows` contains row data only: `identity` and `metrics`.

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -100,12 +100,13 @@ Primary diagnosis evidence uses a small union:
   "dataloader_ms": 40.0,
   "input_wait_ms": 80.0,
   "step_time_ms": 160.0,
+  "iteration_time_ms": 240.0,
   "diagnosis_clock": "gpu",
   "h2d_ms": 0.4,
   "compute_ms": 120.0,
   "residual_ms": 39.6,
   "shares": {
-    "input_wait_pct": 50.0,
+    "input_wait_pct": 33.3,
     "h2d_pct": 0.3,
     "compute_pct": 75.0,
     "residual_pct": 24.8
@@ -115,7 +116,9 @@ Primary diagnosis evidence uses a small union:
 ```
 
 `phase_share` is used for `INPUT_BOUND`, `RESIDUAL_HEAVY`, and `COMPUTE_BOUND`.
-Values come from `step_time.global.average`.
+Values come from `step_time.global.average`. For `INPUT_BOUND`,
+`input_wait_pct` uses `iteration_time_ms = input_wait_ms + step_time_ms`;
+other phase-share percentages use `step_time_ms`.
 
 ```json
 {
@@ -319,8 +322,9 @@ The public `dataloader_ms` key is kept for compatibility and represents CPU
 dataloader fetch wall time.
 The public `total_step_ms` key is also CPU-clocked for compatibility; it is
 not the denominator for selected-clock phase shares. The final text report
-uses selected-clock `step_time_ms` for phase shares and labels CPU
-compatibility rows separately.
+uses selected-clock `step_time_ms` for most phase shares and labels CPU
+compatibility rows separately. `INPUT_BOUND` input-wait share uses derived
+`iteration_time_ms = input_wait_ms + step_time_ms`.
 
 `residual_ms` is residual unattributed step time. It is averaged from
 per-step clamped residuals, not recomputed from already-averaged phase totals:
@@ -329,6 +333,7 @@ per-step clamped residuals, not recomputed from already-averaged phase totals:
 compute_ms = forward_ms + backward_ms + optimizer_ms
 known_step_ms = h2d_ms + compute_ms
 traced_step_ms = selected step envelope timing
+iteration_time_ms = selected input_wait_ms + selected traced_step_ms
 residual_ms = average(max(0, traced_step_ms - known_step_ms))
 total_step_ms = CPU dataloader_ms + CPU step envelope timing
 ```
@@ -338,6 +343,7 @@ The selected-clock diagnosis contract is:
 ```text
 input_wait_ms = selected-clock input wait
 step_time_ms = selected-clock traced step envelope
+iteration_time_ms = input_wait_ms + step_time_ms, emitted only as diagnosis evidence
 diagnosis_clock = "cpu" | "gpu"
 ```
 

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -91,7 +91,8 @@ Selection policy:
   diagnosis gate.
 - Step Time diagnosis may consume advisory runtime training strategy context
   when available. This does not add a public summary metric; missing or
-  unrecognized strategy metadata defaults to `ddp`.
+  unrecognized strategy metadata defaults to `ddp`. FSDP Step Time diagnosis
+  severity is capped at warning.
 
 High temperature, memory pressure, memory creep, high RSS, high CPU, and other
 resource-health findings are not promoted into `primary_diagnosis` in schema

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -73,9 +73,8 @@ section diagnoses.
 
 Selection policy:
 
-- `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`, `H2D_STRAGGLER`,
-  `RESIDUAL_STRAGGLER`, and `STRAGGLER` use rank-comparison evidence and are
-  promoted from `step_time.diagnosis`.
+- `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`, `H2D_STRAGGLER`, and `STRAGGLER`
+  use rank-comparison evidence and are promoted from `step_time.diagnosis`.
 - `RESIDUAL_HEAVY`, `INPUT_BOUND`, and `COMPUTE_BOUND` use phase-share evidence
   and are promoted from `step_time.diagnosis`.
 - `LOW_GPU_UTILIZATION_UNEXPLAINED` appears only when Step Time is `BALANCED`
@@ -144,10 +143,9 @@ other phase-share percentages use `step_time_ms`.
 ```
 
 `rank_comparison` is used for `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`,
-`H2D_STRAGGLER`, `RESIDUAL_STRAGGLER`, and `STRAGGLER`. Values come from
-`step_time.global.median[metric]` and
-`step_time.global.worst[metric]`. Generic `STRAGGLER` may contain a
-`comparisons` array instead of a single metric comparison.
+`H2D_STRAGGLER`, and `STRAGGLER`. Values come from `step_time.global` rank
+summaries. Generic `STRAGGLER` may contain a `comparisons` array instead of a
+single metric comparison.
 
 Fallback evidence types are:
 

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -86,6 +86,8 @@ Selection policy:
   `WARMUP`.
 - Step Time may emit warning-only bottleneck diagnoses before its confident
   threshold; critical Step Time diagnoses require the confident window size.
+  Summary uses a larger selected-clock window, but not a separate Step Time
+  diagnosis gate.
 
 High temperature, memory pressure, memory creep, high RSS, high CPU, and other
 resource-health findings are not promoted into `primary_diagnosis` in schema

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -113,19 +113,18 @@ Primary diagnosis evidence uses a small union:
   "h2d_ms": 0.4,
   "compute_ms": 120.0,
   "residual_ms": 39.6,
-  "shares": {
-    "input_wait_pct": 33.3,
-    "h2d_pct": 0.2,
-    "compute_pct": 50.0,
-    "residual_pct": 16.5
-  },
+  "score": 0.333,
+  "score_basis": "median_per_rank_iteration_share",
+  "score_denominator": "input_wait_ms + step_time_ms per rank",
   "gpu_util_avg_percent": 37.8
 }
 ```
 
 `phase_share` is used for `INPUT_BOUND`, `H2D_BOUND`, `RESIDUAL_HEAVY`, and
-`COMPUTE_BOUND`. Values come from `step_time.global.average`. All phase-share
-percentages use `iteration_time_ms = input_wait_ms + step_time_ms`.
+`COMPUTE_BOUND`. Millisecond values come from `step_time.global.average` and
+are supporting observations only. For scored typical bottlenecks, `score` is
+the authoritative median per-rank iteration-impact fraction. Informational
+`COMPUTE_BOUND` has no fabricated iteration-impact score.
 
 ```json
 {
@@ -333,6 +332,8 @@ The public `total_step_ms` key is also CPU-clocked for compatibility; it is
 not the denominator for selected-clock phase shares. The final text report
 uses derived `iteration_time_ms = input_wait_ms + step_time_ms` for every
 selected-clock phase share and labels CPU compatibility rows separately.
+Those table shares are observational averages and may differ from the
+authoritative median per-rank diagnosis `score`.
 
 `residual_ms` is residual unattributed step time. It is averaged from
 per-step clamped residuals, not recomputed from already-averaged phase totals:

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -124,7 +124,10 @@ Primary diagnosis evidence uses a small union:
 `COMPUTE_BOUND`. Millisecond values come from `step_time.global.average` and
 are supporting observations only. For scored typical bottlenecks, `score` is
 the authoritative median per-rank iteration-impact fraction. Informational
-`COMPUTE_BOUND` has no fabricated iteration-impact score.
+`COMPUTE_BOUND` uses the median per-rank
+`(forward_ms + backward_ms + optimizer_ms) / iteration_time_ms` share with a
+90% threshold, but has no score because it is excluded from impact-based
+primary ordering.
 
 ```json
 {

--- a/src/traceml_ai/reporting/final.py
+++ b/src/traceml_ai/reporting/final.py
@@ -604,6 +604,12 @@ def _append_step_time_evidence_single(
     """Append selected-clock average/share Step Time evidence."""
     widths = (16, 16, 12)
     share_total = _average_value(step_time_summary, "step_time_ms")
+    input_wait = _average_value(step_time_summary, "input_wait_ms")
+    iteration_time = (
+        input_wait + share_total
+        if input_wait is not None and share_total is not None
+        else None
+    )
     lines.append(row("Step Time Evidence", width=SUMMARY_WIDTH))
     lines.append(
         row(
@@ -616,8 +622,10 @@ def _append_step_time_evidence_single(
         value = _average_value(step_time_summary, metric)
         if metric in _STEP_TIME_CPU_COMPAT_METRICS:
             # These fields stay CPU-clocked for compatibility; selected-clock
-            # phase shares use step_time_ms as the denominator.
+            # phase shares generally use step_time_ms as the denominator.
             share = "compat"
+        elif metric == "input_wait_ms":
+            share = _format_share(value, iteration_time)
         elif metric == "step_time_ms":
             share = "100.0%"
         else:

--- a/src/traceml_ai/reporting/final.py
+++ b/src/traceml_ai/reporting/final.py
@@ -603,11 +603,11 @@ def _append_step_time_evidence_single(
 ) -> None:
     """Append selected-clock average/share Step Time evidence."""
     widths = (16, 16, 12)
-    share_total = _average_value(step_time_summary, "step_time_ms")
+    step_time = _average_value(step_time_summary, "step_time_ms")
     input_wait = _average_value(step_time_summary, "input_wait_ms")
     iteration_time = (
-        input_wait + share_total
-        if input_wait is not None and share_total is not None
+        input_wait + step_time
+        if input_wait is not None and step_time is not None
         else None
     )
     lines.append(row("Step Time Evidence", width=SUMMARY_WIDTH))
@@ -622,14 +622,10 @@ def _append_step_time_evidence_single(
         value = _average_value(step_time_summary, metric)
         if metric in _STEP_TIME_CPU_COMPAT_METRICS:
             # These fields stay CPU-clocked for compatibility; selected-clock
-            # phase shares generally use step_time_ms as the denominator.
+            # phase shares use selected-clock iteration time as the denominator.
             share = "compat"
-        elif metric == "input_wait_ms":
-            share = _format_share(value, iteration_time)
-        elif metric == "step_time_ms":
-            share = "100.0%"
         else:
-            share = _format_share(value, share_total)
+            share = _format_share(value, iteration_time)
         lines.append(
             row(
                 _table_line(

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -224,11 +224,18 @@ def _phase_share_evidence(
     *,
     step_time_summary: Mapping[str, Any],
     system_summary: Mapping[str, Any],
+    include_iteration_time: bool = False,
 ) -> JsonDict:
     """Build evidence for diagnoses based on average step-time shares."""
     average = _global_average(step_time_summary)
     total_ms = _float_or_none(average.get("total_step_ms"))
     step_time_ms = _float_or_none(average.get("step_time_ms"))
+    input_wait_ms = _float_or_none(average.get("input_wait_ms"))
+    iteration_time_ms = (
+        input_wait_ms + step_time_ms
+        if input_wait_ms is not None and step_time_ms is not None
+        else None
+    )
     denominator_ms = step_time_ms or total_ms
     window = _global_window(step_time_summary)
     evidence: JsonDict = {
@@ -240,6 +247,8 @@ def _phase_share_evidence(
         "diagnosis_clock": window.get("diagnosis_clock"),
         "dataloader_ms": _round(_float_or_none(average.get("dataloader_ms"))),
     }
+    if include_iteration_time:
+        evidence["iteration_time_ms"] = _round(iteration_time_ms)
 
     for metric in PHASE_METRICS:
         evidence[metric] = _round(_float_or_none(average.get(metric)))
@@ -248,9 +257,16 @@ def _phase_share_evidence(
     for metric in PHASE_METRICS:
         value = _float_or_none(average.get(metric))
         key = metric.replace("_ms", "_pct")
+        metric_denominator_ms = (
+            iteration_time_ms if metric == "input_wait_ms" else denominator_ms
+        )
         shares[key] = (
-            _round(100.0 * value / denominator_ms)
-            if value is not None and denominator_ms and denominator_ms > 0.0
+            _round(100.0 * value / metric_denominator_ms)
+            if (
+                value is not None
+                and metric_denominator_ms
+                and metric_denominator_ms > 0.0
+            )
             else None
         )
     evidence["shares"] = shares
@@ -429,13 +445,13 @@ def _phase_share_summary(kind: str, evidence: Mapping[str, Any]) -> str:
     )
     if kind == "INPUT_BOUND":
         value = _float_or_none(evidence.get("input_wait_ms"))
-        step_time = _float_or_none(evidence.get("step_time_ms"))
-        if value is not None and step_time is not None:
+        iteration_time = _float_or_none(evidence.get("iteration_time_ms"))
+        if value is not None and iteration_time is not None:
             return (
-                f"Input wait was {value:.1f}ms before a "
-                f"{step_time:.1f}ms traced step."
+                f"Input wait was {value:.1f}ms of "
+                f"{iteration_time:.1f}ms iteration time."
             )
-        return "Input wait was a large pre-step delay."
+        return "Input wait took a large share of iteration time."
     if kind == "RESIDUAL_HEAVY":
         value = _float_or_none(evidence.get("residual_ms"))
         if value is not None and total is not None:
@@ -502,6 +518,7 @@ def _promote_step_time_primary(
         evidence = _phase_share_evidence(
             step_time_summary=step_time_summary,
             system_summary=system_summary,
+            include_iteration_time=(kind == "INPUT_BOUND"),
         )
         summary = _phase_share_summary(kind, evidence)
     else:

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -26,7 +26,7 @@ Primary diagnosis policy
 ------------------------
 1. Step-time rank-skew findings become primary performance findings:
    ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``, ``H2D_STRAGGLER``,
-   ``RESIDUAL_STRAGGLER``, ``STRAGGLER``.
+   ``STRAGGLER``.
 2. Step-time phase-share findings become primary performance findings:
    ``RESIDUAL_HEAVY``, ``INPUT_BOUND``, ``COMPUTE_BOUND``.
 3. If Step Time is ``BALANCED`` and System reports low or moderate GPU
@@ -54,9 +54,8 @@ Evidence policy
 
 ``rank_comparison``
     Used for ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``,
-    ``H2D_STRAGGLER``, ``RESIDUAL_STRAGGLER``, and ``STRAGGLER``. Values come
-    from ``step_time.global.median[metric]`` and
-    ``step_time.global.worst[metric]`` because the diagnosis compares ranks.
+    ``H2D_STRAGGLER``, and ``STRAGGLER``. Values come from step-time rank
+    summaries because the diagnosis compares ranks.
 
 ``utilization_fallback``
     Used only when Step Time is balanced and System GPU utilization is low or
@@ -86,7 +85,6 @@ STRAGGLER_KINDS = {
     "INPUT_STRAGGLER",
     "COMPUTE_STRAGGLER",
     "H2D_STRAGGLER",
-    "RESIDUAL_STRAGGLER",
     "STRAGGLER",
 }
 INSUFFICIENT_STEP_TIME_KINDS = {"NO_DATA", "WARMUP"}
@@ -286,8 +284,6 @@ def _metric_for_step_time_issue(issue: Mapping[str, Any]) -> Optional[str]:
         return "compute_ms"
     if kind == "H2D_STRAGGLER":
         return "h2d_ms"
-    if kind == "RESIDUAL_STRAGGLER":
-        return "residual_ms"
     return None
 
 
@@ -305,8 +301,6 @@ def _metric_for_primary_diagnosis(
         return "compute_ms"
     if kind == "H2D_STRAGGLER":
         return "h2d_ms"
-    if kind == "RESIDUAL_STRAGGLER":
-        return "residual_ms"
     return None
 
 
@@ -477,7 +471,7 @@ def _rank_comparison_summary(
 ) -> str:
     """Return a concise primary summary for rank-comparison diagnoses."""
     if kind == "STRAGGLER":
-        return "Multiple clean-step components varied across ranks."
+        return "Visible rank skew was sync-bound or unattributed."
 
     metric = str(evidence.get("metric") or "step_time")
     phase = str(evidence.get("phase") or metric.replace("_ms", ""))

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -382,6 +382,36 @@ def _rank_comparison_evidence(
     return evidence
 
 
+def _step_time_score_evidence(
+    *,
+    kind: str,
+    diagnosis: Mapping[str, Any],
+) -> JsonDict:
+    """Return the exact policy score and denominator for a promoted finding."""
+    score = _float_or_none(diagnosis.get("score"))
+    if score is None:
+        return {}
+
+    if kind in PHASE_SHARE_KINDS:
+        return {
+            "score": score,
+            "score_basis": "median_per_rank_iteration_share",
+            "score_denominator": "input_wait_ms + step_time_ms per rank",
+        }
+
+    issue_evidence = _mapping(diagnosis.get("evidence"))
+    return {
+        "score": score,
+        "score_basis": "visible_cost_ms / victim_iteration_time_ms",
+        "score_numerator_ms": _float_or_none(
+            issue_evidence.get("visible_cost_ms")
+        ),
+        "score_denominator_ms": _float_or_none(
+            issue_evidence.get("iteration_time_ms")
+        ),
+    }
+
+
 def _straggler_comparisons(
     *,
     step_time_summary: Mapping[str, Any],
@@ -529,6 +559,7 @@ def _promote_step_time_primary(
             diagnosis=diagnosis,
         )
         summary = _rank_comparison_summary(kind, evidence)
+    evidence.update(_step_time_score_evidence(kind=kind, diagnosis=diagnosis))
 
     return _primary_payload(
         kind=kind,

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -28,7 +28,7 @@ Primary diagnosis policy
    ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``, ``H2D_STRAGGLER``,
    ``STRAGGLER``.
 2. Step-time phase-share findings become primary performance findings:
-   ``RESIDUAL_HEAVY``, ``INPUT_BOUND``, ``COMPUTE_BOUND``.
+   ``RESIDUAL_HEAVY``, ``INPUT_BOUND``, ``H2D_BOUND``, ``COMPUTE_BOUND``.
 3. If Step Time is ``BALANCED`` and System reports low or moderate GPU
    utilization, the primary becomes ``LOW_GPU_UTILIZATION_UNEXPLAINED``.
    GPU utilization is treated as a symptom or fallback, not root-cause proof.
@@ -48,9 +48,9 @@ primary.
 Evidence policy
 ---------------
 ``phase_share``
-    Used for ``INPUT_BOUND``, ``RESIDUAL_HEAVY``, and ``COMPUTE_BOUND``. Values
-    come from ``step_time.global.average`` because the diagnosis describes
-    where the average step time went.
+    Used for ``INPUT_BOUND``, ``H2D_BOUND``, ``RESIDUAL_HEAVY``, and
+    ``COMPUTE_BOUND``. Values come from ``step_time.global.average`` because
+    the diagnosis describes where the average step time went.
 
 ``rank_comparison``
     Used for ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``,
@@ -80,7 +80,12 @@ JsonDict = Dict[str, Any]
 STEP_TIME_SECTION = "step_time"
 PERFORMANCE_SCOPE = "performance"
 
-PHASE_SHARE_KINDS = {"INPUT_BOUND", "RESIDUAL_HEAVY", "COMPUTE_BOUND"}
+PHASE_SHARE_KINDS = {
+    "INPUT_BOUND",
+    "H2D_BOUND",
+    "RESIDUAL_HEAVY",
+    "COMPUTE_BOUND",
+}
 STRAGGLER_KINDS = {
     "INPUT_STRAGGLER",
     "COMPUTE_STRAGGLER",
@@ -222,9 +227,8 @@ def _phase_share_evidence(
     *,
     step_time_summary: Mapping[str, Any],
     system_summary: Mapping[str, Any],
-    include_iteration_time: bool = False,
 ) -> JsonDict:
-    """Build evidence for diagnoses based on average step-time shares."""
+    """Build evidence with selected-clock iteration-time phase shares."""
     average = _global_average(step_time_summary)
     total_ms = _float_or_none(average.get("total_step_ms"))
     step_time_ms = _float_or_none(average.get("step_time_ms"))
@@ -234,7 +238,6 @@ def _phase_share_evidence(
         if input_wait_ms is not None and step_time_ms is not None
         else None
     )
-    denominator_ms = step_time_ms or total_ms
     window = _global_window(step_time_summary)
     evidence: JsonDict = {
         "type": "phase_share",
@@ -245,8 +248,7 @@ def _phase_share_evidence(
         "diagnosis_clock": window.get("diagnosis_clock"),
         "dataloader_ms": _round(_float_or_none(average.get("dataloader_ms"))),
     }
-    if include_iteration_time:
-        evidence["iteration_time_ms"] = _round(iteration_time_ms)
+    evidence["iteration_time_ms"] = _round(iteration_time_ms)
 
     for metric in PHASE_METRICS:
         evidence[metric] = _round(_float_or_none(average.get(metric)))
@@ -255,15 +257,12 @@ def _phase_share_evidence(
     for metric in PHASE_METRICS:
         value = _float_or_none(average.get(metric))
         key = metric.replace("_ms", "_pct")
-        metric_denominator_ms = (
-            iteration_time_ms if metric == "input_wait_ms" else denominator_ms
-        )
         shares[key] = (
-            _round(100.0 * value / metric_denominator_ms)
+            _round(100.0 * value / iteration_time_ms)
             if (
                 value is not None
-                and metric_denominator_ms
-                and metric_denominator_ms > 0.0
+                and iteration_time_ms
+                and iteration_time_ms > 0.0
             )
             else None
         )
@@ -446,6 +445,15 @@ def _phase_share_summary(kind: str, evidence: Mapping[str, Any]) -> str:
                 f"{iteration_time:.1f}ms iteration time."
             )
         return "Input wait took a large share of iteration time."
+    if kind == "H2D_BOUND":
+        value = _float_or_none(evidence.get("h2d_ms"))
+        iteration_time = _float_or_none(evidence.get("iteration_time_ms"))
+        if value is not None and iteration_time is not None:
+            return (
+                f"H2D transfer took {value:.1f}ms of "
+                f"{iteration_time:.1f}ms iteration time."
+            )
+        return "H2D transfer took a large share of iteration time."
     if kind == "RESIDUAL_HEAVY":
         value = _float_or_none(evidence.get("residual_ms"))
         if value is not None and total is not None:
@@ -512,7 +520,6 @@ def _promote_step_time_primary(
         evidence = _phase_share_evidence(
             step_time_summary=step_time_summary,
             system_summary=system_summary,
-            include_iteration_time=(kind == "INPUT_BOUND"),
         )
         summary = _phase_share_summary(kind, evidence)
     else:

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -49,13 +49,15 @@ Evidence policy
 ---------------
 ``phase_share``
     Used for ``INPUT_BOUND``, ``H2D_BOUND``, ``RESIDUAL_HEAVY``, and
-    ``COMPUTE_BOUND``. Values come from ``step_time.global.average`` because
-    the diagnosis describes where the average step time went.
+    ``COMPUTE_BOUND``. Raw timing values from ``step_time.global.average`` are
+    supporting observations; the promoted diagnosis keeps the policy score
+    emitted by Step Time.
 
 ``rank_comparison``
     Used for ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``,
-    ``H2D_STRAGGLER``, and ``STRAGGLER``. Values come from step-time rank
-    summaries because the diagnosis compares ranks.
+    ``H2D_STRAGGLER``, and ``STRAGGLER``. Rank summaries are supporting
+    observations; culprit, victim, impact, and attribution remain owned by
+    the Step Time diagnosis.
 
 ``utilization_fallback``
     Used only when Step Time is balanced and System GPU utilization is low or
@@ -228,7 +230,7 @@ def _phase_share_evidence(
     step_time_summary: Mapping[str, Any],
     system_summary: Mapping[str, Any],
 ) -> JsonDict:
-    """Build evidence with selected-clock iteration-time phase shares."""
+    """Build supporting average phase observations for a Step Time finding."""
     average = _global_average(step_time_summary)
     total_ms = _float_or_none(average.get("total_step_ms"))
     step_time_ms = _float_or_none(average.get("step_time_ms"))
@@ -253,20 +255,6 @@ def _phase_share_evidence(
     for metric in PHASE_METRICS:
         evidence[metric] = _round(_float_or_none(average.get(metric)))
 
-    shares: JsonDict = {}
-    for metric in PHASE_METRICS:
-        value = _float_or_none(average.get(metric))
-        key = metric.replace("_ms", "_pct")
-        shares[key] = (
-            _round(100.0 * value / iteration_time_ms)
-            if (
-                value is not None
-                and iteration_time_ms
-                and iteration_time_ms > 0.0
-            )
-            else None
-        )
-    evidence["shares"] = shares
     evidence["gpu_util_avg_percent"] = _round(_gpu_util_avg(system_summary))
     return evidence
 
@@ -461,83 +449,6 @@ def _straggler_comparisons(
     ]
 
 
-def _phase_share_summary(kind: str, evidence: Mapping[str, Any]) -> str:
-    """Return a concise primary summary for phase-share diagnoses."""
-    total = _float_or_none(evidence.get("step_time_ms")) or _float_or_none(
-        evidence.get("total_step_ms")
-    )
-    if kind == "INPUT_BOUND":
-        value = _float_or_none(evidence.get("input_wait_ms"))
-        iteration_time = _float_or_none(evidence.get("iteration_time_ms"))
-        if value is not None and iteration_time is not None:
-            return (
-                f"Input wait was {value:.1f}ms of "
-                f"{iteration_time:.1f}ms iteration time."
-            )
-        return "Input wait took a large share of iteration time."
-    if kind == "H2D_BOUND":
-        value = _float_or_none(evidence.get("h2d_ms"))
-        iteration_time = _float_or_none(evidence.get("iteration_time_ms"))
-        if value is not None and iteration_time is not None:
-            return (
-                f"H2D transfer took {value:.1f}ms of "
-                f"{iteration_time:.1f}ms iteration time."
-            )
-        return "H2D transfer took a large share of iteration time."
-    if kind == "RESIDUAL_HEAVY":
-        value = _float_or_none(evidence.get("residual_ms"))
-        if value is not None and total is not None:
-            return (
-                f"Residual time took {value:.1f}ms of a "
-                f"{total:.1f}ms average step."
-            )
-        return "Residual time took a large share of step time."
-    if kind == "COMPUTE_BOUND":
-        value = _float_or_none(evidence.get("compute_ms"))
-        if value is not None and total is not None:
-            return (
-                f"Model compute took {value:.1f}ms of a "
-                f"{total:.1f}ms average step."
-            )
-        return "Most step time was model compute."
-    return "Step time was dominated by one phase."
-
-
-def _rank_comparison_summary(
-    kind: str,
-    evidence: Mapping[str, Any],
-) -> str:
-    """Return a concise primary summary for rank-comparison diagnoses."""
-    if kind == "STRAGGLER":
-        return "Visible rank skew was sync-bound or unattributed."
-
-    metric = str(evidence.get("metric") or "step_time")
-    phase = str(evidence.get("phase") or metric.replace("_ms", ""))
-    phase_label = {
-        "dataloader": "input wait",
-        "input": "input wait",
-        "residual": "residual time",
-    }.get(phase, phase)
-    median = _mapping(evidence.get("median"))
-    worst = _mapping(evidence.get("worst"))
-    worst_rank = _int_or_none(worst.get("rank"))
-    median_rank = _int_or_none(median.get("rank"))
-    worst_value = _float_or_none(worst.get("value_ms"))
-    median_value = _float_or_none(median.get("value_ms"))
-
-    if (
-        worst_rank is not None
-        and median_rank is not None
-        and worst_value is not None
-        and median_value is not None
-    ):
-        return (
-            f"Rank r{worst_rank} {phase_label} was {worst_value:.1f}ms "
-            f"vs median rank r{median_rank} at {median_value:.1f}ms."
-        )
-    return "One rank was materially slower than its peers."
-
-
 def _promote_step_time_primary(
     *,
     kind: str,
@@ -551,14 +462,12 @@ def _promote_step_time_primary(
             step_time_summary=step_time_summary,
             system_summary=system_summary,
         )
-        summary = _phase_share_summary(kind, evidence)
     else:
         evidence = _rank_comparison_evidence(
             step_time_summary=step_time_summary,
             system_summary=system_summary,
             diagnosis=diagnosis,
         )
-        summary = _rank_comparison_summary(kind, evidence)
     evidence.update(_step_time_score_evidence(kind=kind, diagnosis=diagnosis))
 
     return _primary_payload(
@@ -566,7 +475,7 @@ def _promote_step_time_primary(
         status=_diag_field(diagnosis, "status", kind),
         severity=_diag_field(diagnosis, "severity", "info"),
         section=STEP_TIME_SECTION,
-        summary=summary or _diag_field(diagnosis, "summary", ""),
+        summary=_diag_field(diagnosis, "summary", ""),
         action=_diag_field(diagnosis, "action", ""),
         evidence=evidence,
     )

--- a/src/traceml_ai/reporting/sections/step_time/__init__.py
+++ b/src/traceml_ai/reporting/sections/step_time/__init__.py
@@ -60,6 +60,7 @@ class StepTimeSummarySection(
         """Adapt the canonical Step Time window to diagnosis."""
         return StepTimeDiagnosisInput(
             window=data.step_time_window,
+            training_strategy=data.training_strategy,
         )
 
     def diagnose(

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -363,17 +363,8 @@ def _step_time_card_reason(
             f"{_global_rank_label(stats.h2d.worst_global_rank)} H2D was "
             f"slower than median global rank ({evidence})."
         )
-    if kind == "RESIDUAL_STRAGGLER":
-        evidence = _format_ms_pair(
-            stats.residual.worst_ms,
-            stats.residual.median_ms,
-        )
-        return (
-            f"{_global_rank_label(stats.residual.worst_global_rank)} residual "
-            f"time was higher than median global rank ({evidence})."
-        )
     if kind == "STRAGGLER":
-        return "Multiple clean-step components varied across ranks."
+        return "Visible rank skew was sync-bound or unattributed."
     if kind == "INPUT_BOUND":
         issue = _issue_by_kind(issues, "INPUT_BOUND")
         evidence_reason = _input_bound_evidence_reason(issue or diagnosis)

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -265,15 +265,21 @@ def _input_bound_evidence_reason(diagnosis: Any) -> Optional[str]:
     evidence = _diagnosis_evidence(diagnosis)
     input_wait_ms = evidence.get("input_wait_ms")
     step_time_ms = evidence.get("step_time_ms")
+    iteration_time_ms = evidence.get("iteration_time_ms")
     diagnosis_clock = str(evidence.get("diagnosis_clock") or "").lower()
     if input_wait_ms is None or step_time_ms is None:
         return None
+    if iteration_time_ms is None:
+        try:
+            iteration_time_ms = float(input_wait_ms) + float(step_time_ms)
+        except Exception:
+            return None
     clock_text = (
         f" {diagnosis_clock}" if diagnosis_clock in {"cpu", "gpu"} else ""
     )
     return (
-        f"Input wait was {format_ms(input_wait_ms)} before a "
-        f"{format_ms(step_time_ms)}{clock_text} traced step."
+        f"Input wait was {format_ms(input_wait_ms)} of "
+        f"{format_ms(iteration_time_ms)}{clock_text} iteration time."
     )
 
 

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -373,6 +373,12 @@ def _step_time_card_reason(
         return str(
             getattr(diagnosis, "reason", "") or "Input wait was high."
         ).strip()
+    if kind == "H2D_BOUND":
+        evidence = (
+            f"{format_ms(stats.h2d.worst_ms)}/"
+            f"{format_ms(stats.total_step.worst_ms)}"
+        )
+        return f"H2D transfer was high inside the total step ({evidence})."
     if kind == "RESIDUAL_HEAVY":
         evidence = (
             f"{format_ms(stats.residual.worst_ms)}/"

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -232,173 +232,6 @@ def _format_card_ranks(stats: StepTimeCardStats) -> Optional[str]:
     )
 
 
-def _largest_compute_phase(
-    summary: Optional[RankStepSummary],
-) -> Optional[str]:
-    """Return the largest compute bucket for one rank summary."""
-    if summary is None:
-        return None
-    values = {
-        "forward": finite_float(summary.avg_forward_ms),
-        "backward": finite_float(summary.avg_backward_ms),
-        "optimizer": finite_float(summary.avg_optimizer_ms),
-    }
-    return max(values, key=values.get) if values else None
-
-
-def _issue_by_kind(issues: tuple[Any, ...], kind: str) -> Optional[Any]:
-    """Return the first issue with the requested kind."""
-    for issue in issues:
-        if str(getattr(issue, "kind", "") or "") == kind:
-            return issue
-    return None
-
-
-def _diagnosis_evidence(diagnosis: Any) -> Dict[str, Any]:
-    """Return diagnosis evidence as a plain mapping."""
-    evidence = getattr(diagnosis, "evidence", None)
-    return evidence if isinstance(evidence, dict) else {}
-
-
-def _input_bound_evidence_reason(diagnosis: Any) -> Optional[str]:
-    """Build a short input-bound reason from selected-clock evidence."""
-    evidence = _diagnosis_evidence(diagnosis)
-    input_wait_ms = evidence.get("input_wait_ms")
-    step_time_ms = evidence.get("step_time_ms")
-    iteration_time_ms = evidence.get("iteration_time_ms")
-    diagnosis_clock = str(evidence.get("diagnosis_clock") or "").lower()
-    if input_wait_ms is None or step_time_ms is None:
-        return None
-    if iteration_time_ms is None:
-        try:
-            iteration_time_ms = float(input_wait_ms) + float(step_time_ms)
-        except Exception:
-            return None
-    clock_text = (
-        f" {diagnosis_clock}" if diagnosis_clock in {"cpu", "gpu"} else ""
-    )
-    return (
-        f"Input wait was {format_ms(input_wait_ms)} of "
-        f"{format_ms(iteration_time_ms)}{clock_text} iteration time."
-    )
-
-
-def _compute_phase_pair_from_rank_values(
-    phase: str,
-    per_global_rank_summary: Dict[int, RankStepSummary],
-) -> StepTimeMetricPair:
-    """Return median/worst timing values for one compute phase."""
-    phase_key = str(phase or "").lower()
-    field_by_phase = {
-        "forward": "avg_forward_ms",
-        "backward": "avg_backward_ms",
-        "optimizer": "avg_optimizer_ms",
-    }
-    field_name = field_by_phase.get(phase_key)
-    if field_name is None:
-        return StepTimeMetricPair(None, None, None, None)
-
-    return _metric_pair_from_rank_values(
-        {
-            int(rank): finite_float(getattr(summary, field_name))
-            for rank, summary in per_global_rank_summary.items()
-        }
-    )
-
-
-def _step_time_card_reason(
-    diagnosis: Any,
-    *,
-    stats: Optional[StepTimeCardStats],
-    per_global_rank_summary: Dict[int, RankStepSummary],
-    issues: tuple[Any, ...] = (),
-) -> str:
-    """Build the short `Why` line used only by the human card."""
-    kind = str(getattr(diagnosis, "kind", "") or "")
-    if kind == "NO_DATA":
-        return "Need more step-time samples."
-    if kind == "WARMUP":
-        return str(getattr(diagnosis, "reason", "") or "").strip()
-    if stats is None:
-        return str(getattr(diagnosis, "reason", "") or "n/a")
-
-    if kind == "BALANCED":
-        return "No clear timing bottleneck."
-    if kind == "INPUT_STRAGGLER":
-        evidence = _format_ms_pair(stats.input.worst_ms, stats.input.median_ms)
-        return (
-            f"{_global_rank_label(stats.input.worst_global_rank)} input was "
-            f"slower than median global rank ({evidence})."
-        )
-    if kind == "COMPUTE_STRAGGLER":
-        issue = _issue_by_kind(issues, "COMPUTE_STRAGGLER")
-        phase = str(getattr(issue, "phase", "") or "").lower()
-        phase_stats = _compute_phase_pair_from_rank_values(
-            phase,
-            per_global_rank_summary,
-        )
-        if phase_stats.worst_ms is not None:
-            ranks = tuple(getattr(issue, "ranks", ()) or ())
-            rank = int(ranks[0]) if ranks else phase_stats.worst_global_rank
-            evidence = _format_ms_pair(
-                phase_stats.worst_ms,
-                phase_stats.median_ms,
-            )
-            return (
-                f"{_global_rank_label(rank)} {phase} was slower than "
-                f"peer median ({evidence})."
-            )
-
-        evidence = _format_ms_pair(
-            stats.compute.worst_ms,
-            stats.compute.median_ms,
-        )
-        return (
-            f"{_global_rank_label(stats.compute.worst_global_rank)} compute "
-            f"was slower than median global rank ({evidence})."
-        )
-    if kind == "H2D_STRAGGLER":
-        evidence = _format_ms_pair(stats.h2d.worst_ms, stats.h2d.median_ms)
-        return (
-            f"{_global_rank_label(stats.h2d.worst_global_rank)} H2D was "
-            f"slower than median global rank ({evidence})."
-        )
-    if kind == "STRAGGLER":
-        return "Visible rank skew was sync-bound or unattributed."
-    if kind == "INPUT_BOUND":
-        issue = _issue_by_kind(issues, "INPUT_BOUND")
-        evidence_reason = _input_bound_evidence_reason(issue or diagnosis)
-        if evidence_reason:
-            return evidence_reason
-        return str(
-            getattr(diagnosis, "reason", "") or "Input wait was high."
-        ).strip()
-    if kind == "H2D_BOUND":
-        evidence = (
-            f"{format_ms(stats.h2d.worst_ms)}/"
-            f"{format_ms(stats.total_step.worst_ms)}"
-        )
-        return f"H2D transfer was high inside the total step ({evidence})."
-    if kind == "RESIDUAL_HEAVY":
-        evidence = (
-            f"{format_ms(stats.residual.worst_ms)}/"
-            f"{format_ms(stats.total_step.worst_ms)}"
-        )
-        return f"Residual time was high inside the total step ({evidence})."
-    if kind == "COMPUTE_BOUND":
-        summary = per_global_rank_summary.get(stats.compute.worst_global_rank)
-        phase = _largest_compute_phase(summary)
-        suffix = f"; {phase} was largest" if phase else ""
-        evidence = (
-            f"{format_ms(stats.compute.worst_ms)}/"
-            f"{format_ms(stats.total_step.worst_ms)}"
-        )
-        return f"Compute dominated ({evidence}){suffix}."
-
-    reason = str(getattr(diagnosis, "reason", "") or "").strip()
-    return reason or "No clear timing bottleneck."
-
-
 def _global_rank_entry_to_json(
     global_rank: int,
     summary: RankStepSummary,
@@ -456,6 +289,7 @@ def build_step_time_payload(
     summary_diag = diagnosis_result.primary
     issues = diagnosis_result.issues
     diagnosis_json, issues_json = diagnostic_result_to_json(diagnosis_result)
+    primary_issue = issues[0]
 
     global_rollup = build_global_rollup(
         per_global_rank_summary=rank_summary,
@@ -471,12 +305,11 @@ def build_step_time_payload(
     )
     lines = [title, "Step Time"]
     diagnosis_status = summary_diag.status
-    diagnosis_why = _step_time_card_reason(
-        summary_diag,
-        stats=card_stats,
-        per_global_rank_summary=rank_summary,
-        issues=tuple(issues),
-    )
+    diagnosis_why = str(
+        primary_issue.summary
+        or summary_diag.reason
+        or "No clear timing bottleneck."
+    ).strip()
 
     if not rank_summary:
         latest_step_text = (

--- a/src/traceml_ai/reporting/sections/step_time/loader.py
+++ b/src/traceml_ai/reporting/sections/step_time/loader.py
@@ -8,10 +8,9 @@
 
 from __future__ import annotations
 
-import json
 import sqlite3
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, Optional
+from typing import Dict, Iterable, Optional
 
 from traceml_ai.reporting.config import normalize_summary_window_rows
 from traceml_ai.reporting.sections.step_time.model import (
@@ -20,10 +19,8 @@ from traceml_ai.reporting.sections.step_time.model import (
     RankStepSummary,
     rank_summaries_from_window,
 )
-from traceml_ai.utils.step_time_window import (
-    StepTimeWindow,
-    build_step_time_window_from_events,
-)
+from traceml_ai.utils.step_time_sqlite import load_step_time_window_from_sqlite
+from traceml_ai.utils.step_time_window import StepTimeWindow
 
 
 @dataclass(frozen=True)
@@ -36,37 +33,6 @@ class StepTimeSectionData:
     per_global_rank_summary: Dict[int, RankStepSummary]
     identities: Dict[int, GlobalRankIdentity]
     max_rows: int
-
-
-def load_global_rank_step_rows(
-    conn: sqlite3.Connection,
-    *,
-    global_rank: int,
-    max_rows: int,
-) -> list[Dict[str, Any]]:
-    """Load the latest bounded step-time rows for one global rank."""
-    cur = conn.execute(
-        """
-        SELECT step, events_json
-        FROM step_time_samples
-        WHERE global_rank = ?
-        ORDER BY step DESC, id DESC
-        LIMIT ?;
-        """,
-        (int(global_rank), int(max_rows)),
-    )
-
-    rows: list[Dict[str, Any]] = []
-    for step, events_json in cur:
-        if step is None or not events_json:
-            continue
-        try:
-            events = json.loads(events_json)
-        except Exception:
-            continue
-        if isinstance(events, dict):
-            rows.append({"step": int(step), "events": events})
-    return rows
 
 
 def load_global_rank_identities(
@@ -109,7 +75,10 @@ def load_step_time_section_data(
     max_rows: int = MAX_SUMMARY_WINDOW_ROWS,
 ) -> StepTimeSectionData:
     """
-    Load bounded step-time section data from the SQLite history database.
+    Load final-report Step Time data from SQLite.
+
+    Summary uses the shared global-rank Step Time window loader, then adds
+    report-only metadata such as training-step counts and rank identities.
     """
     row_limit = normalize_summary_window_rows(max_rows)
     conn = sqlite3.connect(db_path)
@@ -127,40 +96,14 @@ def load_step_time_section_data(
             latest_step_observed + 1 if latest_step_observed is not None else 0
         )
 
-        global_rank_rows = conn.execute(
-            """
-            SELECT DISTINCT global_rank
-            FROM step_time_samples
-            WHERE global_rank IS NOT NULL
-            ORDER BY global_rank ASC;
-            """
-        ).fetchall()
-        global_ranks_present = [
-            int(row[0]) for row in global_rank_rows if row[0] is not None
-        ]
-        identities = load_global_rank_identities(conn, global_ranks_present)
-
-        per_global_rank_steps: Dict[int, Dict[int, Dict[str, Any]]] = {}
-
-        for global_rank in global_ranks_present:
-            step_rows = load_global_rank_step_rows(
-                conn,
-                global_rank=global_rank,
-                max_rows=row_limit,
-            )
-            step_map = {
-                int(row["step"]): row["events"]
-                for row in step_rows
-                if row.get("step") is not None
-            }
-            if step_map:
-                per_global_rank_steps[int(global_rank)] = step_map
-
-        step_time_window = build_step_time_window_from_events(
-            per_global_rank_steps,
+        loaded = load_step_time_window_from_sqlite(
+            conn,
             max_rows=row_limit,
-            expected_ranks=global_ranks_present,
+            lookback_factor=1,
         )
+        global_ranks_present = loaded.global_ranks
+        identities = load_global_rank_identities(conn, global_ranks_present)
+        step_time_window = loaded.window
         selected_summary = rank_summaries_from_window(step_time_window)
     finally:
         conn.close()
@@ -178,6 +121,5 @@ def load_step_time_section_data(
 __all__ = [
     "StepTimeSectionData",
     "load_global_rank_identities",
-    "load_global_rank_step_rows",
     "load_step_time_section_data",
 ]

--- a/src/traceml_ai/reporting/sections/step_time/loader.py
+++ b/src/traceml_ai/reporting/sections/step_time/loader.py
@@ -33,6 +33,7 @@ class StepTimeSectionData:
     per_global_rank_summary: Dict[int, RankStepSummary]
     identities: Dict[int, GlobalRankIdentity]
     max_rows: int
+    training_strategy: str = "ddp"
 
 
 def load_global_rank_identities(
@@ -78,7 +79,8 @@ def load_step_time_section_data(
     Load final-report Step Time data from SQLite.
 
     Summary uses the shared global-rank Step Time window loader, then adds
-    report-only metadata such as training-step counts and rank identities.
+    report-only metadata such as training-step counts, rank identities, and
+    advisory training strategy context for diagnosis.
     """
     row_limit = normalize_summary_window_rows(max_rows)
     conn = sqlite3.connect(db_path)
@@ -115,6 +117,7 @@ def load_step_time_section_data(
         per_global_rank_summary=selected_summary,
         identities=identities,
         max_rows=row_limit,
+        training_strategy=loaded.training_strategy,
     )
 
 

--- a/src/traceml_ai/runtime/arming.py
+++ b/src/traceml_ai/runtime/arming.py
@@ -1,0 +1,32 @@
+"""Process-local tracing-armed flag.
+
+Patch wrappers consult ``is_tracing_armed()`` to decide whether to time an
+intercepted call. This lives in its own leaf module (no imports beyond the
+standard library) so the patch modules under ``instrumentation/patches/`` can
+import it without pulling in ``traceml_ai.sdk``, whose package init imports
+``sdk.instrumentation``, which imports the patch modules themselves.
+``traceml_ai.sdk.initial`` re-exports this for the public/internal call sites
+that already reference it there.
+"""
+
+from __future__ import annotations
+
+_TRACING_ARMED: bool = False
+
+
+def is_tracing_armed() -> bool:
+    """
+    Return True only after the requested automatic patches installed cleanly.
+
+    Patch wrappers consult this gate so a failed partial installation degrades
+    to native pass-through behavior instead of half-instrumenting training.
+    """
+    return _TRACING_ARMED
+
+
+def _set_tracing_armed(value: bool) -> None:
+    global _TRACING_ARMED
+    _TRACING_ARMED = bool(value)
+
+
+__all__ = ["is_tracing_armed"]

--- a/src/traceml_ai/runtime/environment.py
+++ b/src/traceml_ai/runtime/environment.py
@@ -1,0 +1,226 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime environment classification for a TraceML training rank.
+
+This module classifies the local runtime environment so a future sampler can
+persist rank-scoped context such as topology, torch.distributed state, and the
+observed training strategy. It is not transport metadata: TCP envelope `meta`
+continues to describe the sender, while this data belongs in a sampler body row.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional
+
+from traceml_ai.runtime.identity import (
+    RuntimeIdentity,
+    resolve_runtime_identity,
+)
+
+EnvMapping = Mapping[str, str]
+TorchLoader = Callable[[], Optional[Any]]
+
+
+def _load_torch() -> Optional[Any]:
+    """Import torch lazily so importing this module has no torch side effects."""
+    try:
+        import torch
+    except ModuleNotFoundError:
+        return None
+    return torch
+
+
+@dataclass(frozen=True)
+class RuntimeEnvironmentInfo:
+    """Rank-local runtime environment classification.
+
+    `topology` describes process placement: single process, single-node
+    multi-process, or multi-node. `training_strategy` describes how the model is
+    parallelized when TraceML can observe it, for example DDP or FSDP.
+    """
+
+    topology: str
+    distributed_initialized: bool
+    distributed_backend: Optional[str]
+    training_strategy: str
+    strategy_source: str
+    strategy_confidence: str
+
+    def to_record(self) -> dict[str, Any]:
+        """Return a JSON/msgpack-safe body row for future sampler transport."""
+        return {
+            "topology": self.topology,
+            "distributed_initialized": bool(self.distributed_initialized),
+            "distributed_backend": self.distributed_backend,
+            "training_strategy": self.training_strategy,
+            "strategy_source": self.strategy_source,
+            "strategy_confidence": self.strategy_confidence,
+        }
+
+
+def detect_runtime_environment(
+    model: Optional[Any] = None,
+    *,
+    env: Optional[EnvMapping] = None,
+    torch_loader: Optional[TorchLoader] = None,
+) -> RuntimeEnvironmentInfo:
+    """Detect runtime topology and training strategy best-effort.
+
+    The detector is safe to call from `trace_step(model)`: it does not probe
+    CUDA, does not synchronize, imports torch lazily, and degrades to
+    conservative unknown values if torch or distributed state cannot be read.
+    """
+    torch = _safe_load_torch(torch_loader)
+    identity = _safe_resolve_identity(env=env, torch=torch)
+    topology = _topology(identity)
+    distributed_initialized, distributed_backend = _distributed_state(torch)
+
+    model_strategy = _training_strategy_from_model(torch, model)
+    if model_strategy is not None:
+        training_strategy, strategy_source, strategy_confidence = (
+            model_strategy
+        )
+    elif topology == "single_process":
+        training_strategy = "single_process"
+        strategy_source = "topology"
+        strategy_confidence = "high"
+    elif distributed_initialized:
+        training_strategy = "distributed_unknown"
+        strategy_source = "runtime_distributed"
+        strategy_confidence = "low"
+    elif identity.world_size > 1:
+        training_strategy = "distributed_unknown"
+        strategy_source = "topology"
+        strategy_confidence = "low"
+    else:
+        training_strategy = "unknown"
+        strategy_source = "unknown"
+        strategy_confidence = "low"
+
+    return RuntimeEnvironmentInfo(
+        topology=topology,
+        distributed_initialized=distributed_initialized,
+        distributed_backend=distributed_backend,
+        training_strategy=training_strategy,
+        strategy_source=strategy_source,
+        strategy_confidence=strategy_confidence,
+    )
+
+
+def _safe_load_torch(torch_loader: Optional[TorchLoader]) -> Optional[Any]:
+    loader = torch_loader if torch_loader is not None else _load_torch
+    try:
+        return loader()
+    except Exception:
+        return None
+
+
+def _safe_resolve_identity(
+    *,
+    env: Optional[EnvMapping],
+    torch: Optional[Any],
+) -> RuntimeIdentity:
+    try:
+        return resolve_runtime_identity(
+            env=env if env is not None else os.environ,
+            torch_loader=lambda: torch,
+        )
+    except Exception:
+        return RuntimeIdentity(
+            global_rank=0,
+            local_rank=0,
+            world_size=1,
+            local_world_size=1,
+            node_rank=0,
+            hostname=socket.gethostname(),
+            pid=os.getpid(),
+        )
+
+
+def _topology(identity: RuntimeIdentity) -> str:
+    if identity.world_size <= 1:
+        return "single_process"
+    if identity.is_multinode:
+        return "multi_node"
+    return "single_node_multi_process"
+
+
+def _distributed_state(torch: Optional[Any]) -> tuple[bool, Optional[str]]:
+    dist = getattr(torch, "distributed", None) if torch is not None else None
+    if dist is None:
+        return False, None
+
+    try:
+        initialized = bool(dist.is_available() and dist.is_initialized())
+    except Exception:
+        return False, None
+    if not initialized:
+        return False, None
+
+    try:
+        backend = dist.get_backend()
+    except Exception:
+        backend = None
+
+    return True, str(backend) if backend is not None else None
+
+
+def _training_strategy_from_model(
+    torch: Optional[Any],
+    model: Optional[Any],
+) -> Optional[tuple[str, str, str]]:
+    if model is None or torch is None:
+        return None
+
+    if _isinstance_path(
+        model,
+        torch,
+        "nn.parallel.DistributedDataParallel",
+    ):
+        return "ddp", "runtime_model", "high"
+
+    if _isinstance_path(
+        model,
+        torch,
+        "distributed.fsdp.FullyShardedDataParallel",
+    ) or _isinstance_path(
+        model,
+        torch,
+        "distributed.fsdp.fully_sharded_data_parallel.FullyShardedDataParallel",
+    ):
+        return "fsdp", "runtime_model", "high"
+
+    return None
+
+
+def _isinstance_path(model: Any, root: Any, dotted_path: str) -> bool:
+    cls = _attr_path(root, dotted_path)
+    if cls is None:
+        return False
+    try:
+        return isinstance(model, cls)
+    except TypeError:
+        return False
+
+
+def _attr_path(root: Any, dotted_path: str) -> Optional[Any]:
+    current = root
+    for part in dotted_path.split("."):
+        try:
+            current = getattr(current, part)
+        except Exception:
+            return None
+    return current
+
+
+__all__ = [
+    "RuntimeEnvironmentInfo",
+    "detect_runtime_environment",
+]

--- a/src/traceml_ai/runtime/environment.py
+++ b/src/traceml_ai/runtime/environment.py
@@ -1,0 +1,227 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime environment classification for a TraceML training rank.
+
+This module classifies the local runtime environment so the runtime environment
+sampler can persist rank-scoped context such as topology, torch.distributed
+state, and the observed training strategy. It is not transport metadata: TCP
+envelope `meta` continues to describe the sender, while this data belongs in a
+sampler body row.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional
+
+from traceml_ai.runtime.identity import (
+    RuntimeIdentity,
+    resolve_runtime_identity,
+)
+
+EnvMapping = Mapping[str, str]
+TorchLoader = Callable[[], Optional[Any]]
+
+
+def _load_torch() -> Optional[Any]:
+    """Import torch lazily so importing this module has no torch side effects."""
+    try:
+        import torch
+    except ModuleNotFoundError:
+        return None
+    return torch
+
+
+@dataclass(frozen=True)
+class RuntimeEnvironmentInfo:
+    """Rank-local runtime environment classification.
+
+    `topology` describes process placement: single process, single-node
+    multi-process, or multi-node. `training_strategy` describes how the model is
+    parallelized when TraceML can observe it, for example DDP or FSDP.
+    """
+
+    topology: str
+    distributed_initialized: bool
+    distributed_backend: Optional[str]
+    training_strategy: str
+    strategy_source: str
+    strategy_confidence: str
+
+    def to_record(self) -> dict[str, Any]:
+        """Return a JSON/msgpack-safe body row for sampler transport."""
+        return {
+            "topology": self.topology,
+            "distributed_initialized": bool(self.distributed_initialized),
+            "distributed_backend": self.distributed_backend,
+            "training_strategy": self.training_strategy,
+            "strategy_source": self.strategy_source,
+            "strategy_confidence": self.strategy_confidence,
+        }
+
+
+def detect_runtime_environment(
+    model: Optional[Any] = None,
+    *,
+    env: Optional[EnvMapping] = None,
+    torch_loader: Optional[TorchLoader] = None,
+) -> RuntimeEnvironmentInfo:
+    """Detect runtime topology and training strategy best-effort.
+
+    The detector is safe to call from `trace_step(model)`: it does not probe
+    CUDA, does not synchronize, imports torch lazily, and degrades to
+    conservative unknown values if torch or distributed state cannot be read.
+    """
+    torch = _safe_load_torch(torch_loader)
+    identity = _safe_resolve_identity(env=env, torch=torch)
+    topology = _topology(identity)
+    distributed_initialized, distributed_backend = _distributed_state(torch)
+
+    model_strategy = _training_strategy_from_model(torch, model)
+    if model_strategy is not None:
+        training_strategy, strategy_source, strategy_confidence = (
+            model_strategy
+        )
+    elif topology == "single_process":
+        training_strategy = "single_process"
+        strategy_source = "topology"
+        strategy_confidence = "high"
+    elif distributed_initialized:
+        training_strategy = "distributed_unknown"
+        strategy_source = "runtime_distributed"
+        strategy_confidence = "low"
+    elif identity.world_size > 1:
+        training_strategy = "distributed_unknown"
+        strategy_source = "topology"
+        strategy_confidence = "low"
+    else:
+        training_strategy = "unknown"
+        strategy_source = "unknown"
+        strategy_confidence = "low"
+
+    return RuntimeEnvironmentInfo(
+        topology=topology,
+        distributed_initialized=distributed_initialized,
+        distributed_backend=distributed_backend,
+        training_strategy=training_strategy,
+        strategy_source=strategy_source,
+        strategy_confidence=strategy_confidence,
+    )
+
+
+def _safe_load_torch(torch_loader: Optional[TorchLoader]) -> Optional[Any]:
+    loader = torch_loader if torch_loader is not None else _load_torch
+    try:
+        return loader()
+    except Exception:
+        return None
+
+
+def _safe_resolve_identity(
+    *,
+    env: Optional[EnvMapping],
+    torch: Optional[Any],
+) -> RuntimeIdentity:
+    try:
+        return resolve_runtime_identity(
+            env=env if env is not None else os.environ,
+            torch_loader=lambda: torch,
+        )
+    except Exception:
+        return RuntimeIdentity(
+            global_rank=0,
+            local_rank=0,
+            world_size=1,
+            local_world_size=1,
+            node_rank=0,
+            hostname=socket.gethostname(),
+            pid=os.getpid(),
+        )
+
+
+def _topology(identity: RuntimeIdentity) -> str:
+    if identity.world_size <= 1:
+        return "single_process"
+    if identity.is_multinode:
+        return "multi_node"
+    return "single_node_multi_process"
+
+
+def _distributed_state(torch: Optional[Any]) -> tuple[bool, Optional[str]]:
+    dist = getattr(torch, "distributed", None) if torch is not None else None
+    if dist is None:
+        return False, None
+
+    try:
+        initialized = bool(dist.is_available() and dist.is_initialized())
+    except Exception:
+        return False, None
+    if not initialized:
+        return False, None
+
+    try:
+        backend = dist.get_backend()
+    except Exception:
+        backend = None
+
+    return True, str(backend) if backend is not None else None
+
+
+def _training_strategy_from_model(
+    torch: Optional[Any],
+    model: Optional[Any],
+) -> Optional[tuple[str, str, str]]:
+    if model is None or torch is None:
+        return None
+
+    if _isinstance_path(
+        model,
+        torch,
+        "nn.parallel.DistributedDataParallel",
+    ):
+        return "ddp", "runtime_model", "high"
+
+    if _isinstance_path(
+        model,
+        torch,
+        "distributed.fsdp.FullyShardedDataParallel",
+    ) or _isinstance_path(
+        model,
+        torch,
+        "distributed.fsdp.fully_sharded_data_parallel.FullyShardedDataParallel",
+    ):
+        return "fsdp", "runtime_model", "high"
+
+    return None
+
+
+def _isinstance_path(model: Any, root: Any, dotted_path: str) -> bool:
+    cls = _attr_path(root, dotted_path)
+    if cls is None:
+        return False
+    try:
+        return isinstance(model, cls)
+    except TypeError:
+        return False
+
+
+def _attr_path(root: Any, dotted_path: str) -> Optional[Any]:
+    current = root
+    for part in dotted_path.split("."):
+        try:
+            current = getattr(current, part)
+        except Exception:
+            return None
+    return current
+
+
+__all__ = [
+    "RuntimeEnvironmentInfo",
+    "detect_runtime_environment",
+]

--- a/src/traceml_ai/runtime/environment.py
+++ b/src/traceml_ai/runtime/environment.py
@@ -6,10 +6,11 @@
 
 """Runtime environment classification for a TraceML training rank.
 
-This module classifies the local runtime environment so a future sampler can
-persist rank-scoped context such as topology, torch.distributed state, and the
-observed training strategy. It is not transport metadata: TCP envelope `meta`
-continues to describe the sender, while this data belongs in a sampler body row.
+This module classifies the local runtime environment so the runtime environment
+sampler can persist rank-scoped context such as topology, torch.distributed
+state, and the observed training strategy. It is not transport metadata: TCP
+envelope `meta` continues to describe the sender, while this data belongs in a
+sampler body row.
 """
 
 from __future__ import annotations
@@ -54,7 +55,7 @@ class RuntimeEnvironmentInfo:
     strategy_confidence: str
 
     def to_record(self) -> dict[str, Any]:
-        """Return a JSON/msgpack-safe body row for future sampler transport."""
+        """Return a JSON/msgpack-safe body row for sampler transport."""
         return {
             "topology": self.topology,
             "distributed_initialized": bool(self.distributed_initialized),

--- a/src/traceml_ai/runtime/environment_state.py
+++ b/src/traceml_ai/runtime/environment_state.py
@@ -1,0 +1,83 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-local state for one-shot runtime environment telemetry.
+
+Runtime environment data is rank-scoped context that later travels as sampler
+body rows. This module keeps first-publish-wins state separate from transport
+metadata and from the detector itself.
+"""
+
+from __future__ import annotations
+
+import time
+from queue import Empty, Full, Queue
+from typing import Any
+
+from traceml_ai.runtime.environment import RuntimeEnvironmentInfo
+
+_RUNTIME_ENVIRONMENT_QUEUE: Queue = Queue(maxsize=10)
+_PUBLISHED = False
+
+
+def publish_runtime_environment_once(info: RuntimeEnvironmentInfo) -> bool:
+    """Publish one runtime environment record for this process.
+
+    The first successful publish wins for the lifetime of the process. Later
+    calls are ignored because strategy changes are intentionally out of scope
+    for this version. Returns True only when a new row was queued.
+    """
+    global _PUBLISHED
+
+    if _PUBLISHED:
+        return False
+
+    row = {
+        "seq": 0,
+        "ts": time.time(),
+        **info.to_record(),
+    }
+    try:
+        _RUNTIME_ENVIRONMENT_QUEUE.put_nowait(row)
+    except Full:
+        return False
+
+    _PUBLISHED = True
+    return True
+
+
+def pop_runtime_environment_record() -> dict[str, Any] | None:
+    """Return one pending runtime environment row, if present."""
+    try:
+        row = _RUNTIME_ENVIRONMENT_QUEUE.get_nowait()
+    except Empty:
+        return None
+    return row if isinstance(row, dict) else None
+
+
+def has_runtime_environment_info() -> bool:
+    """Return True after this process has published runtime environment info."""
+    return bool(_PUBLISHED)
+
+
+def reset_runtime_environment_state() -> None:
+    """Reset process-local runtime environment state for tests."""
+    global _PUBLISHED
+
+    while True:
+        try:
+            _RUNTIME_ENVIRONMENT_QUEUE.get_nowait()
+        except Empty:
+            break
+    _PUBLISHED = False
+
+
+__all__ = [
+    "has_runtime_environment_info",
+    "pop_runtime_environment_record",
+    "publish_runtime_environment_once",
+    "reset_runtime_environment_state",
+]

--- a/src/traceml_ai/runtime/environment_state.py
+++ b/src/traceml_ai/runtime/environment_state.py
@@ -6,9 +6,9 @@
 
 """Process-local state for one-shot runtime environment telemetry.
 
-Runtime environment data is rank-scoped context that later travels as sampler
-body rows. This module keeps first-publish-wins state separate from transport
-metadata and from the detector itself.
+Runtime environment data is one rank-scoped context row that later travels as
+sampler body data. This module keeps first-publish-wins state separate from
+transport metadata and from the detector itself.
 """
 
 from __future__ import annotations

--- a/src/traceml_ai/runtime/environment_state.py
+++ b/src/traceml_ai/runtime/environment_state.py
@@ -1,0 +1,83 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-local state for one-shot runtime environment telemetry.
+
+Runtime environment data is one rank-scoped context row that later travels as
+sampler body data. This module keeps first-publish-wins state separate from
+transport metadata and from the detector itself.
+"""
+
+from __future__ import annotations
+
+import time
+from queue import Empty, Full, Queue
+from typing import Any
+
+from traceml_ai.runtime.environment import RuntimeEnvironmentInfo
+
+_RUNTIME_ENVIRONMENT_QUEUE: Queue = Queue(maxsize=10)
+_PUBLISHED = False
+
+
+def publish_runtime_environment_once(info: RuntimeEnvironmentInfo) -> bool:
+    """Publish one runtime environment record for this process.
+
+    The first successful publish wins for the lifetime of the process. Later
+    calls are ignored because strategy changes are intentionally out of scope
+    for this version. Returns True only when a new row was queued.
+    """
+    global _PUBLISHED
+
+    if _PUBLISHED:
+        return False
+
+    row = {
+        "seq": 0,
+        "ts": time.time(),
+        **info.to_record(),
+    }
+    try:
+        _RUNTIME_ENVIRONMENT_QUEUE.put_nowait(row)
+    except Full:
+        return False
+
+    _PUBLISHED = True
+    return True
+
+
+def pop_runtime_environment_record() -> dict[str, Any] | None:
+    """Return one pending runtime environment row, if present."""
+    try:
+        row = _RUNTIME_ENVIRONMENT_QUEUE.get_nowait()
+    except Empty:
+        return None
+    return row if isinstance(row, dict) else None
+
+
+def has_runtime_environment_info() -> bool:
+    """Return True after this process has published runtime environment info."""
+    return bool(_PUBLISHED)
+
+
+def reset_runtime_environment_state() -> None:
+    """Reset process-local runtime environment state for tests."""
+    global _PUBLISHED
+
+    while True:
+        try:
+            _RUNTIME_ENVIRONMENT_QUEUE.get_nowait()
+        except Empty:
+            break
+    _PUBLISHED = False
+
+
+__all__ = [
+    "has_runtime_environment_info",
+    "pop_runtime_environment_record",
+    "publish_runtime_environment_once",
+    "reset_runtime_environment_state",
+]

--- a/src/traceml_ai/runtime/executor.py
+++ b/src/traceml_ai/runtime/executor.py
@@ -24,6 +24,7 @@ from traceml_ai.runtime.lifecycle import start_runtime as start_runtime_handle
 from traceml_ai.runtime.runtime import TraceMLRuntime
 from traceml_ai.runtime.settings import (
     DEFAULT_FINALIZE_TIMEOUT_SEC,
+    DEFAULT_INTERVAL_SEC,
     AggregatorTransportSettings,
     TraceMLSettings,
 )
@@ -35,7 +36,6 @@ DEFAULT_AGGREGATOR_BIND_HOST = "127.0.0.1"
 DEFAULT_AGGREGATOR_PORT = 29765
 DEFAULT_PROFILE = "run"
 DEFAULT_UI_MODE = "cli"
-DEFAULT_INTERVAL_SEC = 1.0
 USER_ERROR_LOG_NAME = "torchrun_error.log"
 RUNTIME_ERROR_LOG_NAME = "runtime_error.log"
 

--- a/src/traceml_ai/runtime/exporter.py
+++ b/src/traceml_ai/runtime/exporter.py
@@ -1,0 +1,191 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Background TCP exporter that drains queued payload batches off a dedicated
+thread, isolating the sampler thread from a slow or unreachable aggregator."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from typing import Any, Deque, List, Optional
+
+from traceml_ai.loggers.error_log import get_error_logger
+
+DEFAULT_EXPORT_QUEUE_SIZE = 2048
+DEFAULT_EXPORT_DRAIN_TIMEOUT_SEC = 2.0
+_EXPORT_POLL_INTERVAL_SEC = 1.0
+
+
+class TelemetryExporter:
+    """
+    Async, thread-backed stand-in for the TCPClient send surface.
+
+    Exposes send/send_batch/close so it can replace the TCP client the
+    publisher holds, but enqueues onto a bounded queue instead of sending
+    inline. One background thread drains the queue via TCPClient.send_batch.
+    """
+
+    def __init__(
+        self,
+        *,
+        tcp_client: Any,
+        max_queue_size: int = DEFAULT_EXPORT_QUEUE_SIZE,
+        drain_timeout_sec: float = DEFAULT_EXPORT_DRAIN_TIMEOUT_SEC,
+        poll_interval_sec: float = _EXPORT_POLL_INTERVAL_SEC,
+        logger: Optional[Any] = None,
+    ) -> None:
+        self._tcp_client = tcp_client
+        self._max_queue_size = max(1, int(max_queue_size))
+        self._drain_timeout_sec = max(0.0, float(drain_timeout_sec))
+        self._poll_interval_sec = max(0.01, float(poll_interval_sec))
+        self._logger = logger or get_error_logger("TelemetryExporter")
+
+        self._queue: Deque[List[Any]] = deque()
+        self._cond = threading.Condition()
+        self._stop_event = threading.Event()
+        self._dropped = 0
+        self._stopped = False
+        self._thread = threading.Thread(
+            target=self._run,
+            name="TraceMLExporter",
+            daemon=True,
+        )
+
+    @property
+    def dropped_count(self) -> int:
+        """Number of payload batches dropped on overflow or shutdown."""
+        with self._cond:
+            return self._dropped
+
+    @property
+    def queue_size(self) -> int:
+        """Current number of queued payload batches."""
+        with self._cond:
+            return len(self._queue)
+
+    def start(self) -> None:
+        """Start the exporter thread."""
+        self._thread.start()
+
+    def send_batch(self, batch: List[Any]) -> None:
+        """Enqueue a collected payload batch. Never blocks on the network."""
+        if not batch:
+            return
+        self._enqueue(list(batch))
+
+    def send(self, payload: Any) -> None:
+        """Enqueue a single payload as a one-item batch (used for control)."""
+        if not payload:
+            return
+        self._enqueue([payload])
+
+    def close(self) -> None:
+        """TCPClient.close parity. Stops with the configured drain budget."""
+        self.stop()
+
+    def stop(self, timeout_sec: Optional[float] = None) -> None:
+        """Signal stop, let the thread do a bounded final drain, then close."""
+        with self._cond:
+            if self._stopped:
+                return
+            self._stopped = True
+            if timeout_sec is not None:
+                self._drain_timeout_sec = max(0.0, float(timeout_sec))
+            self._stop_event.set()
+            self._cond.notify_all()
+
+        if self._thread.is_alive():
+            self._thread.join(
+                timeout=self._drain_timeout_sec + self._poll_interval_sec + 1.0
+            )
+
+        if self._dropped:
+            self._logger.error(
+                f"[TraceML] exporter dropped {self._dropped} payload batches"
+            )
+
+        try:
+            self._tcp_client.close()
+        except Exception as exc:
+            self._log_exception("TCPClient.close failed", exc)
+
+    def _enqueue(self, batch: List[Any]) -> None:
+        with self._cond:
+            if self._stopped:
+                self._dropped += 1
+                return
+            if len(self._queue) >= self._max_queue_size:
+                self._queue.popleft()  # drop oldest
+                self._dropped += 1
+            self._queue.append(batch)
+            self._cond.notify()
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            batch = self._take_next()
+            if batch is not None:
+                self._send(batch)
+        self._final_drain()
+
+    def _take_next(self) -> Optional[List[Any]]:
+        with self._cond:
+            if not self._queue and not self._stop_event.is_set():
+                self._cond.wait(timeout=self._poll_interval_sec)
+            if self._queue:
+                return self._queue.popleft()
+            return None
+
+    def _pop_nowait(self) -> Optional[List[Any]]:
+        with self._cond:
+            if self._queue:
+                return self._queue.popleft()
+            return None
+
+    def _final_drain(self) -> None:
+        deadline = time.monotonic() + self._drain_timeout_sec
+        while time.monotonic() < deadline:
+            batch = self._pop_nowait()
+            if batch is None:
+                return
+            self._send(batch)
+
+        with self._cond:
+            remaining = len(self._queue)
+            if remaining:
+                self._queue.clear()
+                self._dropped += remaining
+
+        if remaining:
+            self._logger.error(
+                "[TraceML] exporter shutdown dropped %d queued payload batches "
+                "after drain timeout",
+                remaining,
+            )
+
+    def _send(self, batch: List[Any]) -> None:
+        # Network send runs outside the queue lock so enqueue never blocks.
+        try:
+            self._tcp_client.send_batch(batch)
+        except Exception as exc:
+            self._log_exception("TCPClient.send_batch failed", exc)
+
+    def _log_exception(self, label: str, exc: Exception) -> None:
+        log = getattr(self._logger, "exception", None)
+        if callable(log):
+            log("[TraceML] %s: %s", label, exc)
+            return
+        fallback = getattr(self._logger, "error", None)
+        if callable(fallback):
+            fallback(f"[TraceML] {label}: {exc}")
+
+
+__all__ = [
+    "DEFAULT_EXPORT_QUEUE_SIZE",
+    "DEFAULT_EXPORT_DRAIN_TIMEOUT_SEC",
+    "TelemetryExporter",
+]

--- a/src/traceml_ai/runtime/lifecycle.py
+++ b/src/traceml_ai/runtime/lifecycle.py
@@ -9,7 +9,9 @@ lifecycle inside one process.
 from __future__ import annotations
 
 import os
+import socket
 import threading
+import time
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional
@@ -34,6 +36,55 @@ class NoOpRuntime:
 
     def stop(self) -> None:
         return None
+
+
+_RUNTIME_STATE_LOCK = threading.Lock()
+_ACTIVE_RUNTIME_HANDLE: Optional["RuntimeHandle"] = None
+
+
+def get_active_runtime_handle() -> Optional["RuntimeHandle"]:
+    """Return the RuntimeHandle started in this process, or None.
+
+    Lets ``traceml.init()`` detect a runtime already started by the CLI
+    executor (the ``traceml run`` path) and avoid starting a second one.
+    """
+    return _ACTIVE_RUNTIME_HANDLE
+
+
+def _register_active_runtime_handle(handle: "RuntimeHandle") -> None:
+    """Record the runtime handle started in this process."""
+    global _ACTIVE_RUNTIME_HANDLE
+    with _RUNTIME_STATE_LOCK:
+        _ACTIVE_RUNTIME_HANDLE = handle
+
+
+def wait_for_aggregator(
+    host: str,
+    port: int,
+    *,
+    timeout_sec: float = 10.0,
+    poll_interval_sec: float = 0.25,
+) -> bool:
+    """Return True once ``(host, port)`` accepts a TCP connection.
+
+    Retries for a bounded period. Used by ``traceml.init()`` as a best-effort
+    reachability probe before starting the runtime.
+
+    Limitation: this is a bare TCP accept, not a TraceML protocol/session
+    handshake, so any listener on the port (a foreign process, a stale
+    aggregator, or one serving a different session) passes the check. A real
+    handshake is a wire-format change tracked as a follow-up; on a genuine
+    mismatch the runtime simply produces no telemetry for this session.
+    """
+    deadline = time.monotonic() + float(timeout_sec)
+    while True:
+        try:
+            with socket.create_connection((host, int(port)), timeout=0.5):
+                return True
+        except OSError:
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(float(poll_interval_sec))
 
 
 @dataclass
@@ -201,24 +252,45 @@ def start_runtime(
     _apply_settings_env(normalized, disabled=disabled)
 
     if disabled:
-        return RuntimeHandle(NoOpRuntime())
+        handle = RuntimeHandle(NoOpRuntime())
+        _register_active_runtime_handle(handle)
+        return handle
 
     try:
         runtime = TraceMLRuntime(settings=normalized)
         runtime.start()
-        return RuntimeHandle(runtime)
+        handle = RuntimeHandle(runtime)
+        _register_active_runtime_handle(handle)
+        return handle
     except BaseException as exc:
         if on_error is not None:
             on_error(exc)
         if not fail_open:
             raise
-        return RuntimeHandle(NoOpRuntime())
+        # Fail-open ladder: the runtime lifecycle for this process has still
+        # been decided here, so register the no-op handle. A later
+        # traceml.init() sees an active handle and does not try to start the
+        # runtime again. Detach LOUDLY (one stderr warning) so a silently
+        # dark integration (e.g. a Ray worker whose aggregator is down) is
+        # never mistaken for a healthy run.
+        import sys
+
+        print(
+            f"[TraceML] Runtime failed to start ({exc}); continuing without "
+            "tracing (no-op). Telemetry for this process will be absent.",
+            file=sys.stderr,
+        )
+        handle = RuntimeHandle(NoOpRuntime())
+        _register_active_runtime_handle(handle)
+        return handle
 
 
 __all__ = [
     "AggregatorHandle",
     "NoOpRuntime",
     "RuntimeHandle",
+    "get_active_runtime_handle",
     "start_aggregator",
     "start_runtime",
+    "wait_for_aggregator",
 ]

--- a/src/traceml_ai/runtime/runtime.py
+++ b/src/traceml_ai/runtime/runtime.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, List, Optional
 
 from traceml_ai.loggers.error_log import get_error_logger, setup_error_logger
 from traceml_ai.runtime.config import config
+from traceml_ai.runtime.exporter import TelemetryExporter
 from traceml_ai.runtime.identity import resolve_runtime_identity
 from traceml_ai.runtime.sampler_registry import build_samplers
 from traceml_ai.runtime.sender import SenderIdentity, TelemetryPublisher
@@ -80,8 +81,14 @@ class TraceMLRuntime:
                 port=int(self._settings.aggregator.port),
             )
         )
-        self._publisher = TelemetryPublisher(
+        # Exporter owns all TCP send/connect work on its own thread. The
+        # publisher enqueues batches into it instead of sending inline.
+        self._exporter = TelemetryExporter(
             tcp_client=self._tcp_client,
+            logger=self._logger,
+        )
+        self._publisher = TelemetryPublisher(
+            tcp_client=self._exporter,
             identity=SenderIdentity(
                 global_rank=self.identity.global_rank,
                 local_rank=self.identity.local_rank,
@@ -189,7 +196,8 @@ class TraceMLRuntime:
 
         Start order:
         1) enable stdout/stderr capture (CLI mode only, dashboard no need)
-        2) start sampler thread
+        2) start exporter thread
+        3) start sampler thread
         """
         if self.mode == "cli":
             _safe(
@@ -197,6 +205,9 @@ class TraceMLRuntime:
                 "Stdout/stderr capture enable failed",
                 StreamCapture.redirect_to_capture,
             )
+
+        # Exporter must be running before samplers start enqueuing batches.
+        self._exporter.start()
 
         try:
             self._sampler_thread.start()
@@ -210,8 +221,8 @@ class TraceMLRuntime:
 
         - Signals the sampler thread to stop
         - Joins the sampler thread
-        - Sends a rank-finished control message for aggregator finalization
-        - Closes TCP client
+        - Enqueues a final telemetry batch and a rank-finished control message
+        - Drains the export queue and closes the TCP client (bounded)
         - Restores stdout/stderr (CLI mode only)
         """
         self._stop_event.set()
@@ -236,8 +247,8 @@ class TraceMLRuntime:
             )
         )
 
-        # close client last
-        self._publisher.close()
+        # drain the export queue and close the client last
+        self._exporter.stop()
 
         # restore stdout/stderr
         if self.mode == "cli":

--- a/src/traceml_ai/runtime/sampler_registry.py
+++ b/src/traceml_ai/runtime/sampler_registry.py
@@ -9,6 +9,9 @@ from traceml_ai.core import Registry
 from traceml_ai.loggers.error_log import get_error_logger
 from traceml_ai.samplers.base_sampler import BaseSampler
 from traceml_ai.samplers.process_sampler import ProcessSampler
+from traceml_ai.samplers.runtime_environment_sampler import (
+    RuntimeEnvironmentSampler,
+)
 from traceml_ai.samplers.stdout_stderr_sampler import StdoutStderrSampler
 from traceml_ai.samplers.step_memory_sampler import StepMemorySampler
 from traceml_ai.samplers.step_time_sampler import StepTimeSampler
@@ -70,6 +73,11 @@ def _spec(
 DEFAULT_SAMPLER_REGISTRY: Registry[SamplerSpec] = Registry(
     [
         _spec("system", SystemSampler, rank_zero_only=True),
+        _spec(
+            "runtime_environment",
+            RuntimeEnvironmentSampler,
+            drain_on_recording_stop=True,
+        ),
         _spec("process", ProcessSampler),
         _spec("stdout_stderr", StdoutStderrSampler, modes=("cli",)),
         _spec(

--- a/src/traceml_ai/runtime/settings.py
+++ b/src/traceml_ai/runtime/settings.py
@@ -21,6 +21,9 @@ from typing import Optional
 from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
 
 DEFAULT_FINALIZE_TIMEOUT_SEC = 300.0
+# The public ``interval`` setting uses this value unless explicitly overridden
+# through the CLI, environment, YAML, or an integration-specific config.
+DEFAULT_INTERVAL_SEC = 2.0
 
 
 @dataclass(frozen=True)
@@ -54,8 +57,9 @@ class TraceMLSettings:
     High-level TraceML settings shared across runtime and aggregator.
 
     Notes:
-    - `sampler_interval_sec` controls sampling cadence (all ranks).
-    - `render_interval_sec` controls UI cadence (aggregator only).
+    - `sampler_interval_sec` controls worker sampling cadence (all ranks).
+    - `render_interval_sec` controls aggregator UI cadence only; TCP telemetry
+      is drained as soon as data arrives.
     - `mode` selects display backend and capture behavior ("cli" | "summary" | "dashboard").
     - `summary` mode disables live rendering and prints only the final
       end-of-run summary.
@@ -65,8 +69,8 @@ class TraceMLSettings:
 
     profile: str = "run"
     mode: str = "cli"
-    sampler_interval_sec: float = 1.0
-    render_interval_sec: float = 1.0
+    sampler_interval_sec: float = DEFAULT_INTERVAL_SEC
+    render_interval_sec: float = DEFAULT_INTERVAL_SEC
     logs_dir: str = "./logs"
     enable_logging: bool = False
     dashboard_port: int = 8765

--- a/src/traceml_ai/samplers/runtime_environment_sampler.py
+++ b/src/traceml_ai/samplers/runtime_environment_sampler.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Sampler bridge for one-shot runtime environment telemetry."""
+"""Sampler bridge for one-shot runtime environment body rows."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from traceml_ai.samplers.base_sampler import BaseSampler
 
 
 class RuntimeEnvironmentSampler(BaseSampler):
-    """Emit rank-scoped runtime environment rows queued by trace_step()."""
+    """Emit rank-scoped body rows queued by trace_step(), not TCP metadata."""
 
     def __init__(self) -> None:
         super().__init__(

--- a/src/traceml_ai/samplers/runtime_environment_sampler.py
+++ b/src/traceml_ai/samplers/runtime_environment_sampler.py
@@ -1,0 +1,33 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sampler bridge for one-shot runtime environment telemetry."""
+
+from __future__ import annotations
+
+from traceml_ai.runtime.environment_state import pop_runtime_environment_record
+from traceml_ai.samplers.base_sampler import BaseSampler
+
+
+class RuntimeEnvironmentSampler(BaseSampler):
+    """Emit rank-scoped runtime environment rows queued by trace_step()."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            sampler_name="RuntimeEnvironmentSampler",
+            table_name="RuntimeEnvironmentTable",
+        )
+
+    def sample(self) -> None:
+        """Pop one pending runtime environment row into the sampler database."""
+        try:
+            row = pop_runtime_environment_record()
+            if row is not None:
+                self._add_record(row)
+        except Exception as exc:
+            self.logger.error(
+                f"[TraceML] RuntimeEnvironmentSampler error: {exc}"
+            )

--- a/src/traceml_ai/samplers/runtime_environment_sampler.py
+++ b/src/traceml_ai/samplers/runtime_environment_sampler.py
@@ -1,0 +1,33 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sampler bridge for one-shot runtime environment body rows."""
+
+from __future__ import annotations
+
+from traceml_ai.runtime.environment_state import pop_runtime_environment_record
+from traceml_ai.samplers.base_sampler import BaseSampler
+
+
+class RuntimeEnvironmentSampler(BaseSampler):
+    """Emit rank-scoped body rows queued by trace_step(), not TCP metadata."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            sampler_name="RuntimeEnvironmentSampler",
+            table_name="RuntimeEnvironmentTable",
+        )
+
+    def sample(self) -> None:
+        """Pop one pending runtime environment row into the sampler database."""
+        try:
+            row = pop_runtime_environment_record()
+            if row is not None:
+                self._add_record(row)
+        except Exception as exc:
+            self.logger.error(
+                f"[TraceML] RuntimeEnvironmentSampler error: {exc}"
+            )

--- a/src/traceml_ai/sdk/initial.py
+++ b/src/traceml_ai/sdk/initial.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from threading import Lock
 from typing import Any, Literal, Optional
 
+from traceml_ai.runtime.arming import _set_tracing_armed, is_tracing_armed
+
 TraceMLInitMode = Literal["auto", "manual", "selective"]
 
 
@@ -43,6 +45,23 @@ _INIT_CONFIG: Optional[TraceMLInitConfig] = None
 # the runtime is stopped exactly once, only when init() actually started it.
 _RUNTIME_HANDLE: Any = None
 _ATEXIT_REGISTERED: bool = False
+
+
+def _noop_config(source: str) -> TraceMLInitConfig:
+    """Build the stored disabled config used by fail-open paths."""
+    import os
+
+    os.environ["TRACEML_DISABLED"] = "1"
+    _set_tracing_armed(False)
+    return TraceMLInitConfig(
+        mode="manual",
+        patch_dataloader=False,
+        patch_forward=False,
+        patch_backward=False,
+        patch_h2d=False,
+        source=source,
+        disabled=True,
+    )
 
 
 def _canonical_mode(mode: str) -> TraceMLInitMode:
@@ -135,6 +154,7 @@ def _build_config(
 
 def _apply_requested_patches(config: TraceMLInitConfig) -> None:
     """Apply the patch set requested by the validated config."""
+    _set_tracing_armed(False)
     if not any(
         (
             config.patch_dataloader,
@@ -177,10 +197,11 @@ def _apply_requested_patches(config: TraceMLInitConfig) -> None:
         raise RuntimeError(
             "TraceML initialization failed while installing automatic "
             f"instrumentation patches for mode={config.mode!r}. "
-            "This error is fatal because partial patch installation can lead "
-            "to inconsistent tracing behavior. "
+            "Patch wrappers will remain disabled so any partial installation "
+            "passes through natively. "
             f"Original error: {exc}"
         ) from exc
+    _set_tracing_armed(True)
 
 
 def get_init_config() -> Optional[TraceMLInitConfig]:
@@ -507,9 +528,9 @@ def init(
     ValueError
         If the init request is invalid.
     RuntimeError
-        If init conflicts with an existing config or patch installation fails.
-        An unreachable aggregator raises only when
-        ``on_missing_aggregator='raise'``; by default it warns and no-ops.
+        If init conflicts with an existing config. Missing aggregators,
+        runtime startup failures, and patch installation failures raise only
+        when ``on_missing_aggregator='raise'``; by default they warn and no-op.
 
     Notes
     -----
@@ -530,16 +551,7 @@ def init(
     )
 
     if is_disabled:
-        os.environ["TRACEML_DISABLED"] = "1"
-        disabled_config = TraceMLInitConfig(
-            mode="manual",
-            patch_dataloader=False,
-            patch_forward=False,
-            patch_backward=False,
-            patch_h2d=False,
-            source=_source,
-            disabled=True,
-        )
+        disabled_config = _noop_config(_source)
         with _INIT_LOCK:
             if _INIT_CONFIG is not None:
                 if _INIT_CONFIG.same_effective_configuration(disabled_config):
@@ -603,18 +615,30 @@ def init(
                 "TRACEML_ON_MISSING_AGGREGATOR=raise) to fail instead.",
                 file=sys.stderr,
             )
-            noop_config = TraceMLInitConfig(
-                mode="manual",
-                patch_dataloader=False,
-                patch_forward=False,
-                patch_backward=False,
-                patch_h2d=False,
-                source=_source,
-                disabled=True,
-            )
+            noop_config = _noop_config(_source)
             _INIT_CONFIG = noop_config
             return noop_config
-        _apply_requested_patches(requested)
+        try:
+            _apply_requested_patches(requested)
+        except RuntimeError as exc:
+            if (
+                _resolve_on_missing_aggregator(on_missing_aggregator)
+                == "raise"
+            ):
+                _stop_runtime_for_init()
+                raise
+            import sys
+
+            _stop_runtime_for_init()
+            print(
+                f"[TraceML] {exc} Continuing without tracing (no-op). Pass "
+                "on_missing_aggregator='raise' (or set "
+                "TRACEML_ON_MISSING_AGGREGATOR=raise) to fail instead.",
+                file=sys.stderr,
+            )
+            noop_config = _noop_config(_source)
+            _INIT_CONFIG = noop_config
+            return noop_config
         _INIT_CONFIG = requested
         return requested
 
@@ -667,6 +691,7 @@ __all__ = [
     "TraceMLInitConfig",
     "TraceMLInitMode",
     "is_initialized",
+    "is_tracing_armed",
     "get_init_config",
     "init",
     "start",

--- a/src/traceml_ai/sdk/initial.py
+++ b/src/traceml_ai/sdk/initial.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from threading import Lock
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 TraceMLInitMode = Literal["auto", "manual", "selective"]
 
@@ -19,13 +19,15 @@ class TraceMLInitConfig:
     patch_backward: bool
     patch_h2d: bool
     source: str = "user"
+    disabled: bool = False
 
     def same_effective_configuration(self, other: "TraceMLInitConfig") -> bool:
         """
         Return True when two init configs result in the same runtime behavior.
         """
         return (
-            self.mode == other.mode
+            self.disabled == other.disabled
+            and self.mode == other.mode
             and self.patch_dataloader == other.patch_dataloader
             and self.patch_forward == other.patch_forward
             and self.patch_backward == other.patch_backward
@@ -35,6 +37,12 @@ class TraceMLInitConfig:
 
 _INIT_LOCK = Lock()
 _INIT_CONFIG: Optional[TraceMLInitConfig] = None
+
+# RuntimeHandle started by init() in this process, and whether the atexit
+# shutdown hook has been registered. Tracked separately from _INIT_CONFIG so
+# the runtime is stopped exactly once, only when init() actually started it.
+_RUNTIME_HANDLE: Any = None
+_ATEXIT_REGISTERED: bool = False
 
 
 def _canonical_mode(mode: str) -> TraceMLInitMode:
@@ -189,6 +197,226 @@ def is_initialized() -> bool:
     return _INIT_CONFIG is not None
 
 
+def _conflict_message(
+    existing: TraceMLInitConfig, requested: TraceMLInitConfig
+) -> str:
+    """Build the error message for an incompatible re-initialization."""
+    return (
+        "TraceML has already been initialized with a different "
+        "configuration in this process. "
+        f"Existing config: mode={existing.mode!r}, "
+        f"disabled={existing.disabled}, "
+        f"patch_dataloader={existing.patch_dataloader}, "
+        f"patch_forward={existing.patch_forward}, "
+        f"patch_backward={existing.patch_backward}, "
+        f"patch_h2d={existing.patch_h2d}, "
+        f"source={existing.source!r}. "
+        f"Requested config: mode={requested.mode!r}, "
+        f"disabled={requested.disabled}, "
+        f"patch_dataloader={requested.patch_dataloader}, "
+        f"patch_forward={requested.patch_forward}, "
+        f"patch_backward={requested.patch_backward}, "
+        f"patch_h2d={requested.patch_h2d}, "
+        f"source={requested.source!r}. "
+        "Initialize TraceML exactly once per process with the intended "
+        "mode at the start of the run."
+    )
+
+
+def _env_str(name: str, default: str) -> str:
+    """Return a non-empty environment value, otherwise ``default``."""
+    import os
+
+    value = os.environ.get(name)
+    return value if value not in (None, "") else default
+
+
+def _resolve_runtime_settings(
+    *,
+    ui_mode: Optional[str],
+    interval: Optional[float],
+    logs_dir: Optional[str],
+    enable_logging: Optional[bool],
+    session_id: Optional[str],
+    aggregator_host: Optional[str],
+    aggregator_port: Optional[int],
+) -> Any:
+    """
+    Build TraceMLSettings for a user-code runtime (direct ``python``/``torchrun``).
+
+    Runtime/telemetry settings (mode, interval, logs_dir, enable_logging, ...)
+    route through the shared config resolver with the same precedence the CLI
+    launcher uses: explicit ``traceml.init(...)`` arg > ``TRACEML_*`` env var >
+    ``traceml.yaml`` > built-in default. Aggregator host/port come from explicit
+    init args, then env, then defaults. Run identity and the aggregator endpoint
+    are launch-owned and are not read from ``traceml.yaml``.
+    """
+    import os
+    from pathlib import Path
+
+    from traceml_ai.config.yaml_loader import (
+        BUILT_IN_DEFAULTS,
+        find_config_file,
+        load_yaml_config,
+        resolve_config,
+    )
+    from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
+    from traceml_ai.runtime.session import get_session_id
+    from traceml_ai.runtime.settings import (
+        AggregatorTransportSettings,
+        TraceMLSettings,
+    )
+
+    try:
+        config_path = find_config_file(Path.cwd())
+        yaml_cfg = (
+            load_yaml_config(config_path) if config_path is not None else {}
+        )
+    except (ValueError, OSError):
+        # A broken traceml.yaml must not crash init(); fall back to env/defaults.
+        yaml_cfg = {}
+
+    cli_overrides = {
+        "mode": ui_mode,
+        "interval": interval,
+        "enable_logging": enable_logging,
+        "logs_dir": logs_dir,
+    }
+    cfg = resolve_config(
+        cli_overrides=cli_overrides,
+        parent_env=os.environ,
+        yaml_config=yaml_cfg,
+        defaults=BUILT_IN_DEFAULTS,
+    )
+
+    resolved_session = str(
+        session_id or _env_str("TRACEML_SESSION_ID", "") or get_session_id()
+    )
+    host = str(
+        aggregator_host
+        if aggregator_host is not None
+        else _env_str("TRACEML_AGGREGATOR_HOST", "127.0.0.1")
+    )
+    port = int(
+        aggregator_port
+        if aggregator_port is not None
+        else int(_env_str("TRACEML_AGGREGATOR_PORT", "29765"))
+    )
+    raw_max_steps = os.environ.get("TRACEML_TRACE_MAX_STEPS", "")
+    trace_max_steps = int(raw_max_steps) if raw_max_steps.strip() else None
+
+    return TraceMLSettings(
+        mode=str(cfg["mode"]),
+        profile=_env_str("TRACEML_PROFILE", "run"),
+        sampler_interval_sec=float(cfg["interval"]),
+        enable_logging=bool(cfg["enable_logging"]),
+        logs_dir=str(cfg["logs_dir"]),
+        history_enabled=bool(cfg["history_enabled"]),
+        session_id=resolved_session,
+        summary_window_rows=int(
+            _env_str(
+                "TRACEML_SUMMARY_WINDOW_ROWS",
+                str(DEFAULT_SUMMARY_WINDOW_ROWS),
+            )
+        ),
+        trace_max_steps=trace_max_steps,
+        aggregator=AggregatorTransportSettings(
+            connect_host=host, bind_host=host, port=port
+        ),
+    )
+
+
+def _resolve_on_missing_aggregator(value: Optional[str]) -> str:
+    """Resolve the missing-aggregator policy: explicit arg > env > 'warn'."""
+    import os
+
+    resolved = (
+        value
+        if value is not None
+        else os.environ.get("TRACEML_ON_MISSING_AGGREGATOR")
+    ) or "warn"
+    resolved = str(resolved).strip().lower()
+    if resolved not in ("warn", "raise"):
+        raise ValueError(
+            "on_missing_aggregator must be 'warn' or 'raise', got "
+            f"{resolved!r}."
+        )
+    return resolved
+
+
+def _start_runtime_for_init(
+    *,
+    ui_mode: Optional[str],
+    interval: Optional[float],
+    logs_dir: Optional[str],
+    enable_logging: Optional[bool],
+    session_id: Optional[str],
+    aggregator_host: Optional[str],
+    aggregator_port: Optional[int],
+    connect_timeout_sec: float,
+    connect_retry_interval_sec: float,
+) -> None:
+    """
+    Start the per-process TraceML runtime from user code.
+
+    No-op when a runtime is already active in this process (for example one
+    started by the ``traceml run`` executor), which keeps the CLI path working
+    even if user code also calls ``traceml.init()``. Otherwise this verifies the
+    aggregator is reachable within a bounded window and raises a clear error if
+    it is not.
+    """
+    global _RUNTIME_HANDLE, _ATEXIT_REGISTERED
+    import atexit
+
+    from traceml_ai.runtime import lifecycle
+
+    if lifecycle.get_active_runtime_handle() is not None:
+        return  # executor/ray already started the runtime in this process
+
+    settings = _resolve_runtime_settings(
+        ui_mode=ui_mode,
+        interval=interval,
+        logs_dir=logs_dir,
+        enable_logging=enable_logging,
+        session_id=session_id,
+        aggregator_host=aggregator_host,
+        aggregator_port=aggregator_port,
+    )
+    host = settings.aggregator.connect_host
+    port = settings.aggregator.port
+
+    if not lifecycle.wait_for_aggregator(
+        host,
+        port,
+        timeout_sec=connect_timeout_sec,
+        poll_interval_sec=connect_retry_interval_sec,
+    ):
+        raise RuntimeError(
+            f"TraceML could not reach the aggregator at {host}:{port} "
+            f"after {connect_timeout_sec:.0f}s. Start it with "
+            "`traceml serve` (matching --aggregator-host/--aggregator-port), "
+            "or call traceml.init(disabled=True) to run without tracing."
+        )
+
+    _RUNTIME_HANDLE = lifecycle.start_runtime(settings, fail_open=False)
+
+    if not _ATEXIT_REGISTERED:
+        atexit.register(_stop_runtime_for_init)
+        _ATEXIT_REGISTERED = True
+
+
+def _stop_runtime_for_init() -> None:
+    """Best-effort runtime shutdown for the user-code path (atexit)."""
+    global _RUNTIME_HANDLE
+    handle = _RUNTIME_HANDLE
+    _RUNTIME_HANDLE = None
+    if handle is not None:
+        try:
+            handle.stop()
+        except Exception:
+            pass
+
+
 def init(
     *,
     mode: str = "auto",
@@ -196,10 +424,31 @@ def init(
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
     patch_h2d: Optional[bool] = None,
+    disabled: Optional[bool] = None,
+    ui_mode: Optional[str] = None,
+    interval: Optional[float] = None,
+    logs_dir: Optional[str] = None,
+    enable_logging: Optional[bool] = None,
+    session_id: Optional[str] = None,
+    aggregator_host: Optional[str] = None,
+    aggregator_port: Optional[int] = None,
+    connect_timeout_sec: float = 10.0,
+    connect_retry_interval_sec: float = 0.25,
+    on_missing_aggregator: Optional[str] = None,
     _source: str = "user",
 ) -> TraceMLInitConfig:
     """
-    Initialize TraceML instrumentation policy for the current Python process.
+    Initialize TraceML for the current Python process and start its runtime.
+
+    This installs the requested instrumentation patches, starts the TraceML
+    runtime (background samplers + telemetry) in-process, and verifies that the
+    aggregator is reachable over TCP. When TraceML is already running in this
+    process (for example under ``traceml run``), runtime startup is skipped and
+    only the instrumentation policy is applied.
+
+    Configuration precedence for the runtime settings below is: explicit
+    argument here > ``TRACEML_*`` env var > ``traceml.yaml`` > built-in default,
+    the same resolver the CLI launcher uses.
 
     Parameters
     ----------
@@ -215,6 +464,38 @@ def init(
         Selective-mode-only override controlling forward timing patching.
     patch_backward:
         Selective-mode-only override controlling backward timing patching.
+    disabled:
+        When True, TraceML is a complete no-op: no patches are installed and no
+        runtime is started. Defaults to the ``TRACEML_DISABLED`` environment
+        variable when not set explicitly.
+    ui_mode:
+        Display/telemetry mode for this run ('cli', 'dashboard', or 'summary').
+        Resolved via the shared config resolver.
+    interval:
+        Sampler interval in seconds. Resolved via the shared config resolver.
+    logs_dir:
+        Directory for TraceML session logs. Resolved via the shared config
+        resolver.
+    enable_logging:
+        Enable TraceML logging output. Resolved via the shared config resolver.
+    session_id:
+        Explicit TraceML run/session id. Defaults to ``TRACEML_SESSION_ID`` or a
+        generated id. Must match the aggregator's session for shared artifacts.
+    aggregator_host:
+        Host the runtime connects to for telemetry. Defaults to
+        ``TRACEML_AGGREGATOR_HOST`` or ``127.0.0.1``.
+    aggregator_port:
+        Port the runtime connects to for telemetry. Defaults to
+        ``TRACEML_AGGREGATOR_PORT`` or ``29765``.
+    connect_timeout_sec:
+        Bounded period to wait for the aggregator before failing.
+    connect_retry_interval_sec:
+        Delay between aggregator connection attempts.
+    on_missing_aggregator:
+        Policy when the aggregator is unreachable (or the runtime fails to
+        start): 'warn' (default) emits one stderr warning and continues as a
+        no-op so instrumentation never crashes training; 'raise' fails hard.
+        Defaults to ``TRACEML_ON_MISSING_AGGREGATOR`` then 'warn'.
 
     Returns
     -------
@@ -227,6 +508,8 @@ def init(
         If the init request is invalid.
     RuntimeError
         If init conflicts with an existing config or patch installation fails.
+        An unreachable aggregator raises only when
+        ``on_missing_aggregator='raise'``; by default it warns and no-ops.
 
     Notes
     -----
@@ -236,6 +519,37 @@ def init(
       This keeps instrumentation behavior deterministic and easy to reason
       about in production environments.
     """
+    import os
+
+    global _INIT_CONFIG
+
+    is_disabled = (
+        bool(disabled)
+        if disabled is not None
+        else os.environ.get("TRACEML_DISABLED", "0") == "1"
+    )
+
+    if is_disabled:
+        os.environ["TRACEML_DISABLED"] = "1"
+        disabled_config = TraceMLInitConfig(
+            mode="manual",
+            patch_dataloader=False,
+            patch_forward=False,
+            patch_backward=False,
+            patch_h2d=False,
+            source=_source,
+            disabled=True,
+        )
+        with _INIT_LOCK:
+            if _INIT_CONFIG is not None:
+                if _INIT_CONFIG.same_effective_configuration(disabled_config):
+                    return _INIT_CONFIG
+                raise RuntimeError(
+                    _conflict_message(_INIT_CONFIG, disabled_config)
+                )
+            _INIT_CONFIG = disabled_config
+            return disabled_config
+
     requested = _build_config(
         mode=mode,
         patch_dataloader=patch_dataloader,
@@ -245,32 +559,61 @@ def init(
         source=_source,
     )
 
-    global _INIT_CONFIG
-
     with _INIT_LOCK:
         if _INIT_CONFIG is not None:
             if _INIT_CONFIG.same_effective_configuration(requested):
                 return _INIT_CONFIG
 
-            raise RuntimeError(
-                "TraceML has already been initialized with a different "
-                "configuration in this process. "
-                f"Existing config: mode={_INIT_CONFIG.mode!r}, "
-                f"patch_dataloader={_INIT_CONFIG.patch_dataloader}, "
-                f"patch_forward={_INIT_CONFIG.patch_forward}, "
-                f"patch_backward={_INIT_CONFIG.patch_backward}, "
-                f"patch_h2d={_INIT_CONFIG.patch_h2d}, "
-                f"source={_INIT_CONFIG.source!r}. "
-                f"Requested config: mode={requested.mode!r}, "
-                f"patch_dataloader={requested.patch_dataloader}, "
-                f"patch_forward={requested.patch_forward}, "
-                f"patch_backward={requested.patch_backward}, "
-                f"patch_h2d={requested.patch_h2d}, "
-                f"source={requested.source!r}. "
-                "Initialize TraceML exactly once per process with the intended "
-                "mode at the start of the run."
-            )
+            raise RuntimeError(_conflict_message(_INIT_CONFIG, requested))
 
+        # Start the runtime first (this also runs the bounded aggregator
+        # preflight). Doing so before installing patches keeps torch untouched
+        # when the aggregator is missing, and matches the runtime-then-patches
+        # order used by the in-process framework integrations.
+        try:
+            _start_runtime_for_init(
+                ui_mode=ui_mode,
+                interval=interval,
+                logs_dir=logs_dir,
+                enable_logging=enable_logging,
+                session_id=session_id,
+                aggregator_host=aggregator_host,
+                aggregator_port=aggregator_port,
+                connect_timeout_sec=connect_timeout_sec,
+                connect_retry_interval_sec=connect_retry_interval_sec,
+            )
+        except RuntimeError as exc:
+            # Fail-open ladder (see project failure-handling policy): a library
+            # call inside user code must never crash the training process for a
+            # transport reason. On an unreachable aggregator (or a runtime that
+            # fails to start) detach to a no-op with ONE loud stderr warning,
+            # installing no patches. Opt into hard failure with
+            # on_missing_aggregator='raise' (e.g. CI that wants misconfigured
+            # telemetry to fail the run).
+            if (
+                _resolve_on_missing_aggregator(on_missing_aggregator)
+                == "raise"
+            ):
+                raise
+            import sys
+
+            print(
+                f"[TraceML] {exc} Continuing without tracing (no-op). Pass "
+                "on_missing_aggregator='raise' (or set "
+                "TRACEML_ON_MISSING_AGGREGATOR=raise) to fail instead.",
+                file=sys.stderr,
+            )
+            noop_config = TraceMLInitConfig(
+                mode="manual",
+                patch_dataloader=False,
+                patch_forward=False,
+                patch_backward=False,
+                patch_h2d=False,
+                source=_source,
+                disabled=True,
+            )
+            _INIT_CONFIG = noop_config
+            return noop_config
         _apply_requested_patches(requested)
         _INIT_CONFIG = requested
         return requested
@@ -283,6 +626,16 @@ def start(
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
     patch_h2d: Optional[bool] = None,
+    disabled: Optional[bool] = None,
+    ui_mode: Optional[str] = None,
+    interval: Optional[float] = None,
+    logs_dir: Optional[str] = None,
+    enable_logging: Optional[bool] = None,
+    session_id: Optional[str] = None,
+    aggregator_host: Optional[str] = None,
+    aggregator_port: Optional[int] = None,
+    connect_timeout_sec: float = 10.0,
+    connect_retry_interval_sec: float = 0.25,
 ) -> TraceMLInitConfig:
     """
     Alias for `init()` for the current transition period.
@@ -296,6 +649,16 @@ def start(
         patch_forward=patch_forward,
         patch_backward=patch_backward,
         patch_h2d=patch_h2d,
+        disabled=disabled,
+        ui_mode=ui_mode,
+        interval=interval,
+        logs_dir=logs_dir,
+        enable_logging=enable_logging,
+        session_id=session_id,
+        aggregator_host=aggregator_host,
+        aggregator_port=aggregator_port,
+        connect_timeout_sec=connect_timeout_sec,
+        connect_retry_interval_sec=connect_retry_interval_sec,
         _source="user",
     )
 

--- a/src/traceml_ai/sdk/instrumentation.py
+++ b/src/traceml_ai/sdk/instrumentation.py
@@ -36,6 +36,11 @@ from traceml_ai.instrumentation.patches.forward_auto_timer_patch import (
 from traceml_ai.instrumentation.patches.h2d_auto_timer_patch import (
     h2d_auto_timer,
 )
+from traceml_ai.runtime.environment import detect_runtime_environment
+from traceml_ai.runtime.environment_state import (
+    has_runtime_environment_info,
+    publish_runtime_environment_once,
+)
 from traceml_ai.runtime.state import (
     TraceSessionState,
     get_trace_session_state,
@@ -101,6 +106,14 @@ def _should_auto_install_optimizer_timing() -> bool:
     return getattr(cfg, "mode", "auto") == "auto"
 
 
+def _publish_runtime_environment(model: nn.Module) -> None:
+    """Queue rank-scoped runtime environment info once, fail-open."""
+    if has_runtime_environment_info():
+        return
+    info = detect_runtime_environment(model)
+    publish_runtime_environment_once(info)
+
+
 class _TraceStateMeta(type):
     @property
     def step(cls) -> int:
@@ -143,6 +156,11 @@ def trace_step(model: nn.Module):
     if _traceml_disabled():
         yield
         return
+
+    try:
+        _publish_runtime_environment(model)
+    except Exception as exc:
+        _log_instrumentation_error("runtime environment detection failed", exc)
 
     trace_state = get_trace_session_state()
     mem_tracker = StepMemoryTracker(model)

--- a/src/traceml_ai/utils/flush_buffers.py
+++ b/src/traceml_ai/utils/flush_buffers.py
@@ -7,11 +7,13 @@ from traceml_ai.runtime.state import should_record_trace_events
 from .step_memory import flush_step_memory_buffer
 from .timing import flush_step_time_buffer
 
-TRACEML_DISABLED = os.environ.get("TRACEML_DISABLED") == "1"
+
+def _traceml_disabled() -> bool:
+    return os.environ.get("TRACEML_DISABLED") == "1"
 
 
 def flush_step_events(model: nn.Module, step: int) -> None:
-    if TRACEML_DISABLED or not should_record_trace_events():
+    if _traceml_disabled() or not should_record_trace_events():
         return
 
     flush_step_memory_buffer(model, step)

--- a/src/traceml_ai/utils/step_memory.py
+++ b/src/traceml_ai/utils/step_memory.py
@@ -13,7 +13,9 @@ step_memory_queue: Queue = Queue(maxsize=2048)
 
 _temp_step_memory_buffer: Dict = {}
 
-TRACEML_DISABLED = os.environ.get("TRACEML_DISABLED") == "1"
+
+def _traceml_disabled() -> bool:
+    return os.environ.get("TRACEML_DISABLED") == "1"
 
 
 @dataclass
@@ -35,7 +37,7 @@ class StepMemoryTracker:
     """
 
     def __init__(self, model: nn.Module):
-        if TRACEML_DISABLED or not should_record_trace_events():
+        if _traceml_disabled() or not should_record_trace_events():
             return  # BYPASS: Do not attach any trackers
 
         self.model = model
@@ -52,7 +54,7 @@ class StepMemoryTracker:
         """
         Reset CUDA peak memory counters at step start.
         """
-        if TRACEML_DISABLED or not should_record_trace_events():
+        if _traceml_disabled() or not should_record_trace_events():
             return
 
         if self.device.type == "cuda":
@@ -68,7 +70,7 @@ class StepMemoryTracker:
           treat step memory as not applicable instead of a real zero-valued
           measurement
         """
-        if TRACEML_DISABLED or not should_record_trace_events():
+        if _traceml_disabled() or not should_record_trace_events():
             return
 
         if self.device.type == "cuda":
@@ -93,7 +95,7 @@ class StepMemoryTracker:
 
 
 def flush_step_memory_buffer(model: nn.Module, step: int) -> None:
-    if TRACEML_DISABLED or not should_record_trace_events():
+    if _traceml_disabled() or not should_record_trace_events():
         return
 
     model_id = id(model)

--- a/src/traceml_ai/utils/step_time_sqlite.py
+++ b/src/traceml_ai/utils/step_time_sqlite.py
@@ -1,0 +1,119 @@
+"""Shared SQLite loading for canonical Step Time windows.
+
+Live CLI/dashboard and final-summary reporting both diagnose Step Time from
+the same global-rank event rows. They differ only in how many rows they load:
+live uses a small recent window with extra lookback, while summary uses a
+larger final-report window.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Sequence
+
+from traceml_ai.utils.step_time_window import (
+    StepTimeWindow,
+    build_step_time_window_from_events,
+)
+
+
+@dataclass(frozen=True)
+class StepTimeSQLiteWindow:
+    """A Step Time window plus the global-rank ids used to build it."""
+
+    window: StepTimeWindow
+    global_ranks: tuple[int, ...]
+
+
+def load_step_time_window_from_sqlite(
+    conn: sqlite3.Connection,
+    *,
+    max_rows: int,
+    lookback_factor: int = 1,
+    table: str = "step_time_samples",
+    rank_filter: Optional[Sequence[int]] = None,
+) -> StepTimeSQLiteWindow:
+    """
+    Load one canonical selected-clock Step Time window from SQLite.
+
+    The loader reads `global_rank` ids and returns them as rank-shaped data for
+    existing diagnosis, CLI/dashboard, and summary contracts. `max_rows` is the
+    final aligned window size; `lookback_factor` only controls how much recent
+    per-rank history is read before common-step alignment.
+    """
+    row_limit = max(1, int(max_rows))
+    lookback = max(row_limit * max(1, int(lookback_factor)), row_limit)
+    allowed_ranks = (
+        {int(rank) for rank in rank_filter}
+        if rank_filter is not None
+        else None
+    )
+
+    rows = conn.execute(
+        f"""
+        SELECT DISTINCT global_rank
+        FROM {table}
+        WHERE global_rank IS NOT NULL
+        ORDER BY global_rank ASC;
+        """
+    ).fetchall()
+    global_ranks = tuple(
+        int(row[0])
+        for row in rows
+        if row[0] is not None
+        and (allowed_ranks is None or int(row[0]) in allowed_ranks)
+    )
+
+    per_rank_steps: Dict[int, Dict[int, Dict[str, Any]]] = {}
+    for global_rank in global_ranks:
+        step_rows = conn.execute(
+            f"""
+            SELECT step, events_json
+            FROM (
+                SELECT id, step, events_json
+                FROM {table}
+                WHERE global_rank = ?
+                ORDER BY step DESC, id DESC
+                LIMIT ?
+            )
+            ORDER BY step ASC, id DESC;
+            """,
+            (int(global_rank), int(lookback)),
+        ).fetchall()
+
+        step_map: Dict[int, Dict[str, Any]] = {}
+        for step, events_json in step_rows:
+            if step is None or not events_json:
+                continue
+
+            step_id = int(step)
+            if step_id in step_map:
+                continue
+
+            try:
+                parsed = json.loads(events_json)
+            except Exception:
+                continue
+
+            if isinstance(parsed, dict):
+                step_map[step_id] = parsed
+
+        if step_map:
+            per_rank_steps[int(global_rank)] = step_map
+
+    return StepTimeSQLiteWindow(
+        window=build_step_time_window_from_events(
+            per_rank_steps,
+            max_rows=row_limit,
+            expected_ranks=global_ranks,
+        ),
+        global_ranks=global_ranks,
+    )
+
+
+__all__ = [
+    "StepTimeSQLiteWindow",
+    "load_step_time_window_from_sqlite",
+]

--- a/src/traceml_ai/utils/step_time_sqlite.py
+++ b/src/traceml_ai/utils/step_time_sqlite.py
@@ -17,14 +17,50 @@ from traceml_ai.utils.step_time_window import (
     StepTimeWindow,
     build_step_time_window_from_events,
 )
+from traceml_ai.utils.training_strategy import (
+    DEFAULT_TRAINING_STRATEGY,
+    KNOWN_TRAINING_STRATEGIES,
+    normalize_training_strategy,
+)
 
 
 @dataclass(frozen=True)
 class StepTimeSQLiteWindow:
-    """A Step Time window plus the global-rank ids used to build it."""
+    """A Step Time window plus run context used by diagnosis."""
 
     window: StepTimeWindow
     global_ranks: tuple[int, ...]
+    training_strategy: str = DEFAULT_TRAINING_STRATEGY
+
+
+def load_training_strategy_from_sqlite(
+    conn: sqlite3.Connection,
+) -> str:
+    """
+    Load best-effort run-level training strategy from runtime metadata.
+
+    Runtime environment rows can arrive from ranks in any order. Step Time uses
+    the latest available non-empty row for this one training run. Missing,
+    old, or unrecognized metadata defaults to `ddp` so existing backward-clean
+    straggler attribution remains unchanged until strategy-specific rules run.
+    """
+    try:
+        row = conn.execute(
+            """
+            SELECT training_strategy
+            FROM runtime_environment
+            WHERE training_strategy IS NOT NULL
+              AND TRIM(training_strategy) != ''
+            ORDER BY id DESC
+            LIMIT 1;
+            """
+        ).fetchone()
+    except Exception:
+        return DEFAULT_TRAINING_STRATEGY
+
+    if not row:
+        return DEFAULT_TRAINING_STRATEGY
+    return normalize_training_strategy(row[0])
 
 
 def load_step_time_window_from_sqlite(
@@ -41,7 +77,8 @@ def load_step_time_window_from_sqlite(
     The loader reads `global_rank` ids and returns them as rank-shaped data for
     existing diagnosis, CLI/dashboard, and summary contracts. `max_rows` is the
     final aligned window size; `lookback_factor` only controls how much recent
-    per-rank history is read before common-step alignment.
+    per-rank history is read before common-step alignment. Training strategy is
+    advisory diagnosis context loaded from the latest runtime metadata row.
     """
     row_limit = max(1, int(max_rows))
     lookback = max(row_limit * max(1, int(lookback_factor)), row_limit)
@@ -110,10 +147,14 @@ def load_step_time_window_from_sqlite(
             expected_ranks=global_ranks,
         ),
         global_ranks=global_ranks,
+        training_strategy=load_training_strategy_from_sqlite(conn),
     )
 
 
 __all__ = [
+    "DEFAULT_TRAINING_STRATEGY",
+    "KNOWN_TRAINING_STRATEGIES",
     "StepTimeSQLiteWindow",
+    "load_training_strategy_from_sqlite",
     "load_step_time_window_from_sqlite",
 ]

--- a/src/traceml_ai/utils/step_time_window.py
+++ b/src/traceml_ai/utils/step_time_window.py
@@ -511,6 +511,7 @@ def diagnose_step_time_window(
     window: StepTimeWindow,
     *,
     policy: "StepTimeDiagnosisPolicy",
+    training_strategy: str = "ddp",
 ) -> "DiagnosticResult[StepDiagnosis]":
     """Run shared Step Time diagnosis over one selected-clock window."""
     from traceml_ai.diagnostics.step_time.api import (
@@ -524,6 +525,7 @@ def diagnose_step_time_window(
         thresholds=policy.thresholds,
         per_rank_timing=window.per_rank_timing,
         diagnosis_clock=window.clock,
+        training_strategy=training_strategy,
     )
 
 

--- a/src/traceml_ai/utils/step_time_window.py
+++ b/src/traceml_ai/utils/step_time_window.py
@@ -512,19 +512,13 @@ def diagnose_step_time_window(
     *,
     policy: "StepTimeDiagnosisPolicy",
 ) -> "DiagnosticResult[StepDiagnosis]":
-    """Run Step Time diagnosis over one canonical selected-clock window."""
+    """Run shared Step Time diagnosis over one selected-clock window."""
     from traceml_ai.diagnostics.step_time.api import (
         build_step_diagnosis_result,
-        build_step_warmup_diagnosis,
     )
 
     if not window.metrics:
         return build_step_diagnosis_result([], thresholds=policy.thresholds)
-    if int(window.coverage.steps_used) < int(policy.min_steps_for_diag):
-        return build_step_warmup_diagnosis(
-            steps_used=int(window.coverage.steps_used),
-            required_steps=int(policy.min_steps_for_diag),
-        )
     return build_step_diagnosis_result(
         window.metrics,
         thresholds=policy.thresholds,

--- a/src/traceml_ai/utils/timing.py
+++ b/src/traceml_ai/utils/timing.py
@@ -26,7 +26,9 @@ import torch
 from traceml_ai.runtime.state import should_record_trace_events
 from traceml_ai.utils.cuda_event_pool import get_cuda_event, return_cuda_event
 
-TRACEML_DISABLED = os.environ.get("TRACEML_DISABLED") == "1"
+
+def _traceml_disabled() -> bool:
+    return os.environ.get("TRACEML_DISABLED") == "1"
 
 
 class TimeScope(str, Enum):
@@ -153,7 +155,7 @@ def record_event(evt: TimeEvent) -> None:
     STEP events are buffered until flush.
     GLOBAL events are enqueued immediately.
     """
-    if TRACEML_DISABLED or not should_record_trace_events():
+    if _traceml_disabled() or not should_record_trace_events():
         return
     if evt.scope == TimeScope.STEP:
         _STEP_BUFFER.append(evt)
@@ -167,7 +169,7 @@ def flush_step_time_buffer(step: int) -> None:
 
     Called once per optimizer step.
     """
-    if TRACEML_DISABLED or not should_record_trace_events():
+    if _traceml_disabled() or not should_record_trace_events():
         return
     if not _STEP_BUFFER:
         return
@@ -204,7 +206,7 @@ def timed_region(
     currently include GPU backend metadata; CUDA and ROCm-specific labeling can
     be added as a separate schema change when needed.
     """
-    if TRACEML_DISABLED or not should_record_trace_events():
+    if _traceml_disabled() or not should_record_trace_events():
         yield
         return
 

--- a/src/traceml_ai/utils/training_strategy.py
+++ b/src/traceml_ai/utils/training_strategy.py
@@ -1,0 +1,25 @@
+"""Shared training-strategy vocabulary and normalization."""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_TRAINING_STRATEGY = "ddp"
+KNOWN_TRAINING_STRATEGIES = frozenset(
+    {"ddp", "fsdp", "distributed_unknown", "single_process", "unknown"}
+)
+
+
+def normalize_training_strategy(value: Any) -> str:
+    """Return a known training strategy, defaulting to current DDP behavior."""
+    strategy = str(value or DEFAULT_TRAINING_STRATEGY).strip().lower()
+    if strategy in KNOWN_TRAINING_STRATEGIES:
+        return strategy
+    return DEFAULT_TRAINING_STRATEGY
+
+
+__all__ = [
+    "DEFAULT_TRAINING_STRATEGY",
+    "KNOWN_TRAINING_STRATEGIES",
+    "normalize_training_strategy",
+]

--- a/tests/aggregator/test_aggregator_main_env.py
+++ b/tests/aggregator/test_aggregator_main_env.py
@@ -8,9 +8,11 @@ from traceml_ai.aggregator.aggregator_main import read_traceml_env
 def test_read_traceml_env_dashboard_defaults(monkeypatch) -> None:
     monkeypatch.delenv("TRACEML_DASHBOARD_PORT", raising=False)
     monkeypatch.delenv("TRACEML_DASHBOARD_AUTO_OPEN", raising=False)
+    monkeypatch.delenv("TRACEML_INTERVAL", raising=False)
     cfg = read_traceml_env()
     assert cfg["dashboard_port"] == 8765
     assert cfg["dashboard_auto_open"] is True
+    assert cfg["interval"] == 2.0
 
 
 def test_read_traceml_env_dashboard_from_env(monkeypatch) -> None:

--- a/tests/config/test_yaml_loader.py
+++ b/tests/config/test_yaml_loader.py
@@ -232,8 +232,13 @@ def test_resolve_config_history_disabled_via_cli() -> None:
     assert result["history_enabled"] is False
 
 
-def test_load_yaml_config_unreadable_file(tmp_path: Path) -> None:
+def test_load_yaml_config_unreadable_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A file that exists but cannot be read raises OSError with a clear message."""
+    import builtins
+    import os
+    import stat
     import sys
 
     if sys.platform == "win32":
@@ -241,6 +246,18 @@ def test_load_yaml_config_unreadable_file(tmp_path: Path) -> None:
 
     p = _write(tmp_path, "mode: cli\n")
     p.chmod(0o000)
+
+    if os.geteuid() == 0:
+        real_open = builtins.open
+
+        # Root ignores the mode bits, so apply the read check the kernel skips.
+        def guarded_open(file, *args, **kwargs):
+            if file == p and not (p.stat().st_mode & stat.S_IRUSR):
+                raise PermissionError(13, "Permission denied")
+            return real_open(file, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", guarded_open)
+
     try:
         with pytest.raises(OSError, match="Cannot read config file"):
             load_yaml_config(p)

--- a/tests/diagnostics/test_common.py
+++ b/tests/diagnostics/test_common.py
@@ -6,7 +6,6 @@ from traceml_ai.diagnostics.common import (
     DiagnosticResult,
     diagnosis_to_issue,
     ensure_primary_issue,
-    sort_issues,
 )
 from traceml_ai.reporting.summaries.issue_summary import (
     diagnostic_result_to_json,
@@ -137,39 +136,3 @@ def test_diagnostic_result_json_uses_first_issue_as_diagnosis() -> None:
 
     assert diagnosis == issues[0]
     assert diagnosis["kind"] == "HIGH_CPU"
-
-
-def test_sort_issues_orders_by_severity_score_and_rank_breadth() -> None:
-    low = DiagnosticIssue(
-        kind="LOW",
-        status="LOW",
-        severity="info",
-        summary="low",
-        action="none",
-        score=1.0,
-        ranks=(0, 1),
-    )
-    high_low_score = DiagnosticIssue(
-        kind="HIGH_LOW_SCORE",
-        status="HIGH LOW SCORE",
-        severity="crit",
-        summary="high",
-        action="none",
-        score=0.1,
-        ranks=(0,),
-    )
-    high_high_score = DiagnosticIssue(
-        kind="HIGH_HIGH_SCORE",
-        status="HIGH HIGH SCORE",
-        severity="crit",
-        summary="high",
-        action="none",
-        score=0.9,
-        ranks=(0,),
-    )
-
-    assert sort_issues((low, high_low_score, high_high_score)) == (
-        high_high_score,
-        high_low_score,
-        low,
-    )

--- a/tests/diagnostics/test_registry.py
+++ b/tests/diagnostics/test_registry.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 
-from traceml_ai.diagnostics.step_memory import LIVE_STEP_MEMORY_POLICY
+import traceml_ai.diagnostics.model_diagnostics as model_diagnostics
 from traceml_ai.diagnostics.model_diagnostics import (
     DEFAULT_MODEL_DIAGNOSTIC_REGISTRY,
     ModelDiagnosisItem,
@@ -11,6 +11,7 @@ from traceml_ai.diagnostics.registry import (
     DiagnosticDomainSpec,
     ModelDiagnosticContext,
 )
+from traceml_ai.diagnostics.step_memory import LIVE_STEP_MEMORY_POLICY
 from traceml_ai.renderers.step_memory.schema import (
     StepMemoryCombinedCoverage,
     StepMemoryCombinedMetric,

--- a/tests/diagnostics/test_registry.py
+++ b/tests/diagnostics/test_registry.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+import traceml_ai.diagnostics.model_diagnostics as model_diagnostics
 from traceml_ai.diagnostics.step_memory import LIVE_STEP_MEMORY_POLICY
 from traceml_ai.diagnostics.model_diagnostics import (
     DEFAULT_MODEL_DIAGNOSTIC_REGISTRY,
@@ -173,6 +174,7 @@ def test_model_step_time_diagnostics_use_selected_metrics(monkeypatch):
     def fake_diagnosis(metrics, **kwargs):
         captured["metrics"] = metrics
         captured["diagnosis_clock"] = kwargs.get("diagnosis_clock")
+        captured["training_strategy"] = kwargs.get("training_strategy")
         return SimpleNamespace(
             kind="INPUT_BOUND",
             severity="warn",
@@ -194,11 +196,13 @@ def test_model_step_time_diagnostics_use_selected_metrics(monkeypatch):
     payload = build_model_diagnostics_payload(
         step_time_diagnosis_metrics=diagnosis_metrics,
         step_time_diagnosis_clock="gpu",
+        step_time_training_strategy="fsdp",
         step_memory_metrics=(),
     )
 
     assert captured["metrics"] == diagnosis_metrics
     assert captured["diagnosis_clock"] == "gpu"
+    assert captured["training_strategy"] == "fsdp"
     assert payload.items[0].status == "INPUT-BOUND"
     assert payload.items[0].evidence["dominant"] == "input wait"
 

--- a/tests/diagnostics/test_registry.py
+++ b/tests/diagnostics/test_registry.py
@@ -285,8 +285,6 @@ def test_default_model_diagnostics_payload_keeps_existing_sources():
 
 
 def test_model_step_memory_diagnostics_use_live_policy(monkeypatch):
-    import traceml_ai.diagnostics.model_diagnostics as model_diagnostics
-
     captured = {}
 
     def fake_diagnosis(metrics, *, thresholds, **kwargs):

--- a/tests/diagnostics/test_registry.py
+++ b/tests/diagnostics/test_registry.py
@@ -1,6 +1,5 @@
 from types import SimpleNamespace
 
-import traceml_ai.diagnostics.model_diagnostics as model_diagnostics
 from traceml_ai.diagnostics.model_diagnostics import (
     DEFAULT_MODEL_DIAGNOSTIC_REGISTRY,
     ModelDiagnosisItem,

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -202,6 +202,7 @@ def _single_rank_step_metrics(
     backward: float = 50.0,
     optimizer: float = 10.0,
     residual: float = 5.0,
+    steps: int = 64,
 ) -> tuple[StepCombinedTimeMetric, ...]:
     return (
         _time_metric(
@@ -210,6 +211,7 @@ def _single_rank_step_metrics(
             worst=step,
             worst_rank=0,
             world_size=1,
+            steps=steps,
         ),
         _time_metric(
             "input_wait",
@@ -217,6 +219,7 @@ def _single_rank_step_metrics(
             worst=dataloader,
             worst_rank=0,
             world_size=1,
+            steps=steps,
         ),
         _time_metric(
             "forward",
@@ -224,6 +227,7 @@ def _single_rank_step_metrics(
             worst=forward,
             worst_rank=0,
             world_size=1,
+            steps=steps,
         ),
         _time_metric(
             "backward",
@@ -231,6 +235,7 @@ def _single_rank_step_metrics(
             worst=backward,
             worst_rank=0,
             world_size=1,
+            steps=steps,
         ),
         _time_metric(
             "optimizer_step",
@@ -238,6 +243,7 @@ def _single_rank_step_metrics(
             worst=optimizer,
             worst_rank=0,
             world_size=1,
+            steps=steps,
         ),
         _time_metric(
             "residual_proxy",
@@ -245,6 +251,7 @@ def _single_rank_step_metrics(
             worst=residual,
             worst_rank=0,
             world_size=1,
+            steps=steps,
         ),
     )
 
@@ -597,6 +604,38 @@ def test_step_time_primary_prefers_clean_straggler_over_residual_heavy() -> (
     }
 
 
+def test_step_time_early_warning_band_caps_severity() -> None:
+    per_rank = {
+        0: _timing_row(dataloader=50.0, step_time=100.0),
+    }
+
+    warmup = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank, steps=1),
+        per_rank_timing=per_rank,
+    )
+    assert warmup.primary.kind == "WARMUP"
+    assert (
+        warmup.primary.reason
+        == "Only 1 step per rank available; diagnosis requires 2."
+    )
+
+    warning = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank, steps=5),
+        per_rank_timing=per_rank,
+    )
+    assert warning.primary.kind == "INPUT_BOUND"
+    assert warning.primary.severity == "warn"
+    assert warning.issues[0].severity == "warn"
+
+    confident = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank, steps=20),
+        per_rank_timing=per_rank,
+    )
+    assert confident.primary.kind == "INPUT_BOUND"
+    assert confident.primary.severity == "crit"
+    assert confident.issues[0].severity == "crit"
+
+
 def test_summary_step_time_window_uses_summary_policy_by_default() -> None:
     warmup = _diagnose_summary_events(
         {0: _summary_step_events(input_wait_gpu=None, steps=40)},
@@ -606,7 +645,7 @@ def test_summary_step_time_window_uses_summary_policy_by_default() -> None:
     assert warmup.primary.kind == "WARMUP"
     assert (
         warmup.primary.reason
-        == "Only 40 steps per rank available; summary diagnosis requires 50."
+        == "Only 40 steps per rank available; diagnosis requires 50."
     )
 
     result = _diagnose_summary_events(

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -457,10 +457,11 @@ def test_input_bound_rule_uses_cpu_clock_when_gpu_is_absent() -> None:
     assert issue.kind == "INPUT_BOUND"
     assert issue.metric == "input_wait"
     assert issue.phase == "input"
-    assert issue.share_pct == pytest.approx(0.35)
+    assert issue.share_pct == pytest.approx(35.0 / 135.0)
     assert issue.evidence["diagnosis_clock"] == "cpu"
     assert issue.evidence["input_wait_ms"] == pytest.approx(35.0)
     assert issue.evidence["step_time_ms"] == pytest.approx(100.0)
+    assert issue.evidence["iteration_time_ms"] == pytest.approx(135.0)
 
 
 def test_input_bound_rule_ignores_duration_without_explicit_clocks() -> None:
@@ -487,7 +488,7 @@ def test_input_bound_rule_uses_input_wait_skew() -> None:
         }
     )
 
-    assert ctx.input_bound_share == pytest.approx(0.35)
+    assert ctx.input_bound_share == pytest.approx(35.0 / 135.0)
     assert InputBoundRule().evaluate(ctx) is None
 
 
@@ -682,6 +683,9 @@ def test_summary_input_bound_uses_explicit_input_clocks() -> None:
     assert high_wait.primary.kind == "INPUT_BOUND"
     assert high_wait.issues[0].evidence["diagnosis_clock"] == "gpu"
     assert high_wait.issues[0].evidence["input_wait_ms"] == pytest.approx(25.0)
+    assert high_wait.issues[0].evidence["iteration_time_ms"] == pytest.approx(
+        85.0
+    )
 
 
 def test_summary_input_bound_trend_uses_selected_input_wait_series() -> None:

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -6,16 +6,21 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import pytest
 
 from traceml_ai.diagnostics.step_time.api import (
     DEFAULT_THRESHOLDS,
+    StepDiagnosis,
     build_step_diagnosis_result,
 )
 from traceml_ai.diagnostics.step_time.context import build_step_time_context
+from traceml_ai.diagnostics.step_time.formatters import format_cli_diagnosis
 from traceml_ai.diagnostics.step_time.policy import SUMMARY_STEP_TIME_POLICY
 from traceml_ai.diagnostics.step_time.rules import (
     ComputeBoundRule,
+    H2DBoundRule,
     InputBoundRule,
     RankStragglerRule,
     ResidualHeavyRule,
@@ -177,12 +182,14 @@ def _rank_context(
     per_rank_timing: dict[int, dict[str, float]],
     *,
     training_strategy: str = "ddp",
+    diagnosis_clock: str = "cpu",
 ):
     return build_step_time_context(
         metrics=_metrics_from_per_rank_timing(per_rank_timing),
         thresholds=DEFAULT_THRESHOLDS,
         per_rank_timing=per_rank_timing,
         training_strategy=training_strategy,
+        diagnosis_clock=diagnosis_clock,
     )
 
 
@@ -425,6 +432,98 @@ def test_input_bound_uses_iteration_share_thresholds(
 
 
 @pytest.mark.parametrize(
+    ("h2d", "expected_severity"),
+    [(10.0, "warn"), (20.0, "crit")],
+)
+def test_h2d_bound_uses_gpu_iteration_share_thresholds(
+    h2d: float,
+    expected_severity: str,
+) -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=h2d,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    issue = H2DBoundRule().evaluate(
+        _rank_context(per_rank, diagnosis_clock="gpu")
+    )
+
+    assert issue is not None
+    assert issue.metric == "h2d"
+    assert issue.phase == "h2d"
+    assert issue.share_pct == pytest.approx(h2d / 100.0)
+    assert issue.severity == expected_severity
+
+
+def test_h2d_bound_abstains_below_warning_threshold() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=9.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    assert (
+        H2DBoundRule().evaluate(_rank_context(per_rank, diagnosis_clock="gpu"))
+        is None
+    )
+
+
+def test_h2d_bound_requires_gpu_selected_timing() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=80.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    assert H2DBoundRule().evaluate(_rank_context(per_rank)) is None
+
+
+def test_h2d_bound_keeps_skew_as_evidence() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=10.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=0.0,
+            h2d=90.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+    }
+
+    issue = H2DBoundRule().evaluate(
+        _rank_context(per_rank, diagnosis_clock="gpu")
+    )
+
+    assert issue is not None
+    assert issue.skew_pct is not None
+    assert issue.ranks == (1,)
+
+
+@pytest.mark.parametrize(
     ("residual", "expected_severity"),
     [(10.0, "warn"), (20.0, "crit")],
 )
@@ -488,6 +587,89 @@ def test_compute_bound_requires_existing_dominance_threshold() -> None:
     }
 
     assert ComputeBoundRule().evaluate(_rank_context(per_rank)) is None
+
+
+def test_compute_bound_abstains_for_material_h2d() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=10.0,
+            forward=90.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    assert (
+        ComputeBoundRule().evaluate(
+            _rank_context(per_rank, diagnosis_clock="gpu")
+        )
+        is None
+    )
+
+
+def test_cpu_h2d_does_not_suppress_compute_bound() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=80.0,
+            forward=90.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    issue = ComputeBoundRule().evaluate(_rank_context(per_rank))
+
+    assert issue is not None
+    assert issue.kind == "COMPUTE_BOUND"
+
+
+def test_input_bound_remains_primary_when_h2d_is_also_material() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=20.0,
+            h2d=20.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+        diagnosis_clock="gpu",
+    )
+
+    assert result.primary.kind == "INPUT_BOUND"
+    assert {issue.kind for issue in result.issues} >= {
+        "INPUT_BOUND",
+        "H2D_BOUND",
+    }
+
+
+@pytest.mark.parametrize(
+    ("severity", "style"),
+    [("warn", "bold yellow"), ("crit", "bold red")],
+)
+def test_h2d_bound_cli_style_matches_severity(
+    severity: Literal["warn", "crit"],
+    style: str,
+) -> None:
+    diagnosis = StepDiagnosis(
+        kind="H2D_BOUND",
+        status="H2D-BOUND",
+        severity=severity,
+        reason="H2D transfer is material.",
+        action="Inspect transfers.",
+        steps_used=64,
+    )
+
+    assert f"[{style}]H2D-BOUND[/{style}]" in format_cli_diagnosis(diagnosis)
 
 
 def test_compute_bound_is_secondary_to_rank_straggler() -> None:
@@ -881,6 +1063,7 @@ def _event_stats(
 def _summary_step_events(
     *,
     input_wait_gpu: float | None,
+    h2d: float = 0.0,
     step_time_gpu: float = 60.0,
     steps: int = 60,
 ) -> dict[int, dict]:
@@ -888,7 +1071,7 @@ def _summary_step_events(
     for step in range(steps):
         events = {
             "_traceml_internal:dataloader_next": _event_stats(cpu_ms=5.0),
-            "_traceml_internal:h2d_time": _event_stats(cpu_ms=0.0),
+            "_traceml_internal:h2d_time": _event_stats(cpu_ms=h2d),
             "_traceml_internal:forward_time": _event_stats(cpu_ms=20.0),
             "_traceml_internal:backward_time": _event_stats(cpu_ms=30.0),
             "_traceml_internal:optimizer_step": _event_stats(cpu_ms=10.0),
@@ -899,7 +1082,7 @@ def _summary_step_events(
                 "_traceml_internal:dataloader_next": _event_stats(
                     gpu_ms=input_wait_gpu
                 ),
-                "_traceml_internal:h2d_time": _event_stats(gpu_ms=0.0),
+                "_traceml_internal:h2d_time": _event_stats(gpu_ms=h2d),
                 "_traceml_internal:forward_time": _event_stats(gpu_ms=20.0),
                 "_traceml_internal:backward_time": _event_stats(gpu_ms=30.0),
                 "_traceml_internal:optimizer_step": _event_stats(gpu_ms=10.0),
@@ -928,6 +1111,28 @@ def test_summary_input_bound_uses_explicit_input_clocks() -> None:
     assert high_wait.issues[0].evidence["iteration_time_ms"] == pytest.approx(
         85.0
     )
+
+
+def test_summary_h2d_bound_uses_gpu_selected_h2d_timing() -> None:
+    result = _diagnose_summary_events(
+        {0: _summary_step_events(input_wait_gpu=0.0, h2d=12.0)},
+        max_rows=100,
+    )
+
+    assert result.primary.kind == "H2D_BOUND"
+    issue = next(issue for issue in result.issues if issue.kind == "H2D_BOUND")
+    assert issue.severity == "crit"
+    assert issue.evidence["diagnosis_clock"] == "gpu"
+    assert issue.share_pct == pytest.approx(12.0 / 60.0)
+
+
+def test_summary_h2d_bound_ignores_cpu_selected_h2d_timing() -> None:
+    result = _diagnose_summary_events(
+        {0: _summary_step_events(input_wait_gpu=None, h2d=80.0)},
+        max_rows=100,
+    )
+
+    assert all(issue.kind != "H2D_BOUND" for issue in result.issues)
 
 
 def test_summary_input_bound_trend_uses_selected_input_wait_series() -> None:

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -635,6 +635,15 @@ def test_step_time_early_warning_band_caps_severity() -> None:
     assert confident.primary.severity == "crit"
     assert confident.issues[0].severity == "crit"
 
+    fsdp = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank, steps=20),
+        per_rank_timing=per_rank,
+        training_strategy="fsdp",
+    )
+    assert fsdp.primary.kind == "INPUT_BOUND"
+    assert fsdp.primary.severity == "warn"
+    assert all(issue.severity == "warn" for issue in fsdp.issues)
+
 
 def test_summary_step_time_window_uses_summary_policy_by_default() -> None:
     short_window = _diagnose_summary_events(

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -15,10 +15,8 @@ from traceml_ai.diagnostics.step_time.api import (
 from traceml_ai.diagnostics.step_time.context import build_step_time_context
 from traceml_ai.diagnostics.step_time.policy import SUMMARY_STEP_TIME_POLICY
 from traceml_ai.diagnostics.step_time.rules import (
-    CleanStragglerRule,
-    ComputeBoundRule,
     InputBoundRule,
-    ResidualHeavyRule,
+    RankStragglerRule,
 )
 from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeCoverage,
@@ -173,12 +171,16 @@ def _metrics_from_per_rank_timing(
     return tuple(metrics)
 
 
-def _clean_context(
+def _rank_context(
     per_rank_timing: dict[int, dict[str, float]],
+    *,
+    training_strategy: str = "ddp",
 ):
-    return _time_context(
-        *_metrics_from_per_rank_timing(per_rank_timing),
+    return build_step_time_context(
+        metrics=_metrics_from_per_rank_timing(per_rank_timing),
+        thresholds=DEFAULT_THRESHOLDS,
         per_rank_timing=per_rank_timing,
+        training_strategy=training_strategy,
     )
 
 
@@ -253,115 +255,6 @@ def _single_rank_step_metrics(
             world_size=1,
             steps=steps,
         ),
-    )
-
-
-def test_step_time_rules_trigger_and_no_trigger_cases() -> None:
-    input_ctx = _clean_context(
-        {
-            0: _timing_row(dataloader=10.0),
-            1: _timing_row(dataloader=90.0),
-        }
-    )
-    assert CleanStragglerRule().evaluate(input_ctx).kind == "INPUT_STRAGGLER"
-    assert (
-        CleanStragglerRule().evaluate(
-            _time_context(*_single_rank_step_metrics())
-        )
-        is None
-    )
-
-    compute_ctx = _clean_context(
-        {
-            0: _timing_row(forward=20.0, backward=30.0),
-            1: _timing_row(forward=90.0, backward=30.0),
-        }
-    )
-    assert CleanStragglerRule().evaluate(compute_ctx).kind == (
-        "COMPUTE_STRAGGLER"
-    )
-
-    input_bound = _time_context(
-        *_single_rank_step_metrics(
-            step=100.0,
-            dataloader=35.0,
-            forward=20.0,
-            backward=30.0,
-            optimizer=5.0,
-            residual=10.0,
-        ),
-        per_rank_timing={
-            0: _timing_row(
-                dataloader=35.0,
-                forward=20.0,
-                backward=30.0,
-                optimizer=5.0,
-                residual=10.0,
-                input_wait_gpu=35.0,
-                step_time_gpu=100.0,
-            )
-        },
-        diagnosis_clock="gpu",
-    )
-    issue = InputBoundRule().evaluate(input_bound)
-    assert issue is not None
-    assert issue.kind == "INPUT_BOUND"
-    assert issue.metric == "input_wait"
-    assert issue.phase == "input"
-    assert issue.evidence["diagnosis_clock"] == "gpu"
-    assert (
-        InputBoundRule().evaluate(
-            _time_context(
-                *_single_rank_step_metrics(dataloader=50.0),
-                per_rank_timing={
-                    0: _timing_row(
-                        dataloader=50.0,
-                        input_wait_gpu=5.0,
-                        step_time_gpu=100.0,
-                    )
-                },
-            )
-        )
-        is None
-    )
-
-    assert (
-        ResidualHeavyRule()
-        .evaluate(_time_context(*_single_rank_step_metrics(residual=20.0)))
-        .kind
-        == "RESIDUAL_HEAVY"
-    )
-    assert (
-        ResidualHeavyRule().evaluate(
-            _time_context(*_single_rank_step_metrics(residual=5.0))
-        )
-        is None
-    )
-
-    assert (
-        ComputeBoundRule()
-        .evaluate(
-            _time_context(
-                *_single_rank_step_metrics(dataloader=2.0, residual=3.0)
-            )
-        )
-        .kind
-        == "COMPUTE_BOUND"
-    )
-    assert (
-        ComputeBoundRule().evaluate(
-            _time_context(
-                *_single_rank_step_metrics(dataloader=5.0, residual=3.0),
-                per_rank_timing={
-                    0: _timing_row(
-                        dataloader=5.0,
-                        input_wait_cpu=35.0,
-                        step_time_cpu=100.0,
-                    )
-                },
-            )
-        )
-        is None
     )
 
 
@@ -480,7 +373,7 @@ def test_input_bound_rule_ignores_duration_without_explicit_clocks() -> None:
 
 
 def test_input_bound_rule_uses_input_wait_skew() -> None:
-    ctx = _clean_context(
+    ctx = _rank_context(
         {
             0: _timing_row(
                 dataloader=10.0,
@@ -499,76 +392,52 @@ def test_input_bound_rule_uses_input_wait_skew() -> None:
     assert InputBoundRule().evaluate(ctx) is None
 
 
-def test_clean_backward_discount_removes_telescoped_delay_from_peer() -> None:
-    per_rank = {
-        0: _timing_row(
-            dataloader=100.0,
-            forward=20.0,
-            backward=20.0,
-            optimizer=0.0,
-            total_step=140.0,
-        ),
-        1: _timing_row(
-            dataloader=0.0,
-            forward=20.0,
-            backward=120.0,
-            optimizer=0.0,
-            total_step=140.0,
-        ),
-    }
-    ctx = _clean_context(per_rank)
-    issue = CleanStragglerRule().evaluate(ctx)
-
-    assert ctx.clean_rank_values["clean_backward"][1] == pytest.approx(20.0)
-    assert ctx.clean_rank_values["clean_compute"][0] == pytest.approx(40.0)
-    assert ctx.clean_rank_values["clean_compute"][1] == pytest.approx(40.0)
-    assert ctx.clean_rank_values["clean_step"][0] == pytest.approx(140.0)
-    assert issue is not None
-    assert issue.kind == "INPUT_STRAGGLER"
-    assert issue.ranks == (0,)
-    assert issue.evidence["component_excesses_ms"]["input"] == pytest.approx(
-        50.0
-    )
-
-
 @pytest.mark.parametrize(
     ("per_rank", "expected_kind", "expected_phase"),
     [
         (
             {
-                0: _timing_row(forward=20.0),
-                1: _timing_row(forward=100.0),
+                0: _timing_row(
+                    dataloader=100.0,
+                    backward=20.0,
+                    optimizer=0.0,
+                ),
+                1: _timing_row(
+                    dataloader=0.0,
+                    backward=120.0,
+                    optimizer=0.0,
+                ),
             },
-            "COMPUTE_STRAGGLER",
-            "compute",
+            "INPUT_STRAGGLER",
+            "input",
         ),
         (
             {
-                0: _timing_row(h2d=0.0),
-                1: _timing_row(h2d=80.0),
+                0: _timing_row(h2d=80.0, backward=20.0, optimizer=0.0),
+                1: _timing_row(h2d=0.0, backward=120.0, optimizer=0.0),
             },
             "H2D_STRAGGLER",
             "h2d",
         ),
         (
             {
-                0: _timing_row(residual=0.0),
-                1: _timing_row(residual=80.0),
+                0: _timing_row(forward=100.0, backward=20.0, optimizer=0.0),
+                1: _timing_row(forward=20.0, backward=120.0, optimizer=0.0),
             },
-            "RESIDUAL_STRAGGLER",
-            "residual",
+            "COMPUTE_STRAGGLER",
+            "forward",
         ),
         (
             {
-                0: _timing_row(dataloader=10.0, forward=20.0),
-                1: _timing_row(dataloader=60.0, forward=40.0),
+                0: _timing_row(forward=20.0, backward=20.0, optimizer=0.0),
+                1: _timing_row(forward=20.0, backward=120.0, optimizer=0.0),
             },
             "STRAGGLER",
-            "mixed",
+            "sync",
         ),
     ],
 )
-def test_clean_straggler_classifies_component_excess(
+def test_rank_straggler_classifies_culprit_excess(
     per_rank: dict[int, dict[str, float]],
     expected_kind: str,
     expected_phase: str,
@@ -579,17 +448,213 @@ def test_clean_straggler_classifies_component_excess(
     )
 
     assert result.primary.kind == expected_kind
-    assert result.primary.worst_rank == 1
+    assert result.primary.worst_rank == 0
     assert result.issues[0].phase == expected_phase
-    assert result.issues[0].evidence["clean_step_slack_ms"] > 0.0
+    assert result.issues[0].evidence["culprit_rank"] == 0
+    assert result.issues[0].evidence["victim_rank"] == 1
+    assert result.issues[0].evidence["visible_cost_ms"] > 0.0
 
 
-def test_step_time_primary_prefers_clean_straggler_over_residual_heavy() -> (
+@pytest.mark.parametrize(
+    ("per_rank", "expected_kind", "expected_phase"),
+    [
+        (
+            {
+                0: _timing_row(
+                    dataloader=100.0,
+                    forward=20.0,
+                    backward=20.0,
+                    optimizer=0.0,
+                ),
+                1: _timing_row(
+                    dataloader=0.0,
+                    forward=80.0,
+                    backward=80.0,
+                    optimizer=0.0,
+                ),
+            },
+            "INPUT_STRAGGLER",
+            "input",
+        ),
+        (
+            {
+                0: _timing_row(
+                    h2d=80.0,
+                    forward=20.0,
+                    backward=20.0,
+                    optimizer=0.0,
+                ),
+                1: _timing_row(
+                    h2d=0.0,
+                    forward=80.0,
+                    backward=80.0,
+                    optimizer=0.0,
+                ),
+            },
+            "H2D_STRAGGLER",
+            "h2d",
+        ),
+        (
+            {
+                0: _timing_row(forward=100.0, backward=20.0, optimizer=0.0),
+                1: _timing_row(forward=20.0, backward=200.0, optimizer=0.0),
+            },
+            "STRAGGLER",
+            "sync",
+        ),
+    ],
+)
+def test_fsdp_rank_straggler_uses_input_h2d_or_unattributed(
+    per_rank: dict[int, dict[str, float]],
+    expected_kind: str,
+    expected_phase: str,
+) -> None:
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+        training_strategy="fsdp",
+    )
+
+    assert result.primary.kind == expected_kind
+    assert result.primary.worst_rank == 0
+    assert result.issues[0].phase == expected_phase
+    if expected_kind == "STRAGGLER":
+        assert result.issues[0].evidence["component"] == "sync_or_unattributed"
+
+
+def test_rank_straggler_not_emitted_below_visible_wait_threshold() -> None:
+    per_rank = {
+        0: _timing_row(backward=115.0),
+        1: _timing_row(backward=120.0),
+    }
+    ctx = _rank_context(per_rank)
+
+    assert ctx.rank_straggler is None
+    assert RankStragglerRule().evaluate(ctx) is None
+
+
+@pytest.mark.parametrize(
+    ("training_strategy", "per_rank", "expected"),
+    [
+        (
+            "ddp",
+            {
+                0: _timing_row(
+                    dataloader=200.0,
+                    backward=0.0,
+                    step_time=200.0,
+                ),
+                1: _timing_row(
+                    dataloader=80.0,
+                    backward=20.0,
+                    step_time=100.0,
+                ),
+                2: _timing_row(
+                    dataloader=0.0,
+                    backward=120.0,
+                    step_time=140.0,
+                ),
+            },
+            ("INPUT_STRAGGLER", 1, 2),
+        ),
+        (
+            "ddp",
+            {
+                0: _timing_row(backward=0.0, step_time=100.0),
+                1: _timing_row(backward=0.0, step_time=120.0),
+            },
+            None,
+        ),
+        (
+            "ddp",
+            {
+                0: _timing_row(
+                    dataloader=200.0,
+                    backward=1.0,
+                    step_time=0.0,
+                ),
+                1: _timing_row(
+                    dataloader=80.0,
+                    backward=20.0,
+                    step_time=100.0,
+                ),
+                2: _timing_row(
+                    dataloader=0.0,
+                    backward=120.0,
+                    step_time=140.0,
+                ),
+            },
+            ("INPUT_STRAGGLER", 1, 2),
+        ),
+        (
+            "fsdp",
+            {
+                0: _timing_row(dataloader=200.0, forward=0.0, backward=1.0),
+                1: _timing_row(dataloader=160.0, forward=10.0, backward=0.0),
+                2: _timing_row(dataloader=80.0, forward=20.0, backward=20.0),
+                3: _timing_row(dataloader=0.0, forward=80.0, backward=80.0),
+            },
+            ("INPUT_STRAGGLER", 2, 3),
+        ),
+    ],
+)
+def test_rank_straggler_uses_only_valid_visible_ranks(
+    training_strategy: str,
+    per_rank: dict[int, dict[str, float]],
+    expected: tuple[str, int, int] | None,
+) -> None:
+    ctx = _rank_context(per_rank, training_strategy=training_strategy)
+    issue = RankStragglerRule().evaluate(ctx)
+
+    if expected is None:
+        assert ctx.rank_straggler is None
+        assert issue is None
+        return
+
+    expected_kind, expected_culprit, expected_victim = expected
+    assert ctx.rank_straggler is not None
+    assert ctx.rank_straggler.culprit_rank == expected_culprit
+    assert ctx.rank_straggler.victim_rank == expected_victim
+    assert issue is not None
+    assert issue.kind == expected_kind
+
+
+def test_ddp_missing_forward_does_not_emit_compute_straggler() -> None:
+    per_rank = {
+        0: _timing_row(forward=100.0, backward=20.0, optimizer=0.0),
+        1: _timing_row(forward=0.0, backward=120.0, optimizer=0.0),
+    }
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+    )
+
+    assert result.primary.kind == "STRAGGLER"
+    assert result.issues[0].phase == "sync"
+    assert result.issues[0].evidence["component"] == "sync_or_unattributed"
+
+
+def test_rank_straggler_uses_actual_upper_median_victim_rank() -> None:
+    per_rank = {
+        0: _timing_row(backward=10.0, forward=10.0, optimizer=0.0),
+        1: _timing_row(backward=20.0, forward=10.0, optimizer=0.0),
+        2: _timing_row(backward=30.0, forward=10.0, optimizer=0.0),
+        3: _timing_row(backward=40.0, forward=10.0, optimizer=0.0),
+    }
+    ctx = _rank_context(per_rank)
+
+    assert ctx.rank_straggler is not None
+    assert ctx.rank_straggler.culprit_rank == 0
+    assert ctx.rank_straggler.victim_rank == 2
+    assert ctx.rank_straggler.visible_victim_ms == pytest.approx(30.0)
+
+
+def test_step_time_primary_prefers_rank_straggler_over_residual_heavy() -> (
     None
 ):
     per_rank = {
-        0: _timing_row(dataloader=10.0, residual=80.0),
-        1: _timing_row(dataloader=110.0, residual=80.0),
+        0: _timing_row(dataloader=110.0, backward=20.0, residual=80.0),
+        1: _timing_row(dataloader=10.0, backward=120.0, residual=80.0),
     }
 
     result = build_step_diagnosis_result(

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -637,16 +637,13 @@ def test_step_time_early_warning_band_caps_severity() -> None:
 
 
 def test_summary_step_time_window_uses_summary_policy_by_default() -> None:
-    warmup = _diagnose_summary_events(
+    short_window = _diagnose_summary_events(
         {0: _summary_step_events(input_wait_gpu=None, steps=40)},
         max_rows=100,
     )
-    assert warmup is not None
-    assert warmup.primary.kind == "WARMUP"
-    assert (
-        warmup.primary.reason
-        == "Only 40 steps per rank available; diagnosis requires 50."
-    )
+    assert short_window is not None
+    assert short_window.primary.kind == "COMPUTE_BOUND"
+    assert short_window.primary.steps_used == 40
 
     result = _diagnose_summary_events(
         {0: _summary_step_events(input_wait_gpu=None, steps=60)},

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -15,8 +15,10 @@ from traceml_ai.diagnostics.step_time.api import (
 from traceml_ai.diagnostics.step_time.context import build_step_time_context
 from traceml_ai.diagnostics.step_time.policy import SUMMARY_STEP_TIME_POLICY
 from traceml_ai.diagnostics.step_time.rules import (
+    ComputeBoundRule,
     InputBoundRule,
     RankStragglerRule,
+    ResidualHeavyRule,
 )
 from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeCoverage,
@@ -372,7 +374,7 @@ def test_input_bound_rule_ignores_duration_without_explicit_clocks() -> None:
     assert InputBoundRule().evaluate(ctx) is None
 
 
-def test_input_bound_rule_uses_input_wait_skew() -> None:
+def test_input_bound_uses_median_per_rank_iteration_share() -> None:
     ctx = _rank_context(
         {
             0: _timing_row(
@@ -388,8 +390,138 @@ def test_input_bound_rule_uses_input_wait_skew() -> None:
         }
     )
 
-    assert ctx.input_bound_share == pytest.approx(35.0 / 135.0)
-    assert InputBoundRule().evaluate(ctx) is None
+    expected = ((10.0 / 110.0) + (60.0 / 160.0)) / 2.0
+
+    assert ctx.input_bound_share == pytest.approx(expected)
+    assert ctx.input_bound_share != pytest.approx(35.0 / 135.0)
+
+    issue = InputBoundRule().evaluate(ctx)
+    assert issue is not None
+    assert issue.severity == "crit"
+    assert issue.skew_pct is not None
+
+
+@pytest.mark.parametrize(
+    ("input_wait", "step_time", "expected_severity"),
+    [(10.0, 90.0, "warn"), (20.0, 80.0, "crit")],
+)
+def test_input_bound_uses_iteration_share_thresholds(
+    input_wait: float,
+    step_time: float,
+    expected_severity: str,
+) -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=input_wait,
+            step_time=step_time,
+        )
+    }
+
+    issue = InputBoundRule().evaluate(_rank_context(per_rank))
+
+    assert issue is not None
+    assert issue.share_pct == pytest.approx(input_wait / 100.0)
+    assert issue.severity == expected_severity
+
+
+@pytest.mark.parametrize(
+    ("residual", "expected_severity"),
+    [(10.0, "warn"), (20.0, "crit")],
+)
+def test_residual_heavy_uses_iteration_share_thresholds(
+    residual: float,
+    expected_severity: str,
+) -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            residual=residual,
+            step_time=100.0,
+        )
+    }
+
+    issue = ResidualHeavyRule().evaluate(_rank_context(per_rank))
+
+    assert issue is not None
+    assert issue.share_pct == pytest.approx(residual / 100.0)
+    assert issue.severity == expected_severity
+
+
+def test_compute_bound_is_informational_despite_compute_skew() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            forward=90.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=0.0,
+            forward=150.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=160.0,
+        ),
+    }
+
+    issue = ComputeBoundRule().evaluate(_rank_context(per_rank))
+
+    assert issue is not None
+    assert issue.severity == "info"
+    assert issue.skew_pct is not None
+
+
+def test_compute_bound_requires_existing_dominance_threshold() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=20.0,
+            forward=80.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    assert ComputeBoundRule().evaluate(_rank_context(per_rank)) is None
+
+
+def test_compute_bound_is_secondary_to_rank_straggler() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            forward=90.0,
+            backward=10.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=0.0,
+            forward=90.0,
+            backward=30.0,
+            optimizer=0.0,
+            step_time=120.0,
+        ),
+    }
+
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+    )
+
+    assert result.primary.kind == "STRAGGLER"
+    assert {issue.kind for issue in result.issues} >= {
+        "STRAGGLER",
+        "COMPUTE_BOUND",
+    }
+    compute_issue = next(
+        issue for issue in result.issues if issue.kind == "COMPUTE_BOUND"
+    )
+    assert compute_issue.severity == "info"
 
 
 @pytest.mark.parametrize(

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -31,6 +31,9 @@ from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeSeries,
     StepCombinedTimeSummary,
 )
+from traceml_ai.reporting.summaries.issue_summary import (
+    diagnostic_result_to_json,
+)
 from traceml_ai.utils.step_time_window import (
     build_step_time_window_from_events,
     diagnose_step_time_window,
@@ -367,6 +370,7 @@ def test_input_bound_rule_uses_cpu_clock_when_gpu_is_absent() -> None:
     assert issue.metric == "input_wait"
     assert issue.phase == "input"
     assert issue.share_pct == pytest.approx(35.0 / 135.0)
+    assert issue.score == issue.share_pct
     assert issue.evidence["diagnosis_clock"] == "cpu"
     assert issue.evidence["input_wait_ms"] == pytest.approx(35.0)
     assert issue.evidence["step_time_ms"] == pytest.approx(100.0)
@@ -458,6 +462,7 @@ def test_h2d_bound_uses_gpu_iteration_share_thresholds(
     assert issue.metric == "h2d"
     assert issue.phase == "h2d"
     assert issue.share_pct == pytest.approx(h2d / 100.0)
+    assert issue.score == issue.share_pct
     assert issue.severity == expected_severity
 
 
@@ -546,6 +551,7 @@ def test_residual_heavy_uses_iteration_share_thresholds(
 
     assert issue is not None
     assert issue.share_pct == pytest.approx(residual / 100.0)
+    assert issue.score == issue.share_pct
     assert issue.severity == expected_severity
 
 
@@ -571,6 +577,7 @@ def test_compute_bound_is_informational_despite_compute_skew() -> None:
 
     assert issue is not None
     assert issue.severity == "info"
+    assert issue.score is None
     assert issue.skew_pct is not None
 
 
@@ -650,6 +657,139 @@ def test_input_bound_remains_primary_when_h2d_is_also_material() -> None:
         "INPUT_BOUND",
         "H2D_BOUND",
     }
+
+
+def test_step_time_primary_orders_by_severity_before_impact() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=20.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            residual=30.0,
+            step_time=100.0,
+        )
+    }
+
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+    )
+
+    assert result.primary.kind == "RESIDUAL_HEAVY"
+    assert [issue.kind for issue in result.issues[:2]] == [
+        "RESIDUAL_HEAVY",
+        "INPUT_BOUND",
+    ]
+    assert result.issues[0].severity == "crit"
+    assert result.issues[1].severity == "warn"
+
+
+def test_step_time_primary_orders_equal_severity_by_impact() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=15.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            residual=19.0,
+            step_time=100.0,
+        )
+    }
+
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+    )
+
+    assert result.primary.kind == "RESIDUAL_HEAVY"
+    assert [issue.kind for issue in result.issues[:2]] == [
+        "RESIDUAL_HEAVY",
+        "INPUT_BOUND",
+    ]
+    assert result.issues[0].severity == result.issues[1].severity == "warn"
+    assert result.issues[0].score > result.issues[1].score
+
+
+def test_rank_straggler_wins_only_an_exact_impact_tie() -> None:
+    tied = {
+        0: _timing_row(
+            dataloader=20.0,
+            forward=0.0,
+            backward=20.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=20.0,
+            forward=0.0,
+            backward=40.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+    }
+    higher_typical = {
+        0: _timing_row(
+            dataloader=20.0,
+            forward=0.0,
+            backward=20.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=20.0,
+            forward=0.0,
+            backward=35.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+    }
+
+    tied_result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(tied),
+        per_rank_timing=tied,
+    )
+    typical_result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(higher_typical),
+        per_rank_timing=higher_typical,
+    )
+
+    assert tied_result.primary.kind == "STRAGGLER"
+    assert [issue.kind for issue in tied_result.issues[:2]] == [
+        "STRAGGLER",
+        "INPUT_BOUND",
+    ]
+    assert tied_result.issues[0].score == tied_result.issues[1].score
+
+    assert typical_result.primary.kind == "INPUT_BOUND"
+    assert [issue.kind for issue in typical_result.issues[:2]] == [
+        "INPUT_BOUND",
+        "STRAGGLER",
+    ]
+    assert typical_result.issues[0].score > typical_result.issues[1].score
+
+
+def test_step_time_primary_uses_capped_severity_before_impact() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=20.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            residual=30.0,
+            step_time=100.0,
+        )
+    }
+
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank, steps=5),
+        per_rank_timing=per_rank,
+    )
+    diagnosis_json, issues_json = diagnostic_result_to_json(result)
+
+    assert result.primary.kind == "RESIDUAL_HEAVY"
+    assert all(issue.severity == "warn" for issue in result.issues)
+    assert diagnosis_json == issues_json[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -793,7 +793,7 @@ def test_rank_straggler_classifies_culprit_excess(
         (
             {
                 0: _timing_row(
-                    h2d=80.0,
+                    h2d=100.0,
                     forward=20.0,
                     backward=20.0,
                     optimizer=0.0,
@@ -845,6 +845,193 @@ def test_rank_straggler_not_emitted_below_visible_wait_threshold() -> None:
 
     assert ctx.rank_straggler is None
     assert RankStragglerRule().evaluate(ctx) is None
+
+
+@pytest.mark.parametrize(
+    ("visible_cost", "expected_severity"),
+    [(9.0, None), (10.0, "warn"), (20.0, "crit")],
+)
+def test_rank_straggler_uses_victim_iteration_impact_thresholds(
+    visible_cost: float,
+    expected_severity: str | None,
+) -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            backward=10.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=0.0,
+            backward=10.0 + visible_cost,
+            step_time=100.0,
+        ),
+    }
+
+    issue = RankStragglerRule().evaluate(_rank_context(per_rank))
+
+    if expected_severity is None:
+        assert issue is None
+        return
+
+    assert issue is not None
+    assert issue.kind == "STRAGGLER"
+    assert issue.severity == expected_severity
+    assert issue.score == pytest.approx(visible_cost / 100.0)
+
+
+@pytest.mark.parametrize(
+    ("component", "excess", "expected_kind"),
+    [
+        ("input", 79.0, "STRAGGLER"),
+        ("input", 80.0, "INPUT_STRAGGLER"),
+        ("h2d", 79.0, "STRAGGLER"),
+        ("h2d", 80.0, "H2D_STRAGGLER"),
+        ("compute", 79.0, "STRAGGLER"),
+        ("compute", 80.0, "COMPUTE_STRAGGLER"),
+    ],
+)
+def test_rank_straggler_requires_component_coverage_for_attribution(
+    component: str,
+    excess: float,
+    expected_kind: str,
+) -> None:
+    culprit = _timing_row(
+        dataloader=0.0,
+        backward=20.0,
+        step_time=100.0,
+    )
+    victim = _timing_row(
+        dataloader=0.0,
+        backward=120.0,
+        step_time=100.0,
+    )
+    if component == "input":
+        culprit["input_wait"] = excess
+        victim["input_wait"] = 0.0
+    elif component == "h2d":
+        culprit["h2d"] = excess
+        victim["h2d"] = 0.0
+    else:
+        culprit["forward"] = 20.0 + excess
+        victim["forward"] = 20.0
+
+    issue = RankStragglerRule().evaluate(
+        _rank_context({0: culprit, 1: victim})
+    )
+
+    assert issue is not None
+    assert issue.kind == expected_kind
+    assert issue.severity == "crit"
+    assert issue.score == pytest.approx(1.0)
+    assert issue.evidence["component_excesses_ms"][component] == pytest.approx(
+        excess
+    )
+    assert issue.evidence["component_coverage"][component] == pytest.approx(
+        excess / 100.0
+    )
+
+
+def test_rank_straggler_coverage_changes_attribution_not_severity() -> None:
+    def _issue(input_excess: float):
+        culprit = _timing_row(
+            dataloader=input_excess,
+            backward=20.0,
+            step_time=100.0,
+        )
+        victim = _timing_row(
+            dataloader=0.0,
+            backward=120.0,
+            step_time=100.0,
+        )
+        issue = RankStragglerRule().evaluate(
+            _rank_context({0: culprit, 1: victim})
+        )
+        assert issue is not None
+        return issue
+
+    generic = _issue(79.0)
+    named = _issue(80.0)
+
+    assert generic.kind == "STRAGGLER"
+    assert named.kind == "INPUT_STRAGGLER"
+    assert generic.score == named.score == pytest.approx(1.0)
+    assert generic.severity == named.severity == "crit"
+
+
+def test_rank_straggler_component_coverage_is_bounded() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=140.0,
+            backward=20.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=0.0,
+            h2d=0.0,
+            backward=120.0,
+            step_time=100.0,
+        ),
+    }
+
+    issue = RankStragglerRule().evaluate(_rank_context(per_rank))
+
+    assert issue is not None
+    assert issue.kind == "H2D_STRAGGLER"
+    assert issue.evidence["component_excesses_ms"]["h2d"] == 140.0
+    assert issue.evidence["component_coverage"]["h2d"] == 1.0
+
+
+def test_rank_straggler_keeps_confidence_and_fsdp_severity_caps() -> None:
+    ddp_per_rank = {
+        0: _timing_row(
+            dataloader=100.0,
+            backward=20.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=0.0,
+            backward=120.0,
+            step_time=100.0,
+        ),
+    }
+    early = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(ddp_per_rank, steps=5),
+        per_rank_timing=ddp_per_rank,
+    )
+    confident = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(ddp_per_rank, steps=20),
+        per_rank_timing=ddp_per_rank,
+    )
+
+    assert early.primary.kind == "INPUT_STRAGGLER"
+    assert early.primary.severity == "warn"
+    assert confident.primary.kind == "INPUT_STRAGGLER"
+    assert confident.primary.severity == "crit"
+
+    fsdp_per_rank = {
+        0: _timing_row(
+            dataloader=100.0,
+            forward=20.0,
+            backward=20.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=0.0,
+            forward=80.0,
+            backward=80.0,
+            step_time=100.0,
+        ),
+    }
+    fsdp = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(fsdp_per_rank, steps=20),
+        per_rank_timing=fsdp_per_rank,
+        training_strategy="fsdp",
+    )
+
+    assert fsdp.primary.kind == "INPUT_STRAGGLER"
+    assert fsdp.primary.severity == "warn"
 
 
 @pytest.mark.parametrize(
@@ -905,7 +1092,7 @@ def test_rank_straggler_not_emitted_below_visible_wait_threshold() -> None:
             {
                 0: _timing_row(dataloader=200.0, forward=0.0, backward=1.0),
                 1: _timing_row(dataloader=160.0, forward=10.0, backward=0.0),
-                2: _timing_row(dataloader=80.0, forward=20.0, backward=20.0),
+                2: _timing_row(dataloader=100.0, forward=20.0, backward=20.0),
                 3: _timing_row(dataloader=0.0, forward=80.0, backward=80.0),
             },
             ("INPUT_STRAGGLER", 2, 3),

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -1097,6 +1097,11 @@ def test_rank_straggler_coverage_changes_attribution_not_severity() -> None:
     assert named.kind == "INPUT_STRAGGLER"
     assert generic.score == named.score == pytest.approx(1.0)
     assert generic.severity == named.severity == "crit"
+    assert "r0 is slower than victim r1" in generic.summary
+    assert "r0 has excess input wait burden relative to victim r1" in (
+        named.summary
+    )
+    assert "~80.0% of visible wait cost" in named.summary
 
 
 def test_rank_straggler_component_coverage_is_bounded() -> None:

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -17,7 +17,10 @@ from traceml_ai.diagnostics.step_time.api import (
 )
 from traceml_ai.diagnostics.step_time.context import build_step_time_context
 from traceml_ai.diagnostics.step_time.formatters import format_cli_diagnosis
-from traceml_ai.diagnostics.step_time.policy import SUMMARY_STEP_TIME_POLICY
+from traceml_ai.diagnostics.step_time.policy import (
+    LIVE_STEP_TIME_POLICY,
+    SUMMARY_STEP_TIME_POLICY,
+)
 from traceml_ai.diagnostics.step_time.rules import (
     ComputeBoundRule,
     H2DBoundRule,
@@ -581,6 +584,57 @@ def test_compute_bound_is_informational_despite_compute_skew() -> None:
     assert issue.skew_pct is not None
 
 
+@pytest.mark.parametrize(
+    ("compute", "expected"),
+    [(89.9, False), (90.0, True)],
+)
+def test_compute_bound_uses_iteration_share_threshold(
+    compute: float,
+    expected: bool,
+) -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            forward=compute,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    issue = ComputeBoundRule().evaluate(_rank_context(per_rank))
+
+    assert (issue is not None) is expected
+    if issue is not None:
+        assert issue.share_pct == pytest.approx(0.90)
+        assert issue.score is None
+
+
+def test_compute_share_is_median_of_per_rank_iteration_shares() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            forward=100.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=100.0,
+            forward=80.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+    }
+
+    context = _rank_context(per_rank)
+
+    assert context.compute_share == pytest.approx(0.70)
+    aggregate_median_ratio = 90.0 / (50.0 + 100.0)
+    assert context.compute_share != pytest.approx(aggregate_median_ratio)
+
+
 def test_compute_bound_requires_existing_dominance_threshold() -> None:
     per_rank = {
         0: _timing_row(
@@ -614,6 +668,31 @@ def test_compute_bound_abstains_for_material_h2d() -> None:
         )
         is None
     )
+
+
+@pytest.mark.parametrize(
+    ("input_wait", "residual", "step_time"),
+    [(10.0, 0.0, 90.0), (0.0, 10.0, 100.0)],
+)
+def test_compute_bound_abstains_for_material_iteration_overhead(
+    input_wait: float,
+    residual: float,
+    step_time: float,
+) -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=input_wait,
+            forward=90.0,
+            backward=0.0,
+            optimizer=0.0,
+            residual=residual,
+            step_time=step_time,
+        )
+    }
+    context = _rank_context(per_rank)
+
+    assert context.compute_share == pytest.approx(0.90)
+    assert ComputeBoundRule().evaluate(context) is None
 
 
 def test_cpu_h2d_does_not_suppress_compute_bound() -> None:
@@ -1372,6 +1451,27 @@ def test_summary_step_time_window_uses_summary_policy_by_default() -> None:
 
     assert result is not None
     assert result.primary.steps_used == 60
+
+
+def test_builtin_live_and_summary_policies_use_identical_thresholds() -> None:
+    live_thresholds = LIVE_STEP_TIME_POLICY.thresholds
+    summary_thresholds = SUMMARY_STEP_TIME_POLICY.thresholds
+
+    assert live_thresholds is summary_thresholds
+    assert live_thresholds.compute_bound_share_warn == pytest.approx(0.90)
+
+    window = build_step_time_window_from_events(
+        {0: _summary_step_events(input_wait_gpu=None, steps=40)},
+        max_rows=100,
+    )
+    live = diagnose_step_time_window(window, policy=LIVE_STEP_TIME_POLICY)
+    summary = diagnose_step_time_window(
+        window,
+        policy=SUMMARY_STEP_TIME_POLICY,
+    )
+
+    assert live.primary == summary.primary
+    assert live.issues == summary.issues
 
 
 def _event_stats(

--- a/tests/integrations/test_deepspeed.py
+++ b/tests/integrations/test_deepspeed.py
@@ -1,0 +1,237 @@
+import pytest
+import torch
+import torch.nn as nn
+
+import traceml_ai as traceml
+
+try:
+    import deepspeed  # noqa: F401
+
+    HAS_DEEPSPEED = True
+except ImportError:
+    HAS_DEEPSPEED = False
+
+INPUT_DIM = 16
+HIDDEN_DIM = 32
+NUM_CLASSES = 4
+BATCH_SIZE = 8
+
+
+class _TinyMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(INPUT_DIM, HIDDEN_DIM),
+            nn.ReLU(),
+            nn.Linear(HIDDEN_DIM, NUM_CLASSES),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+class _FakeDeepSpeedEngine(nn.Module):
+    """A minimal stand-in for DeepSpeed's ``model_engine``.
+
+    It reproduces the exact surface the TraceML recipe touches:
+
+    - ``.module`` is the unwrapped model (what we pass to ``trace_step``),
+    - ``engine(x)`` runs forward through the module,
+    - ``engine.backward(loss)`` calls ``loss.backward()`` (real DeepSpeed
+      reaches the same ``torch.Tensor.backward`` via its loss scaler), so
+      TraceML's backward auto-timer fires,
+    - ``engine.step()`` calls a real torch optimizer's ``step()``, so
+      TraceML's optimizer hook fires.
+    """
+
+    def __init__(self, module: nn.Module):
+        super().__init__()
+        self.module = module
+        self.optimizer = torch.optim.SGD(module.parameters(), lr=0.1)
+
+    def forward(self, x):
+        return self.module(x)
+
+    def backward(self, loss):
+        loss.backward()
+
+    def step(self):
+        self.optimizer.step()
+        self.optimizer.zero_grad(set_to_none=True)
+
+
+def _drain_step_time_queue() -> list:
+    """Drain all StepTimeBatch entries from the shared queue."""
+    from traceml_ai.utils.timing import get_step_time_queue
+
+    queue = get_step_time_queue()
+    batches = []
+    while not queue.empty():
+        batches.append(queue.get_nowait())
+    return batches
+
+
+def _reset_traceml_state() -> None:
+    """Reset TraceML's step counter, recording state, and step-time queue."""
+    from traceml_ai.runtime.state import (
+        configure_trace_recording,
+        reset_trace_session_state,
+    )
+    from traceml_ai.utils.timing import _STEP_BUFFER
+
+    reset_trace_session_state()
+    # Restore a fresh RECORDING state in case a prior test left the runtime in
+    # a draining/complete state (which would silently drop step events).
+    configure_trace_recording(max_steps=None)
+    _drain_step_time_queue()
+    # Iterating a DataLoader to exhaustion leaves one unflushed dataloader_next
+    # event from the terminal StopIteration fetch; clear it so it cannot leak
+    # into the next test's first StepTimeBatch.
+    _STEP_BUFFER.clear()
+
+
+def _install_auto_instrumentation() -> None:
+    from traceml_ai.instrumentation.hooks.optimizer_hooks import (
+        ensure_optimizer_timing_installed,
+    )
+    from traceml_ai.instrumentation.patches.backward_auto_timer_patch import (
+        patch_backward,
+    )
+    from traceml_ai.instrumentation.patches.dataloader_patch import (
+        patch_dataloader,
+    )
+    from traceml_ai.instrumentation.patches.forward_auto_timer_patch import (
+        patch_forward,
+    )
+    from traceml_ai.instrumentation.patches.h2d_auto_timer_patch import (
+        patch_h2d,
+    )
+
+    # Install the full auto set that init(mode="auto") installs, including the
+    # DataLoader patch, so tests can verify the dataloader_next stream too.
+    patch_forward()
+    patch_backward()
+    patch_h2d()
+    patch_dataloader()
+    ensure_optimizer_timing_installed()
+
+
+def test_deepspeed_recipe_brackets_step():
+    from traceml_ai.runtime.state import get_trace_session_state
+
+    _reset_traceml_state()
+    _install_auto_instrumentation()
+
+    engine = _FakeDeepSpeedEngine(_TinyMLP())
+    criterion = nn.CrossEntropyLoss()
+    num_steps = 3
+
+    step_before = get_trace_session_state().step
+
+    for _ in range(num_steps):
+        # This is exactly the recipe shown in the docs and example.
+        with traceml.trace_step(engine.module):
+            x = torch.randn(BATCH_SIZE, INPUT_DIM)
+            y = torch.randint(0, NUM_CLASSES, (BATCH_SIZE,))
+
+            logits = engine(x)
+            loss = criterion(logits, y)
+
+            engine.backward(loss)
+            engine.step()
+
+    step_after = get_trace_session_state().step
+    assert step_after - step_before == num_steps, (
+        "trace_step must advance the TraceML step counter once per "
+        f"DeepSpeed step; advanced by {step_after - step_before}."
+    )
+
+    batches = _drain_step_time_queue()
+    assert len(batches) == num_steps, (
+        f"Expected one StepTimeBatch per step ({num_steps}), "
+        f"got {len(batches)}."
+    )
+
+    def _every_batch_has(event_name: str) -> bool:
+        return all(
+            any(evt.name == event_name for evt in batch.events)
+            for batch in batches
+        )
+
+    assert _every_batch_has(
+        "_traceml_internal:forward_time"
+    ), "forward timing should be captured on model_engine.module."
+    assert _every_batch_has("_traceml_internal:backward_time"), (
+        "backward timing should be captured because engine.backward(loss) "
+        "reaches torch.Tensor.backward()."
+    )
+    assert _every_batch_has("_traceml_internal:optimizer_step"), (
+        "optimizer timing should be captured because engine.step() reaches "
+        "the underlying torch optimizer's step()."
+    )
+    assert _every_batch_has(
+        "_traceml_internal:step_time"
+    ), "step timing should be captured once per trace_step block."
+
+
+def test_deepspeed_recipe_emits_dataloader_next_over_real_loader():
+    """The recipe must emit dataloader_next when iterating a real DataLoader.
+
+    dataloader_next is the fragile stream the docs promise (it records
+    DataLoader fetch time). It rides a class-level patch of
+    ``DataLoader.__iter__``, so it only lands when a real ``torch`` DataLoader
+    is iterated. The recipe iterates the loader OUTSIDE ``trace_step``; the
+    fetch is buffered by the process-wide recording gate and flushed into that
+    step's StepTimeBatch, so every batch must carry the event. Asserted as rows
+    landed, not as "a patch ran".
+    """
+    from torch.utils.data import DataLoader, TensorDataset
+
+    _reset_traceml_state()
+    _install_auto_instrumentation()
+
+    num_steps = 3
+    dataset = TensorDataset(
+        torch.randn(num_steps * BATCH_SIZE, INPUT_DIM),
+        torch.randint(0, NUM_CLASSES, (num_steps * BATCH_SIZE,)),
+    )
+    loader = DataLoader(dataset, batch_size=BATCH_SIZE)
+
+    engine = _FakeDeepSpeedEngine(_TinyMLP())
+    criterion = nn.CrossEntropyLoss()
+
+    for batch_x, batch_y in loader:
+        # Fetch happens OUTSIDE trace_step, exactly like the documented recipe.
+        with traceml.trace_step(engine.module):
+            logits = engine(batch_x)
+            loss = criterion(logits, batch_y)
+            engine.backward(loss)
+            engine.step()
+
+    batches = _drain_step_time_queue()
+    assert len(batches) == num_steps, (
+        f"Expected one StepTimeBatch per step ({num_steps}), "
+        f"got {len(batches)}."
+    )
+
+    dark = [
+        i
+        for i, batch in enumerate(batches)
+        if not any(
+            evt.name == "_traceml_internal:dataloader_next"
+            for evt in batch.events
+        )
+    ]
+    assert not dark, (
+        "dataloader_next stream is dark for the DeepSpeed recipe over a real "
+        f"DataLoader: StepTimeBatch(es) {dark} of {num_steps} carry no event."
+    )
+
+
+@pytest.mark.skipif(not HAS_DEEPSPEED, reason="deepspeed not installed")
+def test_deepspeed_public_api_available():
+    """When DeepSpeed is installed, the symbols the example relies on exist."""
+    import deepspeed
+
+    assert hasattr(deepspeed, "initialize")
+    assert hasattr(deepspeed, "init_distributed")

--- a/tests/integrations/test_hf_trainer.py
+++ b/tests/integrations/test_hf_trainer.py
@@ -438,7 +438,7 @@ def test_hf_trainer_callback_noop_when_disabled(monkeypatch):
 
 
 @pytest.mark.skipif(not HAS_TRANSFORMERS, reason="transformers not installed")
-def test_hf_init_enables_dataloader_and_h2d_patches():
+def test_hf_init_enables_dataloader_and_h2d_patches(monkeypatch):
     """
     init() must enable the process-wide patches the callback cannot install on
     its own. The DataLoader fetch patch in particular is what lets TraceML
@@ -446,6 +446,14 @@ def test_hf_init_enables_dataloader_and_h2d_patches():
     never installs it. The H2D Tensor.to patch is gated the same way: the
     auto-timer trace_step arms each step is a no-op unless the patch is on.
     """
+    # This test verifies patch policy, not runtime startup. Stub the runtime
+    # bootstrap so init() does not try to reach an aggregator over TCP.
+    import traceml_ai.sdk.initial as initialization
+
+    monkeypatch.setattr(
+        initialization, "_start_runtime_for_init", lambda **kwargs: None
+    )
+
     config = init()
 
     assert config.patch_dataloader, (

--- a/tests/integrations/test_hf_trainer.py
+++ b/tests/integrations/test_hf_trainer.py
@@ -131,8 +131,11 @@ def _drain_step_time_queue() -> list:
 def _reset_traceml_state() -> None:
     """Reset TraceML's process-local step counter and drain shared queues."""
     from traceml_ai.runtime.state import reset_trace_session_state
+    from traceml_ai.utils import timing
 
     reset_trace_session_state()
+    # Unflushed step events from a previous test would land in our first batch.
+    timing._STEP_BUFFER.clear()
     _drain_step_time_queue()
     # Drain any leftover step-memory events. We don't filter by model_id here
     # because we want a clean slate; older tests' events would otherwise leak
@@ -221,6 +224,8 @@ def test_hf_trainer_callback_grad_accum_folds_microbatches():
     accumulated micro-batches within a single trace_step bracket.
     """
     _reset_traceml_state()
+    # Auto-timers trace_step arms are no-ops until init() installs the patches.
+    init()
     max_steps = 3
     grad_accum = 2
 

--- a/tests/integrations/test_lightning.py
+++ b/tests/integrations/test_lightning.py
@@ -84,6 +84,70 @@ def test_lightning_forward_wrapper_times_only_forward(monkeypatch):
     assert calls == [("_traceml_internal:forward_time", TimeScope.STEP, True)]
 
 
+def test_lightning_disabled_after_import_does_not_wrap_or_record(monkeypatch):
+    _enable_callback_without_lightning(monkeypatch)
+    monkeypatch.setenv("TRACEML_DISABLED", "1")
+    calls = []
+
+    @contextmanager
+    def fake_timed_region(name, scope, record_gpu_events=True):
+        calls.append((name, scope, record_gpu_events))
+        yield
+
+    class FakeStrategy:
+        root_device = "cuda:0"
+
+        def batch_to_device(self, batch, *args, **kwargs):
+            return batch
+
+    class FakeModule(nn.Module):
+        device = "cuda:0"
+
+        def forward(self, value):
+            return value + 1
+
+    monkeypatch.setattr(
+        lightning_integration,
+        "timed_region",
+        fake_timed_region,
+    )
+    monkeypatch.setattr(
+        lightning_integration,
+        "StepMemoryTracker",
+        lambda module: (_ for _ in ()).throw(
+            AssertionError("disabled callback must not create memory tracker")
+        ),
+    )
+
+    strategy = FakeStrategy()
+    original_batch_to_device = strategy.batch_to_device
+    trainer = SimpleNamespace(training=True, strategy=strategy)
+    module = FakeModule()
+    callback = lightning_integration.TraceMLCallback()
+
+    callback.setup(trainer, module)
+    assert "forward" not in module.__dict__
+    assert (
+        strategy.batch_to_device.__func__ is original_batch_to_device.__func__
+    )
+
+    callback.on_train_batch_start(trainer, module, batch=None, batch_idx=0)
+    callback.on_before_backward(trainer, module, loss=None)
+    callback.on_after_backward(trainer, module)
+    callback.on_before_optimizer_step(trainer, module, optimizer=None)
+    callback.on_before_zero_grad(trainer, module, optimizer=None)
+    callback.on_train_batch_end(
+        trainer,
+        module,
+        outputs=None,
+        batch=None,
+        batch_idx=0,
+    )
+
+    assert module(1) == 2
+    assert calls == []
+
+
 def test_lightning_batch_start_does_not_open_forward_region(monkeypatch):
     _enable_callback_without_lightning(monkeypatch)
     calls = []

--- a/tests/integrations/test_ray.py
+++ b/tests/integrations/test_ray.py
@@ -86,3 +86,60 @@ def test_worker_settings_connect_to_actor_endpoint():
     assert settings.sampler_interval_sec == 2.0
     assert settings.aggregator.connect_host == "10.0.0.9"
     assert settings.aggregator.port == 34567
+
+
+def test_ray_disabled_delegates_to_native_torch_trainer(monkeypatch):
+    import traceml_ai.integrations.ray as ray_integration
+
+    observed = {}
+
+    class _FakeRay:
+        def remote(self, *args, **kwargs):
+            raise AssertionError("disabled Ray path must not create actors")
+
+    class _FakeTorchTrainer:
+        def __init__(
+            self,
+            train_loop_per_worker,
+            *,
+            train_loop_config=None,
+            **kwargs,
+        ):
+            observed["train_loop_per_worker"] = train_loop_per_worker
+            observed["train_loop_config"] = dict(train_loop_config or {})
+            observed["kwargs"] = dict(kwargs)
+
+        def fit(self):
+            return self._run_native()
+
+        def _run_native(self):
+            return observed["train_loop_per_worker"](
+                observed["train_loop_config"]
+            )
+
+    def _train_loop(config):
+        return {"native": True, "config": config}
+
+    monkeypatch.setenv("TRACEML_DISABLED", "1")
+    monkeypatch.setattr(
+        ray_integration,
+        "_require_ray",
+        lambda: (_FakeRay(), _FakeTorchTrainer),
+    )
+
+    trainer = ray_integration.TraceMLTorchTrainer(
+        _train_loop,
+        train_loop_config={"batch_size": 4},
+        scaling_config="native-scaling",
+    )
+
+    assert trainer.fit() == {
+        "native": True,
+        "config": {"batch_size": 4},
+    }
+    assert not isinstance(
+        observed["train_loop_per_worker"],
+        ray_integration._TraceMLWorkerLoop,
+    )
+    assert observed["kwargs"] == {"scaling_config": "native-scaling"}
+    assert trainer.last_endpoint is None

--- a/tests/integrations/test_ray.py
+++ b/tests/integrations/test_ray.py
@@ -32,6 +32,7 @@ def test_normalize_config_generates_session_id():
     assert config.session_id.startswith("ray_")
     assert config.mode == "summary"
     assert config.port == 0
+    assert config.sampler_interval_sec == 2.0
 
 
 def test_normalize_config_preserves_explicit_session_id():
@@ -67,6 +68,7 @@ def test_aggregator_settings_use_actor_node_as_connect_host():
     assert settings.aggregator.connect_host == "10.0.0.9"
     assert settings.aggregator.bind_host == "0.0.0.0"
     assert settings.aggregator.port == 0
+    assert settings.render_interval_sec == 2.0
 
 
 def test_worker_settings_connect_to_actor_endpoint():

--- a/tests/renderers/test_step_time_compute.py
+++ b/tests/renderers/test_step_time_compute.py
@@ -15,6 +15,7 @@ def test_step_time_compute_uses_selected_gpu_diagnosis_clock(
             CREATE TABLE step_time_samples (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 rank INTEGER,
+                global_rank INTEGER,
                 step INTEGER,
                 events_json TEXT NOT NULL
             );
@@ -62,17 +63,17 @@ def test_step_time_compute_uses_selected_gpu_diagnosis_clock(
         }
         conn.execute(
             """
-            INSERT INTO step_time_samples(rank, step, events_json)
-            VALUES (?, ?, ?);
+            INSERT INTO step_time_samples(rank, global_rank, step, events_json)
+            VALUES (?, ?, ?, ?);
             """,
-            (0, 1, json.dumps(events_1)),
+            (0, 0, 1, json.dumps(events_1)),
         )
         conn.execute(
             """
-            INSERT INTO step_time_samples(rank, step, events_json)
-            VALUES (?, ?, ?);
+            INSERT INTO step_time_samples(rank, global_rank, step, events_json)
+            VALUES (?, ?, ?, ?);
             """,
-            (0, 2, json.dumps(events_2)),
+            (0, 0, 2, json.dumps(events_2)),
         )
         conn.commit()
     finally:

--- a/tests/renderers/test_step_time_compute.py
+++ b/tests/renderers/test_step_time_compute.py
@@ -92,6 +92,7 @@ def test_step_time_compute_uses_selected_gpu_diagnosis_clock(
     assert metrics["input_wait"].series.worst == [4.0, 6.0]
     assert metrics["input_wait"].series.sum == [4.0, 6.0]
     assert result.diagnosis_clock == "gpu"
+    assert result.training_strategy == "ddp"
 
     per_rank = result.per_rank_timing[0]
     assert per_rank["input_wait"] == 5.0

--- a/tests/renderers/test_step_time_renderer.py
+++ b/tests/renderers/test_step_time_renderer.py
@@ -58,6 +58,7 @@ def test_step_time_cli_diagnosis_uses_selected_metrics(monkeypatch) -> None:
     payload = StepCombinedTimeResult(
         per_rank_timing={0: {"input_wait": 40.0, "step_time": 100.0}},
         diagnosis_clock="gpu",
+        training_strategy="fsdp",
         diagnosis_metrics=diagnosis_metrics,
     )
     seen = {}
@@ -65,6 +66,7 @@ def test_step_time_cli_diagnosis_uses_selected_metrics(monkeypatch) -> None:
     def fake_build_step_diagnosis(metrics, **kwargs):
         seen["metrics"] = metrics
         seen["diagnosis_clock"] = kwargs.get("diagnosis_clock")
+        seen["training_strategy"] = kwargs.get("training_strategy")
         return StepDiagnosis(
             kind="INPUT_BOUND",
             status="INPUT-BOUND",
@@ -86,6 +88,7 @@ def test_step_time_cli_diagnosis_uses_selected_metrics(monkeypatch) -> None:
 
     assert seen["metrics"] is diagnosis_metrics
     assert seen["diagnosis_clock"] == "gpu"
+    assert seen["training_strategy"] == "fsdp"
     assert "IW" in text
     assert "DL" not in text
     assert "Average (1 steps)" in text

--- a/tests/reporting/summary/test_final.py
+++ b/tests/reporting/summary/test_final.py
@@ -224,14 +224,14 @@ def test_final_text_uses_single_process_average_layout():
 
     text = payload["text"]
     assert "TraceML Verdict: INPUT-BOUND / CRITICAL" in text
-    assert "Why: Input wait was 130.8ms before a 139.1ms traced step." in text
+    assert "Why: Input wait was 130.8ms of 269.9ms iteration time." in text
     assert "Next: Increase workers, prefetch, or storage throughput." in text
     assert "System Evidence" in text
     assert "Metric            Average" in text
     assert "Step Time Evidence" in text
     assert "Phase             Average           Share" in text
     assert "Total             139.1ms           compat" in text
-    assert "Input Wait        130.8ms           94.0%" in text
+    assert "Input Wait        130.8ms           48.5%" in text
     assert "Dataloader        120.0ms           compat" in text
     assert "Step Time         139.1ms           100.0%" in text
     assert "Median" not in text

--- a/tests/reporting/summary/test_final.py
+++ b/tests/reporting/summary/test_final.py
@@ -233,7 +233,7 @@ def test_final_text_uses_single_process_average_layout():
     assert "Total             139.1ms           compat" in text
     assert "Input Wait        130.8ms           48.5%" in text
     assert "Dataloader        120.0ms           compat" in text
-    assert "Step Time         139.1ms           100.0%" in text
+    assert "Step Time         139.1ms           51.5%" in text
     assert "Median" not in text
     assert "Worst" not in text
     assert "Skew" not in text
@@ -274,10 +274,49 @@ def test_final_text_uses_selected_step_time_for_phase_shares():
     text = payload["text"]
     assert "Total             10.5ms            compat" in text
     assert "Dataloader        0.5ms             compat" in text
-    assert "Step Time         50.0ms            100.0%" in text
-    assert "Compute           48.0ms            96.0%" in text
+    assert "Step Time         50.0ms            96.2%" in text
+    assert "Compute           48.0ms            92.3%" in text
     assert "457.1%" not in text
     assert "476.2%" not in text
+
+
+def test_final_text_includes_h2d_bound_diagnosis():
+    step_time = _payload(
+        metadata={"global_ranks_used": 1},
+        diagnosis=_diagnosis(
+            "H2D_BOUND",
+            "H2D-BOUND",
+            severity="crit",
+            action="Inspect pinned memory and batch transfers.",
+        ),
+        global_summary={
+            "window": {"steps_analyzed": 60, "diagnosis_clock": "gpu"},
+            "average": {
+                "total_step_ms": 150.0,
+                "dataloader_ms": 40.0,
+                "input_wait_ms": 40.0,
+                "step_time_ms": 100.0,
+                "h2d_ms": 20.0,
+                "compute_ms": 70.0,
+                "residual_ms": 10.0,
+            },
+        },
+    )
+
+    payload = build_summary_payload(
+        "fake.db",
+        generator=_generator(
+            _PayloadSection("system", _status_payload("NORMAL")),
+            _PayloadSection("process", _status_payload("NORMAL")),
+            _PayloadSection("step_time", step_time),
+            _PayloadSection("step_memory", _status_payload("BALANCED")),
+        ),
+    )
+
+    assert "TraceML Verdict: H2D-BOUND / CRITICAL" in payload["text"]
+    assert "Why: H2D transfer took 20.0ms of 140.0ms iteration time." in (
+        payload["text"]
+    )
 
 
 def test_final_text_uses_multi_process_comparison_layout():

--- a/tests/reporting/summary/test_final.py
+++ b/tests/reporting/summary/test_final.py
@@ -178,6 +178,7 @@ def test_final_text_uses_single_process_average_layout():
         "INPUT_BOUND",
         "INPUT-BOUND",
         severity="crit",
+        summary="Input wait is 48.5% of the typical GPU iteration time.",
         action="Increase workers, prefetch, or storage throughput.",
     )
     step_time = _payload(
@@ -224,7 +225,9 @@ def test_final_text_uses_single_process_average_layout():
 
     text = payload["text"]
     assert "TraceML Verdict: INPUT-BOUND / CRITICAL" in text
-    assert "Why: Input wait was 130.8ms of 269.9ms iteration time." in text
+    assert (
+        "Why: Input wait is 48.5% of the typical GPU iteration time." in text
+    )
     assert "Next: Increase workers, prefetch, or storage throughput." in text
     assert "System Evidence" in text
     assert "Metric            Average" in text
@@ -287,6 +290,7 @@ def test_final_text_includes_h2d_bound_diagnosis():
             "H2D_BOUND",
             "H2D-BOUND",
             severity="crit",
+            summary="H2D transfer is 14.3% of the typical GPU iteration time.",
             action="Inspect pinned memory and batch transfers.",
         ),
         global_summary={
@@ -314,7 +318,7 @@ def test_final_text_includes_h2d_bound_diagnosis():
     )
 
     assert "TraceML Verdict: H2D-BOUND / CRITICAL" in payload["text"]
-    assert "Why: H2D transfer took 20.0ms of 140.0ms iteration time." in (
+    assert "Why: H2D transfer is 14.3% of the typical GPU iteration time." in (
         payload["text"]
     )
 
@@ -324,6 +328,10 @@ def test_final_text_uses_multi_process_comparison_layout():
         "INPUT_STRAGGLER",
         "INPUT STRAGGLER",
         severity="crit",
+        summary=(
+            "r0 has excess input wait burden relative to victim r1 "
+            "(~82.6% impact; ~100.0% of visible wait cost)."
+        ),
         phase="input",
         action=(
             "Inspect input wait, collate_fn, preprocessing, and storage "
@@ -406,9 +414,11 @@ def test_final_text_uses_multi_process_comparison_layout():
 
     text = payload["text"]
     assert "TraceML Verdict: INPUT STRAGGLER / CRITICAL" in text
-    assert (
-        "Rank r0 input wait was 264.5ms vs median rank r1 at 13.8ms." in text
+    assert payload["primary_diagnosis"]["summary"] == (
+        "r0 has excess input wait burden relative to victim r1 "
+        "(~82.6% impact; ~100.0% of visible wait cost)."
     )
+    assert "Why: r0 has excess input wait burden relative to victim r1" in text
     assert (
         "Metric          Median        Worst         Skew        Scope" in text
     )

--- a/tests/reporting/summary/test_primary_diagnosis.py
+++ b/tests/reporting/summary/test_primary_diagnosis.py
@@ -150,82 +150,55 @@ def test_compute_bound_uses_neutral_compute_phase_share() -> None:
     assert primary["evidence"]["shares"]["compute_pct"] == 75.0
 
 
-def test_input_straggler_uses_rank_comparison_evidence() -> None:
-    primary = _primary(
-        _step_time(
+@pytest.mark.parametrize(
+    (
+        "kind",
+        "phase",
+        "expected_metric",
+        "expected_summary",
+    ),
+    [
+        (
             "INPUT_STRAGGLER",
-            status="INPUT STRAGGLER",
-            phase="dataloader",
-        )
-    )
-
-    assert primary["kind"] == "INPUT_STRAGGLER"
-    assert primary["summary"] == (
-        "Rank r2 input wait was 120.0ms vs median rank r0 at 8.0ms."
-    )
-    assert primary["evidence"] == {
-        "type": "rank_comparison",
-        "steps_analyzed": 256,
-        "gpu_util_avg_percent": 87.0,
-        "metric": "input_wait_ms",
-        "phase": "dataloader",
-        "median": {"rank": 0, "value_ms": 8.0},
-        "worst": {"rank": 2, "value_ms": 120.0},
-        "delta_ms": 112.0,
-        "ratio": 15.0,
-    }
-
-
-def test_compute_straggler_uses_diagnosed_compute_phase() -> None:
-    primary = _primary(
-        _step_time(
+            "dataloader",
+            "input_wait_ms",
+            "Rank r2 input wait was 120.0ms vs median rank r0 at 8.0ms.",
+        ),
+        (
             "COMPUTE_STRAGGLER",
-            status="COMPUTE STRAGGLER",
-            phase="optimizer",
-        )
-    )
-
-    assert primary["kind"] == "COMPUTE_STRAGGLER"
-    assert primary["evidence"]["metric"] == "optimizer_ms"
-    assert primary["evidence"]["phase"] == "optimizer"
-    assert primary["evidence"]["median"] == {"rank": 3, "value_ms": 10.0}
-    assert primary["evidence"]["worst"] == {"rank": 2, "value_ms": 90.0}
-    assert primary["evidence"]["delta_ms"] == 80.0
-    assert primary["evidence"]["ratio"] == 9.0
-
-
-def test_h2d_straggler_uses_rank_comparison_evidence() -> None:
-    primary = _primary(
-        _step_time(
+            "optimizer",
+            "optimizer_ms",
+            None,
+        ),
+        (
             "H2D_STRAGGLER",
-            status="H2D STRAGGLER",
-            phase="h2d",
-        )
-    )
-
-    assert primary["kind"] == "H2D_STRAGGLER"
-    assert primary["summary"] == (
-        "Rank r2 h2d was 40.0ms vs median rank r1 at 10.0ms."
-    )
-    assert primary["evidence"]["metric"] == "h2d_ms"
-    assert primary["evidence"]["phase"] == "h2d"
-
-
-def test_residual_straggler_uses_rank_comparison_evidence() -> None:
+            "h2d",
+            "h2d_ms",
+            "Rank r2 h2d was 40.0ms vs median rank r1 at 10.0ms.",
+        ),
+    ],
+)
+def test_rank_stragglers_use_rank_comparison_evidence(
+    kind: str,
+    phase: str,
+    expected_metric: str,
+    expected_summary: str | None,
+) -> None:
     primary = _primary(
         _step_time(
-            "RESIDUAL_STRAGGLER",
-            status="RESIDUAL STRAGGLER",
-            phase="residual",
+            kind,
+            status=kind.replace("_", " "),
+            phase=phase,
         )
     )
 
-    assert primary["kind"] == "RESIDUAL_STRAGGLER"
-    assert primary["summary"] == (
-        "Rank r2 residual time was 70.0ms vs median rank r0 at 20.0ms."
-    )
-    assert primary["evidence"]["metric"] == "residual_ms"
-    assert primary["evidence"]["phase"] == "residual"
+    assert primary["kind"] == kind
+    assert primary["evidence"]["type"] == "rank_comparison"
+    assert primary["evidence"]["metric"] == expected_metric
+    assert primary["evidence"]["phase"] == phase
+    assert primary["evidence"]["worst"]["rank"] == 2
+    if expected_summary is not None:
+        assert primary["summary"] == expected_summary
 
 
 def test_straggler_includes_input_and_compute_comparisons() -> None:

--- a/tests/reporting/summary/test_primary_diagnosis.py
+++ b/tests/reporting/summary/test_primary_diagnosis.py
@@ -104,7 +104,7 @@ def test_input_bound_uses_phase_share_evidence() -> None:
     assert primary["section"] == "step_time"
     assert primary["scope"] == "performance"
     assert primary["summary"] == (
-        "Input wait was 80.0ms before a 160.0ms traced step."
+        "Input wait was 80.0ms of 240.0ms iteration time."
     )
     assert primary["evidence"] == {
         "type": "phase_share",
@@ -112,6 +112,7 @@ def test_input_bound_uses_phase_share_evidence() -> None:
         "steps_analyzed": 256,
         "total_step_ms": 200.0,
         "step_time_ms": 160.0,
+        "iteration_time_ms": 240.0,
         "diagnosis_clock": "gpu",
         "dataloader_ms": 50.0,
         "input_wait_ms": 80.0,
@@ -119,7 +120,7 @@ def test_input_bound_uses_phase_share_evidence() -> None:
         "compute_ms": 120.0,
         "residual_ms": 20.0,
         "shares": {
-            "input_wait_pct": 50.0,
+            "input_wait_pct": 33.333,
             "h2d_pct": 6.25,
             "compute_pct": 75.0,
             "residual_pct": 12.5,

--- a/tests/reporting/summary/test_primary_diagnosis.py
+++ b/tests/reporting/summary/test_primary_diagnosis.py
@@ -121,11 +121,28 @@ def test_input_bound_uses_phase_share_evidence() -> None:
         "residual_ms": 20.0,
         "shares": {
             "input_wait_pct": 33.333,
-            "h2d_pct": 6.25,
-            "compute_pct": 75.0,
-            "residual_pct": 12.5,
+            "h2d_pct": 4.167,
+            "compute_pct": 50.0,
+            "residual_pct": 8.333,
         },
         "gpu_util_avg_percent": 38.0,
+    }
+
+
+def test_h2d_bound_uses_iteration_phase_share_evidence() -> None:
+    primary = _primary(_step_time("H2D_BOUND", status="H2D-BOUND"))
+
+    assert primary["kind"] == "H2D_BOUND"
+    assert primary["summary"] == (
+        "H2D transfer took 10.0ms of 240.0ms iteration time."
+    )
+    assert primary["evidence"]["type"] == "phase_share"
+    assert primary["evidence"]["iteration_time_ms"] == 240.0
+    assert primary["evidence"]["shares"] == {
+        "input_wait_pct": 33.333,
+        "h2d_pct": 4.167,
+        "compute_pct": 50.0,
+        "residual_pct": 8.333,
     }
 
 
@@ -137,7 +154,7 @@ def test_residual_heavy_uses_residual_phase_share() -> None:
         "Residual time took 20.0ms of a 160.0ms average step."
     )
     assert primary["evidence"]["type"] == "phase_share"
-    assert primary["evidence"]["shares"]["residual_pct"] == 12.5
+    assert primary["evidence"]["shares"]["residual_pct"] == 8.333
 
 
 def test_compute_bound_uses_neutral_compute_phase_share() -> None:
@@ -147,7 +164,7 @@ def test_compute_bound_uses_neutral_compute_phase_share() -> None:
     assert primary["summary"] == (
         "Model compute took 120.0ms of a 160.0ms average step."
     )
-    assert primary["evidence"]["shares"]["compute_pct"] == 75.0
+    assert primary["evidence"]["shares"]["compute_pct"] == 50.0
 
 
 @pytest.mark.parametrize(

--- a/tests/reporting/summary/test_primary_diagnosis.py
+++ b/tests/reporting/summary/test_primary_diagnosis.py
@@ -146,6 +146,48 @@ def test_h2d_bound_uses_iteration_phase_share_evidence() -> None:
     }
 
 
+def test_phase_share_primary_keeps_the_diagnosis_impact_score() -> None:
+    step_time = _step_time("H2D_BOUND", status="H2D-BOUND")
+    step_time["diagnosis"].update(
+        {
+            "score": 0.23125,
+            "evidence": {"h2d_share": 0.23125},
+        }
+    )
+
+    primary = _primary(step_time)
+
+    assert primary["evidence"]["score"] == 0.23125
+    assert primary["evidence"]["score_basis"] == (
+        "median_per_rank_iteration_share"
+    )
+    assert primary["evidence"]["score_denominator"] == (
+        "input_wait_ms + step_time_ms per rank"
+    )
+
+
+def test_straggler_primary_keeps_the_diagnosis_impact_score() -> None:
+    step_time = _step_time("STRAGGLER", status="STRAGGLER")
+    step_time["diagnosis"].update(
+        {
+            "score": 0.23,
+            "evidence": {
+                "visible_cost_ms": 23.0,
+                "iteration_time_ms": 100.0,
+            },
+        }
+    )
+
+    primary = _primary(step_time)
+
+    assert primary["evidence"]["score"] == 0.23
+    assert primary["evidence"]["score_basis"] == (
+        "visible_cost_ms / victim_iteration_time_ms"
+    )
+    assert primary["evidence"]["score_numerator_ms"] == 23.0
+    assert primary["evidence"]["score_denominator_ms"] == 100.0
+
+
 def test_residual_heavy_uses_residual_phase_share() -> None:
     primary = _primary(_step_time("RESIDUAL_HEAVY", status="RESIDUAL-HEAVY"))
 

--- a/tests/reporting/summary/test_primary_diagnosis.py
+++ b/tests/reporting/summary/test_primary_diagnosis.py
@@ -37,6 +37,7 @@ def _step_time(
     kind: str,
     *,
     status: str | None = None,
+    summary: str = "step-time summary",
     phase: str | None = None,
     issues: list[dict] | None = None,
 ) -> dict:
@@ -44,7 +45,7 @@ def _step_time(
         "kind": kind,
         "status": status or kind.replace("_", "-"),
         "severity": "warn",
-        "summary": "step-time summary",
+        "summary": summary,
         "action": "step-time action",
         "metric": None,
         "phase": phase,
@@ -96,7 +97,11 @@ def _primary(step_time: dict, system: dict | None = None) -> dict:
 
 def test_input_bound_uses_phase_share_evidence() -> None:
     primary = _primary(
-        _step_time("INPUT_BOUND", status="INPUT-BOUND"),
+        _step_time(
+            "INPUT_BOUND",
+            status="INPUT-BOUND",
+            summary="Input wait is 33.3% of the typical GPU iteration time.",
+        ),
         _system(gpu_util=38.0),
     )
 
@@ -104,7 +109,7 @@ def test_input_bound_uses_phase_share_evidence() -> None:
     assert primary["section"] == "step_time"
     assert primary["scope"] == "performance"
     assert primary["summary"] == (
-        "Input wait was 80.0ms of 240.0ms iteration time."
+        "Input wait is 33.3% of the typical GPU iteration time."
     )
     assert primary["evidence"] == {
         "type": "phase_share",
@@ -119,31 +124,26 @@ def test_input_bound_uses_phase_share_evidence() -> None:
         "h2d_ms": 10.0,
         "compute_ms": 120.0,
         "residual_ms": 20.0,
-        "shares": {
-            "input_wait_pct": 33.333,
-            "h2d_pct": 4.167,
-            "compute_pct": 50.0,
-            "residual_pct": 8.333,
-        },
         "gpu_util_avg_percent": 38.0,
     }
 
 
 def test_h2d_bound_uses_iteration_phase_share_evidence() -> None:
-    primary = _primary(_step_time("H2D_BOUND", status="H2D-BOUND"))
+    primary = _primary(
+        _step_time(
+            "H2D_BOUND",
+            status="H2D-BOUND",
+            summary="H2D transfer is 23.1% of the typical GPU iteration time.",
+        )
+    )
 
     assert primary["kind"] == "H2D_BOUND"
     assert primary["summary"] == (
-        "H2D transfer took 10.0ms of 240.0ms iteration time."
+        "H2D transfer is 23.1% of the typical GPU iteration time."
     )
     assert primary["evidence"]["type"] == "phase_share"
     assert primary["evidence"]["iteration_time_ms"] == 240.0
-    assert primary["evidence"]["shares"] == {
-        "input_wait_pct": 33.333,
-        "h2d_pct": 4.167,
-        "compute_pct": 50.0,
-        "residual_pct": 8.333,
-    }
+    assert "shares" not in primary["evidence"]
 
 
 def test_phase_share_primary_keeps_the_diagnosis_impact_score() -> None:
@@ -158,12 +158,16 @@ def test_phase_share_primary_keeps_the_diagnosis_impact_score() -> None:
     primary = _primary(step_time)
 
     assert primary["evidence"]["score"] == 0.23125
+    assert primary["evidence"]["h2d_ms"] == 10.0
+    assert primary["evidence"]["iteration_time_ms"] == 240.0
+    assert primary["evidence"]["score"] != pytest.approx(10.0 / 240.0)
     assert primary["evidence"]["score_basis"] == (
         "median_per_rank_iteration_share"
     )
     assert primary["evidence"]["score_denominator"] == (
         "input_wait_ms + step_time_ms per rank"
     )
+    assert "shares" not in primary["evidence"]
 
 
 def test_straggler_primary_keeps_the_diagnosis_impact_score() -> None:
@@ -189,24 +193,38 @@ def test_straggler_primary_keeps_the_diagnosis_impact_score() -> None:
 
 
 def test_residual_heavy_uses_residual_phase_share() -> None:
-    primary = _primary(_step_time("RESIDUAL_HEAVY", status="RESIDUAL-HEAVY"))
+    primary = _primary(
+        _step_time(
+            "RESIDUAL_HEAVY",
+            status="RESIDUAL-HEAVY",
+            summary=(
+                "Residual time is 21.0% of the typical GPU iteration time."
+            ),
+        )
+    )
 
     assert primary["kind"] == "RESIDUAL_HEAVY"
     assert primary["summary"] == (
-        "Residual time took 20.0ms of a 160.0ms average step."
+        "Residual time is 21.0% of the typical GPU iteration time."
     )
     assert primary["evidence"]["type"] == "phase_share"
-    assert primary["evidence"]["shares"]["residual_pct"] == 8.333
+    assert "shares" not in primary["evidence"]
 
 
 def test_compute_bound_uses_neutral_compute_phase_share() -> None:
-    primary = _primary(_step_time("COMPUTE_BOUND", status="COMPUTE-BOUND"))
+    primary = _primary(
+        _step_time(
+            "COMPUTE_BOUND",
+            status="COMPUTE-BOUND",
+            summary="Compute-bound; backward is the largest phase.",
+        )
+    )
 
     assert primary["kind"] == "COMPUTE_BOUND"
-    assert primary["summary"] == (
-        "Model compute took 120.0ms of a 160.0ms average step."
+    assert (
+        primary["summary"] == "Compute-bound; backward is the largest phase."
     )
-    assert primary["evidence"]["shares"]["compute_pct"] == 50.0
+    assert "shares" not in primary["evidence"]
 
 
 @pytest.mark.parametrize(
@@ -214,26 +232,22 @@ def test_compute_bound_uses_neutral_compute_phase_share() -> None:
         "kind",
         "phase",
         "expected_metric",
-        "expected_summary",
     ),
     [
         (
             "INPUT_STRAGGLER",
             "dataloader",
             "input_wait_ms",
-            "Rank r2 input wait was 120.0ms vs median rank r0 at 8.0ms.",
         ),
         (
             "COMPUTE_STRAGGLER",
             "optimizer",
             "optimizer_ms",
-            None,
         ),
         (
             "H2D_STRAGGLER",
             "h2d",
             "h2d_ms",
-            "Rank r2 h2d was 40.0ms vs median rank r1 at 10.0ms.",
         ),
     ],
 )
@@ -241,7 +255,6 @@ def test_rank_stragglers_use_rank_comparison_evidence(
     kind: str,
     phase: str,
     expected_metric: str,
-    expected_summary: str | None,
 ) -> None:
     primary = _primary(
         _step_time(
@@ -256,8 +269,7 @@ def test_rank_stragglers_use_rank_comparison_evidence(
     assert primary["evidence"]["metric"] == expected_metric
     assert primary["evidence"]["phase"] == phase
     assert primary["evidence"]["worst"]["rank"] == 2
-    if expected_summary is not None:
-        assert primary["summary"] == expected_summary
+    assert primary["summary"] == "step-time summary"
 
 
 def test_straggler_includes_input_and_compute_comparisons() -> None:

--- a/tests/reporting/summary/test_step_time.py
+++ b/tests/reporting/summary/test_step_time.py
@@ -16,6 +16,9 @@ from traceml_ai.reporting.sections.step_time.loader import (
 from traceml_ai.reporting.sections.step_time.model import (
     rank_summaries_from_window,
 )
+from traceml_ai.utils.step_time_sqlite import (
+    load_training_strategy_from_sqlite,
+)
 from traceml_ai.utils.step_time_window import (
     build_step_time_window_from_events,
 )
@@ -42,6 +45,21 @@ def _create_step_time_db(path: str) -> None:
                 events_json        TEXT NOT NULL
             );
             """
+        )
+        conn.execute(
+            """
+            CREATE TABLE runtime_environment (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                training_strategy TEXT
+            );
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO runtime_environment(training_strategy)
+            VALUES (?);
+            """,
+            [("ddp",), ("fsdp",)],
         )
         events = {
             "_traceml_internal:dataloader_next": {
@@ -160,6 +178,27 @@ def test_step_time_summary_uses_persisted_events_json(tmp_path) -> None:
     assert "Global: n/a" not in summary["card"]
 
 
+def test_training_strategy_loader_uses_latest_available_row(tmp_path) -> None:
+    db_path = tmp_path / "telemetry"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE runtime_environment (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                training_strategy TEXT
+            );
+            """
+        )
+        conn.executemany(
+            "INSERT INTO runtime_environment(training_strategy) VALUES (?);",
+            [("fsdp",), ("ddp",)],
+        )
+        assert load_training_strategy_from_sqlite(conn) == "ddp"
+    finally:
+        conn.close()
+
+
 def test_rank_summary_extracts_input_bound_clocks_from_events() -> None:
     window = build_step_time_window_from_events(
         {
@@ -209,8 +248,11 @@ def test_step_time_section_loader_and_builder_use_sqlite_fixture(
 
     assert data.training_steps == 3
     assert data.latest_step_observed == 2
+    assert data.training_strategy == "fsdp"
     assert data.per_global_rank_summary[0].steps_analyzed == 2
     assert data.step_time_window.coverage.steps_used == 2
+    diagnosis_input = StepTimeSummarySection().to_diagnosis_input(data)
+    assert diagnosis_input.training_strategy == "fsdp"
     assert result.section == "step_time"
     assert result.payload["metadata"]["global_ranks_seen"] == 1
     assert result.payload["global"]["median"]["total_step_ms"]["value"] == 31.0

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -147,6 +147,7 @@ def _input_bound_step_metrics(
     step_time_cpu: float = 90.0,
     input_wait_gpu: float,
     step_time_gpu: float,
+    h2d_gpu: float = 0.0,
     steps: int = 64,
 ) -> dict[int, dict]:
     return {
@@ -154,6 +155,7 @@ def _input_bound_step_metrics(
             "_traceml_internal:dataloader_next": _event_stats(
                 cpu_ms=dataloader_cpu, gpu_ms=input_wait_gpu
             ),
+            "_traceml_internal:h2d_time": _event_stats(gpu_ms=h2d_gpu),
             "_traceml_internal:step_time": _event_stats(
                 cpu_ms=step_time_cpu,
                 gpu_ms=step_time_gpu,
@@ -311,6 +313,40 @@ def test_step_time_input_bound_card_uses_short_reason() -> None:
     assert (
         "- Why: Input wait was 40.0ms of 140.0ms gpu iteration time."
         in payload["card"]
+    )
+    _assert_compact_card(payload["card"])
+
+
+def test_step_time_h2d_bound_card_uses_short_reason() -> None:
+    payload = _summary(
+        {
+            0: _rank(
+                dataloader=12.0,
+                h2d=20.0,
+                forward=20.0,
+                backward=35.0,
+                optimizer=5.0,
+                step_cpu=100.0,
+            )
+        },
+        per_rank_steps={
+            0: _input_bound_step_metrics(
+                input_wait_gpu=0.0,
+                h2d_gpu=20.0,
+                step_time_cpu=100.0,
+                step_time_gpu=100.0,
+            )
+        },
+    )
+
+    assert payload["diagnosis"] == payload["issues"][0]
+    assert payload["diagnosis"]["status"] == "H2D-BOUND"
+    assert payload["diagnosis"]["metric"] == "h2d"
+    assert payload["diagnosis"]["phase"] == "h2d"
+    assert payload["diagnosis"]["evidence"]["h2d_ms"] == 20.0
+    assert payload["diagnosis"]["evidence"]["diagnosis_clock"] == "gpu"
+    assert (
+        "- Why: H2D transfer was high inside the total step" in payload["card"]
     )
     _assert_compact_card(payload["card"])
 

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -84,10 +84,12 @@ def _summary(
         per_global_rank_summary=selected_summary,
         identities={},
         max_rows=window_size,
+        training_strategy="ddp",
     )
     diagnosis = diagnose_step_time_summary(
         StepTimeDiagnosisInput(
             window=window,
+            training_strategy=data.training_strategy,
         )
     )
     return build_step_time_payload(data, diagnosis)

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -214,17 +214,19 @@ def test_step_time_balanced_card_is_compact() -> None:
         {
             0: _rank(
                 dataloader=5.0,
+                h2d=15.0,
                 forward=20.0,
                 backward=35.0,
                 optimizer=5.0,
-                step_cpu=70.0,
+                step_cpu=75.0,
             ),
             1: _rank(
                 dataloader=5.0,
+                h2d=15.0,
                 forward=21.0,
                 backward=34.0,
                 optimizer=5.0,
-                step_cpu=70.0,
+                step_cpu=75.0,
             ),
         }
     )
@@ -388,6 +390,7 @@ def test_step_time_input_straggler_card_shows_rank_evidence() -> None:
     )
     assert "issues" not in payload["groups"]["rows"]["1"]
     assert {issue["kind"] for issue in payload["issues"]} == {
-        "INPUT_STRAGGLER"
+        "INPUT_STRAGGLER",
+        "INPUT_BOUND",
     }
     _assert_compact_card(payload["card"])

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -148,6 +148,7 @@ def _input_bound_step_metrics(
     input_wait_gpu: float,
     step_time_gpu: float,
     h2d_gpu: float = 0.0,
+    compute_gpu: float = 0.0,
     steps: int = 64,
 ) -> dict[int, dict]:
     return {
@@ -156,6 +157,7 @@ def _input_bound_step_metrics(
                 cpu_ms=dataloader_cpu, gpu_ms=input_wait_gpu
             ),
             "_traceml_internal:h2d_time": _event_stats(gpu_ms=h2d_gpu),
+            "_traceml_internal:forward_time": _event_stats(gpu_ms=compute_gpu),
             "_traceml_internal:step_time": _event_stats(
                 cpu_ms=step_time_cpu,
                 gpu_ms=step_time_gpu,
@@ -286,6 +288,7 @@ def test_step_time_input_bound_card_uses_short_reason() -> None:
             0: _input_bound_step_metrics(
                 input_wait_gpu=40.0,
                 step_time_gpu=100.0,
+                compute_gpu=90.0,
             )
         },
     )
@@ -333,6 +336,7 @@ def test_step_time_h2d_bound_card_uses_short_reason() -> None:
             0: _input_bound_step_metrics(
                 input_wait_gpu=0.0,
                 h2d_gpu=20.0,
+                compute_gpu=70.0,
                 step_time_cpu=100.0,
                 step_time_gpu=100.0,
             )

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -211,14 +211,14 @@ def test_step_time_balanced_card_is_compact() -> None:
     payload = _summary(
         {
             0: _rank(
-                dataloader=20.0,
+                dataloader=5.0,
                 forward=20.0,
                 backward=35.0,
                 optimizer=5.0,
                 step_cpu=70.0,
             ),
             1: _rank(
-                dataloader=20.0,
+                dataloader=5.0,
                 forward=21.0,
                 backward=34.0,
                 optimizer=5.0,
@@ -290,6 +290,7 @@ def test_step_time_input_bound_card_uses_short_reason() -> None:
     assert payload["diagnosis"]["phase"] == "input"
     assert payload["diagnosis"]["evidence"]["input_wait_ms"] == 40.0
     assert payload["diagnosis"]["evidence"]["step_time_ms"] == 100.0
+    assert payload["diagnosis"]["evidence"]["iteration_time_ms"] == 140.0
     assert payload["diagnosis"]["evidence"]["diagnosis_clock"] == "gpu"
     assert payload["global"]["window"]["diagnosis_clock"] == "gpu"
     average = payload["global"]["average"]
@@ -304,7 +305,7 @@ def test_step_time_input_bound_card_uses_short_reason() -> None:
     assert row_metrics["total_step_ms"] == 102.0
     _assert_public_step_metrics_keep_dataloader(payload)
     assert (
-        "- Why: Input wait was 40.0ms before a 100.0ms gpu traced step."
+        "- Why: Input wait was 40.0ms of 140.0ms gpu iteration time."
         in payload["card"]
     )
     _assert_compact_card(payload["card"])

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -209,7 +209,7 @@ def test_step_time_no_data_card_is_compact() -> None:
     assert payload["diagnosis"]["kind"] == "NO_DATA"
     assert "- Diagnosis: NO DATA" in payload["card"]
     assert "- Stats: n/a" in payload["card"]
-    assert "- Why: Need more step-time samples." in payload["card"]
+    assert "- Why: step_time metric is missing." in payload["card"]
     _assert_compact_card(payload["card"])
 
 
@@ -242,7 +242,10 @@ def test_step_time_balanced_card_is_compact() -> None:
     assert "- Residual: median/worst" in payload["card"]
     assert "- Ranks: median/worst |" in payload["card"]
     assert "- Residual ranks: median/worst" in payload["card"]
-    assert "- Why: No clear timing bottleneck." in payload["card"]
+    assert (
+        "- Why: No dominant bottleneck is visible in this window."
+        in payload["card"]
+    )
     _assert_compact_card(payload["card"])
 
 
@@ -267,7 +270,7 @@ def test_step_time_compute_bound_card_uses_short_reason() -> None:
     )
     assert "- Residual: 5.0ms" in payload["card"]
     assert (
-        "- Why: Compute dominated (90.0ms/97.0ms); backward was largest."
+        "- Why: Compute-bound; backward is the largest phase."
         in payload["card"]
     )
     _assert_compact_card(payload["card"])
@@ -314,7 +317,7 @@ def test_step_time_input_bound_card_uses_short_reason() -> None:
     assert row_metrics["total_step_ms"] == 102.0
     _assert_public_step_metrics_keep_dataloader(payload)
     assert (
-        "- Why: Input wait was 40.0ms of 140.0ms gpu iteration time."
+        "- Why: Input wait is 28.6% of the typical gpu iteration time."
         in payload["card"]
     )
     _assert_compact_card(payload["card"])
@@ -350,7 +353,8 @@ def test_step_time_h2d_bound_card_uses_short_reason() -> None:
     assert payload["diagnosis"]["evidence"]["h2d_ms"] == 20.0
     assert payload["diagnosis"]["evidence"]["diagnosis_clock"] == "gpu"
     assert (
-        "- Why: H2D transfer was high inside the total step" in payload["card"]
+        "- Why: H2D transfer is 20.0% of the typical GPU iteration time."
+        in payload["card"]
     )
     _assert_compact_card(payload["card"])
 
@@ -371,10 +375,43 @@ def test_step_time_residual_heavy_card_uses_short_reason() -> None:
     assert payload["diagnosis"] == payload["issues"][0]
     assert payload["diagnosis"]["status"] == "RESIDUAL-HEAVY"
     assert (
-        "- Why: Residual time was high inside the total step (30.0ms/102.0ms)."
+        "- Why: Residual time is 29.4% of the typical cpu iteration time."
         in payload["card"]
     )
     _assert_compact_card(payload["card"])
+
+
+def test_step_time_card_uses_h2d_diagnosis_score_not_worst_rollups() -> None:
+    payload = _summary(
+        {
+            0: _rank(h2d=10.0, forward=90.0, backward=0.0, optimizer=0.0),
+            1: _rank(h2d=90.0, forward=10.0, backward=0.0, optimizer=0.0),
+        },
+        per_rank_steps={
+            0: _input_bound_step_metrics(
+                input_wait_gpu=0.0,
+                h2d_gpu=10.0,
+                compute_gpu=90.0,
+                step_time_cpu=300.0,
+                step_time_gpu=100.0,
+            ),
+            1: _input_bound_step_metrics(
+                input_wait_gpu=20.0,
+                h2d_gpu=90.0,
+                compute_gpu=10.0,
+                step_time_cpu=120.0,
+                step_time_gpu=100.0,
+            ),
+        },
+    )
+
+    assert payload["diagnosis"]["status"] == "H2D-BOUND"
+    assert payload["diagnosis"]["score"] == 0.425
+    assert (
+        "- Why: H2D transfer is 42.5% of the typical GPU iteration time."
+        in payload["card"]
+    )
+    assert "90.0ms/312.0ms" not in payload["card"]
 
 
 def test_step_time_residual_uses_average_of_per_step_clamps() -> None:
@@ -399,7 +436,8 @@ def test_step_time_residual_uses_average_of_per_step_clamps() -> None:
     )
     assert primary["kind"] == "RESIDUAL_HEAVY"
     assert primary["evidence"]["residual_ms"] == 25.0
-    assert primary["evidence"]["shares"]["residual_pct"] == 33.333
+    assert primary["evidence"]["score"] == payload["diagnosis"]["score"]
+    assert "shares" not in primary["evidence"]
 
 
 def test_step_time_input_straggler_card_shows_rank_evidence() -> None:
@@ -425,8 +463,8 @@ def test_step_time_input_straggler_card_shows_rank_evidence() -> None:
     _assert_public_step_metrics_keep_dataloader(payload)
     assert "- Ranks: median/worst |" in payload["card"]
     assert (
-        "- Why: r1 input was slower than median global rank (70.0/40.0ms)."
-        in payload["card"]
+        "- Why: r1 has excess input wait burden relative to victim r0 "
+        "(~24.0% impact; ~100.0% of visible wait cost)." in payload["card"]
     )
     assert "issues" not in payload["groups"]["rows"]["1"]
     assert {issue["kind"] for issue in payload["issues"]} == {
@@ -434,3 +472,18 @@ def test_step_time_input_straggler_card_shows_rank_evidence() -> None:
         "INPUT_BOUND",
     }
     _assert_compact_card(payload["card"])
+
+
+def test_step_time_generic_straggler_card_uses_canonical_summary() -> None:
+    payload = _summary(
+        {
+            0: _rank(backward=50.0),
+            1: _rank(backward=100.0),
+        }
+    )
+
+    assert payload["diagnosis"]["kind"] == "STRAGGLER"
+    assert (
+        "- Why: r0 is slower than victim r1 (~34.5% impact); no measured "
+        "component explains 80.0% of visible wait cost." in payload["card"]
+    )

--- a/tests/runtime/test_environment.py
+++ b/tests/runtime/test_environment.py
@@ -1,0 +1,205 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from traceml_ai.runtime.environment import detect_runtime_environment
+
+
+class _FakeDistributed:
+    def __init__(
+        self,
+        *,
+        available=True,
+        initialized=True,
+        backend="nccl",
+        rank=0,
+        world_size=1,
+    ):
+        self._available = available
+        self._initialized = initialized
+        self._backend = backend
+        self._rank = rank
+        self._world_size = world_size
+
+    def is_available(self):
+        return self._available
+
+    def is_initialized(self):
+        return self._initialized
+
+    def get_backend(self):
+        return self._backend
+
+    def get_rank(self):
+        return self._rank
+
+    def get_world_size(self):
+        return self._world_size
+
+
+class _BrokenDistributed:
+    def is_available(self):
+        raise RuntimeError("distributed unavailable")
+
+    def is_initialized(self):
+        raise RuntimeError("distributed unavailable")
+
+    def get_rank(self):
+        raise RuntimeError("rank unavailable")
+
+    def get_world_size(self):
+        raise RuntimeError("world unavailable")
+
+
+class _FakeDDP:
+    pass
+
+
+class _FakeFSDP:
+    pass
+
+
+class _PlainModel:
+    pass
+
+
+def _fake_torch(*, distributed=None, ddp_cls=None, fsdp_cls=None):
+    dist = distributed or _FakeDistributed()
+    dist.fsdp = SimpleNamespace(
+        FullyShardedDataParallel=fsdp_cls,
+        fully_sharded_data_parallel=SimpleNamespace(
+            FullyShardedDataParallel=fsdp_cls
+        ),
+    )
+    return SimpleNamespace(
+        distributed=dist,
+        nn=SimpleNamespace(
+            parallel=SimpleNamespace(DistributedDataParallel=ddp_cls)
+        ),
+    )
+
+
+def test_runtime_environment_single_process_without_torch():
+    info = detect_runtime_environment(env={}, torch_loader=lambda: None)
+
+    assert info.topology == "single_process"
+    assert not info.distributed_initialized
+    assert info.distributed_backend is None
+    assert info.training_strategy == "single_process"
+    assert info.strategy_source == "topology"
+    assert info.strategy_confidence == "high"
+    assert info.to_record() == {
+        "topology": "single_process",
+        "distributed_initialized": False,
+        "distributed_backend": None,
+        "training_strategy": "single_process",
+        "strategy_source": "topology",
+        "strategy_confidence": "high",
+    }
+
+
+def test_runtime_environment_single_node_multi_process_from_env():
+    info = detect_runtime_environment(
+        env={
+            "RANK": "0",
+            "LOCAL_RANK": "0",
+            "WORLD_SIZE": "4",
+            "LOCAL_WORLD_SIZE": "4",
+            "GROUP_RANK": "0",
+        },
+        torch_loader=lambda: None,
+    )
+
+    assert info.topology == "single_node_multi_process"
+    assert info.training_strategy == "distributed_unknown"
+    assert info.strategy_source == "topology"
+    assert info.strategy_confidence == "low"
+
+
+def test_runtime_environment_multi_node_from_env():
+    info = detect_runtime_environment(
+        env={
+            "RANK": "5",
+            "LOCAL_RANK": "1",
+            "WORLD_SIZE": "8",
+            "LOCAL_WORLD_SIZE": "4",
+            "GROUP_RANK": "1",
+        },
+        torch_loader=lambda: None,
+    )
+
+    assert info.topology == "multi_node"
+    assert info.training_strategy == "distributed_unknown"
+
+
+def test_runtime_environment_detects_ddp_model():
+    torch = _fake_torch(
+        distributed=_FakeDistributed(world_size=4),
+        ddp_cls=_FakeDDP,
+    )
+
+    info = detect_runtime_environment(
+        model=_FakeDDP(),
+        env={"RANK": "0", "WORLD_SIZE": "4", "LOCAL_WORLD_SIZE": "4"},
+        torch_loader=lambda: torch,
+    )
+
+    assert info.training_strategy == "ddp"
+    assert info.strategy_source == "runtime_model"
+    assert info.strategy_confidence == "high"
+
+
+def test_runtime_environment_detects_fsdp_model():
+    torch = _fake_torch(
+        distributed=_FakeDistributed(world_size=4),
+        fsdp_cls=_FakeFSDP,
+    )
+
+    info = detect_runtime_environment(
+        model=_FakeFSDP(),
+        env={"RANK": "0", "WORLD_SIZE": "4", "LOCAL_WORLD_SIZE": "4"},
+        torch_loader=lambda: torch,
+    )
+
+    assert info.training_strategy == "fsdp"
+    assert info.strategy_source == "runtime_model"
+    assert info.strategy_confidence == "high"
+
+
+def test_runtime_environment_captures_distributed_backend():
+    torch = _fake_torch(
+        distributed=_FakeDistributed(
+            initialized=True,
+            backend="gloo",
+            rank=1,
+            world_size=2,
+        )
+    )
+
+    info = detect_runtime_environment(env={}, torch_loader=lambda: torch)
+
+    assert info.topology == "multi_node"
+    assert info.distributed_initialized
+    assert info.distributed_backend == "gloo"
+    assert info.training_strategy == "distributed_unknown"
+    assert info.strategy_source == "runtime_distributed"
+
+
+def test_runtime_environment_degrades_when_distributed_raises():
+    torch = _fake_torch(distributed=_BrokenDistributed())
+
+    info = detect_runtime_environment(
+        model=_PlainModel(),
+        env={"RANK": "0", "WORLD_SIZE": "2", "LOCAL_WORLD_SIZE": "2"},
+        torch_loader=lambda: torch,
+    )
+
+    assert info.topology == "single_node_multi_process"
+    assert not info.distributed_initialized
+    assert info.distributed_backend is None
+    assert info.training_strategy == "distributed_unknown"
+    assert info.strategy_confidence == "low"

--- a/tests/runtime/test_environment_state.py
+++ b/tests/runtime/test_environment_state.py
@@ -1,0 +1,60 @@
+import pytest
+
+from traceml_ai.runtime.environment import RuntimeEnvironmentInfo
+from traceml_ai.runtime import environment_state
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_environment_state():
+    environment_state.reset_runtime_environment_state()
+    yield
+    environment_state.reset_runtime_environment_state()
+
+
+def _info(strategy: str = "single_process") -> RuntimeEnvironmentInfo:
+    return RuntimeEnvironmentInfo(
+        topology="single_process",
+        distributed_initialized=False,
+        distributed_backend=None,
+        training_strategy=strategy,
+        strategy_source="topology",
+        strategy_confidence="high",
+    )
+
+
+def test_publish_once_drain_once_and_reset(monkeypatch) -> None:
+    monkeypatch.setattr(environment_state.time, "time", lambda: 123.5)
+
+    assert environment_state.has_runtime_environment_info() is False
+    assert environment_state.publish_runtime_environment_once(_info()) is True
+    assert environment_state.has_runtime_environment_info() is True
+
+    row = environment_state.pop_runtime_environment_record()
+    assert row == {
+        "seq": 0,
+        "ts": 123.5,
+        "topology": "single_process",
+        "distributed_initialized": False,
+        "distributed_backend": None,
+        "training_strategy": "single_process",
+        "strategy_source": "topology",
+        "strategy_confidence": "high",
+    }
+    assert environment_state.pop_runtime_environment_record() is None
+
+    environment_state.reset_runtime_environment_state()
+
+    assert environment_state.has_runtime_environment_info() is False
+    assert environment_state.pop_runtime_environment_record() is None
+
+
+def test_second_publish_is_ignored() -> None:
+    assert environment_state.publish_runtime_environment_once(_info("ddp"))
+    assert not environment_state.publish_runtime_environment_once(
+        _info("fsdp")
+    )
+
+    row = environment_state.pop_runtime_environment_record()
+
+    assert row is not None
+    assert row["training_strategy"] == "ddp"

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -39,6 +39,7 @@ from traceml_ai.runtime.executor import (  # noqa: E402
 )
 from traceml_ai.runtime.settings import (
     DEFAULT_FINALIZE_TIMEOUT_SEC,
+    TraceMLSettings,
 )  # noqa: E402
 
 
@@ -143,6 +144,20 @@ def test_read_traceml_env_parses_trace_max_steps(monkeypatch):
     assert cfg["trace_max_steps"] == 123
     assert cfg["finalize_timeout_sec"] == 42.5
     assert cfg["expected_world_size"] == 8
+
+
+def test_read_traceml_env_defaults_to_two_second_interval(monkeypatch):
+    monkeypatch.setenv("TRACEML_SCRIPT_PATH", "train.py")
+    monkeypatch.delenv("TRACEML_INTERVAL", raising=False)
+
+    assert read_traceml_env()["interval"] == 2.0
+
+
+def test_trace_settings_default_to_two_second_cadences():
+    settings = TraceMLSettings()
+
+    assert settings.sampler_interval_sec == 2.0
+    assert settings.render_interval_sec == 2.0
 
 
 def test_build_runtime_settings_carries_trace_max_steps():

--- a/tests/runtime/test_exporter.py
+++ b/tests/runtime/test_exporter.py
@@ -1,0 +1,228 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+import time
+
+from traceml_ai.runtime.exporter import TelemetryExporter
+from traceml_ai.runtime.sender import SenderIdentity, TelemetryPublisher
+
+
+class _FakeLogger:
+    def __init__(self) -> None:
+        self.exceptions: list[str] = []
+        self.errors: list[str] = []
+
+    def exception(self, message: str, *args: object) -> None:
+        self.exceptions.append(message % args if args else message)
+
+    def error(self, message: str, *args: object) -> None:
+        self.errors.append(message % args if args else message)
+
+
+class _FakeClient:
+    """Records send_batch calls; can be told to raise or sleep."""
+
+    def __init__(
+        self,
+        *,
+        raise_on_send: bool = False,
+        send_delay: float = 0.0,
+    ) -> None:
+        self._lock = threading.Lock()
+        self.batches: list[list] = []
+        self.send_calls = 0
+        self.closed = False
+        self._raise_on_send = raise_on_send
+        self._send_delay = send_delay
+
+    def send_batch(self, batch: list) -> None:
+        with self._lock:
+            self.send_calls += 1
+        if self._send_delay:
+            time.sleep(self._send_delay)
+        if self._raise_on_send:
+            raise RuntimeError("send failed")
+        with self._lock:
+            self.batches.append(batch)
+
+    def send(self, payload: object) -> None:
+        self.send_batch([payload])
+
+    def close(self) -> None:
+        with self._lock:
+            self.closed = True
+
+    def snapshot(self) -> list[list]:
+        with self._lock:
+            return list(self.batches)
+
+    @property
+    def call_count(self) -> int:
+        with self._lock:
+            return self.send_calls
+
+
+class _FakeSender:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+        self.sender = None
+        self.identity = None
+
+    def collect_payload(self) -> object:
+        return self.payload
+
+
+class _FakeSampler:
+    def __init__(self, name: str, *, sender: _FakeSender) -> None:
+        self.sampler_name = name
+        self.sender = sender
+        self.db = None
+
+
+def _wait_until(pred, timeout: float = 2.0, interval: float = 0.01) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return True
+        time.sleep(interval)
+    return pred()
+
+
+def test_normal_enqueue_and_export() -> None:
+    client = _FakeClient()
+    exporter = TelemetryExporter(tcp_client=client, logger=_FakeLogger())
+    exporter.start()
+    try:
+        exporter.send_batch([{"id": 1}])
+        assert _wait_until(lambda: client.snapshot() == [[{"id": 1}]])
+    finally:
+        exporter.stop()
+    assert client.closed is True
+
+
+def test_drop_oldest_when_full() -> None:
+    client = _FakeClient()
+    exporter = TelemetryExporter(
+        tcp_client=client,
+        max_queue_size=2,
+        logger=_FakeLogger(),
+    )
+    # Thread not started, so nothing drains and the queue fills.
+    exporter.send_batch([{"id": 1}])
+    exporter.send_batch([{"id": 2}])
+    exporter.send_batch([{"id": 3}])  # drops the oldest ([{"id": 1}])
+
+    assert exporter.queue_size == 2
+    assert exporter.dropped_count == 1
+
+    # The newest two survive, in order.
+    exporter.start()
+    try:
+        assert _wait_until(
+            lambda: client.snapshot() == [[{"id": 2}], [{"id": 3}]]
+        )
+    finally:
+        exporter.stop()
+    assert exporter.dropped_count == 1
+
+
+def test_aggregator_unavailable_does_not_block_or_crash() -> None:
+    logger = _FakeLogger()
+    client = _FakeClient(raise_on_send=True)
+    exporter = TelemetryExporter(tcp_client=client, logger=logger)
+    exporter.start()
+    try:
+        # Enqueue must return immediately and never raise.
+        for i in range(5):
+            exporter.send_batch([{"id": i}])
+        # The exporter thread keeps attempting sends and swallows failures.
+        assert _wait_until(lambda: client.call_count >= 5)
+        assert exporter.dropped_count == 0
+        assert len(logger.exceptions) >= 5
+    finally:
+        exporter.stop()
+
+
+def test_enqueue_after_stop_is_dropped() -> None:
+    client = _FakeClient()
+    exporter = TelemetryExporter(tcp_client=client, logger=_FakeLogger())
+    exporter.start()
+    exporter.stop()
+
+    exporter.send_batch([{"id": 1}])
+
+    assert exporter.queue_size == 0
+    assert exporter.dropped_count == 1
+    assert client.call_count == 0
+
+
+def test_shutdown_drain_timeout_is_bounded() -> None:
+    client = _FakeClient(send_delay=2.0)
+    exporter = TelemetryExporter(
+        tcp_client=client,
+        drain_timeout_sec=0.2,
+        poll_interval_sec=0.1,
+        logger=_FakeLogger(),
+    )
+    exporter.start()
+    for i in range(10):
+        exporter.send_batch([{"id": i}])
+
+    start = time.monotonic()
+    exporter.stop()
+    elapsed = time.monotonic() - start
+
+    # Must return before a single slow send completes, not after draining all.
+    assert elapsed < 2.0
+
+
+def test_shutdown_drain_timeout_counts_and_logs_remaining_batches() -> None:
+    logger = _FakeLogger()
+    client = _FakeClient(send_delay=0.2)
+    exporter = TelemetryExporter(
+        tcp_client=client,
+        drain_timeout_sec=0.0,
+        poll_interval_sec=0.01,
+        logger=logger,
+    )
+    exporter.start()
+    exporter.send_batch([{"id": 1}])
+    assert _wait_until(lambda: client.call_count == 1)
+    exporter.send_batch([{"id": 2}])
+    exporter.send_batch([{"id": 3}])
+
+    exporter.stop()
+
+    assert exporter.queue_size == 0
+    assert exporter.dropped_count == 2
+    assert any(
+        "shutdown dropped 2 queued payload batches" in e for e in logger.errors
+    )
+
+
+def test_tick_enqueues_and_does_not_send_inline() -> None:
+    client = _FakeClient()
+    exporter = TelemetryExporter(tcp_client=client, logger=_FakeLogger())
+    publisher = TelemetryPublisher(
+        tcp_client=exporter,
+        identity=SenderIdentity(global_rank=0, local_rank=0),
+        logger=_FakeLogger(),
+    )
+    sampler = _FakeSampler("A", sender=_FakeSender(payload={"rows": [1]}))
+
+    # Exporter thread not started: publish must only enqueue, never send.
+    publisher.publish([sampler])
+    assert client.call_count == 0
+    assert exporter.queue_size == 1
+
+    # Once the exporter runs, the batch is sent.
+    exporter.start()
+    try:
+        assert _wait_until(lambda: client.call_count == 1)
+        assert client.snapshot() == [[{"rows": [1]}]]
+    finally:
+        exporter.stop()

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -125,6 +125,35 @@ def test_serve_threads_expected_world_size(monkeypatch) -> None:
     assert _resolve_serve_settings(args).expected_world_size == 1
 
 
+def test_serve_dashboard_missing_deps_reports_hint_not_nameerror(
+    monkeypatch,
+) -> None:
+    # Regression: run_serve referenced an undefined constant on the
+    # dashboard-deps-missing path, so it raised NameError instead of the
+    # SystemExit install hint. Pin that it names the missing deps and exits.
+    import importlib.util as importlib_util
+
+    real_find_spec = importlib_util.find_spec
+    monkeypatch.setattr(
+        importlib_util,
+        "find_spec",
+        lambda name, *a, **k: (
+            None
+            if name in ("nicegui", "plotly")
+            else real_find_spec(name, *a, **k)
+        ),
+    )
+    from traceml_ai.launcher.commands import run_serve
+
+    args = build_parser().parse_args(["serve", "--mode", "dashboard"])
+    with pytest.raises(SystemExit) as excinfo:
+        run_serve(args)
+
+    message = str(excinfo.value)
+    assert "nicegui" in message and "plotly" in message
+    assert "Missing:" in message
+
+
 def test_serve_configures_logging_without_preset_env(
     monkeypatch, tmp_path
 ) -> None:

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+import traceml_ai.launcher.commands as launcher_commands
 from traceml_ai.launcher.cli import build_parser
 from traceml_ai.launcher.commands import (
     _dashboard_access_box,
@@ -255,6 +256,16 @@ def test_build_parser_preserves_launch_commands() -> None:
     assert default_args.mode is None
 
 
+def test_build_parser_accepts_disable_traceml_aliases() -> None:
+    parser = build_parser()
+
+    dashed = parser.parse_args(["run", "train.py", "--disable-traceml"])
+    underscored = parser.parse_args(["run", "train.py", "--disable_traceml"])
+
+    assert dashed.disable_traceml is True
+    assert underscored.disable_traceml is True
+
+
 def test_launch_defaults_use_dashboard_for_single_node_topologies() -> None:
     defaults = {"mode": "summary", "interval": 2.0}
 
@@ -346,6 +357,167 @@ def test_summary_mode_requires_history() -> None:
 
     with pytest.raises(SystemExit):
         validate_launch_args(args)
+
+
+def test_disabled_launch_validation_skips_traceml_only_checks(
+    monkeypatch,
+) -> None:
+    args = argparse.Namespace(
+        mode="dashboard",
+        no_history=True,
+        html_report=True,
+        nnodes=2,
+        nproc_per_node=1,
+        node_rank=0,
+        master_addr="127.0.0.1",
+        master_port=29500,
+        aggregator_host=None,
+        aggregator_bind_host=None,
+        aggregator_port=0,
+        run_name="",
+        session_id="",
+        summary_window_rows=0,
+        finalize_timeout_sec=-1.0,
+        trace_max_steps=0,
+        disable_traceml=True,
+    )
+    monkeypatch.setattr(
+        "traceml_ai.launcher.commands.importlib.util.find_spec",
+        lambda package: None,
+    )
+
+    validate_launch_args(args)
+
+
+def test_disabled_launch_validation_honors_env_kill_switch(
+    monkeypatch,
+) -> None:
+    args = argparse.Namespace(
+        mode="summary",
+        no_history=True,
+        html_report=True,
+        nnodes=2,
+        nproc_per_node=1,
+        node_rank=0,
+        master_addr="127.0.0.1",
+        master_port=29500,
+        aggregator_host=None,
+        aggregator_bind_host=None,
+        aggregator_port=0,
+        run_name="",
+        session_id="",
+        summary_window_rows=0,
+        finalize_timeout_sec=-1.0,
+        trace_max_steps=0,
+        disable_traceml=None,
+    )
+    monkeypatch.setenv("TRACEML_DISABLED", "1")
+
+    validate_launch_args(args)
+
+
+def test_disabled_launch_runs_script_directly_and_skips_traceml_setup(
+    monkeypatch, tmp_path
+) -> None:
+    script = tmp_path / "train.py"
+    script.write_text("print('native')\n", encoding="utf-8")
+    (tmp_path / "traceml.yaml").write_text("mode: [\n", encoding="utf-8")
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "run",
+            str(script),
+            "--disable-traceml",
+            "--mode",
+            "summary",
+            "--no-history",
+            "--html-report",
+            "--capture-stderr",
+            "--logs-dir",
+            str(tmp_path / "logs"),
+            "--aggregator-port",
+            "0",
+            "--nnodes",
+            "2",
+            "--nproc-per-node",
+            "3",
+            "--node-rank",
+            "1",
+            "--master-addr",
+            "10.0.0.10",
+            "--master-port",
+            "29511",
+            "--args",
+            "--epochs",
+            "1",
+        ]
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TRACEML_AGGREGATOR_PORT", "9999")
+    observed = {}
+
+    class _Proc:
+        pid = 12345
+        returncode = 17
+
+        def wait(self):
+            return self.returncode
+
+    def _start_training_process(train_cmd, env, cwd, *, capture_stderr=False):
+        observed["train_cmd"] = train_cmd
+        observed["env"] = env
+        observed["cwd"] = cwd
+        observed["capture_stderr"] = capture_stderr
+        return _Proc()
+
+    def _record_shutdown_handler(get_procs, manifest_path=None):
+        observed["manifest_path"] = manifest_path
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError("TraceML setup must not run when disabled")
+
+    monkeypatch.setattr(
+        launcher_commands,
+        "start_training_process",
+        _start_training_process,
+    )
+    monkeypatch.setattr(
+        launcher_commands,
+        "install_shutdown_handlers",
+        _record_shutdown_handler,
+    )
+    monkeypatch.setattr(
+        launcher_commands, "start_aggregator_process", _forbidden
+    )
+    monkeypatch.setattr(launcher_commands, "write_code_manifest", _forbidden)
+    monkeypatch.setattr(launcher_commands, "write_run_manifest", _forbidden)
+    monkeypatch.setattr(launcher_commands, "update_run_manifest", _forbidden)
+
+    with pytest.raises(SystemExit) as exc:
+        launcher_commands.launch_process(str(script), args)
+
+    assert exc.value.code == 17
+    assert observed["train_cmd"] == [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        "--nnodes=2",
+        "--nproc_per_node=3",
+        "--node_rank=1",
+        "--master_addr=10.0.0.10",
+        "--master_port=29511",
+        str(script),
+        "--epochs",
+        "1",
+    ]
+    assert observed["env"]["TRACEML_DISABLED"] == "1"
+    assert [key for key in observed["env"] if key.startswith("TRACEML_")] == [
+        "TRACEML_DISABLED"
+    ]
+    assert observed["cwd"] == str(tmp_path.resolve())
+    assert observed["capture_stderr"] is False
+    assert observed["manifest_path"] is None
+    assert not (tmp_path / "logs").exists()
 
 
 def test_summary_window_rows_must_be_positive() -> None:

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -6,6 +6,7 @@
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -15,9 +16,14 @@ from traceml_ai.launcher.cli import build_parser
 from traceml_ai.launcher.commands import (
     _dashboard_access_box,
     _launch_defaults_for_topology,
+    _resolve_serve_settings,
     resolve_existing_script_path,
     run_view,
     validate_launch_args,
+)
+from traceml_ai.launcher.launch_config import (
+    DistributedLaunchConfig,
+    RunIdentity,
 )
 from traceml_ai.launcher.manifest import (
     collect_existing_artifacts,
@@ -25,12 +31,161 @@ from traceml_ai.launcher.manifest import (
     update_run_manifest,
     write_run_manifest,
 )
-from traceml_ai.launcher.launch_config import (
-    DistributedLaunchConfig,
-    RunIdentity,
-)
 from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
 from traceml_ai.runtime.settings import DEFAULT_FINALIZE_TIMEOUT_SEC
+
+
+def test_serve_is_a_public_command() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(
+        [
+            "serve",
+            "--mode",
+            "cli",
+            "--logs-dir",
+            "mylogs",
+            "--run-name",
+            "demo",
+            "--aggregator-host",
+            "10.0.0.9",
+            "--aggregator-bind-host",
+            "0.0.0.0",
+            "--aggregator-port",
+            "40000",
+        ]
+    )
+
+    assert args.command == "serve"
+    assert args.mode == "cli"
+    assert args.aggregator_host == "10.0.0.9"
+    assert args.aggregator_bind_host == "0.0.0.0"
+    assert args.aggregator_port == 40000
+
+
+def test_serve_maps_flags_into_aggregator_settings(monkeypatch) -> None:
+    # Isolate from any TRACEML_* env so the CLI flags drive the result.
+    for var in (
+        "TRACEML_UI_MODE",
+        "TRACEML_MODE",
+        "TRACEML_LOGS_DIR",
+        "TRACEML_INTERVAL",
+        "TRACEML_ENABLE_LOGGING",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "serve",
+            "--mode",
+            "cli",
+            "--logs-dir",
+            "mylogs",
+            "--run-name",
+            "demo",
+            "--aggregator-host",
+            "10.0.0.9",
+            "--aggregator-bind-host",
+            "0.0.0.0",
+            "--aggregator-port",
+            "40000",
+        ]
+    )
+
+    settings = _resolve_serve_settings(args)
+
+    assert settings.mode == "cli"
+    assert settings.logs_dir == "mylogs"
+    assert settings.session_id == "demo"
+    assert settings.aggregator.connect_host == "10.0.0.9"
+    assert settings.aggregator.bind_host == "0.0.0.0"
+    assert settings.aggregator.port == 40000
+
+
+def test_serve_threads_expected_world_size(monkeypatch) -> None:
+    monkeypatch.delenv("TRACEML_EXPECTED_WORLD_SIZE", raising=False)
+    parser = build_parser()
+
+    # Explicit --nnodes x --nproc-per-node sets the rank count so the
+    # aggregator waits for ALL ranks before finalizing.
+    args = parser.parse_args(
+        ["serve", "--nnodes", "2", "--nproc-per-node", "4"]
+    )
+    assert _resolve_serve_settings(args).expected_world_size == 8
+
+    # Falls back to TRACEML_EXPECTED_WORLD_SIZE (matching `traceml run`).
+    monkeypatch.setenv("TRACEML_EXPECTED_WORLD_SIZE", "3")
+    args = parser.parse_args(["serve"])
+    assert _resolve_serve_settings(args).expected_world_size == 3
+
+    # Default is 1 when neither flags nor env are set.
+    monkeypatch.delenv("TRACEML_EXPECTED_WORLD_SIZE", raising=False)
+    args = parser.parse_args(["serve"])
+    assert _resolve_serve_settings(args).expected_world_size == 1
+
+
+def test_serve_configures_logging_without_preset_env(
+    monkeypatch, tmp_path
+) -> None:
+    import logging
+
+    import traceml_ai.aggregator.aggregator_main as agg_main
+    from traceml_ai.runtime.settings import (
+        AggregatorTransportSettings,
+        TraceMLSettings,
+    )
+
+    saved_env = {
+        key: os.environ.get(key)
+        for key in ("TRACEML_LOGS_DIR", "TRACEML_SESSION_ID")
+    }
+    os.environ.pop("TRACEML_LOGS_DIR", None)
+    os.environ.pop("TRACEML_SESSION_ID", None)
+
+    traceml_logger = logging.getLogger("traceml")
+    saved_handlers = traceml_logger.handlers[:]
+    traceml_logger.handlers.clear()
+
+    # Do not clobber the process signal handlers, and stop before the blocking
+    # wait by making aggregator startup raise a controlled error.
+    monkeypatch.setattr(agg_main, "_install_signal_handlers", lambda ev: None)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("stop before blocking")
+
+    monkeypatch.setattr(agg_main, "start_aggregator", _boom)
+
+    settings = TraceMLSettings(
+        mode="summary",
+        logs_dir=str(tmp_path),
+        session_id="serve-test",
+        aggregator=AggregatorTransportSettings(
+            connect_host="127.0.0.1", bind_host="127.0.0.1", port=0
+        ),
+    )
+
+    try:
+        rc = agg_main.run_aggregator(settings)
+
+        # Clean fatal exit (return 1), not a TypeError in logging setup.
+        assert rc == 1
+        assert os.environ["TRACEML_LOGS_DIR"] == str(tmp_path)
+        assert os.environ["TRACEML_SESSION_ID"] == "serve-test"
+    finally:
+        for handler in traceml_logger.handlers[:]:
+            traceml_logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+        for handler in saved_handlers:
+            traceml_logger.addHandler(handler)
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 def test_build_parser_preserves_launch_commands() -> None:

--- a/tests/runtime/test_lifecycle.py
+++ b/tests/runtime/test_lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import socket
 from dataclasses import dataclass
 from typing import Any
 
@@ -67,3 +68,91 @@ def test_start_aggregator_returns_idempotent_handle(
 
     assert handle.stop_event.is_set()
     assert created[0].stops == 1
+
+
+class _FakeRuntime:
+    """Minimal TraceMLRuntime stand-in for start_runtime() tests."""
+
+    def __init__(self, settings: TraceMLSettings | None = None) -> None:
+        self.started = False
+        self.stopped = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+def test_wait_for_aggregator_true_when_listening() -> None:
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+    try:
+        assert lifecycle.wait_for_aggregator(
+            "127.0.0.1", port, timeout_sec=2.0, poll_interval_sec=0.05
+        )
+    finally:
+        server.close()
+
+
+def test_wait_for_aggregator_false_when_closed() -> None:
+    # Bind then close to obtain a port that is (very likely) not listening.
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    assert not lifecycle.wait_for_aggregator(
+        "127.0.0.1", port, timeout_sec=0.3, poll_interval_sec=0.05
+    )
+
+
+def test_start_runtime_registers_active_handle(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(lifecycle, "TraceMLRuntime", _FakeRuntime)
+    lifecycle._ACTIVE_RUNTIME_HANDLE = None
+    try:
+        handle = lifecycle.start_runtime(
+            TraceMLSettings(logs_dir=str(tmp_path), session_id="reg-test"),
+            fail_open=False,
+        )
+        assert lifecycle.get_active_runtime_handle() is handle
+        assert handle.runtime.started is True
+    finally:
+        lifecycle._ACTIVE_RUNTIME_HANDLE = None
+
+
+class _BoomRuntime:
+    """TraceMLRuntime stand-in whose start() fails, to test fail_open."""
+
+    def __init__(self, settings: TraceMLSettings | None = None) -> None:
+        pass
+
+    def start(self) -> None:
+        raise RuntimeError("boom")
+
+    def stop(self) -> None:
+        pass
+
+
+def test_start_runtime_fail_open_registers_noop_handle(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    # A failed start with fail_open=True must still register a no-op active
+    # handle so a later traceml.init() does not try to start the runtime again,
+    # and it must detach LOUDLY (one stderr warning) so a silently dark
+    # integration is never mistaken for a healthy run.
+    monkeypatch.setattr(lifecycle, "TraceMLRuntime", _BoomRuntime)
+    lifecycle._ACTIVE_RUNTIME_HANDLE = None
+    try:
+        handle = lifecycle.start_runtime(
+            TraceMLSettings(logs_dir=str(tmp_path), session_id="fail-open"),
+            fail_open=True,
+        )
+        assert lifecycle.get_active_runtime_handle() is handle
+        assert isinstance(handle.runtime, lifecycle.NoOpRuntime)
+        assert "[TraceML]" in capsys.readouterr().err  # detached loudly
+    finally:
+        lifecycle._ACTIVE_RUNTIME_HANDLE = None

--- a/tests/runtime/test_runtime_environment_sampler.py
+++ b/tests/runtime/test_runtime_environment_sampler.py
@@ -1,0 +1,77 @@
+import pytest
+
+from traceml_ai.runtime.environment import RuntimeEnvironmentInfo
+from traceml_ai.runtime.environment_state import (
+    publish_runtime_environment_once,
+    reset_runtime_environment_state,
+)
+from traceml_ai.runtime.sender import SenderIdentity
+from traceml_ai.samplers.runtime_environment_sampler import (
+    RuntimeEnvironmentSampler,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_environment_state():
+    reset_runtime_environment_state()
+    yield
+    reset_runtime_environment_state()
+
+
+def _info(strategy: str = "ddp") -> RuntimeEnvironmentInfo:
+    return RuntimeEnvironmentInfo(
+        topology="single_node_multi_process",
+        distributed_initialized=True,
+        distributed_backend="nccl",
+        training_strategy=strategy,
+        strategy_source="runtime_model",
+        strategy_confidence="high",
+    )
+
+
+def test_sampler_emits_no_row_before_publish() -> None:
+    sampler = RuntimeEnvironmentSampler()
+
+    sampler.sample()
+
+    assert sampler.db.get_table("RuntimeEnvironmentTable") is None
+    assert sampler.sender.collect_payload() is None
+
+
+def test_sampler_drains_one_published_environment_row() -> None:
+    publish_runtime_environment_once(_info())
+    sampler = RuntimeEnvironmentSampler()
+
+    sampler.sample()
+    sampler.sample()
+
+    rows = list(sampler.db.get_table("RuntimeEnvironmentTable") or [])
+    assert len(rows) == 1
+    assert rows[0]["seq"] == 0
+    assert rows[0]["training_strategy"] == "ddp"
+    assert rows[0]["distributed_backend"] == "nccl"
+
+
+def test_sender_envelope_body_contains_runtime_environment_table() -> None:
+    publish_runtime_environment_once(_info("fsdp"))
+    sampler = RuntimeEnvironmentSampler()
+    sampler.sender.identity = SenderIdentity(
+        global_rank=3,
+        local_rank=1,
+        world_size=8,
+        local_world_size=4,
+        node_rank=0,
+        hostname="worker-0",
+        pid=1234,
+    )
+
+    sampler.sample()
+    payload = sampler.sender.collect_payload()
+
+    assert payload is not None
+    assert payload["meta"]["sampler"] == "RuntimeEnvironmentSampler"
+    assert payload["meta"]["global_rank"] == 3
+    rows = payload["body"]["tables"]["RuntimeEnvironmentTable"]
+    assert len(rows) == 1
+    assert rows[0]["training_strategy"] == "fsdp"
+    assert rows[0]["strategy_source"] == "runtime_model"

--- a/tests/runtime/test_sampler_registry.py
+++ b/tests/runtime/test_sampler_registry.py
@@ -80,6 +80,7 @@ def _selected_keys(
 def test_watch_cli_selects_host_process_and_stdout_samplers() -> None:
     assert _selected_keys(profile="watch", mode="cli") == (
         "system",
+        "runtime_environment",
         "process",
         "stdout_stderr",
     )
@@ -88,6 +89,7 @@ def test_watch_cli_selects_host_process_and_stdout_samplers() -> None:
 def test_watch_dashboard_omits_stdout_sampler() -> None:
     assert _selected_keys(profile="watch", mode="dashboard") == (
         "system",
+        "runtime_environment",
         "process",
     )
 
@@ -95,6 +97,7 @@ def test_watch_dashboard_omits_stdout_sampler() -> None:
 def test_run_cli_selects_step_samplers() -> None:
     assert _selected_keys(profile="run", mode="cli") == (
         "system",
+        "runtime_environment",
         "process",
         "stdout_stderr",
         "step_time",
@@ -118,6 +121,7 @@ def test_ddp_nonzero_rank_skips_rank_zero_only_system_sampler() -> None:
         is_ddp=True,
         local_rank=1,
     ) == (
+        "runtime_environment",
         "process",
         "stdout_stderr",
         "step_time",
@@ -133,6 +137,7 @@ def test_ddp_rank_zero_keeps_rank_zero_only_system_sampler() -> None:
         local_rank=0,
     ) == (
         "system",
+        "runtime_environment",
         "process",
         "stdout_stderr",
         "step_time",
@@ -143,6 +148,7 @@ def test_ddp_rank_zero_keeps_rank_zero_only_system_sampler() -> None:
 def test_unknown_profile_keeps_only_profile_agnostic_samplers() -> None:
     assert _selected_keys(profile="unknown", mode="cli") == (
         "system",
+        "runtime_environment",
         "process",
         "stdout_stderr",
     )
@@ -237,6 +243,7 @@ def test_queue_backed_samplers_are_marked_for_final_recording_drain() -> None:
     }
 
     assert specs["system"].drain_on_recording_stop is False
+    assert specs["runtime_environment"].drain_on_recording_stop is True
     assert specs["process"].drain_on_recording_stop is False
     assert specs["step_time"].drain_on_recording_stop is True
     assert specs["step_memory"].drain_on_recording_stop is True

--- a/tests/sdk/test_init_and_wrappers.py
+++ b/tests/sdk/test_init_and_wrappers.py
@@ -262,6 +262,11 @@ def _run_trace_step_once(*, mode, monkeypatch):
         "ensure_optimizer_timing_installed",
         lambda: calls.append("optimizer"),
     )
+    monkeypatch.setattr(
+        instrumentation,
+        "_publish_runtime_environment",
+        lambda model: None,
+    )
 
     model = nn.Linear(2, 2)
     with instrumentation.trace_step(model):
@@ -278,6 +283,71 @@ def test_trace_step_only_auto_installs_optimizer_timing(monkeypatch):
     assert (
         _run_trace_step_once(mode="selective", monkeypatch=monkeypatch) == []
     )
+
+
+def test_trace_step_publishes_runtime_environment_once(monkeypatch):
+    _reload_initialization_module()
+    instrumentation = _reload_instrumentation_module()
+    published = []
+
+    monkeypatch.setattr(
+        instrumentation,
+        "timed_region",
+        _noop_context_manager,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "forward_auto_timer",
+        _noop_context_manager,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "backward_auto_timer",
+        _noop_context_manager,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "h2d_auto_timer",
+        _noop_context_manager,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "StepMemoryTracker",
+        _NoopStepMemoryTracker,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "flush_step_events",
+        lambda model, step: None,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "ensure_optimizer_timing_installed",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "has_runtime_environment_info",
+        lambda: bool(published),
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "detect_runtime_environment",
+        lambda model: ("runtime-info", id(model)),
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "publish_runtime_environment_once",
+        lambda info: published.append(info) or True,
+    )
+
+    model = nn.Linear(2, 2)
+    with instrumentation.trace_step(model):
+        pass
+    with instrumentation.trace_step(model):
+        pass
+
+    assert published == [("runtime-info", id(model))]
 
 
 def test_trace_step_without_init_does_not_auto_install_optimizer_timing(

--- a/tests/sdk/test_init_and_wrappers.py
+++ b/tests/sdk/test_init_and_wrappers.py
@@ -16,7 +16,11 @@ if str(SRC) not in sys.path:
 def _reload_initialization_module():
     import traceml_ai.sdk.initial as initialization
 
-    return importlib.reload(initialization)
+    importlib.reload(initialization)
+    # These tests exercise instrumentation patch policy, not runtime startup.
+    # Stub the runtime bootstrap so init() does not try to reach an aggregator.
+    initialization._start_runtime_for_init = lambda **kwargs: None
+    return initialization
 
 
 def _reload_instrumentation_module():

--- a/tests/sdk/test_init_and_wrappers.py
+++ b/tests/sdk/test_init_and_wrappers.py
@@ -555,6 +555,11 @@ def test_auto_dataloader_patch_records_gpu_events(monkeypatch):
         "timed_region",
         fake_timed_region,
     )
+    monkeypatch.setattr(
+        dataloader_patch,
+        "is_tracing_armed",
+        lambda: True,
+    )
 
     from torch.utils.data import DataLoader
 
@@ -567,6 +572,35 @@ def test_auto_dataloader_patch_records_gpu_events(monkeypatch):
         ("_traceml_internal:dataloader_next", "step", True),
         ("_traceml_internal:dataloader_next", "step", True),
     ]
+
+
+def test_auto_dataloader_patch_passes_through_when_unarmed(monkeypatch):
+    import traceml_ai.instrumentation.patches.dataloader_patch as dataloader_patch
+
+    calls = []
+
+    @contextmanager
+    def fake_timed_region(name, scope, record_gpu_events):
+        calls.append((name, scope, record_gpu_events))
+        yield
+
+    monkeypatch.setattr(
+        dataloader_patch,
+        "timed_region",
+        fake_timed_region,
+    )
+    monkeypatch.setattr(
+        dataloader_patch,
+        "is_tracing_armed",
+        lambda: False,
+    )
+
+    from torch.utils.data import DataLoader
+
+    loader = DataLoader([1, 2, 3], batch_size=1)
+
+    assert len(list(dataloader_patch._traceml_dataloader_iter(loader))) == 3
+    assert calls == []
 
 
 def test_wrap_dataloader_fetch_records_gpu_events(monkeypatch):

--- a/tests/sdk/test_init_runtime.py
+++ b/tests/sdk/test_init_runtime.py
@@ -1,0 +1,220 @@
+"""Tests for runtime startup driven by `traceml.init(...)` (issue #84)."""
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+class _FakeHandle:
+    """Minimal RuntimeHandle stand-in that records stop() calls."""
+
+    def __init__(self) -> None:
+        self.stops = 0
+
+    def stop(self) -> None:
+        self.stops += 1
+
+
+@pytest.fixture
+def initialization():
+    """Reload sdk.initial and reset process-global runtime state per test.
+
+    ``init(disabled=...)`` writes ``TRACEML_DISABLED`` straight to os.environ,
+    so this fixture snapshots and restores it to avoid leaking into other
+    tests (monkeypatch.delenv does not register a restore for an absent var).
+    """
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    original_disabled = os.environ.get("TRACEML_DISABLED")
+    os.environ.pop("TRACEML_DISABLED", None)
+    lifecycle._ACTIVE_RUNTIME_HANDLE = None
+    module = importlib.reload(
+        importlib.import_module("traceml_ai.sdk.initial")
+    )
+    try:
+        yield module
+    finally:
+        lifecycle._ACTIVE_RUNTIME_HANDLE = None
+        if original_disabled is None:
+            os.environ.pop("TRACEML_DISABLED", None)
+        else:
+            os.environ["TRACEML_DISABLED"] = original_disabled
+
+
+def test_init_disabled_is_noop(initialization, monkeypatch):
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+
+    started = []
+    patched = []
+    monkeypatch.setattr(
+        initialization,
+        "_start_runtime_for_init",
+        lambda **kwargs: started.append(kwargs),
+    )
+    monkeypatch.setattr(
+        initialization,
+        "_apply_requested_patches",
+        lambda cfg: patched.append(cfg),
+    )
+
+    cfg = initialization.init(disabled=True)
+
+    assert cfg.disabled is True
+    assert started == []  # runtime never started
+    assert patched == []  # no instrumentation patches installed
+    assert os.environ["TRACEML_DISABLED"] == "1"
+
+
+def test_init_disabled_via_env(initialization, monkeypatch):
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    monkeypatch.setenv("TRACEML_DISABLED", "1")
+    started = []
+    monkeypatch.setattr(lifecycle, "get_active_runtime_handle", lambda: None)
+    monkeypatch.setattr(
+        lifecycle, "start_runtime", lambda *a, **k: started.append(1)
+    )
+
+    cfg = initialization.init()  # mode defaults to 'auto'; disabled env wins
+
+    assert cfg.disabled is True
+    assert started == []
+
+
+def test_init_starts_runtime_when_aggregator_reachable(
+    initialization, monkeypatch
+):
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+    monkeypatch.delenv("TRACEML_AGGREGATOR_HOST", raising=False)
+    monkeypatch.delenv("TRACEML_AGGREGATOR_PORT", raising=False)
+
+    waited = {}
+
+    def fake_wait(host, port, **kwargs):
+        waited["host"] = host
+        waited["port"] = port
+        return True
+
+    captured = {}
+    fake_handle = _FakeHandle()
+
+    def fake_start(settings, **kwargs):
+        captured["settings"] = settings
+        return fake_handle
+
+    monkeypatch.setattr(lifecycle, "get_active_runtime_handle", lambda: None)
+    monkeypatch.setattr(lifecycle, "wait_for_aggregator", fake_wait)
+    monkeypatch.setattr(lifecycle, "start_runtime", fake_start)
+
+    cfg = initialization.init(
+        mode="manual",
+        aggregator_host="10.0.0.5",
+        aggregator_port=40000,
+    )
+
+    assert cfg.disabled is False
+    assert waited == {"host": "10.0.0.5", "port": 40000}
+    assert captured["settings"].aggregator.connect_host == "10.0.0.5"
+    assert captured["settings"].aggregator.port == 40000
+    assert initialization._RUNTIME_HANDLE is fake_handle
+
+
+def test_init_warns_and_noops_when_aggregator_unreachable(
+    initialization, monkeypatch, capsys
+):
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+    monkeypatch.delenv("TRACEML_ON_MISSING_AGGREGATOR", raising=False)
+    started = []
+    monkeypatch.setattr(lifecycle, "get_active_runtime_handle", lambda: None)
+    monkeypatch.setattr(
+        lifecycle, "wait_for_aggregator", lambda *a, **k: False
+    )
+    monkeypatch.setattr(
+        lifecycle, "start_runtime", lambda *a, **k: started.append(1)
+    )
+
+    # Default is fail-open: a library call inside user code must never crash
+    # the training process for a transport reason. Detach to a no-op + warn.
+    cfg = initialization.init(mode="manual", connect_timeout_sec=1.0)
+
+    assert cfg.disabled is True
+    assert started == []  # never started after a failed preflight
+    assert "[TraceML]" in capsys.readouterr().err  # detached loudly
+    assert initialization.get_init_config() is cfg  # no-op config stored
+
+
+def test_init_raises_when_aggregator_unreachable_and_strict(
+    initialization, monkeypatch
+):
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+    monkeypatch.delenv("TRACEML_ON_MISSING_AGGREGATOR", raising=False)
+    started = []
+    monkeypatch.setattr(lifecycle, "get_active_runtime_handle", lambda: None)
+    monkeypatch.setattr(
+        lifecycle, "wait_for_aggregator", lambda *a, **k: False
+    )
+    monkeypatch.setattr(
+        lifecycle, "start_runtime", lambda *a, **k: started.append(1)
+    )
+
+    with pytest.raises(RuntimeError, match="could not reach the aggregator"):
+        initialization.init(
+            mode="manual",
+            connect_timeout_sec=1.0,
+            on_missing_aggregator="raise",
+        )
+
+    assert started == []  # never started after a failed preflight
+    assert initialization.get_init_config() is None  # config not stored
+
+
+def test_init_skips_runtime_when_already_active(initialization, monkeypatch):
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+    monkeypatch.setattr(
+        lifecycle, "get_active_runtime_handle", lambda: object()
+    )
+
+    waited = []
+    started = []
+    monkeypatch.setattr(
+        lifecycle,
+        "wait_for_aggregator",
+        lambda *a, **k: waited.append(1) or True,
+    )
+    monkeypatch.setattr(
+        lifecycle, "start_runtime", lambda *a, **k: started.append(1)
+    )
+
+    cfg = initialization.init(mode="manual")
+
+    assert cfg.disabled is False
+    assert waited == []  # no preflight when a runtime already runs here
+    assert started == []  # no second runtime started
+    assert initialization._RUNTIME_HANDLE is None
+
+
+def test_stop_runtime_for_init_is_idempotent(initialization):
+    handle = _FakeHandle()
+    initialization._RUNTIME_HANDLE = handle
+
+    initialization._stop_runtime_for_init()
+    initialization._stop_runtime_for_init()
+
+    assert handle.stops == 1
+    assert initialization._RUNTIME_HANDLE is None

--- a/tests/sdk/test_init_runtime.py
+++ b/tests/sdk/test_init_runtime.py
@@ -89,6 +89,56 @@ def test_init_disabled_via_env(initialization, monkeypatch):
     assert started == []
 
 
+def test_disabled_env_dynamically_silences_low_level_utilities(monkeypatch):
+    import torch.nn as nn
+
+    from traceml_ai.utils.step_memory import (
+        StepMemoryTracker,
+        flush_step_memory_buffer,
+        step_memory_queue,
+    )
+    from traceml_ai.utils.timing import (
+        TimeEvent,
+        TimeScope,
+        flush_step_time_buffer,
+        get_step_time_queue,
+        record_event,
+        timed_region,
+    )
+
+    step_time_queue = get_step_time_queue()
+    while not step_time_queue.empty():
+        step_time_queue.get_nowait()
+    while not step_memory_queue.empty():
+        step_memory_queue.get_nowait()
+
+    monkeypatch.setenv("TRACEML_DISABLED", "1")
+
+    record_event(
+        TimeEvent(
+            name="disabled_step",
+            device="cpu",
+            cpu_start=0.0,
+            cpu_end=1.0,
+            scope=TimeScope.STEP,
+        )
+    )
+    flush_step_time_buffer(1)
+
+    model = nn.Linear(1, 1)
+    tracker = StepMemoryTracker(model)
+    tracker.reset()
+    tracker.record()
+    flush_step_memory_buffer(model, 1)
+
+    with timed_region("disabled_region"):
+        pass
+    flush_step_time_buffer(2)
+
+    assert step_time_queue.empty()
+    assert step_memory_queue.empty()
+
+
 def test_init_starts_runtime_when_aggregator_reachable(
     initialization, monkeypatch
 ):
@@ -127,6 +177,79 @@ def test_init_starts_runtime_when_aggregator_reachable(
     assert captured["settings"].aggregator.connect_host == "10.0.0.5"
     assert captured["settings"].aggregator.port == 40000
     assert initialization._RUNTIME_HANDLE is fake_handle
+
+
+def test_patch_install_failure_warns_noops_and_stops_runtime(
+    initialization, monkeypatch, capsys
+):
+    import traceml_ai.instrumentation.patches.forward_auto_timer_patch as forward_patch
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+    monkeypatch.delenv("TRACEML_ON_MISSING_AGGREGATOR", raising=False)
+    fake_handle = _FakeHandle()
+
+    monkeypatch.setattr(lifecycle, "get_active_runtime_handle", lambda: None)
+    monkeypatch.setattr(lifecycle, "wait_for_aggregator", lambda *a, **k: True)
+    monkeypatch.setattr(
+        lifecycle, "start_runtime", lambda *a, **k: fake_handle
+    )
+    monkeypatch.setattr(
+        forward_patch,
+        "patch_forward",
+        lambda: (_ for _ in ()).throw(RuntimeError("patch boom")),
+    )
+
+    cfg = initialization.init(
+        mode="selective",
+        patch_forward=True,
+        aggregator_host="127.0.0.1",
+        aggregator_port=40000,
+    )
+
+    assert cfg.disabled is True
+    assert cfg.patch_forward is False
+    assert fake_handle.stops == 1
+    assert initialization.get_init_config() is cfg
+    assert initialization.is_tracing_armed() is False
+    assert os.environ["TRACEML_DISABLED"] == "1"
+    captured = capsys.readouterr()
+    assert "[TraceML]" in captured.err
+    assert "patch boom" in captured.err
+
+
+def test_patch_install_failure_strict_raises_and_cleans_up(
+    initialization, monkeypatch
+):
+    import traceml_ai.instrumentation.patches.forward_auto_timer_patch as forward_patch
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+    fake_handle = _FakeHandle()
+
+    monkeypatch.setattr(lifecycle, "get_active_runtime_handle", lambda: None)
+    monkeypatch.setattr(lifecycle, "wait_for_aggregator", lambda *a, **k: True)
+    monkeypatch.setattr(
+        lifecycle, "start_runtime", lambda *a, **k: fake_handle
+    )
+    monkeypatch.setattr(
+        forward_patch,
+        "patch_forward",
+        lambda: (_ for _ in ()).throw(RuntimeError("patch boom")),
+    )
+
+    with pytest.raises(RuntimeError, match="patch boom"):
+        initialization.init(
+            mode="selective",
+            patch_forward=True,
+            aggregator_host="127.0.0.1",
+            aggregator_port=40000,
+            on_missing_aggregator="raise",
+        )
+
+    assert fake_handle.stops == 1
+    assert initialization.get_init_config() is None
+    assert initialization.is_tracing_armed() is False
 
 
 def test_init_warns_and_noops_when_aggregator_unreachable(

--- a/tests/telemetry/test_runtime_environment_projection.py
+++ b/tests/telemetry/test_runtime_environment_projection.py
@@ -1,0 +1,128 @@
+import sqlite3
+
+from traceml_ai.aggregator.sqlite_writers import (
+    runtime_environment as runtime_environment_projection,
+)
+from traceml_ai.telemetry.envelope import normalize_telemetry_envelope
+
+
+def _runtime_environment_payload(
+    *,
+    sampler: str = "RuntimeEnvironmentSampler",
+    tables: dict | None = None,
+) -> dict:
+    return {
+        "rank": 5,
+        "global_rank": 5,
+        "local_rank": 1,
+        "world_size": 8,
+        "local_world_size": 4,
+        "node_rank": 1,
+        "hostname": "worker-1",
+        "pid": 4321,
+        "sampler": sampler,
+        "timestamp": 123.0,
+        "tables": (
+            tables
+            if tables is not None
+            else {
+                "RuntimeEnvironmentTable": [
+                    {
+                        "seq": 0,
+                        "ts": 123.25,
+                        "topology": "single_node_multi_process",
+                        "distributed_initialized": True,
+                        "distributed_backend": "nccl",
+                        "training_strategy": "ddp",
+                        "strategy_source": "runtime_model",
+                        "strategy_confidence": "high",
+                    }
+                ]
+            }
+        ),
+    }
+
+
+def _envelope(payload: dict):
+    envelope = normalize_telemetry_envelope(payload)
+    assert envelope is not None
+    return envelope
+
+
+def test_runtime_environment_projection_creates_table() -> None:
+    conn = sqlite3.connect(":memory:")
+    runtime_environment_projection.init_schema(conn)
+
+    tables = {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table';"
+        )
+    }
+
+    assert "runtime_environment" in tables
+
+
+def test_runtime_environment_projection_inserts_identity_and_strategy() -> (
+    None
+):
+    conn = sqlite3.connect(":memory:")
+    runtime_environment_projection.init_schema(conn)
+
+    rows = runtime_environment_projection.build_rows(
+        _envelope(_runtime_environment_payload()),
+        recv_ts_ns=999,
+    )
+    runtime_environment_projection.insert_rows(conn, rows)
+
+    row = conn.execute(
+        """
+        SELECT recv_ts_ns, rank, global_rank, local_rank, world_size,
+               local_world_size, node_rank, hostname, pid, sample_ts_s, seq,
+               topology, distributed_initialized, distributed_backend,
+               training_strategy, strategy_source, strategy_confidence
+        FROM runtime_environment;
+        """
+    ).fetchone()
+
+    assert row == (
+        999,
+        5,
+        5,
+        1,
+        8,
+        4,
+        1,
+        "worker-1",
+        4321,
+        123.25,
+        0,
+        "single_node_multi_process",
+        1,
+        "nccl",
+        "ddp",
+        "runtime_model",
+        "high",
+    )
+
+
+def test_runtime_environment_projection_ignores_non_matching_sampler() -> None:
+    rows = runtime_environment_projection.build_rows(
+        _envelope(_runtime_environment_payload(sampler="ProcessSampler")),
+        recv_ts_ns=999,
+    )
+
+    assert rows == {"runtime_environment": []}
+
+
+def test_runtime_environment_projection_ignores_malformed_payload() -> None:
+    rows = runtime_environment_projection.build_rows(
+        _envelope(
+            _runtime_environment_payload(
+                tables={"UnexpectedTable": [{"training_strategy": "ddp"}]}
+            )
+        ),
+        recv_ts_ns=999,
+    )
+
+    assert rows == {"runtime_environment": []}

--- a/tests/test_h2d_timing.py
+++ b/tests/test_h2d_timing.py
@@ -55,7 +55,11 @@ h2d_auto_timer = h2d_patch.h2d_auto_timer
 def _reload_initialization():
     import traceml_ai.sdk.initial as m
 
-    return importlib.reload(m)
+    importlib.reload(m)
+    # These tests exercise instrumentation patch policy, not runtime startup.
+    # Stub the runtime bootstrap so init() does not try to reach an aggregator.
+    m._start_runtime_for_init = lambda **kwargs: None
+    return m
 
 
 def _reload_h2d_patch():


### PR DESCRIPTION
# Normalize Step Time Diagnosis by Iteration Impact

## Summary

This PR makes Step Time diagnosis consistent across the CLI, dashboard, and end-of-run summary. It bases typical bottlenecks and rank-straggler severity on selected-clock iteration impact, promotes the strongest canonical issue as
the primary diagnosis, and removes duplicate reporting-side diagnosis logic.

## What Changed

- Calculate input, H2D, residual, and compute shares per rank, then use the median share across ranks for typical bottleneck decisions.
- Use the victim rank's iteration impact to score DDP/FSDP rank stragglers.
- Keep cause attribution separate from straggler detection:  input, H2D, and DDP forward-compute causes must explain at least 80% of the visible rank-wait cost; otherwise TraceML reports generic `STRAGGLER`.
- Add `H2D_BOUND` throughout diagnostics, summary output, dashboard/CLI  formatting, primary-diagnosis selection, and reporting schema.
- Select the primary diagnosis by severity, then impact score, instead of a  fixed diagnosis-kind priority table.
- Reuse the canonical Step Time issue in cards and final summaries so the  reported explanation, score, and evidence cannot drift.
- Keep `COMPUTE_BOUND` informational: it requires a 90% median per-rank  compute share and does not compete as an impact-scored bottleneck.

## Rank-Straggler Semantics

- DDP uses backward timing as the visible synchronization phase; FSDP uses  forward plus backward.
- `INPUT STRAGGLER` and `H2D STRAGGLER` name an attributable rank-local  cause.
- `COMPUTE STRAGGLER` is intentionally conservative: for DDP/default strategy  it requires excess **forward** time. Optimizer-side work without sufficient  forward attribution remains generic `STRAGGLER`.
- Generic `STRAGGLER` is therefore a useful result, not a failure: it means a  slow rank was identified but the measured components cannot safely name its cause.

## User-Visible Effects

- Typical input, H2D, and residual bottlenecks remain visible even when rank skew is also present.
- A rank straggler is labeled with a specific cause only when evidence meets the 80% attribution threshold.
- The final summary, compact metrics, cards, and CLI use the same diagnosis and rationale.

## Validation

### Automated

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/diagnostics/test_step_time.py \
  tests/reporting/summary/test_primary_diagnosis.py \
  tests/reporting/summary/test_step_time_card.py \
  tests/reporting/summary/test_final.py \
  tests/config -q
```

Result: **128 passed**.

Also verified `git diff --check` and a full launcher/aggregator lifecycle
smoke test.

### GPU: 4-rank DDP validation

Ran on a CUDA host using the distributed rank-straggler demo:

| Scenario | Result | Verification |
| --- | --- | --- |
| Balanced | `COMPUTE-BOUND` / INFO | No rank skew; expected compute-heavy baseline. |
| Input straggler on `r0` | `INPUT STRAGGLER` / CRITICAL | Correctly attributed approximately 201 ms input wait on `r0`. |
| Optimizer-side compute straggler on `r0` | `STRAGGLER` / CRITICAL | Correctly identified `r0` as slow; attribution correctly remained generic because the policy only names excess DDP forward time as compute. |

The GPU runs also confirmed end-to-end aggregator startup, four-rank telemetry,
GPU utilization/memory collection, final summary generation, and session-log
output.

## Scope

- No telemetry transport or SQLite schema change.
- No new public configuration surface.
- Existing selected-clock, warmup, minimum-step, confidence, and FSDP safety
  gates remain in effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `traceml serve` command for standalone aggregator launches.
  * Added DeepSpeed integration, setup guidance, and a runnable example.
  * Added runtime environment detection and reporting.
  * Added Docker and Dev Container workflows.
  * Added safer disabled-mode execution and configurable runtime initialization.

* **Bug Fixes**
  * Improved tracing safety when instrumentation is inactive.
  * Improved telemetry delivery and shutdown behavior.

* **Documentation**
  * Updated step-time diagnoses to use culprit and reference ranks.
  * Expanded launch, integration, configuration, and troubleshooting guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->