### PR TITLE
fix: serve dashboard-deps guard references undefined constant (NameError)

### DIFF
--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -680,7 +680,8 @@ def run_serve(args: argparse.Namespace) -> None:
         if missing:
             raise SystemExit(
                 "[TraceML] ERROR: "
-                f"{DASHBOARD_EXTRA_INSTALL_HINT} Missing: {', '.join(missing)}."
+                f"{DASHBOARD_DEPENDENCY_INSTALL_HINT} "
+                f"Missing: {', '.join(missing)}."
             )
 
     try:

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -125,6 +125,35 @@ def test_serve_threads_expected_world_size(monkeypatch) -> None:
     assert _resolve_serve_settings(args).expected_world_size == 1
 
 
+def test_serve_dashboard_missing_deps_reports_hint_not_nameerror(
+    monkeypatch,
+) -> None:
+    # Regression: run_serve referenced an undefined constant on the
+    # dashboard-deps-missing path, so it raised NameError instead of the
+    # SystemExit install hint. Pin that it names the missing deps and exits.
+    import importlib.util as importlib_util
+
+    real_find_spec = importlib_util.find_spec
+    monkeypatch.setattr(
+        importlib_util,
+        "find_spec",
+        lambda name, *a, **k: (
+            None
+            if name in ("nicegui", "plotly")
+            else real_find_spec(name, *a, **k)
+        ),
+    )
+    from traceml_ai.launcher.commands import run_serve
+
+    args = build_parser().parse_args(["serve", "--mode", "dashboard"])
+    with pytest.raises(SystemExit) as excinfo:
+        run_serve(args)
+
+    message = str(excinfo.value)
+    assert "nicegui" in message and "plotly" in message
+    assert "Missing:" in message
+
+
 def test_serve_configures_logging_without_preset_env(
     monkeypatch, tmp_path
 ) -> None:


### PR DESCRIPTION
## What

`traceml serve --mode dashboard` raises `NameError: name 'DASHBOARD_EXTRA_INSTALL_HINT' is not defined` when `nicegui`/`plotly` are missing, instead of the intended install-hint message.

`run_serve` builds its dependency-missing error from `DASHBOARD_EXTRA_INSTALL_HINT` (`commands.py:683`), but v0.3.4 (#206) renamed that constant to `DASHBOARD_DEPENDENCY_INSTALL_HINT` (`commands.py:49`). The rename and the serve guard (added in #163) landed in separate hunks, so the squash merge of #163 onto v0.3.4 left the reference dangling. `git grep` finds no definition of the old name anywhere.

Since v0.3.4 made dashboard the default single-node mode, a user who runs dashboard mode without the dashboard extras now hits a `NameError` in place of the "install these packages" hint.

## Fix

Reference the current constant (`DASHBOARD_DEPENDENCY_INSTALL_HINT`) in the serve guard.

## Test

Adds `test_serve_dashboard_missing_deps_reports_hint_not_nameerror`: it stubs the two packages as missing and asserts `run_serve` raises `SystemExit` naming the missing packages, not `NameError`. The test fails on the current branch (reproduces the bug) and passes with the fix. This path had no test, which is why the rename collision shipped.

Targets `version_0.3.5`. Verified locally: `black` + `ruff` clean, `tests/runtime/test_launcher.py` green (33 passed), and no `DASHBOARD_EXTRA_INSTALL_HINT` reference remains.
