### PR TITLE
fix: restore dropped model_diagnostics import in test_registry (v0.3.4 NameError regression)

### DIFF
--- a/tests/diagnostics/test_registry.py
+++ b/tests/diagnostics/test_registry.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 
-from traceml_ai.diagnostics.step_memory import LIVE_STEP_MEMORY_POLICY
+import traceml_ai.diagnostics.model_diagnostics as model_diagnostics
 from traceml_ai.diagnostics.model_diagnostics import (
     DEFAULT_MODEL_DIAGNOSTIC_REGISTRY,
     ModelDiagnosisItem,
@@ -11,6 +11,7 @@ from traceml_ai.diagnostics.registry import (
     DiagnosticDomainSpec,
     ModelDiagnosticContext,
 )
+from traceml_ai.diagnostics.step_memory import LIVE_STEP_MEMORY_POLICY
 from traceml_ai.renderers.step_memory.schema import (
     StepMemoryCombinedCoverage,
     StepMemoryCombinedMetric,


### PR DESCRIPTION
## What

Three tests in `tests/diagnostics/test_registry.py` fail with `NameError: name 'model_diagnostics' is not defined` on `version_0.3.5`: `test_model_step_time_diagnostics_receive_per_rank_timing`, `_use_selected_metrics`, and `_do_not_fallback_to_public_metrics`. Each calls `monkeypatch.setattr(model_diagnostics, "build_step_diagnosis", ...)`, but the `model_diagnostics` module alias was dropped from those tests. It survives in only one other test in the file, so the module is never bound for these three.

This is a v0.3.4 (#206) regression: the three tests pass on `e7813c1` (pre-v0.3.4) and `NameError` on `fd120b5`. The full suite went from 1 failing to 4 failing across that merge.

## Why it went unnoticed

`tests/diagnostics/test_registry.py` is not in the `ci.yml` allowlist, so CI never ran it and v0.3.4 shipped it red. A concrete case for running the full suite in CI: had CI run this file, the merge would have been blocked.

## Fix

Restore the module import (`import traceml_ai.diagnostics.model_diagnostics as model_diagnostics`) at module scope. isort keeps the import block sorted; no other change.

Targets `version_0.3.5`. Verified locally: the three tests go red then green, `tests/diagnostics/test_registry.py` is fully green (8 passed), and isort/black/ruff are clean.
