### PR TITLE
docs: add uv installation quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ For the live browser dashboard:
 pip install traceml-ai
 ```
 
+Or install with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv pip install traceml-ai
+```
+
+For a uv-managed project, add TraceML to the project's dependencies instead:
+
+```bash
+uv add traceml-ai
+```
+
+Extras use the same syntax with pip and uv. For example:
+
+```bash
+pip install "traceml-ai[dashboard]"
+uv add "traceml-ai[dashboard]"
+uv add "traceml-ai[torch]"
+```
+
+To try TraceML immediately in an environment managed by uv, install the
+`torch` extra required by the example:
+
+```bash
+uv pip install "traceml-ai[torch]"
+traceml run examples/quickstart.py
+```
+
 Using Hugging Face Trainer, PyTorch Lightning, Ray Train, W&B, or MLflow?
 Start with the native integration path in
 [Use With Your Stack](docs/user_guide/integrations.md).

--- a/README.md
+++ b/README.md
@@ -131,6 +131,40 @@ traceml run train.py --mode=summary
 For DDP, FSDP, Slurm, and multi-node runs, see
 [Distributed Training](docs/user_guide/distributed-training.md).
 
+### Or launch your script directly
+
+Prefer to launch training yourself with `python` or `torchrun`? Start the
+TraceML aggregator once with `traceml serve`, then run your script directly.
+`traceml.init(...)` connects to the aggregator over TCP:
+
+```bash
+# terminal 1: start the TraceML aggregator
+traceml serve --aggregator-host 127.0.0.1 --aggregator-port 29765
+
+# terminal 2: run your script directly
+python train.py
+```
+
+For torchrun and multi-node, bind the aggregator so workers on other nodes can
+reach it:
+
+```bash
+# on the aggregator node (--nnodes x --nproc-per-node = total workers, so the
+# aggregator waits for every rank before finalizing)
+traceml serve --aggregator-bind-host 0.0.0.0 --aggregator-host <node0-ip> \
+  --aggregator-port 29765 --nnodes <N> --nproc-per-node <M>
+
+# on each training node: point workers at node 0's aggregator, then launch
+TRACEML_AGGREGATOR_HOST=<node0-ip> TRACEML_AGGREGATOR_PORT=29765 \
+  torchrun ... train.py
+```
+
+`traceml.init(...)` takes runtime settings as arguments (for example
+`traceml.init(mode="auto", logs_dir="logs", aggregator_port=29765)`), and falls
+back to `TRACEML_*` environment variables and `traceml.yaml`. The aggregator
+endpoint is configured with `traceml serve` flags. See
+[Public API](docs/user_guide/public-api.md#direct-launch-with-traceml-serve).
+
 ---
 
 ## Example Diagnosis

--- a/docs/user_guide/public-api.md
+++ b/docs/user_guide/public-api.md
@@ -68,6 +68,7 @@ traceml run <script> --mode=summary  # final summary JSON/text only
 traceml run <script> --mode=cli      # explicit live terminal view
 traceml run <script> --mode=dashboard # live browser view
 traceml watch <script>               # zero-code system/process view
+traceml serve                        # standalone aggregator for direct launch
 ```
 
 Live `cli` and `dashboard` modes are intended for single-node runs. Multi-node
@@ -78,6 +79,102 @@ TraceML no longer ships layer-level/deep profiling. Use PyTorch Profiler,
 Nsight, or another operator-level profiler when you need that detail.
 
 See `traceml --help` for the full set of options.
+
+## Direct launch with `traceml serve`
+
+`traceml run` starts the aggregator and your script together. If you would
+rather launch training yourself with `python` or `torchrun`, run the aggregator
+as a standalone process and call `traceml.init(...)` inside your script.
+
+`traceml serve` owns only the aggregator. It binds a host/port, prints the
+reachable endpoint, blocks until SIGINT/SIGTERM, shuts down cleanly, and writes
+the final summary on exit. It never launches or wraps your training script.
+
+```bash
+# terminal 1: start the aggregator
+traceml serve --aggregator-host 127.0.0.1 --aggregator-port 29765
+
+# terminal 2: run your script directly
+python train.py
+```
+
+For torchrun and multi-node, bind the aggregator so workers on other nodes can
+connect:
+
+```bash
+# aggregator node: --nnodes x --nproc-per-node = total workers, so the
+# aggregator waits for every rank before finalizing (and warns about ranks
+# that never report)
+traceml serve --aggregator-bind-host 0.0.0.0 --aggregator-host <node0-ip> \
+  --aggregator-port 29765 --nnodes <N> --nproc-per-node <M>
+
+# each training node: workers read the aggregator endpoint from the
+# environment, so set it before torchrun
+TRACEML_AGGREGATOR_HOST=<node0-ip> TRACEML_AGGREGATOR_PORT=29765 \
+  torchrun ... train.py
+```
+
+Workers resolve the aggregator host from `TRACEML_AGGREGATOR_HOST` (default
+`127.0.0.1`), so on multi-node it must be set on every non-aggregator node or
+those workers cannot reach node 0.
+
+`traceml serve` flags:
+
+| Flag | Meaning |
+|---|---|
+| `--aggregator-host` | Address workers connect to. Default `127.0.0.1`. |
+| `--aggregator-bind-host` | Address the aggregator binds to. Use `0.0.0.0` for multi-node. Default `127.0.0.1`. |
+| `--aggregator-port` | Aggregator TCP port. Default `29765`. |
+| `--nnodes` / `--nproc-per-node` | Total ranks = product. The aggregator waits for all of them before finalizing and warns about missing ranks. Falls back to `TRACEML_EXPECTED_WORLD_SIZE`, else 1. |
+| `--mode` | Display mode: `summary` (default), `cli`, or `dashboard`. |
+| `--logs-dir` | Directory for session logs. |
+| `--run-name` / `--session-id` | Run identity. Workers must use the same value for shared artifacts. |
+
+### Configuration in the direct-launch path
+
+In the direct `python` path you cannot pass `traceml run` flags, so runtime
+settings are resolved with this precedence:
+
+1. explicit `traceml.init(...)` arguments
+2. `TRACEML_*` environment variables
+3. `traceml.yaml`
+4. built-in defaults
+
+```python
+traceml.init(
+    mode="auto",          # instrumentation mode
+    ui_mode="summary",    # display/telemetry mode
+    logs_dir="logs",
+    session_id="my_run",
+    aggregator_host="127.0.0.1",
+    aggregator_port=29765,
+)
+```
+
+The aggregator endpoint (`aggregator_host`, `aggregator_port`) is a launch
+setting, not read from `traceml.yaml`. If the aggregator is not reachable,
+`traceml.init(...)` retries for a short bounded period and then raises a clear
+error. Use `traceml.init(disabled=True)` (or `TRACEML_DISABLED=1`) to run with
+tracing fully disabled as a no-op.
+
+### Matching display modes across processes
+
+`traceml run` configures one display mode for the whole run. In the direct-launch
+path the aggregator and the worker are launched separately, so their display
+modes are set independently: `traceml serve --mode` for the aggregator, and
+`ui_mode` (via `traceml.init(ui_mode=...)` or `TRACEML_UI_MODE`) for the worker.
+
+For the live `cli` STDOUT/STDERR panel to show your script's output, set both to
+`cli` so the worker mirrors its stdout to the aggregator:
+
+```bash
+traceml serve --mode cli --run-name demo --aggregator-port 29765
+TRACEML_UI_MODE=cli TRACEML_SESSION_ID=demo python train.py
+```
+
+If the modes differ (for example a `cli` aggregator with a worker left on the
+default `summary`), telemetry, diagnosis, and the final summary are unaffected;
+only worker stdout mirroring into the live panel is skipped.
 
 ## Summary APIs
 

--- a/docs/user_guide/quickstart.md
+++ b/docs/user_guide/quickstart.md
@@ -100,6 +100,43 @@ tables.)
 For DDP, FSDP, and multi-node launches, see
 [Distributed Training](distributed-training.md).
 
+### Alternative: launch your script directly
+
+If you would rather launch training yourself with `python` or `torchrun`, start
+the TraceML aggregator once, then run your script directly. `traceml.init(...)`
+connects to the running aggregator:
+
+```bash
+# terminal 1
+traceml serve --aggregator-host 127.0.0.1 --aggregator-port 29765
+
+# terminal 2
+python train.py
+```
+
+For torchrun and multi-node, bind the aggregator so other nodes can connect:
+
+```bash
+# aggregator node: --nnodes x --nproc-per-node = total workers, so the
+# aggregator waits for every rank before finalizing
+traceml serve --aggregator-bind-host 0.0.0.0 --aggregator-host <node0-ip> \
+  --aggregator-port 29765 --nnodes <N> --nproc-per-node <M>
+
+# each training node: point workers at node 0's aggregator, then launch
+TRACEML_AGGREGATOR_HOST=<node0-ip> TRACEML_AGGREGATOR_PORT=29765 \
+  torchrun ... train.py
+```
+
+In the direct-launch path you cannot pass `traceml run` flags, so runtime
+settings come from `traceml.init(...)` arguments, then `TRACEML_*` environment
+variables, then `traceml.yaml`, then built-in defaults. The aggregator endpoint
+is set with `traceml serve` flags. If the aggregator is not reachable,
+`traceml.init(...)` prints one warning and continues without tracing (a no-op),
+so instrumentation never crashes your training run. Pass
+`traceml.init(on_missing_aggregator="raise")` to fail hard instead, or
+`traceml.init(disabled=True)` to silence it entirely. See
+[Public API](public-api.md#direct-launch-with-traceml-serve).
+
 ## 4. Read Your Diagnosis
 
 ```text

--- a/src/traceml_ai/aggregator/aggregator_main.py
+++ b/src/traceml_ai/aggregator/aggregator_main.py
@@ -30,6 +30,7 @@ import signal
 import sys
 import threading
 import traceback
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -166,29 +167,43 @@ def _install_signal_handlers(stop_event: threading.Event) -> None:
     signal.signal(signal.SIGTERM, _handler)
 
 
-def main() -> None:
+def run_aggregator(
+    settings: TraceMLSettings,
+    *,
+    logger: Optional[Any] = None,
+) -> int:
     """
-    Aggregator process entrypoint.
+    Own one aggregator lifecycle until a shutdown signal, then exit cleanly.
 
-    Execution flow
-    --------------
-    1. Initialize logging
-    2. Read configuration from environment variables
-    3. Create the session directory and settings
-    4. Start the aggregator
-    5. Wait for a shutdown request
-    6. Stop the aggregator and report any fatal errors
+    This is the single aggregator-owning entry point shared by the standalone
+    aggregator process (started by ``traceml run``) and the ``traceml serve``
+    command. It:
+
+    - starts only the aggregator (never a user training script)
+    - prints the reachable endpoint
+    - blocks until SIGINT/SIGTERM
+    - shuts down cleanly, preserving final-summary behavior
+    - logs fatal aggregator errors to ``aggregator_error.log``
+
+    Returns a process exit code (0 on clean shutdown, 1 on fatal error).
     """
-    setup_error_logger(is_aggregator=True)
-    logger = get_error_logger("TraceMLAggregatorMain")
-
-    cfg = read_traceml_env()
-
-    session_id = str(cfg["session_id"] or "default")
-    session_root = Path(str(cfg["logs_dir"])).resolve() / session_id
+    session_id = str(settings.session_id or "default")
+    session_root = Path(str(settings.logs_dir)).resolve() / session_id
     session_dir = session_root / "aggregator"
     session_dir.mkdir(parents=True, exist_ok=True)
     db_path = session_dir / "telemetry"
+    settings = replace(settings, session_id=session_id, db_path=str(db_path))
+
+    # The shared error logger resolves its directory from TRACEML_LOGS_DIR and
+    # TRACEML_SESSION_ID. The `traceml run` launcher sets these before spawning
+    # the aggregator subprocess; the `traceml serve` path runs in-process and
+    # does not, so mirror them from the resolved settings before logging setup.
+    os.environ["TRACEML_LOGS_DIR"] = str(settings.logs_dir)
+    os.environ["TRACEML_SESSION_ID"] = session_id
+
+    if logger is None:
+        setup_error_logger(is_aggregator=True)
+        logger = get_error_logger("TraceMLAggregatorMain")
 
     stop_event = threading.Event()
     _install_signal_handlers(stop_event)
@@ -197,34 +212,24 @@ def main() -> None:
     err: Optional[BaseException] = None
 
     try:
-        settings = TraceMLSettings(
-            mode=str(cfg["mode"]),
-            profile=str(cfg["profile"]),
-            render_interval_sec=float(cfg["interval"]),
-            enable_logging=bool(cfg["enable_logging"]),
-            logs_dir=str(cfg["logs_dir"]),
-            dashboard_port=int(cfg["dashboard_port"]),
-            dashboard_auto_open=bool(cfg["dashboard_auto_open"]),
-            session_id=session_id,
-            history_enabled=bool(cfg["history_enabled"]),
-            summary_window_rows=int(cfg["summary_window_rows"]),
-            html_report=bool(cfg["html_report"]),
-            finalize_timeout_sec=float(cfg["finalize_timeout_sec"]),
-            expected_world_size=int(cfg["expected_world_size"]),
-            aggregator=AggregatorTransportSettings(
-                connect_host=str(cfg["aggregator_host"]),
-                bind_host=str(cfg["aggregator_bind_host"]),
-                port=int(cfg["aggregator_port"]),
-            ),
-            db_path=str(db_path),
-        )
-
         logger.info("[TraceML] Starting aggregator")
         handle = start_aggregator(
             settings,
             logger=logger,
             stop_event=stop_event,
         )
+
+        endpoint = handle.endpoint
+        print(
+            "[TraceML] Aggregator ready on "
+            f"{settings.aggregator.bind_host}:{endpoint.port} "
+            f"(workers connect to {endpoint.host}:{endpoint.port}, "
+            f"session={endpoint.session_id}, ui={settings.mode}). "
+            "Press Ctrl+C to stop.",
+            file=sys.stderr,
+            flush=True,
+        )
+
         stop_event.wait()
 
     except BaseException as exc:
@@ -234,7 +239,7 @@ def main() -> None:
         if handle is not None:
             try:
                 logger.info("[TraceML] Stopping aggregator")
-                handle.stop(timeout_sec=float(cfg["finalize_timeout_sec"]))
+                handle.stop(timeout_sec=float(settings.finalize_timeout_sec))
             except Exception as stop_exc:
                 if err is None:
                     err = stop_exc
@@ -270,10 +275,47 @@ def main() -> None:
                 file=sys.stderr,
             )
             sys.stderr.flush()
