### PR TITLE
Add a CPU-first TraceML demo container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.DS_Store
+Thumbs.db
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.tox
+.venv
+__pycache__
+*.py[cod]
+*.egg-info
+build
+dist
+logs
+site

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN python -m pip install --no-cache-dir --timeout 120 ".[torch]" \
+    && rm -rf build src/traceml_ai.egg-info
+
+CMD ["traceml", "run", "examples/diagnosis/dataloader_bottleneck_demo.py", "--mode=summary", "--args", "--scenario", "slow"]

--- a/README.md
+++ b/README.md
@@ -46,26 +46,6 @@ TraceML produces actionable diagnostics with under 1% overhead in current benchm
 
 ## Quickstart
 
-### Try it in Docker
-
-Build the image from the repository checkout, then run the default CPU demo:
-
-```bash
-docker build -t traceml-demo .
-docker run --rm traceml-demo
-```
-
-The image installs TraceML from the checkout with PyTorch support and runs the
-slow DataLoader diagnosis demo in summary mode. The final report should identify
-the run as input-bound; no external dataset or GPU is required.
-
-If the host has the NVIDIA Container Toolkit configured and the installed
-PyTorch build supports CUDA, the same demo can optionally access the GPU:
-
-```bash
-docker run --rm --gpus all traceml-demo
-```
-
 ### 1. Install TraceML
 
 For the live browser dashboard:
@@ -184,6 +164,26 @@ TRACEML_AGGREGATOR_HOST=<node0-ip> TRACEML_AGGREGATOR_PORT=29765 \
 back to `TRACEML_*` environment variables and `traceml.yaml`. The aggregator
 endpoint is configured with `traceml serve` flags. See
 [Public API](docs/user_guide/public-api.md#direct-launch-with-traceml-serve).
+
+### Try it in Docker
+
+Build the image from the repository checkout, then run the default CPU demo:
+
+```bash
+docker build -t traceml-demo .
+docker run --rm traceml-demo
+```
+
+The image installs TraceML from the checkout with PyTorch support and runs the
+slow DataLoader diagnosis demo in summary mode. The final report should identify
+the run as input-bound; no external dataset or GPU is required.
+
+If the host has the NVIDIA Container Toolkit configured and the installed
+PyTorch build supports CUDA, the same demo can optionally access the GPU:
+
+```bash
+docker run --rm --gpus all traceml-demo
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ TraceML produces actionable diagnostics with under 1% overhead in current benchm
 
 ## Quickstart
 
+### Try it in Docker
+
+Build the image from the repository checkout, then run the default CPU demo:
+
+```bash
+docker build -t traceml-demo .
+docker run --rm traceml-demo
+```
+
+The image installs TraceML from the checkout with PyTorch support and runs the
+slow DataLoader diagnosis demo in summary mode. The final report should identify
+the run as input-bound; no external dataset or GPU is required.
+
+If the host has the NVIDIA Container Toolkit configured and the installed
+PyTorch build supports CUDA, the same demo can optionally access the GPU:
+
+```bash
+docker run --rm --gpus all traceml-demo
+```
+
 ### 1. Install TraceML
 
 For the live browser dashboard:


### PR DESCRIPTION
## What changed

- Add a root Dockerfile based on Python 3.10 slim.
- Install TraceML from the checked-out source with `.[torch]`.
- Run the slow DataLoader bottleneck demo in summary mode by default.
- Exclude repository metadata and local or generated artifacts from the image.
- Document the CPU-first build and run commands, with GPU access presented only as optional guidance for configured NVIDIA environments.

## Why

TraceML did not have a container-based first-run path. This gives new users a single-image demo that requires no host Python environment, external dataset, or GPU and prints the input-bound diagnosis requested in #216.

## How I tested

- [ ] Tests added or updated
- [ ] Existing tests run
- [x] Manual smoke test
- [ ] Not run; reason:

Validation performed in an isolated Docker context:

- `docker build -t traceml-demo .`
- `docker run --rm traceml-demo`
  - exited with status 0
  - ran on `Device: cpu`
  - completed 60 training steps
  - printed `TraceML Verdict: INPUT-BOUND / CRITICAL`
- Verified the image excludes Git metadata, OS files, Python caches, virtual environments, generated logs, and pip build artifacts.
- `git diff --check`

No unit tests were added or run because the change is limited to the container entry point, build context, and documentation; the issue's end-to-end Docker acceptance path was exercised directly.

## Runtime impact

- [x] No training-path impact
- [ ] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes: The change only adds an opt-in container entry point and documentation. The locally resolved image is about 3 GB because the current Linux PyTorch dependency set is substantial.

## Docs

- [x] Updated
- [ ] Not needed

## Extra context

The default command follows the maintainer-confirmed CPU-first scope:

```text
traceml run examples/diagnosis/dataloader_bottleneck_demo.py --mode=summary --args --scenario slow
```

The optional `--gpus all` example does not guarantee CUDA support; it is conditional on NVIDIA Container Toolkit and a CUDA-capable PyTorch installation. GPU execution was not tested and is not an acceptance requirement.

Closes #216
