### PR TITLE
docs: add uv installation quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ For the live browser dashboard:
 pip install traceml-ai
 ```
 
+Or install with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv pip install traceml-ai
+```
+
+For a uv-managed project, add TraceML to the project's dependencies instead:
+
+```bash
+uv add traceml-ai
+```
+
+Extras use the same syntax with pip and uv. For example:
+
+```bash
+pip install "traceml-ai[dashboard]"
+uv add "traceml-ai[dashboard]"
+uv add "traceml-ai[torch]"
+```
+
+To try TraceML immediately in an environment managed by uv, install the
+`torch` extra required by the example:
+
+```bash
+uv pip install "traceml-ai[torch]"
+traceml run examples/quickstart.py
+```
+
 Using Hugging Face Trainer, PyTorch Lightning, Ray Train, W&B, or MLflow?
 Start with the native integration path in
 [Use With Your Stack](docs/user_guide/integrations.md).


### PR DESCRIPTION
## What changed

This PR adds a `uv` installation path and a short copy-paste quickstart to the README.

It documents:
- `uv pip install traceml-ai`
- `uv add traceml-ai` for uv-managed projects
- `uv add "traceml-ai[torch]"` for the example workflow

## Why

Many PyTorch users manage environments with `uv`. The README previously showed only the `pip` path, which made the first-run experience less obvious for users already working in `uv`.

## How I tested

I verified the documented install path with a fresh uv-managed environment:

- `uv venv --python 3.12 ...`
- `uv pip install --python ... "traceml-ai[torch]"`

Validation evidence:
- `traceml_ai` imports successfully
- `torch` imports successfully in the created environment

I also ran `git diff --check` successfully.

Fixes #215