### PR TITLE
docs: add PyPI downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 
 [![PyPI version](https://img.shields.io/pypi/v/traceml-ai.svg)](https://pypi.org/project/traceml-ai/)
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/traceml-ai?period=total&units=INTERNATIONAL_SYSTEM&left_color=grey&right_color=blue&left_text=downloads)](https://pepy.tech/projects/traceml-ai)
 [![CI](https://github.com/traceopt-ai/traceml/actions/workflows/ci.yml/badge.svg)](https://github.com/traceopt-ai/traceml/actions/workflows/ci.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](./LICENSE)


### PR DESCRIPTION
## What changed

Adds a PyPI Downloads badge to the README badge row, right after the existing PyPI version badge, per #225.

## Why

Closes #225. The badge row already shows a PyPI version badge but not a downloads badge, so total install counts are not visible at a glance from the README.

## How I tested

Rendered the README markdown locally and confirmed the new badge shows in the row between PyPI version and CI. The count is served live by pepy, so nothing is hardcoded.

- [ ] Tests added or updated
- [ ] Existing tests run
- [x] Manual smoke test
- [ ] Not run; reason:

## Runtime impact

- [x] No training-path impact
- [ ] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes: README-only change.

## Docs

- [x] Updated
- [ ] Not needed

## Extra context

Badge markup and colors match the exact spec in #225 (grey/blue to match the rest of the shields row).