-            raise SystemExit(1)
+            return 1
 
     print("\n[TraceML] Aggregator stopped.", file=sys.stderr, flush=True)
-    raise SystemExit(0)
+    return 0
+
+
+def main() -> None:
+    """
+    Standalone aggregator process entrypoint.
+
+    Reads configuration from the ``TRACEML_*`` environment variables set by the
+    ``traceml run`` launcher, builds settings, and delegates the lifecycle to
+    :func:`run_aggregator`.
+    """
+    setup_error_logger(is_aggregator=True)
+    logger = get_error_logger("TraceMLAggregatorMain")
+
+    cfg = read_traceml_env()
+
+    settings = TraceMLSettings(
+        mode=str(cfg["mode"]),
+        profile=str(cfg["profile"]),
+        render_interval_sec=float(cfg["interval"]),
+        enable_logging=bool(cfg["enable_logging"]),
+        logs_dir=str(cfg["logs_dir"]),
+        dashboard_port=int(cfg["dashboard_port"]),
+        dashboard_auto_open=bool(cfg["dashboard_auto_open"]),
+        session_id=str(cfg["session_id"] or "default"),
+        history_enabled=bool(cfg["history_enabled"]),
+        summary_window_rows=int(cfg["summary_window_rows"]),
+        html_report=bool(cfg["html_report"]),
+        finalize_timeout_sec=float(cfg["finalize_timeout_sec"]),
+        expected_world_size=int(cfg["expected_world_size"]),
+        aggregator=AggregatorTransportSettings(
+            connect_host=str(cfg["aggregator_host"]),
+            bind_host=str(cfg["aggregator_bind_host"]),
+            port=int(cfg["aggregator_port"]),
+        ),
+    )
+
+    raise SystemExit(run_aggregator(settings, logger=logger))
 
 
 if __name__ == "__main__":

--- a/src/traceml_ai/api.py
+++ b/src/traceml_ai/api.py
@@ -98,8 +98,26 @@ def init(
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
     patch_h2d: Optional[bool] = None,
+    disabled: Optional[bool] = None,
+    ui_mode: Optional[str] = None,
+    interval: Optional[float] = None,
+    logs_dir: Optional[str] = None,
+    enable_logging: Optional[bool] = None,
+    session_id: Optional[str] = None,
+    aggregator_host: Optional[str] = None,
+    aggregator_port: Optional[int] = None,
+    connect_timeout_sec: float = 10.0,
+    connect_retry_interval_sec: float = 0.25,
+    on_missing_aggregator: Optional[str] = None,
 ) -> TraceMLInitConfig:
