### PR TITLE
Runtime metadata

### DIFF
--- a/src/traceml_ai/aggregator/sqlite_writer.py
+++ b/src/traceml_ai/aggregator/sqlite_writer.py
@@ -16,6 +16,9 @@ from typing import Any, Dict, Iterator, Optional
 
 from traceml_ai.aggregator.sqlite_writers import process as process_sql_writer
 from traceml_ai.aggregator.sqlite_writers import (
+    runtime_environment as runtime_environment_sql_writer,
+)
+from traceml_ai.aggregator.sqlite_writers import (
     stdout_stderr as stdout_stderr_sql_writer,
 )
 from traceml_ai.aggregator.sqlite_writers import (
@@ -36,6 +39,7 @@ from traceml_ai.telemetry.envelope import (
 )
 
 _PROJECTION_WRITERS = [
+    runtime_environment_sql_writer,
     system_sql_writer,
     process_sql_writer,
     step_time_sql_writer,

--- a/src/traceml_ai/aggregator/sqlite_writers/runtime_environment.py
+++ b/src/traceml_ai/aggregator/sqlite_writers/runtime_environment.py
@@ -1,0 +1,209 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SQLite projection writer for RuntimeEnvironmentSampler.
+
+The runtime environment table stores one small rank-scoped context row, such as
+topology and observed training strategy. It is sampler body data, not TCP
+envelope metadata, and is intentionally excluded from retention pruning.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from traceml_ai.telemetry.envelope import TelemetryEnvelope, TelemetryMeta
+
+SAMPLER_NAME = "RuntimeEnvironmentSampler"
+TABLE_NAME = "RuntimeEnvironmentTable"
+
+
+def _optional_float(value: Any) -> Optional[float]:
+    """Best-effort float coercion for runtime environment rows."""
+    try:
+        return float(value) if value is not None else None
+    except Exception:
+        return None
+
+
+def _optional_int(value: Any) -> Optional[int]:
+    """Best-effort integer coercion for runtime environment rows."""
+    try:
+        return int(value) if value is not None else None
+    except Exception:
+        return None
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    """Best-effort string coercion for runtime environment rows."""
+    if value is None:
+        return None
+    try:
+        return str(value)
+    except Exception:
+        return None
+
+
+def _optional_bool_int(value: Any) -> Optional[int]:
+    """Return booleans as 1/0 while preserving unknown as NULL."""
+    if value is True:
+        return 1
+    if value is False:
+        return 0
+    return None
+
+
+@dataclass(frozen=True)
+class RuntimeEnvironmentPayloadIdentity:
+    """Distributed identity stored with runtime environment telemetry."""
+
+    rank: Optional[int]
+    global_rank: Optional[int]
+    local_rank: Optional[int]
+    world_size: Optional[int]
+    local_world_size: Optional[int]
+    node_rank: Optional[int]
+    hostname: Optional[str]
+    pid: Optional[int]
+
+
+def _payload_identity(
+    meta: TelemetryMeta,
+) -> RuntimeEnvironmentPayloadIdentity:
+    """Return storage identity for one RuntimeEnvironmentSampler payload."""
+    return RuntimeEnvironmentPayloadIdentity(
+        rank=_optional_int(meta.rank),
+        global_rank=_optional_int(meta.global_rank),
+        local_rank=_optional_int(meta.local_rank),
+        world_size=_optional_int(meta.world_size),
+        local_world_size=_optional_int(meta.local_world_size),
+        node_rank=_optional_int(meta.node_rank),
+        hostname=_optional_str(meta.hostname),
+        pid=_optional_int(meta.pid),
+    )
+
+
+def accepts_sampler(sampler: Optional[str]) -> bool:
+    """Return True if this projection writer handles the given sampler."""
+    return sampler == SAMPLER_NAME
+
+
+def init_schema(conn: sqlite3.Connection) -> None:
+    """Create the query-friendly runtime environment table."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS runtime_environment (
+            id                         INTEGER PRIMARY KEY AUTOINCREMENT,
+            recv_ts_ns                 INTEGER NOT NULL,
+            rank                       INTEGER,
+            global_rank                INTEGER,
+            local_rank                 INTEGER,
+            world_size                 INTEGER,
+            local_world_size           INTEGER,
+            node_rank                  INTEGER,
+            hostname                   TEXT,
+            pid                        INTEGER,
+            sample_ts_s                REAL,
+            seq                        INTEGER,
+            topology                   TEXT,
+            distributed_initialized    INTEGER,
+            distributed_backend        TEXT,
+            training_strategy          TEXT,
+            strategy_source            TEXT,
+            strategy_confidence        TEXT
+        );
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_runtime_environment_global_rank
+        ON runtime_environment(global_rank, id);
+        """
+    )
+
+
+def build_rows(
+    envelope: TelemetryEnvelope,
+    recv_ts_ns: int,
+) -> Dict[str, list[tuple]]:
+    """Build SQLite rows from one decoded RuntimeEnvironmentSampler payload."""
+    out: Dict[str, list[tuple]] = {"runtime_environment": []}
+
+    sampler = envelope.meta.sampler
+    if not accepts_sampler(sampler):
+        return out
+
+    identity = _payload_identity(envelope.meta)
+    tables = envelope.tables
+    if not isinstance(tables, dict):
+        return out
+
+    rows = tables.get(TABLE_NAME)
+    if not isinstance(rows, list):
+        return out
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+
+        out["runtime_environment"].append(
+            (
+                recv_ts_ns,
+                identity.rank,
+                identity.global_rank,
+                identity.local_rank,
+                identity.world_size,
+                identity.local_world_size,
+                identity.node_rank,
+                identity.hostname,
+                identity.pid,
+                _optional_float(row.get("ts")),
+                _optional_int(row.get("seq")),
+                _optional_str(row.get("topology")),
+                _optional_bool_int(row.get("distributed_initialized")),
+                _optional_str(row.get("distributed_backend")),
+                _optional_str(row.get("training_strategy")),
+                _optional_str(row.get("strategy_source")),
+                _optional_str(row.get("strategy_confidence")),
+            )
+        )
+
+    return out
+
+
+def insert_rows(
+    conn: sqlite3.Connection,
+    rows_by_table: Dict[str, list[tuple]],
+) -> None:
+    """Insert runtime environment projection rows into SQLite."""
+    rows = rows_by_table.get("runtime_environment", [])
+    if rows:
+        conn.executemany(
+            """
+            INSERT INTO runtime_environment(
+                recv_ts_ns,
+                rank,
+                global_rank,
+                local_rank,
+                world_size,
+                local_world_size,
+                node_rank,
+                hostname,
+                pid,
+                sample_ts_s,
+                seq,
+                topology,
+                distributed_initialized,
+                distributed_backend,
+                training_strategy,
+                strategy_source,
+                strategy_confidence
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """,
+            rows,
+        )

--- a/src/traceml_ai/runtime/environment.py
+++ b/src/traceml_ai/runtime/environment.py
@@ -1,0 +1,226 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime environment classification for a TraceML training rank.
+
+This module classifies the local runtime environment so a future sampler can
+persist rank-scoped context such as topology, torch.distributed state, and the
+observed training strategy. It is not transport metadata: TCP envelope `meta`
+continues to describe the sender, while this data belongs in a sampler body row.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional
+
+from traceml_ai.runtime.identity import (
+    RuntimeIdentity,
+    resolve_runtime_identity,
+)
+
+EnvMapping = Mapping[str, str]
+TorchLoader = Callable[[], Optional[Any]]
+
+
+def _load_torch() -> Optional[Any]:
+    """Import torch lazily so importing this module has no torch side effects."""
+    try:
+        import torch
+    except ModuleNotFoundError:
+        return None
+    return torch
+
+
+@dataclass(frozen=True)
+class RuntimeEnvironmentInfo:
+    """Rank-local runtime environment classification.
+
+    `topology` describes process placement: single process, single-node
+    multi-process, or multi-node. `training_strategy` describes how the model is
+    parallelized when TraceML can observe it, for example DDP or FSDP.
+    """
+
+    topology: str
+    distributed_initialized: bool
+    distributed_backend: Optional[str]
+    training_strategy: str
+    strategy_source: str
+    strategy_confidence: str
+
+    def to_record(self) -> dict[str, Any]:
+        """Return a JSON/msgpack-safe body row for future sampler transport."""
+        return {
+            "topology": self.topology,
+            "distributed_initialized": bool(self.distributed_initialized),
+            "distributed_backend": self.distributed_backend,
+            "training_strategy": self.training_strategy,
+            "strategy_source": self.strategy_source,
+            "strategy_confidence": self.strategy_confidence,
+        }
+
+
+def detect_runtime_environment(
+    model: Optional[Any] = None,
+    *,
+    env: Optional[EnvMapping] = None,
+    torch_loader: Optional[TorchLoader] = None,
+) -> RuntimeEnvironmentInfo:
+    """Detect runtime topology and training strategy best-effort.
+
+    The detector is safe to call from `trace_step(model)`: it does not probe
+    CUDA, does not synchronize, imports torch lazily, and degrades to
+    conservative unknown values if torch or distributed state cannot be read.
+    """
+    torch = _safe_load_torch(torch_loader)
+    identity = _safe_resolve_identity(env=env, torch=torch)
+    topology = _topology(identity)
+    distributed_initialized, distributed_backend = _distributed_state(torch)
+
+    model_strategy = _training_strategy_from_model(torch, model)
+    if model_strategy is not None:
+        training_strategy, strategy_source, strategy_confidence = (
+            model_strategy
+        )
+    elif topology == "single_process":
+        training_strategy = "single_process"
+        strategy_source = "topology"
+        strategy_confidence = "high"
+    elif distributed_initialized:
+        training_strategy = "distributed_unknown"
+        strategy_source = "runtime_distributed"
+        strategy_confidence = "low"
+    elif identity.world_size > 1:
+        training_strategy = "distributed_unknown"
+        strategy_source = "topology"
+        strategy_confidence = "low"
+    else:
+        training_strategy = "unknown"
+        strategy_source = "unknown"
+        strategy_confidence = "low"
+
+    return RuntimeEnvironmentInfo(
+        topology=topology,
+        distributed_initialized=distributed_initialized,
+        distributed_backend=distributed_backend,
+        training_strategy=training_strategy,
+        strategy_source=strategy_source,
+        strategy_confidence=strategy_confidence,
+    )
+
+
+def _safe_load_torch(torch_loader: Optional[TorchLoader]) -> Optional[Any]:
+    loader = torch_loader if torch_loader is not None else _load_torch
+    try:
+        return loader()
+    except Exception:
+        return None
+
+
+def _safe_resolve_identity(
+    *,
+    env: Optional[EnvMapping],
+    torch: Optional[Any],
+) -> RuntimeIdentity:
+    try:
+        return resolve_runtime_identity(
+            env=env if env is not None else os.environ,
+            torch_loader=lambda: torch,
+        )
+    except Exception:
+        return RuntimeIdentity(
+            global_rank=0,
+            local_rank=0,
+            world_size=1,
+            local_world_size=1,
+            node_rank=0,
+            hostname=socket.gethostname(),
+            pid=os.getpid(),
+        )
+
+
+def _topology(identity: RuntimeIdentity) -> str:
+    if identity.world_size <= 1:
+        return "single_process"
+    if identity.is_multinode:
+        return "multi_node"
+    return "single_node_multi_process"
+
+
+def _distributed_state(torch: Optional[Any]) -> tuple[bool, Optional[str]]:
+    dist = getattr(torch, "distributed", None) if torch is not None else None
+    if dist is None:
+        return False, None
+
+    try:
+        initialized = bool(dist.is_available() and dist.is_initialized())
+    except Exception:
+        return False, None
+    if not initialized:
+        return False, None
+
+    try:
+        backend = dist.get_backend()
+    except Exception:
+        backend = None
+
+    return True, str(backend) if backend is not None else None
+
+
+def _training_strategy_from_model(
+    torch: Optional[Any],
+    model: Optional[Any],
+) -> Optional[tuple[str, str, str]]:
+    if model is None or torch is None:
+        return None
+
+    if _isinstance_path(
+        model,
+        torch,
+        "nn.parallel.DistributedDataParallel",
+    ):
+        return "ddp", "runtime_model", "high"
+
+    if _isinstance_path(
+        model,
+        torch,
+        "distributed.fsdp.FullyShardedDataParallel",
+    ) or _isinstance_path(
+        model,
+        torch,
+        "distributed.fsdp.fully_sharded_data_parallel.FullyShardedDataParallel",
+    ):
+        return "fsdp", "runtime_model", "high"
+
+    return None
+
+
+def _isinstance_path(model: Any, root: Any, dotted_path: str) -> bool:
+    cls = _attr_path(root, dotted_path)
+    if cls is None:
+        return False
+    try:
+        return isinstance(model, cls)
+    except TypeError:
+        return False
+
+
+def _attr_path(root: Any, dotted_path: str) -> Optional[Any]:
+    current = root
+    for part in dotted_path.split("."):
+        try:
+            current = getattr(current, part)
+        except Exception:
+            return None
+    return current
+
+
+__all__ = [
+    "RuntimeEnvironmentInfo",
+    "detect_runtime_environment",
+]

--- a/src/traceml_ai/runtime/environment.py
+++ b/src/traceml_ai/runtime/environment.py
@@ -6,10 +6,11 @@
 
 """Runtime environment classification for a TraceML training rank.
 
-This module classifies the local runtime environment so a future sampler can
-persist rank-scoped context such as topology, torch.distributed state, and the
-observed training strategy. It is not transport metadata: TCP envelope `meta`
-continues to describe the sender, while this data belongs in a sampler body row.
+This module classifies the local runtime environment so the runtime environment
+sampler can persist rank-scoped context such as topology, torch.distributed
+state, and the observed training strategy. It is not transport metadata: TCP
+envelope `meta` continues to describe the sender, while this data belongs in a
+sampler body row.
 """
 
 from __future__ import annotations
@@ -54,7 +55,7 @@ class RuntimeEnvironmentInfo:
     strategy_confidence: str
 
     def to_record(self) -> dict[str, Any]:
-        """Return a JSON/msgpack-safe body row for future sampler transport."""
+        """Return a JSON/msgpack-safe body row for sampler transport."""
         return {
             "topology": self.topology,
             "distributed_initialized": bool(self.distributed_initialized),

--- a/src/traceml_ai/runtime/environment_state.py
+++ b/src/traceml_ai/runtime/environment_state.py
@@ -1,0 +1,83 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-local state for one-shot runtime environment telemetry.
+
+Runtime environment data is rank-scoped context that later travels as sampler
+body rows. This module keeps first-publish-wins state separate from transport
+metadata and from the detector itself.
+"""
+
+from __future__ import annotations
+
+import time
+from queue import Empty, Full, Queue
+from typing import Any
+
+from traceml_ai.runtime.environment import RuntimeEnvironmentInfo
+
+_RUNTIME_ENVIRONMENT_QUEUE: Queue = Queue(maxsize=10)
+_PUBLISHED = False
+
+
+def publish_runtime_environment_once(info: RuntimeEnvironmentInfo) -> bool:
+    """Publish one runtime environment record for this process.
+
+    The first successful publish wins for the lifetime of the process. Later
+    calls are ignored because strategy changes are intentionally out of scope
+    for this version. Returns True only when a new row was queued.
+    """
+    global _PUBLISHED
+
+    if _PUBLISHED:
+        return False
+
+    row = {
+        "seq": 0,
+        "ts": time.time(),
+        **info.to_record(),
+    }
+    try:
+        _RUNTIME_ENVIRONMENT_QUEUE.put_nowait(row)
+    except Full:
+        return False
+
+    _PUBLISHED = True
+    return True
+
+
+def pop_runtime_environment_record() -> dict[str, Any] | None:
+    """Return one pending runtime environment row, if present."""
+    try:
+        row = _RUNTIME_ENVIRONMENT_QUEUE.get_nowait()
+    except Empty:
+        return None
+    return row if isinstance(row, dict) else None
+
+
+def has_runtime_environment_info() -> bool:
+    """Return True after this process has published runtime environment info."""
+    return bool(_PUBLISHED)
+
+
+def reset_runtime_environment_state() -> None:
+    """Reset process-local runtime environment state for tests."""
+    global _PUBLISHED
+
+    while True:
+        try:
+            _RUNTIME_ENVIRONMENT_QUEUE.get_nowait()
+        except Empty:
+            break
+    _PUBLISHED = False
+
+
+__all__ = [
+    "has_runtime_environment_info",
+    "pop_runtime_environment_record",
+    "publish_runtime_environment_once",
+    "reset_runtime_environment_state",
+]

--- a/src/traceml_ai/runtime/environment_state.py
+++ b/src/traceml_ai/runtime/environment_state.py
@@ -6,9 +6,9 @@
 
 """Process-local state for one-shot runtime environment telemetry.
 
-Runtime environment data is rank-scoped context that later travels as sampler
-body rows. This module keeps first-publish-wins state separate from transport
-metadata and from the detector itself.
+Runtime environment data is one rank-scoped context row that later travels as
+sampler body data. This module keeps first-publish-wins state separate from
+transport metadata and from the detector itself.
 """
 
 from __future__ import annotations

--- a/src/traceml_ai/runtime/sampler_registry.py
+++ b/src/traceml_ai/runtime/sampler_registry.py
@@ -9,6 +9,9 @@ from traceml_ai.core import Registry
 from traceml_ai.loggers.error_log import get_error_logger
 from traceml_ai.samplers.base_sampler import BaseSampler
 from traceml_ai.samplers.process_sampler import ProcessSampler
+from traceml_ai.samplers.runtime_environment_sampler import (
+    RuntimeEnvironmentSampler,
+)
 from traceml_ai.samplers.stdout_stderr_sampler import StdoutStderrSampler
 from traceml_ai.samplers.step_memory_sampler import StepMemorySampler
 from traceml_ai.samplers.step_time_sampler import StepTimeSampler
@@ -70,6 +73,11 @@ def _spec(
 DEFAULT_SAMPLER_REGISTRY: Registry[SamplerSpec] = Registry(
     [
         _spec("system", SystemSampler, rank_zero_only=True),
+        _spec(
+            "runtime_environment",
+            RuntimeEnvironmentSampler,
+            drain_on_recording_stop=True,
+        ),
         _spec("process", ProcessSampler),
         _spec("stdout_stderr", StdoutStderrSampler, modes=("cli",)),
         _spec(

--- a/src/traceml_ai/samplers/runtime_environment_sampler.py
+++ b/src/traceml_ai/samplers/runtime_environment_sampler.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Sampler bridge for one-shot runtime environment telemetry."""
+"""Sampler bridge for one-shot runtime environment body rows."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from traceml_ai.samplers.base_sampler import BaseSampler
 
 
 class RuntimeEnvironmentSampler(BaseSampler):
-    """Emit rank-scoped runtime environment rows queued by trace_step()."""
+    """Emit rank-scoped body rows queued by trace_step(), not TCP metadata."""
 
     def __init__(self) -> None:
         super().__init__(

--- a/src/traceml_ai/samplers/runtime_environment_sampler.py
+++ b/src/traceml_ai/samplers/runtime_environment_sampler.py
@@ -1,0 +1,33 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sampler bridge for one-shot runtime environment telemetry."""
+
+from __future__ import annotations
+
+from traceml_ai.runtime.environment_state import pop_runtime_environment_record
+from traceml_ai.samplers.base_sampler import BaseSampler
+
+
+class RuntimeEnvironmentSampler(BaseSampler):
+    """Emit rank-scoped runtime environment rows queued by trace_step()."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            sampler_name="RuntimeEnvironmentSampler",
+            table_name="RuntimeEnvironmentTable",
+        )
+
+    def sample(self) -> None:
+        """Pop one pending runtime environment row into the sampler database."""
+        try:
+            row = pop_runtime_environment_record()
+            if row is not None:
+                self._add_record(row)
+        except Exception as exc:
+            self.logger.error(
+                f"[TraceML] RuntimeEnvironmentSampler error: {exc}"
+            )

--- a/src/traceml_ai/sdk/instrumentation.py
+++ b/src/traceml_ai/sdk/instrumentation.py
@@ -36,6 +36,11 @@ from traceml_ai.instrumentation.patches.forward_auto_timer_patch import (
 from traceml_ai.instrumentation.patches.h2d_auto_timer_patch import (
     h2d_auto_timer,
 )
+from traceml_ai.runtime.environment import detect_runtime_environment
+from traceml_ai.runtime.environment_state import (
+    has_runtime_environment_info,
+    publish_runtime_environment_once,
+)
 from traceml_ai.runtime.state import (
     TraceSessionState,
     get_trace_session_state,
@@ -101,6 +106,14 @@ def _should_auto_install_optimizer_timing() -> bool:
     return getattr(cfg, "mode", "auto") == "auto"
 
 
+def _publish_runtime_environment(model: nn.Module) -> None:
+    """Queue rank-scoped runtime environment info once, fail-open."""
+    if has_runtime_environment_info():
+        return
+    info = detect_runtime_environment(model)
+    publish_runtime_environment_once(info)
+
+
 class _TraceStateMeta(type):
     @property
     def step(cls) -> int:
@@ -143,6 +156,11 @@ def trace_step(model: nn.Module):
     if _traceml_disabled():
         yield
         return
+
+    try:
+        _publish_runtime_environment(model)
+    except Exception as exc:
+        _log_instrumentation_error("runtime environment detection failed", exc)
 
     trace_state = get_trace_session_state()
     mem_tracker = StepMemoryTracker(model)

--- a/tests/runtime/test_environment.py
+++ b/tests/runtime/test_environment.py
@@ -1,0 +1,205 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from traceml_ai.runtime.environment import detect_runtime_environment
+
+
+class _FakeDistributed:
+    def __init__(
+        self,
+        *,
+        available=True,
+        initialized=True,
+        backend="nccl",
+        rank=0,
+        world_size=1,
+    ):
+        self._available = available
+        self._initialized = initialized
+        self._backend = backend
+        self._rank = rank
+        self._world_size = world_size
+
+    def is_available(self):
+        return self._available
+
+    def is_initialized(self):
+        return self._initialized
+
+    def get_backend(self):
+        return self._backend
+
+    def get_rank(self):
+        return self._rank
+
+    def get_world_size(self):
+        return self._world_size
+
+
+class _BrokenDistributed:
+    def is_available(self):
+        raise RuntimeError("distributed unavailable")
+
+    def is_initialized(self):
+        raise RuntimeError("distributed unavailable")
+
+    def get_rank(self):
+        raise RuntimeError("rank unavailable")
+
+    def get_world_size(self):
+        raise RuntimeError("world unavailable")
+
+
+class _FakeDDP:
+    pass
+
+
+class _FakeFSDP:
+    pass
+
+
+class _PlainModel:
+    pass
+
+
+def _fake_torch(*, distributed=None, ddp_cls=None, fsdp_cls=None):
+    dist = distributed or _FakeDistributed()
+    dist.fsdp = SimpleNamespace(
+        FullyShardedDataParallel=fsdp_cls,
+        fully_sharded_data_parallel=SimpleNamespace(
+            FullyShardedDataParallel=fsdp_cls
+        ),
+    )
+    return SimpleNamespace(
+        distributed=dist,
+        nn=SimpleNamespace(
+            parallel=SimpleNamespace(DistributedDataParallel=ddp_cls)
+        ),
+    )
+
+
+def test_runtime_environment_single_process_without_torch():
+    info = detect_runtime_environment(env={}, torch_loader=lambda: None)
+
+    assert info.topology == "single_process"
+    assert not info.distributed_initialized
+    assert info.distributed_backend is None
+    assert info.training_strategy == "single_process"
+    assert info.strategy_source == "topology"
+    assert info.strategy_confidence == "high"
+    assert info.to_record() == {
+        "topology": "single_process",
+        "distributed_initialized": False,
+        "distributed_backend": None,
+        "training_strategy": "single_process",
+        "strategy_source": "topology",
+        "strategy_confidence": "high",
+    }
+
+
+def test_runtime_environment_single_node_multi_process_from_env():
+    info = detect_runtime_environment(
+        env={
+            "RANK": "0",
+            "LOCAL_RANK": "0",
+            "WORLD_SIZE": "4",
+            "LOCAL_WORLD_SIZE": "4",
+            "GROUP_RANK": "0",
+        },
+        torch_loader=lambda: None,
+    )
+
+    assert info.topology == "single_node_multi_process"
+    assert info.training_strategy == "distributed_unknown"
+    assert info.strategy_source == "topology"
+    assert info.strategy_confidence == "low"
+
+
+def test_runtime_environment_multi_node_from_env():
+    info = detect_runtime_environment(
+        env={
+            "RANK": "5",
+            "LOCAL_RANK": "1",
+            "WORLD_SIZE": "8",
+            "LOCAL_WORLD_SIZE": "4",
+            "GROUP_RANK": "1",
+        },
+        torch_loader=lambda: None,
+    )
+
+    assert info.topology == "multi_node"
+    assert info.training_strategy == "distributed_unknown"
+
+
+def test_runtime_environment_detects_ddp_model():
+    torch = _fake_torch(
+        distributed=_FakeDistributed(world_size=4),
+        ddp_cls=_FakeDDP,
+    )
+
+    info = detect_runtime_environment(
+        model=_FakeDDP(),
+        env={"RANK": "0", "WORLD_SIZE": "4", "LOCAL_WORLD_SIZE": "4"},
+        torch_loader=lambda: torch,
+    )
+
+    assert info.training_strategy == "ddp"
+    assert info.strategy_source == "runtime_model"
+    assert info.strategy_confidence == "high"
+
+
+def test_runtime_environment_detects_fsdp_model():
+    torch = _fake_torch(
+        distributed=_FakeDistributed(world_size=4),
+        fsdp_cls=_FakeFSDP,
+    )
+
+    info = detect_runtime_environment(
+        model=_FakeFSDP(),
+        env={"RANK": "0", "WORLD_SIZE": "4", "LOCAL_WORLD_SIZE": "4"},
+        torch_loader=lambda: torch,
+    )
+
+    assert info.training_strategy == "fsdp"
+    assert info.strategy_source == "runtime_model"
+    assert info.strategy_confidence == "high"
+
+
+def test_runtime_environment_captures_distributed_backend():
+    torch = _fake_torch(
+        distributed=_FakeDistributed(
+            initialized=True,
+            backend="gloo",
+            rank=1,
+            world_size=2,
+        )
+    )
+
+    info = detect_runtime_environment(env={}, torch_loader=lambda: torch)
+
+    assert info.topology == "multi_node"
+    assert info.distributed_initialized
+    assert info.distributed_backend == "gloo"
+    assert info.training_strategy == "distributed_unknown"
+    assert info.strategy_source == "runtime_distributed"
+
+
+def test_runtime_environment_degrades_when_distributed_raises():
+    torch = _fake_torch(distributed=_BrokenDistributed())
+
+    info = detect_runtime_environment(
+        model=_PlainModel(),
+        env={"RANK": "0", "WORLD_SIZE": "2", "LOCAL_WORLD_SIZE": "2"},
+        torch_loader=lambda: torch,
+    )
+
+    assert info.topology == "single_node_multi_process"
+    assert not info.distributed_initialized
+    assert info.distributed_backend is None
+    assert info.training_strategy == "distributed_unknown"
+    assert info.strategy_confidence == "low"

--- a/tests/runtime/test_environment_state.py
+++ b/tests/runtime/test_environment_state.py
@@ -1,0 +1,60 @@
+import pytest
+
+from traceml_ai.runtime.environment import RuntimeEnvironmentInfo
+from traceml_ai.runtime import environment_state
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_environment_state():
+    environment_state.reset_runtime_environment_state()
+    yield
+    environment_state.reset_runtime_environment_state()
+
+
+def _info(strategy: str = "single_process") -> RuntimeEnvironmentInfo:
+    return RuntimeEnvironmentInfo(
+        topology="single_process",
+        distributed_initialized=False,
+        distributed_backend=None,
+        training_strategy=strategy,
+        strategy_source="topology",
+        strategy_confidence="high",
+    )
+
+
+def test_publish_once_drain_once_and_reset(monkeypatch) -> None:
+    monkeypatch.setattr(environment_state.time, "time", lambda: 123.5)
+
+    assert environment_state.has_runtime_environment_info() is False
+    assert environment_state.publish_runtime_environment_once(_info()) is True
+    assert environment_state.has_runtime_environment_info() is True
+
+    row = environment_state.pop_runtime_environment_record()
+    assert row == {
+        "seq": 0,
+        "ts": 123.5,
+        "topology": "single_process",
+        "distributed_initialized": False,
+        "distributed_backend": None,
+        "training_strategy": "single_process",
+        "strategy_source": "topology",
+        "strategy_confidence": "high",
+    }
+    assert environment_state.pop_runtime_environment_record() is None
+
+    environment_state.reset_runtime_environment_state()
+
+    assert environment_state.has_runtime_environment_info() is False
+    assert environment_state.pop_runtime_environment_record() is None
+
+
+def test_second_publish_is_ignored() -> None:
+    assert environment_state.publish_runtime_environment_once(_info("ddp"))
+    assert not environment_state.publish_runtime_environment_once(
+        _info("fsdp")
+    )
+
+    row = environment_state.pop_runtime_environment_record()
+
+    assert row is not None
+    assert row["training_strategy"] == "ddp"

--- a/tests/runtime/test_runtime_environment_sampler.py
+++ b/tests/runtime/test_runtime_environment_sampler.py
@@ -1,0 +1,77 @@
+import pytest
+
+from traceml_ai.runtime.environment import RuntimeEnvironmentInfo
+from traceml_ai.runtime.environment_state import (
+    publish_runtime_environment_once,
+    reset_runtime_environment_state,
+)
+from traceml_ai.runtime.sender import SenderIdentity
+from traceml_ai.samplers.runtime_environment_sampler import (
+    RuntimeEnvironmentSampler,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_environment_state():
+    reset_runtime_environment_state()
+    yield
+    reset_runtime_environment_state()
+
+
+def _info(strategy: str = "ddp") -> RuntimeEnvironmentInfo:
+    return RuntimeEnvironmentInfo(
+        topology="single_node_multi_process",
+        distributed_initialized=True,
+        distributed_backend="nccl",
+        training_strategy=strategy,
+        strategy_source="runtime_model",
+        strategy_confidence="high",
+    )
+
+
+def test_sampler_emits_no_row_before_publish() -> None:
+    sampler = RuntimeEnvironmentSampler()
+
+    sampler.sample()
+
+    assert sampler.db.get_table("RuntimeEnvironmentTable") is None
+    assert sampler.sender.collect_payload() is None
+
+
+def test_sampler_drains_one_published_environment_row() -> None:
+    publish_runtime_environment_once(_info())
+    sampler = RuntimeEnvironmentSampler()
+
+    sampler.sample()
+    sampler.sample()
+
+    rows = list(sampler.db.get_table("RuntimeEnvironmentTable") or [])
+    assert len(rows) == 1
+    assert rows[0]["seq"] == 0
+    assert rows[0]["training_strategy"] == "ddp"
+    assert rows[0]["distributed_backend"] == "nccl"
+
+
+def test_sender_envelope_body_contains_runtime_environment_table() -> None:
+    publish_runtime_environment_once(_info("fsdp"))
+    sampler = RuntimeEnvironmentSampler()
+    sampler.sender.identity = SenderIdentity(
+        global_rank=3,
+        local_rank=1,
+        world_size=8,
+        local_world_size=4,
+        node_rank=0,
+        hostname="worker-0",
+        pid=1234,
+    )
+
+    sampler.sample()
+    payload = sampler.sender.collect_payload()
+
+    assert payload is not None
+    assert payload["meta"]["sampler"] == "RuntimeEnvironmentSampler"
+    assert payload["meta"]["global_rank"] == 3
+    rows = payload["body"]["tables"]["RuntimeEnvironmentTable"]
+    assert len(rows) == 1
+    assert rows[0]["training_strategy"] == "fsdp"
+    assert rows[0]["strategy_source"] == "runtime_model"

--- a/tests/runtime/test_sampler_registry.py
+++ b/tests/runtime/test_sampler_registry.py
@@ -80,6 +80,7 @@ def _selected_keys(
 def test_watch_cli_selects_host_process_and_stdout_samplers() -> None:
     assert _selected_keys(profile="watch", mode="cli") == (
         "system",
+        "runtime_environment",
         "process",
         "stdout_stderr",
     )
@@ -88,6 +89,7 @@ def test_watch_cli_selects_host_process_and_stdout_samplers() -> None:
 def test_watch_dashboard_omits_stdout_sampler() -> None:
     assert _selected_keys(profile="watch", mode="dashboard") == (
         "system",
+        "runtime_environment",
         "process",
     )
 
@@ -95,6 +97,7 @@ def test_watch_dashboard_omits_stdout_sampler() -> None:
 def test_run_cli_selects_step_samplers() -> None:
     assert _selected_keys(profile="run", mode="cli") == (
         "system",
+        "runtime_environment",
         "process",
         "stdout_stderr",
         "step_time",
@@ -118,6 +121,7 @@ def test_ddp_nonzero_rank_skips_rank_zero_only_system_sampler() -> None:
         is_ddp=True,
         local_rank=1,
     ) == (
+        "runtime_environment",
         "process",
         "stdout_stderr",
         "step_time",
@@ -133,6 +137,7 @@ def test_ddp_rank_zero_keeps_rank_zero_only_system_sampler() -> None:
         local_rank=0,
     ) == (
         "system",
+        "runtime_environment",
         "process",
         "stdout_stderr",
         "step_time",
@@ -143,6 +148,7 @@ def test_ddp_rank_zero_keeps_rank_zero_only_system_sampler() -> None:
 def test_unknown_profile_keeps_only_profile_agnostic_samplers() -> None:
     assert _selected_keys(profile="unknown", mode="cli") == (
         "system",
+        "runtime_environment",
         "process",
         "stdout_stderr",
     )
@@ -237,6 +243,7 @@ def test_queue_backed_samplers_are_marked_for_final_recording_drain() -> None:
     }
 
     assert specs["system"].drain_on_recording_stop is False
+    assert specs["runtime_environment"].drain_on_recording_stop is True
     assert specs["process"].drain_on_recording_stop is False
     assert specs["step_time"].drain_on_recording_stop is True
     assert specs["step_memory"].drain_on_recording_stop is True

--- a/tests/sdk/test_init_and_wrappers.py
+++ b/tests/sdk/test_init_and_wrappers.py
@@ -262,6 +262,11 @@ def _run_trace_step_once(*, mode, monkeypatch):
         "ensure_optimizer_timing_installed",
         lambda: calls.append("optimizer"),
     )
+    monkeypatch.setattr(
+        instrumentation,
+        "_publish_runtime_environment",
+        lambda model: None,
+    )
 
     model = nn.Linear(2, 2)
     with instrumentation.trace_step(model):
@@ -278,6 +283,71 @@ def test_trace_step_only_auto_installs_optimizer_timing(monkeypatch):
     assert (
         _run_trace_step_once(mode="selective", monkeypatch=monkeypatch) == []
     )
+
+
+def test_trace_step_publishes_runtime_environment_once(monkeypatch):
+    _reload_initialization_module()
+    instrumentation = _reload_instrumentation_module()
+    published = []
+
+    monkeypatch.setattr(
+        instrumentation,
+        "timed_region",
+        _noop_context_manager,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "forward_auto_timer",
+        _noop_context_manager,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "backward_auto_timer",
+        _noop_context_manager,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "h2d_auto_timer",
+        _noop_context_manager,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "StepMemoryTracker",
+        _NoopStepMemoryTracker,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "flush_step_events",
+        lambda model, step: None,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "ensure_optimizer_timing_installed",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "has_runtime_environment_info",
+        lambda: bool(published),
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "detect_runtime_environment",
+        lambda model: ("runtime-info", id(model)),
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "publish_runtime_environment_once",
+        lambda info: published.append(info) or True,
+    )
+
+    model = nn.Linear(2, 2)
+    with instrumentation.trace_step(model):
+        pass
+    with instrumentation.trace_step(model):
+        pass
+
+    assert published == [("runtime-info", id(model))]
 
 
 def test_trace_step_without_init_does_not_auto_install_optimizer_timing(

--- a/tests/telemetry/test_runtime_environment_projection.py
+++ b/tests/telemetry/test_runtime_environment_projection.py
@@ -1,0 +1,128 @@
+import sqlite3
+
+from traceml_ai.aggregator.sqlite_writers import (
+    runtime_environment as runtime_environment_projection,
+)
+from traceml_ai.telemetry.envelope import normalize_telemetry_envelope
+
+
+def _runtime_environment_payload(
+    *,
+    sampler: str = "RuntimeEnvironmentSampler",
+    tables: dict | None = None,
+) -> dict:
+    return {
+        "rank": 5,
+        "global_rank": 5,
+        "local_rank": 1,
+        "world_size": 8,
+        "local_world_size": 4,
+        "node_rank": 1,
+        "hostname": "worker-1",
+        "pid": 4321,
+        "sampler": sampler,
+        "timestamp": 123.0,
+        "tables": (
+            tables
+            if tables is not None
+            else {
+                "RuntimeEnvironmentTable": [
+                    {
+                        "seq": 0,
+                        "ts": 123.25,
+                        "topology": "single_node_multi_process",
+                        "distributed_initialized": True,
+                        "distributed_backend": "nccl",
+                        "training_strategy": "ddp",
+                        "strategy_source": "runtime_model",
+                        "strategy_confidence": "high",
+                    }
+                ]
+            }
+        ),
+    }
+
+
+def _envelope(payload: dict):
+    envelope = normalize_telemetry_envelope(payload)
+    assert envelope is not None
+    return envelope
+
+
+def test_runtime_environment_projection_creates_table() -> None:
+    conn = sqlite3.connect(":memory:")
+    runtime_environment_projection.init_schema(conn)
+
+    tables = {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table';"
+        )
+    }
+
+    assert "runtime_environment" in tables
+
+
+def test_runtime_environment_projection_inserts_identity_and_strategy() -> (
+    None
+):
+    conn = sqlite3.connect(":memory:")
+    runtime_environment_projection.init_schema(conn)
+
+    rows = runtime_environment_projection.build_rows(
+        _envelope(_runtime_environment_payload()),
+        recv_ts_ns=999,
+    )
+    runtime_environment_projection.insert_rows(conn, rows)
+
+    row = conn.execute(
+        """
+        SELECT recv_ts_ns, rank, global_rank, local_rank, world_size,
+               local_world_size, node_rank, hostname, pid, sample_ts_s, seq,
+               topology, distributed_initialized, distributed_backend,
+               training_strategy, strategy_source, strategy_confidence
+        FROM runtime_environment;
+        """
+    ).fetchone()
+
+    assert row == (
+        999,
+        5,
+        5,
+        1,
+        8,
+        4,
+        1,
+        "worker-1",
+        4321,
+        123.25,
+        0,
+        "single_node_multi_process",
+        1,
+        "nccl",
+        "ddp",
+        "runtime_model",
+        "high",
+    )
+
+
+def test_runtime_environment_projection_ignores_non_matching_sampler() -> None:
+    rows = runtime_environment_projection.build_rows(
+        _envelope(_runtime_environment_payload(sampler="ProcessSampler")),
+        recv_ts_ns=999,
+    )
+
+    assert rows == {"runtime_environment": []}
+
+
+def test_runtime_environment_projection_ignores_malformed_payload() -> None:
+    rows = runtime_environment_projection.build_rows(
+        _envelope(
+            _runtime_environment_payload(
+                tables={"UnexpectedTable": [{"training_strategy": "ddp"}]}
+            )
+        ),
+        recv_ts_ns=999,
+    )
+
+    assert rows == {"runtime_environment": []}


### PR DESCRIPTION
## What changed

This adds one-shot runtime environment metadata for each traced training rank.

- Adds a runtime environment detector that classifies process topology as `single_process`, `single_node_multi_process`, or `multi_node`.
- Captures whether `torch.distributed` is initialized, the distributed backend, and the observed training strategy when TraceML can identify it from the runtime model wrapper (`ddp` or `fsdp`).
- Publishes this runtime environment record once from `trace_step(model)` using process-local state, with fail-open behavior if detection cannot run.
- Adds `RuntimeEnvironmentSampler` and registers it in the default sampler registry so the queued row is drained with normal sampler payloads.
- Adds a SQLite projection writer and `runtime_environment` table containing rank identity, topology, distributed state, backend, strategy source, and confidence.
- Adds focused coverage for detection, one-shot state, sampler payloads, registry selection, SDK publish behavior, and SQLite projection.

## Why

TraceML needs rank-scoped runtime context in persisted telemetry, separate from TCP sender metadata.

Downstream analysis can see samples from ranks but cannot easily tell whether they came from a single process, single-node DDP/FSDP, or multi-node distributed training. Persisting this small context row helps future reporting and diagnostics explain runtime behavior with the right topology and training-strategy assumptions.

## How I tested

Focused tests for the changed runtime, sampler, SDK, registry, and SQLite projection paths:

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/runtime/test_environment.py \
  tests/runtime/test_environment_state.py \
  tests/runtime/test_runtime_environment_sampler.py \
  tests/runtime/test_sampler_registry.py \
  tests/sdk/test_init_and_wrappers.py \
  tests/telemetry/test_runtime_environment_projection.py \
  -q
```

Result:

```text
52 passed, 1 warning in 3.56s
```

The warning was the existing PyTorch `pynvml` deprecation warning from
`torch/cuda/__init__.py`.

- [x] Tests added or updated
- [x] Existing tests run
- [ ] Manual smoke test
- [ ] Not run; reason:

## Runtime impact

- [ ] No training-path impact
- [x] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes:

This touches `trace_step(model)` by adding a one-time runtime environment detection and publish step. The detector is designed to be low overhead: it imports torch lazily, does not query CUDA, does not synchronize, performs only
environment/distributed state reads plus `isinstance` checks for DDP/FSDP, and fails open through instrumentation error logging.

Sampler/runtime impact is limited to adding a small queued row and a new default sampler that drains on recording stop. Aggregator impact is the new `runtime_environment` SQLite projection table; retention pruning is intentionally not applied to this rank-context table.

## Docs

- [ ] Updated
- [x] Not needed

## Extra context

Base comparison used for this PR body:
`version_0.3.5...runtime_metadata`.

The local repository has a `version_0.3.5` branch, but no `v0.3.5` tag; local
tags currently stop at `v0.3.4`.

Current branch commits included in this comparison:

```text
b3d3d5b runtime
c0384b7 sampler and data in db added
de362e4 added runtime
```

There are unrelated untracked local files in the working tree; this PR body is
based on the committed branch diff only.