-    """Initialize TraceML instrumentation for this process."""
+    """Initialize TraceML and start its runtime for this process.
+
+    ``on_missing_aggregator`` controls what happens when the aggregator is
+    unreachable (or the runtime fails to start): ``'warn'`` (default) emits one
+    stderr warning and continues as a no-op so tracing never crashes training;
+    ``'raise'`` fails hard. Defaults to ``TRACEML_ON_MISSING_AGGREGATOR`` then
+    ``'warn'``.
+    """
     from traceml_ai.sdk.initial import init as _init
 
     return _init(
@@ -108,6 +126,17 @@ def init(
         patch_forward=patch_forward,
         patch_backward=patch_backward,
         patch_h2d=patch_h2d,
+        disabled=disabled,
+        ui_mode=ui_mode,
+        interval=interval,
+        logs_dir=logs_dir,
+        enable_logging=enable_logging,
+        session_id=session_id,
+        aggregator_host=aggregator_host,
+        aggregator_port=aggregator_port,
+        connect_timeout_sec=connect_timeout_sec,
+        connect_retry_interval_sec=connect_retry_interval_sec,
+        on_missing_aggregator=on_missing_aggregator,
     )
 
 
@@ -118,6 +147,16 @@ def start(
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
     patch_h2d: Optional[bool] = None,
+    disabled: Optional[bool] = None,
+    ui_mode: Optional[str] = None,
+    interval: Optional[float] = None,
+    logs_dir: Optional[str] = None,
+    enable_logging: Optional[bool] = None,
+    session_id: Optional[str] = None,
+    aggregator_host: Optional[str] = None,
+    aggregator_port: Optional[int] = None,
+    connect_timeout_sec: float = 10.0,
+    connect_retry_interval_sec: float = 0.25,
 ) -> TraceMLInitConfig:
     """Alias for `traceml.init(...)`."""
     from traceml_ai.sdk.initial import start as _start
@@ -128,6 +167,16 @@ def start(
         patch_forward=patch_forward,
         patch_backward=patch_backward,
         patch_h2d=patch_h2d,
+        disabled=disabled,
+        ui_mode=ui_mode,
+        interval=interval,
+        logs_dir=logs_dir,
+        enable_logging=enable_logging,
+        session_id=session_id,
+        aggregator_host=aggregator_host,
+        aggregator_port=aggregator_port,
+        connect_timeout_sec=connect_timeout_sec,
+        connect_retry_interval_sec=connect_retry_interval_sec,
     )
 
 

--- a/src/traceml_ai/launcher/cli.py
+++ b/src/traceml_ai/launcher/cli.py
@@ -13,6 +13,7 @@ import argparse
 from traceml_ai.launcher.commands import (
     run_compare,
     run_inspect,
+    run_serve,
     run_view,
     run_with_tracing,
     validate_launch_args,
@@ -245,6 +246,97 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_launch_args(run_parser)
 
+    serve_parser = sub.add_parser(
+        "serve",
+        help=(
+            "Start the TraceML aggregator standalone. Use with scripts "
+            "launched directly via `python` or `torchrun` that call "
+            "traceml.init(...)."
+        ),
+    )
+    serve_parser.add_argument(
+        "--mode",
+        type=str,
+        default=None,
+        choices=["cli", "dashboard", "summary"],
+        help="TraceML display mode for the aggregator. Default: summary.",
+    )
+    serve_parser.add_argument(
+        "--logs-dir",
+        type=str,
+        default=None,
+        help="Directory for TraceML session logs.",
+    )
+    serve_parser.add_argument(
+        "--run-name",
+        type=str,
+        default="",
+        help=(
+            "Human-readable TraceML run name. Determines the output folder "
+            "under --logs-dir. Workers must use the same run name."
+        ),
+    )
+    serve_parser.add_argument(
+        "--session-id",
+        type=str,
+        default="",
+        help="Backward-compatible alias for --run-name.",
+    )
+    serve_parser.add_argument(
+        "--nnodes",
+        type=int,
+        default=None,
+        help=(
+            "Total nodes in the training job. With --nproc-per-node, sets the "
+            "expected worker count so the aggregator waits for ALL ranks "
+            "before finalizing (and warns about ranks that never report). "
+            "Without it the aggregator finalizes after the first rank."
+        ),
+    )
+    serve_parser.add_argument(
+        "--nproc-per-node",
+        type=int,
+        default=None,
+        help="Workers per node. Multiplied by --nnodes for the rank count.",
+    )
+    serve_parser.add_argument(
+        "--interval",
+        type=float,
+        default=None,
+        help="Aggregator render/polling interval in seconds.",
+    )
+    serve_parser.add_argument(
+        "--enable-logging",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Enable TraceML logging output.",
+    )
+    serve_parser.add_argument(
+        "--aggregator-host",
+        type=str,
+        default=None,
+        help=(
+            "Address workers use to connect to this aggregator. Defaults to "
+            "127.0.0.1. Set to node 0's reachable address for multi-node."
+        ),
+    )
+    serve_parser.add_argument(
+        "--aggregator-bind-host",
+        type=str,
+        default=None,
+        help=(
+            "Address the aggregator binds to. Defaults to 127.0.0.1. Use "
+            "0.0.0.0 when workers on other nodes must connect."
+        ),
+    )
+    serve_parser.add_argument(
+        "--aggregator-port",
+        type=int,
+        default=29765,
+        help="TraceML aggregator port.",
+    )
+
     compare_parser = sub.add_parser(
         "compare",
         help="Compare two TraceML final summary JSON files.",
@@ -309,6 +401,8 @@ def main() -> None:
         run_with_tracing(args, profile="watch")
     elif args.command == "run":
         run_with_tracing(args, profile="run")
+    elif args.command == "serve":
+        run_serve(args)
     elif args.command == "compare":
         run_compare(args)
     elif args.command == "view":

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -577,6 +577,122 @@ def run_with_tracing(args: argparse.Namespace, profile: str) -> None:
     launch_process(script_path=script_path, args=args)
 
 
+def _resolve_serve_settings(args: argparse.Namespace):
+    """Resolve aggregator settings for ``traceml serve``.
+
+    UI/telemetry settings route through the shared config resolver
+    (CLI > env > traceml.yaml > default), the same resolver the launcher uses.
+    Aggregator host/bind-host/port come from serve's own flags, and run
+    identity reuses the launcher's ``RunIdentity``.
+    """
+    from traceml_ai.config.yaml_loader import (
+        BUILT_IN_DEFAULTS,
+        find_config_file,
+        load_yaml_config,
+        resolve_config,
+    )
+    from traceml_ai.runtime.settings import (
+        AggregatorTransportSettings,
+        TraceMLSettings,
+    )
+
+    config_path = find_config_file(Path.cwd())
+    try:
+        yaml_cfg = (
+            load_yaml_config(config_path) if config_path is not None else {}
+        )
+    except (ValueError, OSError) as exc:
+        raise SystemExit(f"[TraceML] ERROR: {exc}")
+
+    cli_overrides = {
+        "mode": args.mode,
+        "interval": args.interval,
+        "enable_logging": args.enable_logging,
+        "logs_dir": args.logs_dir,
+    }
+    cfg = resolve_config(
+        cli_overrides=cli_overrides,
+        parent_env=os.environ,
+        yaml_config=yaml_cfg,
+        defaults=BUILT_IN_DEFAULTS,
+    )
+
+    run_identity = RunIdentity.from_args(
+        args,
+        generated_session_id=get_session_id(),
+        require_explicit=False,
+    )
+
+    connect_host = str(getattr(args, "aggregator_host", None) or "127.0.0.1")
+    bind_host = str(getattr(args, "aggregator_bind_host", None) or "127.0.0.1")
+    port = int(getattr(args, "aggregator_port", 29765))
+
+    # Expected worker count so the aggregator waits for ALL ranks before
+    # finalizing (and warns about ranks that never report). Prefer explicit
+    # --nnodes x --nproc-per-node, else TRACEML_EXPECTED_WORLD_SIZE (matching
+    # the `traceml run` launcher), else 1. Without this the finalize gate
+    # treats the first finished rank as "all done" on multi-rank jobs.
+    nnodes = getattr(args, "nnodes", None)
+    nproc = getattr(args, "nproc_per_node", None)
+    if nnodes and nproc:
+        expected_world_size = int(nnodes) * int(nproc)
+    else:
+        env_ws = os.environ.get("TRACEML_EXPECTED_WORLD_SIZE")
+        try:
+            expected_world_size = int(env_ws) if env_ws else 1
+        except ValueError:
+            expected_world_size = 1
+    expected_world_size = max(1, expected_world_size)
+
+    return TraceMLSettings(
+        mode=str(cfg["mode"]),
+        expected_world_size=expected_world_size,
+        render_interval_sec=float(cfg["interval"]),
+        enable_logging=bool(cfg["enable_logging"]),
+        logs_dir=str(cfg["logs_dir"]),
+        history_enabled=bool(cfg["history_enabled"]),
+        dashboard_port=int(cfg["dashboard_port"]),
+        dashboard_auto_open=bool(cfg["dashboard_auto_open"]),
+        finalize_timeout_sec=float(cfg["finalize_timeout_sec"]),
+        session_id=run_identity.session_id,
+        aggregator=AggregatorTransportSettings(
+            connect_host=connect_host,
+            bind_host=bind_host,
+            port=port,
+        ),
+    )
+
+
+def run_serve(args: argparse.Namespace) -> None:
+    """Run the TraceML aggregator standalone in the foreground.
+
+    Starts only the aggregator; it never launches or wraps a user training
+    script. Reuses ``aggregator_main.run_aggregator`` so it binds host/port,
+    prints the reachable endpoint, blocks until SIGINT/SIGTERM, shuts down
+    cleanly, and preserves final-summary behavior.
+    """
+    if getattr(args, "mode", None) == "dashboard":
+        missing = [
+            package
+            for package in ("nicegui", "plotly")
+            if importlib.util.find_spec(package) is None
+        ]
+        if missing:
+            raise SystemExit(
+                "[TraceML] ERROR: "
+                f"{DASHBOARD_EXTRA_INSTALL_HINT} Missing: {', '.join(missing)}."
+            )
+
+    try:
+        settings = _resolve_serve_settings(args)
+    except ValueError as exc:
+        raise SystemExit(f"[TraceML] ERROR: {exc}") from exc
+
+    from traceml_ai.aggregator.aggregator_main import run_aggregator
+
+    raise SystemExit(run_aggregator(settings))
+
+
 def run_inspect(args: argparse.Namespace) -> None:
     """Decode and print binary msgpack logs for debugging."""
     path = Path(args.file)

--- a/src/traceml_ai/runtime/lifecycle.py
+++ b/src/traceml_ai/runtime/lifecycle.py
@@ -9,7 +9,9 @@ lifecycle inside one process.
 from __future__ import annotations
 
 import os
+import socket
 import threading
+import time
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional
@@ -34,6 +36,55 @@ class NoOpRuntime:
 
     def stop(self) -> None:
         return None
+
+
+_RUNTIME_STATE_LOCK = threading.Lock()
+_ACTIVE_RUNTIME_HANDLE: Optional["RuntimeHandle"] = None
+
+
+def get_active_runtime_handle() -> Optional["RuntimeHandle"]:
+    """Return the RuntimeHandle started in this process, or None.
+
+    Lets ``traceml.init()`` detect a runtime already started by the CLI
+    executor (the ``traceml run`` path) and avoid starting a second one.
+    """
+    return _ACTIVE_RUNTIME_HANDLE
+
+
+def _register_active_runtime_handle(handle: "RuntimeHandle") -> None:
+    """Record the runtime handle started in this process."""
+    global _ACTIVE_RUNTIME_HANDLE
+    with _RUNTIME_STATE_LOCK:
+        _ACTIVE_RUNTIME_HANDLE = handle
+
+
+def wait_for_aggregator(
+    host: str,
+    port: int,
+    *,
+    timeout_sec: float = 10.0,
+    poll_interval_sec: float = 0.25,
+) -> bool:
+    """Return True once ``(host, port)`` accepts a TCP connection.
+
+    Retries for a bounded period. Used by ``traceml.init()`` as a best-effort
+    reachability probe before starting the runtime.
+
+    Limitation: this is a bare TCP accept, not a TraceML protocol/session
+    handshake, so any listener on the port (a foreign process, a stale
+    aggregator, or one serving a different session) passes the check. A real
+    handshake is a wire-format change tracked as a follow-up; on a genuine
+    mismatch the runtime simply produces no telemetry for this session.
+    """
+    deadline = time.monotonic() + float(timeout_sec)
+    while True:
+        try:
+            with socket.create_connection((host, int(port)), timeout=0.5):
+                return True
+        except OSError:
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(float(poll_interval_sec))
 
 
 @dataclass
@@ -201,24 +252,45 @@ def start_runtime(
     _apply_settings_env(normalized, disabled=disabled)
 
     if disabled:
-        return RuntimeHandle(NoOpRuntime())
+        handle = RuntimeHandle(NoOpRuntime())
+        _register_active_runtime_handle(handle)
+        return handle
 
     try:
         runtime = TraceMLRuntime(settings=normalized)
         runtime.start()
-        return RuntimeHandle(runtime)
+        handle = RuntimeHandle(runtime)
+        _register_active_runtime_handle(handle)
+        return handle
     except BaseException as exc:
         if on_error is not None:
             on_error(exc)
         if not fail_open:
             raise
-        return RuntimeHandle(NoOpRuntime())
+        # Fail-open ladder: the runtime lifecycle for this process has still
+        # been decided here, so register the no-op handle. A later
+        # traceml.init() sees an active handle and does not try to start the
+        # runtime again. Detach LOUDLY (one stderr warning) so a silently
+        # dark integration (e.g. a Ray worker whose aggregator is down) is
+        # never mistaken for a healthy run.
+        import sys
+
+        print(
+            f"[TraceML] Runtime failed to start ({exc}); continuing without "
+            "tracing (no-op). Telemetry for this process will be absent.",
+            file=sys.stderr,
+        )
+        handle = RuntimeHandle(NoOpRuntime())
+        _register_active_runtime_handle(handle)
+        return handle
 
 
 __all__ = [
     "AggregatorHandle",
     "NoOpRuntime",
     "RuntimeHandle",
+    "get_active_runtime_handle",
     "start_aggregator",
     "start_runtime",
+    "wait_for_aggregator",
 ]

--- a/src/traceml_ai/sdk/initial.py
+++ b/src/traceml_ai/sdk/initial.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from threading import Lock
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 TraceMLInitMode = Literal["auto", "manual", "selective"]
 
@@ -19,13 +19,15 @@ class TraceMLInitConfig:
     patch_backward: bool
     patch_h2d: bool
     source: str = "user"
+    disabled: bool = False
 
     def same_effective_configuration(self, other: "TraceMLInitConfig") -> bool:
         """
         Return True when two init configs result in the same runtime behavior.
         """
         return (
-            self.mode == other.mode
+            self.disabled == other.disabled
+            and self.mode == other.mode
             and self.patch_dataloader == other.patch_dataloader
             and self.patch_forward == other.patch_forward
             and self.patch_backward == other.patch_backward
@@ -35,6 +37,12 @@ class TraceMLInitConfig:
 
 _INIT_LOCK = Lock()
 _INIT_CONFIG: Optional[TraceMLInitConfig] = None
+
+# RuntimeHandle started by init() in this process, and whether the atexit
+# shutdown hook has been registered. Tracked separately from _INIT_CONFIG so
+# the runtime is stopped exactly once, only when init() actually started it.
+_RUNTIME_HANDLE: Any = None
+_ATEXIT_REGISTERED: bool = False
 
 
 def _canonical_mode(mode: str) -> TraceMLInitMode:
@@ -189,6 +197,226 @@ def is_initialized() -> bool:
     return _INIT_CONFIG is not None
 
 
+def _conflict_message(
+    existing: TraceMLInitConfig, requested: TraceMLInitConfig
+) -> str:
+    """Build the error message for an incompatible re-initialization."""
+    return (
+        "TraceML has already been initialized with a different "
+        "configuration in this process. "
+        f"Existing config: mode={existing.mode!r}, "
+        f"disabled={existing.disabled}, "
+        f"patch_dataloader={existing.patch_dataloader}, "
+        f"patch_forward={existing.patch_forward}, "
+        f"patch_backward={existing.patch_backward}, "
+        f"patch_h2d={existing.patch_h2d}, "
+        f"source={existing.source!r}. "
+        f"Requested config: mode={requested.mode!r}, "
+        f"disabled={requested.disabled}, "
+        f"patch_dataloader={requested.patch_dataloader}, "
+        f"patch_forward={requested.patch_forward}, "
+        f"patch_backward={requested.patch_backward}, "
+        f"patch_h2d={requested.patch_h2d}, "
+        f"source={requested.source!r}. "
+        "Initialize TraceML exactly once per process with the intended "
+        "mode at the start of the run."
+    )
+
+
+def _env_str(name: str, default: str) -> str:
+    """Return a non-empty environment value, otherwise ``default``."""
+    import os
+
+    value = os.environ.get(name)
+    return value if value not in (None, "") else default
+
+
+def _resolve_runtime_settings(
+    *,
+    ui_mode: Optional[str],
+    interval: Optional[float],
+    logs_dir: Optional[str],
+    enable_logging: Optional[bool],
+    session_id: Optional[str],
+    aggregator_host: Optional[str],
+    aggregator_port: Optional[int],
+) -> Any:
+    """
+    Build TraceMLSettings for a user-code runtime (direct ``python``/``torchrun``).
+
+    Runtime/telemetry settings (mode, interval, logs_dir, enable_logging, ...)
+    route through the shared config resolver with the same precedence the CLI
+    launcher uses: explicit ``traceml.init(...)`` arg > ``TRACEML_*`` env var >
+    ``traceml.yaml`` > built-in default. Aggregator host/port come from explicit
+    init args, then env, then defaults. Run identity and the aggregator endpoint
+    are launch-owned and are not read from ``traceml.yaml``.
+    """
+    import os
+    from pathlib import Path
+
+    from traceml_ai.config.yaml_loader import (
+        BUILT_IN_DEFAULTS,
+        find_config_file,
+        load_yaml_config,
+        resolve_config,
+    )
+    from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
+    from traceml_ai.runtime.session import get_session_id
+    from traceml_ai.runtime.settings import (
+        AggregatorTransportSettings,
+        TraceMLSettings,
+    )
+
+    try:
+        config_path = find_config_file(Path.cwd())
+        yaml_cfg = (
+            load_yaml_config(config_path) if config_path is not None else {}
+        )
+    except (ValueError, OSError):
+        # A broken traceml.yaml must not crash init(); fall back to env/defaults.
+        yaml_cfg = {}
+
+    cli_overrides = {
+        "mode": ui_mode,
+        "interval": interval,
+        "enable_logging": enable_logging,
+        "logs_dir": logs_dir,
+    }
+    cfg = resolve_config(
+        cli_overrides=cli_overrides,
+        parent_env=os.environ,
+        yaml_config=yaml_cfg,
+        defaults=BUILT_IN_DEFAULTS,
+    )
+
+    resolved_session = str(
+        session_id or _env_str("TRACEML_SESSION_ID", "") or get_session_id()
+    )
+    host = str(
+        aggregator_host
+        if aggregator_host is not None
+        else _env_str("TRACEML_AGGREGATOR_HOST", "127.0.0.1")
+    )
+    port = int(
+        aggregator_port
+        if aggregator_port is not None
+        else int(_env_str("TRACEML_AGGREGATOR_PORT", "29765"))
+    )
+    raw_max_steps = os.environ.get("TRACEML_TRACE_MAX_STEPS", "")
+    trace_max_steps = int(raw_max_steps) if raw_max_steps.strip() else None
+
+    return TraceMLSettings(
+        mode=str(cfg["mode"]),
+        profile=_env_str("TRACEML_PROFILE", "run"),
+        sampler_interval_sec=float(cfg["interval"]),
+        enable_logging=bool(cfg["enable_logging"]),
+        logs_dir=str(cfg["logs_dir"]),
+        history_enabled=bool(cfg["history_enabled"]),
+        session_id=resolved_session,
+        summary_window_rows=int(
+            _env_str(
+                "TRACEML_SUMMARY_WINDOW_ROWS",
+                str(DEFAULT_SUMMARY_WINDOW_ROWS),
+            )
+        ),
+        trace_max_steps=trace_max_steps,
+        aggregator=AggregatorTransportSettings(
+            connect_host=host, bind_host=host, port=port
+        ),
+    )
+
+
+def _resolve_on_missing_aggregator(value: Optional[str]) -> str:
+    """Resolve the missing-aggregator policy: explicit arg > env > 'warn'."""
+    import os
+
+    resolved = (
+        value
+        if value is not None
+        else os.environ.get("TRACEML_ON_MISSING_AGGREGATOR")
+    ) or "warn"
+    resolved = str(resolved).strip().lower()
+    if resolved not in ("warn", "raise"):
+        raise ValueError(
+            "on_missing_aggregator must be 'warn' or 'raise', got "
+            f"{resolved!r}."
+        )
+    return resolved
+
+
+def _start_runtime_for_init(
+    *,
+    ui_mode: Optional[str],
+    interval: Optional[float],
+    logs_dir: Optional[str],
+    enable_logging: Optional[bool],
+    session_id: Optional[str],
+    aggregator_host: Optional[str],
+    aggregator_port: Optional[int],
+    connect_timeout_sec: float,
+    connect_retry_interval_sec: float,
+) -> None:
+    """
+    Start the per-process TraceML runtime from user code.
+
+    No-op when a runtime is already active in this process (for example one
+    started by the ``traceml run`` executor), which keeps the CLI path working
+    even if user code also calls ``traceml.init()``. Otherwise this verifies the
+    aggregator is reachable within a bounded window and raises a clear error if
+    it is not.
+    """
+    global _RUNTIME_HANDLE, _ATEXIT_REGISTERED
+    import atexit
+
+    from traceml_ai.runtime import lifecycle
+
+    if lifecycle.get_active_runtime_handle() is not None:
+        return  # executor/ray already started the runtime in this process
+
+    settings = _resolve_runtime_settings(
+        ui_mode=ui_mode,
+        interval=interval,
+        logs_dir=logs_dir,
+        enable_logging=enable_logging,
+        session_id=session_id,
+        aggregator_host=aggregator_host,
+        aggregator_port=aggregator_port,
+    )
+    host = settings.aggregator.connect_host
+    port = settings.aggregator.port
+
+    if not lifecycle.wait_for_aggregator(
+        host,
+        port,
+        timeout_sec=connect_timeout_sec,
+        poll_interval_sec=connect_retry_interval_sec,
+    ):
+        raise RuntimeError(
+            f"TraceML could not reach the aggregator at {host}:{port} "
+            f"after {connect_timeout_sec:.0f}s. Start it with "
+            "`traceml serve` (matching --aggregator-host/--aggregator-port), "
+            "or call traceml.init(disabled=True) to run without tracing."
+        )
+
+    _RUNTIME_HANDLE = lifecycle.start_runtime(settings, fail_open=False)
+
+    if not _ATEXIT_REGISTERED:
+        atexit.register(_stop_runtime_for_init)
+        _ATEXIT_REGISTERED = True
+
+
+def _stop_runtime_for_init() -> None:
+    """Best-effort runtime shutdown for the user-code path (atexit)."""
+    global _RUNTIME_HANDLE
+    handle = _RUNTIME_HANDLE
+    _RUNTIME_HANDLE = None
+    if handle is not None:
+        try:
+            handle.stop()
+        except Exception:
+            pass
+
+
 def init(
     *,
     mode: str = "auto",
@@ -196,10 +424,31 @@ def init(
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
     patch_h2d: Optional[bool] = None,
+    disabled: Optional[bool] = None,
+    ui_mode: Optional[str] = None,
+    interval: Optional[float] = None,
+    logs_dir: Optional[str] = None,
+    enable_logging: Optional[bool] = None,
+    session_id: Optional[str] = None,
+    aggregator_host: Optional[str] = None,
+    aggregator_port: Optional[int] = None,
+    connect_timeout_sec: float = 10.0,
+    connect_retry_interval_sec: float = 0.25,
+    on_missing_aggregator: Optional[str] = None,
     _source: str = "user",
 ) -> TraceMLInitConfig:
     """
-    Initialize TraceML instrumentation policy for the current Python process.
+    Initialize TraceML for the current Python process and start its runtime.
+
+    This installs the requested instrumentation patches, starts the TraceML
+    runtime (background samplers + telemetry) in-process, and verifies that the
+    aggregator is reachable over TCP. When TraceML is already running in this
+    process (for example under ``traceml run``), runtime startup is skipped and
+    only the instrumentation policy is applied.
+
+    Configuration precedence for the runtime settings below is: explicit
+    argument here > ``TRACEML_*`` env var > ``traceml.yaml`` > built-in default,
+    the same resolver the CLI launcher uses.
 
     Parameters
     ----------
@@ -215,6 +464,38 @@ def init(
         Selective-mode-only override controlling forward timing patching.
     patch_backward:
         Selective-mode-only override controlling backward timing patching.
+    disabled:
+        When True, TraceML is a complete no-op: no patches are installed and no
+        runtime is started. Defaults to the ``TRACEML_DISABLED`` environment
+        variable when not set explicitly.
+    ui_mode:
+        Display/telemetry mode for this run ('cli', 'dashboard', or 'summary').
+        Resolved via the shared config resolver.
+    interval:
+        Sampler interval in seconds. Resolved via the shared config resolver.
+    logs_dir:
+        Directory for TraceML session logs. Resolved via the shared config
+        resolver.
+    enable_logging:
+        Enable TraceML logging output. Resolved via the shared config resolver.
+    session_id:
+        Explicit TraceML run/session id. Defaults to ``TRACEML_SESSION_ID`` or a
+        generated id. Must match the aggregator's session for shared artifacts.
+    aggregator_host:
+        Host the runtime connects to for telemetry. Defaults to
+        ``TRACEML_AGGREGATOR_HOST`` or ``127.0.0.1``.
+    aggregator_port:
+        Port the runtime connects to for telemetry. Defaults to
+        ``TRACEML_AGGREGATOR_PORT`` or ``29765``.
+    connect_timeout_sec:
+        Bounded period to wait for the aggregator before failing.
+    connect_retry_interval_sec:
+        Delay between aggregator connection attempts.
+    on_missing_aggregator:
+        Policy when the aggregator is unreachable (or the runtime fails to
+        start): 'warn' (default) emits one stderr warning and continues as a
+        no-op so instrumentation never crashes training; 'raise' fails hard.
+        Defaults to ``TRACEML_ON_MISSING_AGGREGATOR`` then 'warn'.
 
     Returns
     -------
@@ -227,6 +508,8 @@ def init(
         If the init request is invalid.
     RuntimeError
         If init conflicts with an existing config or patch installation fails.
+        An unreachable aggregator raises only when
+        ``on_missing_aggregator='raise'``; by default it warns and no-ops.
 
     Notes
     -----
@@ -236,6 +519,37 @@ def init(
       This keeps instrumentation behavior deterministic and easy to reason
       about in production environments.
     """
+    import os
+
+    global _INIT_CONFIG
+
+    is_disabled = (
+        bool(disabled)
+        if disabled is not None
+        else os.environ.get("TRACEML_DISABLED", "0") == "1"
+    )
+
+    if is_disabled:
+        os.environ["TRACEML_DISABLED"] = "1"
+        disabled_config = TraceMLInitConfig(
+            mode="manual",
+            patch_dataloader=False,
+            patch_forward=False,
+            patch_backward=False,
+            patch_h2d=False,
+            source=_source,
+            disabled=True,
+        )
+        with _INIT_LOCK:
+            if _INIT_CONFIG is not None:
+                if _INIT_CONFIG.same_effective_configuration(disabled_config):
+                    return _INIT_CONFIG
+                raise RuntimeError(
+                    _conflict_message(_INIT_CONFIG, disabled_config)
+                )
+            _INIT_CONFIG = disabled_config
+            return disabled_config
+
     requested = _build_config(
         mode=mode,
         patch_dataloader=patch_dataloader,
@@ -245,32 +559,61 @@ def init(
         source=_source,
     )
 
-    global _INIT_CONFIG
-
     with _INIT_LOCK:
         if _INIT_CONFIG is not None:
             if _INIT_CONFIG.same_effective_configuration(requested):
                 return _INIT_CONFIG
 
-            raise RuntimeError(
-                "TraceML has already been initialized with a different "
-                "configuration in this process. "
-                f"Existing config: mode={_INIT_CONFIG.mode!r}, "
-                f"patch_dataloader={_INIT_CONFIG.patch_dataloader}, "
-                f"patch_forward={_INIT_CONFIG.patch_forward}, "
-                f"patch_backward={_INIT_CONFIG.patch_backward}, "
-                f"patch_h2d={_INIT_CONFIG.patch_h2d}, "
-                f"source={_INIT_CONFIG.source!r}. "
-                f"Requested config: mode={requested.mode!r}, "
-                f"patch_dataloader={requested.patch_dataloader}, "
-                f"patch_forward={requested.patch_forward}, "
-                f"patch_backward={requested.patch_backward}, "
-                f"patch_h2d={requested.patch_h2d}, "
-                f"source={requested.source!r}. "
-                "Initialize TraceML exactly once per process with the intended "
-                "mode at the start of the run."
-            )
+            raise RuntimeError(_conflict_message(_INIT_CONFIG, requested))
 
+        # Start the runtime first (this also runs the bounded aggregator
+        # preflight). Doing so before installing patches keeps torch untouched
+        # when the aggregator is missing, and matches the runtime-then-patches
+        # order used by the in-process framework integrations.
+        try:
+            _start_runtime_for_init(
+                ui_mode=ui_mode,
+                interval=interval,
+                logs_dir=logs_dir,
+                enable_logging=enable_logging,
+                session_id=session_id,
+                aggregator_host=aggregator_host,
+                aggregator_port=aggregator_port,
+                connect_timeout_sec=connect_timeout_sec,
+                connect_retry_interval_sec=connect_retry_interval_sec,
+            )
+        except RuntimeError as exc:
+            # Fail-open ladder (see project failure-handling policy): a library
+            # call inside user code must never crash the training process for a
+            # transport reason. On an unreachable aggregator (or a runtime that
+            # fails to start) detach to a no-op with ONE loud stderr warning,
+            # installing no patches. Opt into hard failure with
+            # on_missing_aggregator='raise' (e.g. CI that wants misconfigured
+            # telemetry to fail the run).
+            if (
+                _resolve_on_missing_aggregator(on_missing_aggregator)
+                == "raise"
+            ):
+                raise
+            import sys
+
+            print(
+                f"[TraceML] {exc} Continuing without tracing (no-op). Pass "
+                "on_missing_aggregator='raise' (or set "
+                "TRACEML_ON_MISSING_AGGREGATOR=raise) to fail instead.",
+                file=sys.stderr,
+            )
+            noop_config = TraceMLInitConfig(
+                mode="manual",
+                patch_dataloader=False,
+                patch_forward=False,
+                patch_backward=False,
+                patch_h2d=False,
+                source=_source,
+                disabled=True,
+            )
+            _INIT_CONFIG = noop_config
+            return noop_config
         _apply_requested_patches(requested)
         _INIT_CONFIG = requested
         return requested
@@ -283,6 +626,16 @@ def start(
     patch_forward: Optional[bool] = None,
     patch_backward: Optional[bool] = None,
     patch_h2d: Optional[bool] = None,
+    disabled: Optional[bool] = None,
+    ui_mode: Optional[str] = None,
+    interval: Optional[float] = None,
+    logs_dir: Optional[str] = None,
+    enable_logging: Optional[bool] = None,
+    session_id: Optional[str] = None,
+    aggregator_host: Optional[str] = None,
+    aggregator_port: Optional[int] = None,
+    connect_timeout_sec: float = 10.0,
+    connect_retry_interval_sec: float = 0.25,
 ) -> TraceMLInitConfig:
     """
     Alias for `init()` for the current transition period.
@@ -296,6 +649,16 @@ def start(
         patch_forward=patch_forward,
         patch_backward=patch_backward,
         patch_h2d=patch_h2d,
+        disabled=disabled,
+        ui_mode=ui_mode,
+        interval=interval,
+        logs_dir=logs_dir,
+        enable_logging=enable_logging,
+        session_id=session_id,
+        aggregator_host=aggregator_host,
+        aggregator_port=aggregator_port,
+        connect_timeout_sec=connect_timeout_sec,
+        connect_retry_interval_sec=connect_retry_interval_sec,
         _source="user",
     )
 

--- a/tests/integrations/test_hf_trainer.py
+++ b/tests/integrations/test_hf_trainer.py
@@ -438,7 +438,7 @@ def test_hf_trainer_callback_noop_when_disabled(monkeypatch):
 
 
 @pytest.mark.skipif(not HAS_TRANSFORMERS, reason="transformers not installed")
-def test_hf_init_enables_dataloader_and_h2d_patches():
+def test_hf_init_enables_dataloader_and_h2d_patches(monkeypatch):
     """
     init() must enable the process-wide patches the callback cannot install on
     its own. The DataLoader fetch patch in particular is what lets TraceML
@@ -446,6 +446,14 @@ def test_hf_init_enables_dataloader_and_h2d_patches():
     never installs it. The H2D Tensor.to patch is gated the same way: the
     auto-timer trace_step arms each step is a no-op unless the patch is on.
     """
+    # This test verifies patch policy, not runtime startup. Stub the runtime
+    # bootstrap so init() does not try to reach an aggregator over TCP.
+    import traceml_ai.sdk.initial as initialization
+
+    monkeypatch.setattr(
+        initialization, "_start_runtime_for_init", lambda **kwargs: None
+    )
+
     config = init()
 
     assert config.patch_dataloader, (

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -6,6 +6,7 @@
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -15,9 +16,14 @@ from traceml_ai.launcher.cli import build_parser
 from traceml_ai.launcher.commands import (
     _dashboard_access_box,
     _launch_defaults_for_topology,
+    _resolve_serve_settings,
     resolve_existing_script_path,
     run_view,
     validate_launch_args,
+)
+from traceml_ai.launcher.launch_config import (
+    DistributedLaunchConfig,
+    RunIdentity,
 )
 from traceml_ai.launcher.manifest import (
     collect_existing_artifacts,
@@ -25,12 +31,161 @@ from traceml_ai.launcher.manifest import (
     update_run_manifest,
     write_run_manifest,
 )
-from traceml_ai.launcher.launch_config import (
-    DistributedLaunchConfig,
-    RunIdentity,
-)
 from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
 from traceml_ai.runtime.settings import DEFAULT_FINALIZE_TIMEOUT_SEC
+
+
+def test_serve_is_a_public_command() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(
+        [
+            "serve",
+            "--mode",
+            "cli",
+            "--logs-dir",
+            "mylogs",
+            "--run-name",
+            "demo",
+            "--aggregator-host",
+            "10.0.0.9",
+            "--aggregator-bind-host",
+            "0.0.0.0",
+            "--aggregator-port",
+            "40000",
+        ]
+    )
+
+    assert args.command == "serve"
+    assert args.mode == "cli"
+    assert args.aggregator_host == "10.0.0.9"
+    assert args.aggregator_bind_host == "0.0.0.0"
+    assert args.aggregator_port == 40000
+
+
+def test_serve_maps_flags_into_aggregator_settings(monkeypatch) -> None:
+    # Isolate from any TRACEML_* env so the CLI flags drive the result.
+    for var in (
+        "TRACEML_UI_MODE",
+        "TRACEML_MODE",
+        "TRACEML_LOGS_DIR",
+        "TRACEML_INTERVAL",
+        "TRACEML_ENABLE_LOGGING",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "serve",
+            "--mode",
+            "cli",
+            "--logs-dir",
+            "mylogs",
+            "--run-name",
+            "demo",
+            "--aggregator-host",
+            "10.0.0.9",
+            "--aggregator-bind-host",
+            "0.0.0.0",
+            "--aggregator-port",
+            "40000",
+        ]
+    )
+
+    settings = _resolve_serve_settings(args)
+
+    assert settings.mode == "cli"
+    assert settings.logs_dir == "mylogs"
+    assert settings.session_id == "demo"
+    assert settings.aggregator.connect_host == "10.0.0.9"
+    assert settings.aggregator.bind_host == "0.0.0.0"
+    assert settings.aggregator.port == 40000
+
+
+def test_serve_threads_expected_world_size(monkeypatch) -> None:
+    monkeypatch.delenv("TRACEML_EXPECTED_WORLD_SIZE", raising=False)
+    parser = build_parser()
+
+    # Explicit --nnodes x --nproc-per-node sets the rank count so the
+    # aggregator waits for ALL ranks before finalizing.
+    args = parser.parse_args(
+        ["serve", "--nnodes", "2", "--nproc-per-node", "4"]
+    )
+    assert _resolve_serve_settings(args).expected_world_size == 8
+
+    # Falls back to TRACEML_EXPECTED_WORLD_SIZE (matching `traceml run`).
+    monkeypatch.setenv("TRACEML_EXPECTED_WORLD_SIZE", "3")
+    args = parser.parse_args(["serve"])
+    assert _resolve_serve_settings(args).expected_world_size == 3
+
+    # Default is 1 when neither flags nor env are set.
+    monkeypatch.delenv("TRACEML_EXPECTED_WORLD_SIZE", raising=False)
+    args = parser.parse_args(["serve"])
+    assert _resolve_serve_settings(args).expected_world_size == 1
+
+
+def test_serve_configures_logging_without_preset_env(
+    monkeypatch, tmp_path
+) -> None:
+    import logging
+
+    import traceml_ai.aggregator.aggregator_main as agg_main
+    from traceml_ai.runtime.settings import (
+        AggregatorTransportSettings,
+        TraceMLSettings,
+    )
+
+    saved_env = {
+        key: os.environ.get(key)
+        for key in ("TRACEML_LOGS_DIR", "TRACEML_SESSION_ID")
+    }
+    os.environ.pop("TRACEML_LOGS_DIR", None)
+    os.environ.pop("TRACEML_SESSION_ID", None)
+
+    traceml_logger = logging.getLogger("traceml")
+    saved_handlers = traceml_logger.handlers[:]
+    traceml_logger.handlers.clear()
+
+    # Do not clobber the process signal handlers, and stop before the blocking
+    # wait by making aggregator startup raise a controlled error.
+    monkeypatch.setattr(agg_main, "_install_signal_handlers", lambda ev: None)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("stop before blocking")
+
+    monkeypatch.setattr(agg_main, "start_aggregator", _boom)
+
+    settings = TraceMLSettings(
+        mode="summary",
+        logs_dir=str(tmp_path),
+        session_id="serve-test",
+        aggregator=AggregatorTransportSettings(
+            connect_host="127.0.0.1", bind_host="127.0.0.1", port=0
+        ),
+    )
+
+    try:
+        rc = agg_main.run_aggregator(settings)
+
+        # Clean fatal exit (return 1), not a TypeError in logging setup.
+        assert rc == 1
+        assert os.environ["TRACEML_LOGS_DIR"] == str(tmp_path)
+        assert os.environ["TRACEML_SESSION_ID"] == "serve-test"
+    finally:
+        for handler in traceml_logger.handlers[:]:
+            traceml_logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+        for handler in saved_handlers:
+            traceml_logger.addHandler(handler)
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 def test_build_parser_preserves_launch_commands() -> None:

--- a/tests/runtime/test_lifecycle.py
+++ b/tests/runtime/test_lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import socket
 from dataclasses import dataclass
 from typing import Any
 
@@ -67,3 +68,91 @@ def test_start_aggregator_returns_idempotent_handle(
 
     assert handle.stop_event.is_set()
     assert created[0].stops == 1
+
+
+class _FakeRuntime:
+    """Minimal TraceMLRuntime stand-in for start_runtime() tests."""
+
+    def __init__(self, settings: TraceMLSettings | None = None) -> None:
+        self.started = False
+        self.stopped = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+def test_wait_for_aggregator_true_when_listening() -> None:
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+    try:
+        assert lifecycle.wait_for_aggregator(
+            "127.0.0.1", port, timeout_sec=2.0, poll_interval_sec=0.05
+        )
+    finally:
+        server.close()
+
+
+def test_wait_for_aggregator_false_when_closed() -> None:
+    # Bind then close to obtain a port that is (very likely) not listening.
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    assert not lifecycle.wait_for_aggregator(
+        "127.0.0.1", port, timeout_sec=0.3, poll_interval_sec=0.05
+    )
+
+
+def test_start_runtime_registers_active_handle(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(lifecycle, "TraceMLRuntime", _FakeRuntime)
+    lifecycle._ACTIVE_RUNTIME_HANDLE = None
+    try:
+        handle = lifecycle.start_runtime(
+            TraceMLSettings(logs_dir=str(tmp_path), session_id="reg-test"),
+            fail_open=False,
+        )
+        assert lifecycle.get_active_runtime_handle() is handle
+        assert handle.runtime.started is True
+    finally:
+        lifecycle._ACTIVE_RUNTIME_HANDLE = None
+
+
+class _BoomRuntime:
+    """TraceMLRuntime stand-in whose start() fails, to test fail_open."""
+
+    def __init__(self, settings: TraceMLSettings | None = None) -> None:
+        pass
+
+    def start(self) -> None:
+        raise RuntimeError("boom")
+
+    def stop(self) -> None:
+        pass
+
+
+def test_start_runtime_fail_open_registers_noop_handle(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    # A failed start with fail_open=True must still register a no-op active
+    # handle so a later traceml.init() does not try to start the runtime again,
+    # and it must detach LOUDLY (one stderr warning) so a silently dark
+    # integration is never mistaken for a healthy run.
+    monkeypatch.setattr(lifecycle, "TraceMLRuntime", _BoomRuntime)
+    lifecycle._ACTIVE_RUNTIME_HANDLE = None
+    try:
+        handle = lifecycle.start_runtime(
+            TraceMLSettings(logs_dir=str(tmp_path), session_id="fail-open"),
+            fail_open=True,
+        )
+        assert lifecycle.get_active_runtime_handle() is handle
+        assert isinstance(handle.runtime, lifecycle.NoOpRuntime)
+        assert "[TraceML]" in capsys.readouterr().err  # detached loudly
+    finally:
+        lifecycle._ACTIVE_RUNTIME_HANDLE = None

--- a/tests/sdk/test_init_and_wrappers.py
+++ b/tests/sdk/test_init_and_wrappers.py
@@ -16,7 +16,11 @@ if str(SRC) not in sys.path:
 def _reload_initialization_module():
     import traceml_ai.sdk.initial as initialization
 
-    return importlib.reload(initialization)
+    importlib.reload(initialization)
+    # These tests exercise instrumentation patch policy, not runtime startup.
+    # Stub the runtime bootstrap so init() does not try to reach an aggregator.
+    initialization._start_runtime_for_init = lambda **kwargs: None
+    return initialization
 
 
 def _reload_instrumentation_module():

--- a/tests/sdk/test_init_runtime.py
+++ b/tests/sdk/test_init_runtime.py
@@ -1,0 +1,220 @@
+"""Tests for runtime startup driven by `traceml.init(...)` (issue #84)."""
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+class _FakeHandle:
+    """Minimal RuntimeHandle stand-in that records stop() calls."""
+
+    def __init__(self) -> None:
+        self.stops = 0
+
+    def stop(self) -> None:
+        self.stops += 1
+
+
+@pytest.fixture
+def initialization():
+    """Reload sdk.initial and reset process-global runtime state per test.
+
+    ``init(disabled=...)`` writes ``TRACEML_DISABLED`` straight to os.environ,
+    so this fixture snapshots and restores it to avoid leaking into other
+    tests (monkeypatch.delenv does not register a restore for an absent var).
+    """
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    original_disabled = os.environ.get("TRACEML_DISABLED")
+    os.environ.pop("TRACEML_DISABLED", None)
+    lifecycle._ACTIVE_RUNTIME_HANDLE = None
+    module = importlib.reload(
+        importlib.import_module("traceml_ai.sdk.initial")
+    )
+    try:
+        yield module
+    finally:
+        lifecycle._ACTIVE_RUNTIME_HANDLE = None
+        if original_disabled is None:
+            os.environ.pop("TRACEML_DISABLED", None)
+        else:
+            os.environ["TRACEML_DISABLED"] = original_disabled
+
+
+def test_init_disabled_is_noop(initialization, monkeypatch):
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+
+    started = []
+    patched = []
+    monkeypatch.setattr(
+        initialization,
+        "_start_runtime_for_init",
+        lambda **kwargs: started.append(kwargs),
+    )
+    monkeypatch.setattr(
+        initialization,
+        "_apply_requested_patches",
+        lambda cfg: patched.append(cfg),
+    )
+
+    cfg = initialization.init(disabled=True)
+
+    assert cfg.disabled is True
+    assert started == []  # runtime never started
+    assert patched == []  # no instrumentation patches installed
+    assert os.environ["TRACEML_DISABLED"] == "1"
+
+
+def test_init_disabled_via_env(initialization, monkeypatch):
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    monkeypatch.setenv("TRACEML_DISABLED", "1")
+    started = []
+    monkeypatch.setattr(lifecycle, "get_active_runtime_handle", lambda: None)
+    monkeypatch.setattr(
+        lifecycle, "start_runtime", lambda *a, **k: started.append(1)
+    )
+
+    cfg = initialization.init()  # mode defaults to 'auto'; disabled env wins
+
+    assert cfg.disabled is True
+    assert started == []
+
+
+def test_init_starts_runtime_when_aggregator_reachable(
+    initialization, monkeypatch
+):
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+    monkeypatch.delenv("TRACEML_AGGREGATOR_HOST", raising=False)
+    monkeypatch.delenv("TRACEML_AGGREGATOR_PORT", raising=False)
+
+    waited = {}
+
+    def fake_wait(host, port, **kwargs):
+        waited["host"] = host
+        waited["port"] = port
+        return True
+
+    captured = {}
+    fake_handle = _FakeHandle()
+
+    def fake_start(settings, **kwargs):
+        captured["settings"] = settings
+        return fake_handle
+
+    monkeypatch.setattr(lifecycle, "get_active_runtime_handle", lambda: None)
+    monkeypatch.setattr(lifecycle, "wait_for_aggregator", fake_wait)
+    monkeypatch.setattr(lifecycle, "start_runtime", fake_start)
+
+    cfg = initialization.init(
+        mode="manual",
+        aggregator_host="10.0.0.5",
+        aggregator_port=40000,
+    )
+
+    assert cfg.disabled is False
+    assert waited == {"host": "10.0.0.5", "port": 40000}
+    assert captured["settings"].aggregator.connect_host == "10.0.0.5"
+    assert captured["settings"].aggregator.port == 40000
+    assert initialization._RUNTIME_HANDLE is fake_handle
+
+
+def test_init_warns_and_noops_when_aggregator_unreachable(
+    initialization, monkeypatch, capsys
+):
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+    monkeypatch.delenv("TRACEML_ON_MISSING_AGGREGATOR", raising=False)
+    started = []
+    monkeypatch.setattr(lifecycle, "get_active_runtime_handle", lambda: None)
+    monkeypatch.setattr(
+        lifecycle, "wait_for_aggregator", lambda *a, **k: False
+    )
+    monkeypatch.setattr(
+        lifecycle, "start_runtime", lambda *a, **k: started.append(1)
+    )
+
+    # Default is fail-open: a library call inside user code must never crash
+    # the training process for a transport reason. Detach to a no-op + warn.
+    cfg = initialization.init(mode="manual", connect_timeout_sec=1.0)
+
+    assert cfg.disabled is True
+    assert started == []  # never started after a failed preflight
+    assert "[TraceML]" in capsys.readouterr().err  # detached loudly
+    assert initialization.get_init_config() is cfg  # no-op config stored
+
+
+def test_init_raises_when_aggregator_unreachable_and_strict(
+    initialization, monkeypatch
+):
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+    monkeypatch.delenv("TRACEML_ON_MISSING_AGGREGATOR", raising=False)
+    started = []
+    monkeypatch.setattr(lifecycle, "get_active_runtime_handle", lambda: None)
+    monkeypatch.setattr(
+        lifecycle, "wait_for_aggregator", lambda *a, **k: False
+    )
+    monkeypatch.setattr(
+        lifecycle, "start_runtime", lambda *a, **k: started.append(1)
+    )
+
+    with pytest.raises(RuntimeError, match="could not reach the aggregator"):
+        initialization.init(
+            mode="manual",
+            connect_timeout_sec=1.0,
+            on_missing_aggregator="raise",
+        )
+
+    assert started == []  # never started after a failed preflight
+    assert initialization.get_init_config() is None  # config not stored
+
+
+def test_init_skips_runtime_when_already_active(initialization, monkeypatch):
+    import traceml_ai.runtime.lifecycle as lifecycle
+
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+    monkeypatch.setattr(
+        lifecycle, "get_active_runtime_handle", lambda: object()
+    )
+
+    waited = []
+    started = []
+    monkeypatch.setattr(
+        lifecycle,
+        "wait_for_aggregator",
+        lambda *a, **k: waited.append(1) or True,
+    )
+    monkeypatch.setattr(
+        lifecycle, "start_runtime", lambda *a, **k: started.append(1)
+    )
+
+    cfg = initialization.init(mode="manual")
+
+    assert cfg.disabled is False
+    assert waited == []  # no preflight when a runtime already runs here
+    assert started == []  # no second runtime started
+    assert initialization._RUNTIME_HANDLE is None
+
+
+def test_stop_runtime_for_init_is_idempotent(initialization):
+    handle = _FakeHandle()
+    initialization._RUNTIME_HANDLE = handle
+
+    initialization._stop_runtime_for_init()
+    initialization._stop_runtime_for_init()
+
+    assert handle.stops == 1
+    assert initialization._RUNTIME_HANDLE is None

--- a/tests/test_h2d_timing.py
+++ b/tests/test_h2d_timing.py
@@ -55,7 +55,11 @@ h2d_auto_timer = h2d_patch.h2d_auto_timer
 def _reload_initialization():
     import traceml_ai.sdk.initial as m
 
-    return importlib.reload(m)
+    importlib.reload(m)
+    # These tests exercise instrumentation patch policy, not runtime startup.
+    # Stub the runtime bootstrap so init() does not try to reach an aggregator.
+    m._start_runtime_for_init = lambda **kwargs: None
+    return m
 
 
 def _reload_h2d_patch():


### PR DESCRIPTION
## What changed

This PR adds a `uv` installation path and a short copy-paste quickstart to the README.

It documents:
- `uv pip install traceml-ai`
- `uv add traceml-ai` for uv-managed projects
- `uv add "traceml-ai[torch]"` for the example workflow

## Why

Many PyTorch users manage environments with `uv`. The README previously showed only the `pip` path, which made the first-run experience less obvious for users already working in `uv`.

## How I tested

I verified the documented install path with a fresh uv-managed environment:

- `uv venv --python 3.12 ...`
- `uv pip install --python ... "traceml-ai[torch]"`

Validation evidence:
- `traceml_ai` imports successfully
- `torch` imports successfully in the created environment

I also ran `git diff --check` successfully.

## Runtime impact

- [x] No training-path impact

## Docs

- [x] Updated