### PR TITLE
Straggler simplified

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 
 [![PyPI version](https://img.shields.io/pypi/v/traceml-ai.svg)](https://pypi.org/project/traceml-ai/)
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/traceml-ai?period=total&units=INTERNATIONAL_SYSTEM&left_color=grey&right_color=blue&left_text=downloads)](https://pepy.tech/projects/traceml-ai)
 [![CI](https://github.com/traceopt-ai/traceml/actions/workflows/ci.yml/badge.svg)](https://github.com/traceopt-ai/traceml/actions/workflows/ci.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](./LICENSE)

--- a/docs/developer_guide/architecture.md
+++ b/docs/developer_guide/architecture.md
@@ -104,7 +104,7 @@ Architectural risks and known structural debt. Day-to-day bugs live in the issue
 | Step / trace_step | A training iteration; `with trace_step(model)` marks the boundary that phase timing is computed against. |
 | Residual (residual_proxy) | Residual step time, `max(0, step - h2d - forward - backward - optimizer)`. |
 | INPUT_BOUND / COMPUTE_BOUND | Input wait dominates iteration time, or compute dominates the traced step. |
-| INPUT_STRAGGLER / COMPUTE_STRAGGLER / H2D_STRAGGLER / RESIDUAL_STRAGGLER / STRAGGLER | One rank is slower than typical after accounting for backward waiting; the label names the dominant timing difference, or `STRAGGLER` when mixed. |
+| INPUT_STRAGGLER / COMPUTE_STRAGGLER / H2D_STRAGGLER / STRAGGLER | Visible rank skew exists; the label names the culprit's material input, DDP-forward, or H2D excess, or `STRAGGLER` when the skew is sync-bound or unattributed. |
 | RESIDUAL_HEAVY | A large window-wide share of step time is unattributed residual time. |
 | HIGH_PRESSURE / IMBALANCE | GPU memory is near capacity, or uneven across ranks. |
 | CREEP_EARLY / CREEP_CONFIRMED | Direction-confirmed GPU-memory growth across the run, early or confirmed. |

--- a/docs/developer_guide/rank-straggler-policy.md
+++ b/docs/developer_guide/rank-straggler-policy.md
@@ -1,0 +1,122 @@
+# Rank Straggler Policy
+
+This page documents how TraceML decides that one rank in a distributed job is a
+straggler, which rank it blames, and how confident it is. It is the developer
+reference behind the Step Time rank-straggler diagnoses. For the user-facing
+walkthrough of a slow rank, see
+[Diagnosing a slow rank in DDP](../guides/ddp-slow-training-rank-straggler.md).
+
+The implementation lives in `src/traceml_ai/diagnostics/` (rule evaluation and
+culprit/victim context) and `src/traceml_ai/reporting/primary_diagnosis.py`
+(evidence assembly). The canonical policy summary is
+`src/traceml_ai/diagnostics/DIAGNOSIS.md` (Step Time section); this page expands
+on it.
+
+## Diagnosis kinds
+
+Rank-straggler diagnoses describe skew *across ranks* in a single analyzed
+window, as opposed to the single-rank bottleneck kinds (`INPUT_BOUND`,
+`COMPUTE_BOUND`, `RESIDUAL_HEAVY`).
+
+| Kind | Meaning |
+|---|---|
+| `STRAGGLER` | Visible rank skew exists, but input wait, H2D, and forward do not explain the likely culprit. |
+| `INPUT_STRAGGLER` | The culprit rank has materially higher selected-clock input wait than the victim. |
+| `COMPUTE_STRAGGLER` | DDP / default strategy only: the culprit rank has materially higher forward time than the victim. |
+| `H2D_STRAGGLER` | The culprit rank has materially higher host-to-device transfer time than the victim. |
+
+## Selected clock and eligibility
+
+Step Time diagnosis analyzes one *selected clock* for the window. It uses GPU
+event timing when every rank and step has GPU timing for the step envelope,
+input wait, and traced phase events; otherwise it falls back to explicit
+`cpu_ms` timing. All rank-straggler comparisons below are in that selected
+clock.
+
+TraceML first picks one visible synchronization phase per rank:
+
+```text
+visible_r = backward_r              # DDP / default
+visible_r = forward_r + backward_r  # FSDP
+```
+
+Only ranks with a measured visible-phase anchor and a measured step envelope are
+eligible:
+
+```text
+DDP / default: backward_r > 0 and step_time_r > 0
+FSDP:          forward_r > 0 and backward_r > 0 and step_time_r > 0
+```
+
+If fewer than two ranks are eligible, TraceML does not report a rank straggler.
+Missing visible instrumentation makes the rule abstain rather than treat a
+zero as a fast rank. Component values of `input_wait == 0` and `h2d == 0` are
+still valid measurements and are kept.
+
+## Culprit and victim selection
+
+- The **culprit** is the rank with the minimum visible value. It is the rank
+  that most likely arrived late at the synchronization phase and therefore
+  waited least in it.
+- The **victim** is the upper actual median rank by visible value. Using the
+  upper median rather than the maximum keeps the reference rank representative
+  of the group instead of a single outlier.
+
+## Straggler score
+
+The score normalizes the visible gap between victim and culprit by the victim's
+own selected-clock iteration cost:
+
+```text
+denom = input_wait_victim + step_time_victim
+score = (visible_victim - visible_culprit) / denom
+```
+
+If `score < 0.10`, TraceML does not report a rank straggler. The gap is treated
+as normal run-to-run variation rather than a real straggler.
+
+## Attribution
+
+Once the score clears the threshold, TraceML compares the culprit directly with
+the victim to explain the visible wait:
+
+```text
+input_excess   = input_wait_culprit - input_wait_victim
+h2d_excess     = h2d_culprit - h2d_victim
+forward_excess = forward_culprit - forward_victim   # DDP / default only
+```
+
+The largest material positive excess selects the kind: `INPUT_STRAGGLER`,
+`H2D_STRAGGLER`, or (DDP / default only) `COMPUTE_STRAGGLER`. DDP / default
+compute attribution requires measured forward time on both the culprit and the
+victim. If no excess explains the visible wait cost, the diagnosis stays
+`STRAGGLER` with a sync-or-unattributed component. That residual can cover
+validation, checkpointing, logging, framework orchestration, CPU stalls, or
+unobserved transfer stalls inside the timed step. It is not direct NCCL,
+all-reduce, or synchronization timing.
+
+## Training strategy context
+
+When runtime environment metadata is available, Step Time diagnosis receives an
+advisory training strategy such as `ddp` or `fsdp`. This context only chooses
+attribution behavior; it is not a public Step Time metric. Missing or
+unrecognized strategy metadata defaults to `ddp` to preserve the DDP / default
+visible-backward straggler behavior.
+
+- DDP / default stays eligible for critical rank-straggler diagnoses once
+  thresholds and confidence gates are met.
+- FSDP diagnoses are capped at warning, because collective masking can make
+  cross-rank attribution under-confident.
+
+## Confidence gates
+
+Shared Step Time diagnosis needs at least 2 steps to emit warning-only
+diagnoses, and at least 20 steps before a critical diagnosis is allowed. The
+live CLI table, dashboard, and final summary use the same gates and the same
+global-rank window loader; they differ only by the selected timing window size.
+
+## See also
+
+- [Diagnosing a slow rank in DDP](../guides/ddp-slow-training-rank-straggler.md)
+- [Reading Output](../user_guide/reading-output.md)
+- `src/traceml_ai/diagnostics/DIAGNOSIS.md` (canonical Step Time policy)

--- a/docs/guides/ddp-slow-training-rank-straggler.md
+++ b/docs/guides/ddp-slow-training-rank-straggler.md
@@ -1,11 +1,11 @@
 # Debug slow DDP training and rank stragglers
 
 Use this guide when PyTorch DDP training is slow, uneven, or controlled by one
-slow rank.
+culprit rank.
 
-TraceML compares worst-rank and median-rank timing in distributed runs. It can
-surface input stragglers, compute stragglers, mixed stragglers, and residual-heavy
-windows.
+TraceML looks for visible rank skew in distributed runs, identifies a culprit
+rank and a victim/reference rank, then attributes material culprit excess to
+input, H2D, DDP forward compute, or sync/unattributed work.
 
 For whole-run triage, start with
 [Find why PyTorch training is slow](slow-pytorch-training.md). This page stays
@@ -92,56 +92,56 @@ Start with the Step Time diagnosis.
 | Diagnosis | Meaning |
 |---|---|
 | `INPUT STRAGGLER` | one rank spends much longer waiting for input than peer ranks |
-| `COMPUTE STRAGGLER` | one rank has meaningfully more observed forward/backward/optimizer time; in FSDP this may include collective wait |
-| `H2D STRAGGLER` | one rank has meaningfully more host-to-device transfer burden than a typical rank |
-| `RESIDUAL STRAGGLER` | one rank has meaningfully more rank-local residual `residual_proxy` than a typical rank |
-| `STRAGGLER` | one rank is slower, but input wait, compute, H2D, and residual signals are mixed |
+| `COMPUTE STRAGGLER` | in DDP, the culprit rank has materially more forward-time burden than the victim rank |
+| `H2D STRAGGLER` | the culprit rank has meaningfully more host-to-device transfer burden than the victim rank |
+| `STRAGGLER` | visible rank skew exists, but input wait, H2D, and DDP forward do not explain it |
 | `INPUT-BOUND` | input work is broad, not just one bad rank |
 | `RESIDUAL-HEAVY` | meaningful residual time is not attributed to input wait, H2D, forward, backward, or optimizer work |
 
-For rank-local stragglers, TraceML first accounts for time a rank may spend
-waiting during backward because another rank arrived late. It then compares
-ranks and labels the largest timing difference among input wait, compute, H2D,
-and residual. The largest difference must be at least `1.25x` the next-largest
-difference.
+For rank stragglers, TraceML first looks for visible wait cost: in DDP this is
+the gap between the upper-median backward time and the rank with the smallest
+backward time. The smallest-backward rank is the likely culprit because it
+arrived late and waited least. TraceML then compares that culprit with the
+victim rank to see whether input wait, H2D, or DDP forward time explains the
+cost.
 
 Then inspect:
 
-- `Worst Rank`
-- worst vs median timing
+- culprit rank
+- victim/reference rank
+- visible rank skew
 - `Input Wait`
 - `Forward`
 - `Backward`
 - `Optimizer Step`
 - `Residual`
 
-## How to triage the worst rank
+## How to triage the culprit rank
 
-If the diagnosis is `INPUT STRAGGLER`, inspect input loading on the worst rank:
+If the diagnosis is `INPUT STRAGGLER`, inspect input loading on the culprit
+rank:
 
 - uneven shards or batch construction
 - rank-local preprocessing jitter
 - slow storage path on one host
 - custom collation or tokenization on one rank
 
-If the diagnosis is `COMPUTE STRAGGLER`, inspect observed compute-phase work on
-the worst rank:
+If the diagnosis is `COMPUTE STRAGGLER`, inspect DDP forward work on the
+culprit rank:
 
 - uneven input shapes
 - rank-local branching
-- extra forward, backward, or optimizer work
+- extra forward work
 - framework hooks or callbacks that run on one rank
 
 If the diagnosis is `H2D STRAGGLER`, inspect host-to-device transfer on the
-worst rank: batch shapes, transfer placement, pinned memory, and transfer
+culprit rank: batch shapes, transfer placement, pinned memory, and transfer
 jitter.
 
-If the diagnosis is `RESIDUAL STRAGGLER`, inspect rank-local host-side work on the
-worst rank: logging, checkpointing, validation, callbacks, CPU stalls, or
-unobserved transfer work.
-
-If the diagnosis is `STRAGGLER`, reduce the problem one phase at a time. Start
-with the largest timing gap on the slow rank.
+If the diagnosis is `STRAGGLER`, inspect synchronization, collectives, and
+unattributed work around the culprit rank. Explicit collective timing is not
+available yet, so this is the honest fallback when input, H2D, and DDP forward
+do not explain the visible wait cost.
 
 If the diagnosis is `RESIDUAL-HEAVY`, remember that TraceML reports residual
 time as a derived bucket. It is not direct NCCL or all-reduce timing. Inspect logging,
@@ -154,12 +154,11 @@ TraceML supports single-node multi-GPU DDP and FSDP in the current public docs.
 Multi-node DDP summary reports are supported. Multi-node FSDP uses the same
 distributed launch path as DDP, but should be validated in your environment.
 
-TraceML's clean-step rank attribution is calibrated for DDP-style backward
-synchronization. In FSDP, forward time can include parameter all-gather wait
-caused by another rank arriving late. Use this guide for FSDP rank-skew
-symptoms, but treat `COMPUTE STRAGGLER` as observed compute-phase skew, not
-proof of rank-local model compute. TraceML does not yet report explicit FSDP
-all-gather or reduce-scatter timing.
+TraceML uses backward as the visible rank-skew phase for DDP/default strategy.
+For FSDP, it uses forward + backward because sharding communication can appear
+in both phases. FSDP rank stragglers can still be attributed to input wait or
+H2D, but TraceML does not emit `COMPUTE STRAGGLER` from the FSDP rank-skew
+rule without explicit all-gather or reduce-scatter timing.
 
 ## Compare a fix
 
@@ -170,8 +169,8 @@ the old and new summaries:
 traceml compare old_run/final_summary.json new_run/final_summary.json
 ```
 
-Look for changes in total step time, worst-rank skew, input time, compute time,
-residual time, and diagnosis.
+Look for changes in total step time, visible rank skew, input time, compute
+time, residual time, and diagnosis.
 
 ## Related
 

--- a/docs/guides/low-gpu-utilization-pytorch.md
+++ b/docs/guides/low-gpu-utilization-pytorch.md
@@ -32,12 +32,11 @@ After confirming low or moderate GPU utilization, read the Step Time diagnosis.
 | Step Time diagnosis | What to do |
 |---|---|
 | `INPUT-BOUND` | Inspect input loading, preprocessing, collation, and storage. |
-| `INPUT STRAGGLER` | Inspect the slow input rank. |
-| `H2D STRAGGLER` | Inspect host-to-device transfer on the worst rank. |
-| `RESIDUAL STRAGGLER` | Inspect rank-local host-side work on the worst rank. |
+| `INPUT STRAGGLER` | Inspect input loading on the culprit rank. |
+| `H2D STRAGGLER` | Inspect host-to-device transfer on the culprit rank. |
 | `RESIDUAL-HEAVY` | Inspect work outside traced phases, such as logging, checkpointing, validation, CPU stalls, framework orchestration, or unobserved transfers. |
 | `COMPUTE-BOUND` | Inspect forward, backward, and optimizer time before changing the DataLoader. |
-| `COMPUTE STRAGGLER` or `STRAGGLER` | Inspect rank skew and the called-out worst rank. |
+| `COMPUTE STRAGGLER` or `STRAGGLER` | Inspect visible rank skew and the culprit rank. |
 | `BALANCED` | Compare against a known good run or use a heavier profiler for lower-level detail. |
 
 Low GPU utilization plus `INPUT-BOUND` is a strong signal to start with the
@@ -68,7 +67,7 @@ If residual time is high:
 If one rank is worse than the others:
 
 - use the [DDP rank straggler guide](ddp-slow-training-rank-straggler.md)
-- compare the worst rank with the median rank
+- compare the culprit rank with the victim/reference rank
 
 ## Compare a fix
 

--- a/docs/guides/slow-pytorch-training.md
+++ b/docs/guides/slow-pytorch-training.md
@@ -34,7 +34,7 @@ diagnosis or symptom.
 |---|---|
 | Step Time says `INPUT-BOUND` | [Find Input Pipeline Bottlenecks](pytorch-input-pipeline-bottleneck.md) |
 | System says `LOW_GPU_UTILIZATION` or `MODERATE_GPU_UTILIZATION` | [Debug Low GPU Utilization](low-gpu-utilization-pytorch.md) |
-| Step Time says `INPUT STRAGGLER`, `COMPUTE STRAGGLER`, `H2D STRAGGLER`, `RESIDUAL STRAGGLER`, or `STRAGGLER` | [Debug DDP Rank Stragglers](ddp-slow-training-rank-straggler.md) |
+| Step Time says `INPUT STRAGGLER`, `COMPUTE STRAGGLER`, `H2D STRAGGLER`, or `STRAGGLER` | [Debug DDP Rank Stragglers](ddp-slow-training-rank-straggler.md) |
 | Step Memory says `MEMORY CREEP` or `MEMORY RISING` | [Find PyTorch Memory Creep](pytorch-memory-creep.md) |
 | A recent change made the run slower | [Compare Runs](../user_guide/compare.md) |
 | Step Time says `COMPUTE-BOUND` or `RESIDUAL-HEAVY` | [How to Read TraceML Output](../user_guide/reading-output.md) |
@@ -48,9 +48,9 @@ Confirm the input path before tuning model compute.
 They say the GPU was not fully busy, not why it was not fully busy. Pair them
 with Step Time.
 
-`INPUT STRAGGLER`, `COMPUTE STRAGGLER`, `H2D STRAGGLER`,
-`RESIDUAL STRAGGLER`, and `STRAGGLER` are distributed rank-skew signals.
-Inspect the called-out worst rank and compare it with the median rank.
+`INPUT STRAGGLER`, `COMPUTE STRAGGLER`, `H2D STRAGGLER`, and `STRAGGLER` are
+distributed rank-skew signals. Inspect the culprit rank and compare it with the
+victim/reference rank.
 
 `MEMORY CREEP` and `MEMORY RISING` are step-memory trend signals. Inspect
 retained tensors, caches, and per-step state that may stay alive.

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -371,9 +371,10 @@ See:
 
 It means one rank is slower in the input path than the typical rank.
 
-In distributed runs, TraceML accounts for time another rank may spend waiting
-during backward. `INPUT STRAGGLER` means input-wait excess on the slowest rank
-dominates compute, H2D, and residual differences by at least `1.25x`.
+In distributed runs, TraceML first finds visible wait cost. In DDP/default
+strategy that signal comes from backward time; in FSDP it comes from forward +
+backward time. `INPUT STRAGGLER` means the likely culprit rank has material
+input-wait excess compared with the victim rank.
 
 Common causes:
 
@@ -389,19 +390,19 @@ See:
 
 ## What does `COMPUTE STRAGGLER` mean?
 
-It means one rank spends more time in observed compute phases than the typical
-rank.
+It means the likely culprit rank spends materially more time in DDP forward
+compute than the victim rank.
 
-TraceML accounts for backward time that can be explained by another rank
-arriving late. It uses `COMPUTE STRAGGLER` when compute-time excess dominates
-input wait, H2D, and residual differences by at least `1.25x`; otherwise the
-mixed case remains `STRAGGLER`.
+TraceML emits `COMPUTE STRAGGLER` from the rank-skew rule for DDP/default
+strategy only. For FSDP, forward and backward can include sharding
+communication, so unexplained rank skew remains `STRAGGLER` unless input wait
+or H2D explains it.
 
 Common causes:
 
 - uneven shapes or data
 - rank-local branching or extra work
-- compute imbalance in forward, backward, or optimizer
+- compute imbalance in forward
 
 See:
 

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -135,7 +135,7 @@ It is based on:
 - optimizer time
 - step time
 - residual / overhead
-- worst-rank vs median-rank differences in distributed runs
+- culprit/victim visible rank skew in distributed runs
 
 ### `BALANCED`
 
@@ -227,10 +227,12 @@ Meaning:
 
 TraceML uses this idea:
 
-- account for backward time that can be explained by another rank arriving late
-- compare the slowest rank to the typical rank
-- blame input wait when its worst-rank excess over peer median dominates the
-  other timing differences by at least `1.25x`
+- detect visible wait cost from backward in DDP/default, or forward + backward
+  in FSDP
+- identify the likely culprit as the rank that waited least in the visible
+  phase
+- blame input wait when the culprit has material input-wait excess compared
+  with the victim rank
 
 In simpler words:
 
@@ -246,13 +248,14 @@ Common causes:
 What to look at:
 
 - `Input Wait`
-- worst rank
+- culprit rank
+- victim/reference rank
 - skew (%)
 - diagnosis evidence
 
 What to do next:
 
-- inspect input loading on the worst rank
+- inspect input loading on the culprit rank
 - compare batch preparation across ranks
 - check for host-side interference or noisy neighbors
 
@@ -262,23 +265,21 @@ What to do next:
 
 Meaning:
 
-- one rank has meaningfully more observed compute-phase burden than a typical
-  rank
+- in DDP/default strategy, the likely culprit rank has materially more forward
+  time than the victim rank
 
-For FSDP, observed forward time may include parameter all-gather wait, so this
-is not proof of pure rank-local model compute.
+FSDP does not emit `COMPUTE STRAGGLER` from the rank-skew rule for now because
+forward and backward can include sharding communication.
 
 TraceML uses this idea:
 
-- account for backward time that can be explained by another rank arriving late
-- compare the worst rank's compute time to peer median
-- blame compute when compute-time excess dominates input wait, H2D, and
-  residual differences by at least `1.25x`
+- detect visible wait cost from backward in DDP/default strategy
+- compare the culprit rank's forward time with the victim rank
+- blame compute when the forward excess is material
 
 In simpler words:
 
-- one rank is spending more time in the observed forward, backward, or optimizer
-  phases than the others
+- one rank is spending more time in forward work than the victim rank
 
 Common causes:
 
@@ -289,17 +290,15 @@ Common causes:
 What to look at:
 
 - `Forward`
-- `Backward`
-- `Optimizer Step`
-- worst rank
+- culprit rank
+- victim/reference rank
 - skew (%)
 - diagnosis note
 
 What to do next:
 
-- inspect the called-out compute phase on the worst rank
+- inspect the called-out forward phase on the culprit rank
 - compare input shapes and rank-local logic
-- inspect imbalance in backward or optimizer time
 
 ---
 
@@ -310,7 +309,7 @@ Meaning:
 - one rank spends meaningfully more time in host-to-device transfer than a
   typical rank
 
-TraceML reports this when H2D is the largest timing difference on the slow
+TraceML reports this when H2D is the largest material excess on the culprit
 rank.
 
 Common causes:
@@ -321,30 +320,8 @@ Common causes:
 
 What to do next:
 
-- inspect batch shapes and transfer placement on the worst rank
+- inspect batch shapes and transfer placement on the culprit rank
 - compare CPU-to-GPU copy timing across ranks
-
----
-
-### `RESIDUAL STRAGGLER`
-
-Meaning:
-
-- one rank has meaningfully more rank-local residual `residual_proxy` than a
-  typical rank
-
-This is rank-local residual excess. It differs from `RESIDUAL-HEAVY`, which
-describes a window-wide residual time share.
-
-Common causes:
-
-- rank-local logging, checkpointing, validation, callbacks, CPU stalls, or
-  unobserved transfer work inside the timed step
-
-What to do next:
-
-- inspect host-side work on the worst rank
-- compare callbacks and per-rank side effects
 
 ---
 
@@ -352,15 +329,15 @@ What to do next:
 
 Meaning:
 
-- one rank is slower, but no single timing category clearly dominates
+- visible rank skew exists, but input wait, H2D, and DDP forward do not explain
+  the likely culprit
 
 In the current policy, this is used when:
 
 - the rank difference is large enough to matter
-- the largest worst-rank excess among input wait, compute, H2D, and residual
-  is less than `1.25x` the next-largest excess
+- the culprit's input wait, H2D, and DDP forward excesses are not material
 
-This is a mixed unevenness case.
+This is sync-bound or unattributed rank skew.
 
 Common causes:
 
@@ -371,7 +348,7 @@ Common causes:
 What to do next:
 
 - inspect input wait, H2D, compute, and residual signals
-- inspect the worst rank and the largest uneven phases
+- inspect sync, collective, and unattributed work around the culprit rank
 - reduce complexity by isolating one issue at a time
 
 ---
@@ -730,9 +707,9 @@ It gives:
 
 This card shows:
 
-- median vs worst step breakdown
-- gap
-- worst rank
+- median/reference vs rank breakdown
+- visible rank skew
+- culprit rank when a rank straggler is diagnosed
 - residual time
 - dominant split
 
@@ -764,11 +741,10 @@ Use these as context cards:
 |---|---|
 | `INPUT-BOUND` | inspect input loading, preprocessing, and storage |
 | `COMPUTE-BOUND` | inspect forward/backward/optimizer cost |
-| `INPUT STRAGGLER` | inspect input path on the worst rank |
-| `COMPUTE STRAGGLER` | inspect observed compute-phase skew on the worst rank |
-| `H2D STRAGGLER` | inspect host-to-device transfer on the worst rank |
-| `RESIDUAL STRAGGLER` | inspect rank-local host-side work on the worst rank |
-| `STRAGGLER` | inspect mixed rank unevenness |
+| `INPUT STRAGGLER` | inspect input path on the culprit rank |
+| `COMPUTE STRAGGLER` | inspect DDP forward work on the culprit rank |
+| `H2D STRAGGLER` | inspect host-to-device transfer on the culprit rank |
+| `STRAGGLER` | inspect sync, collective, or unattributed work around the culprit rank |
 | `RESIDUAL-HEAVY` | inspect logging, checkpointing, validation, CPU stalls, and unobserved transfer paths |
 | `MEMORY RISING` | inspect retained state and watch the next window |
 | `MEMORY CREEP` | inspect retained tensors and growing caches |
@@ -824,8 +800,8 @@ Always read:
 If you are in a hurry:
 
 1. read the diagnosis
-2. identify the worst rank if shown
-3. compare worst vs median
+2. identify the culprit rank if shown
+3. compare culprit vs victim/reference rank
 4. look at residual time or memory trend
 5. take the suggested next action
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,5 +94,6 @@ nav:
       - Public API: user_guide/public-api.md
   - Developer Guide:
       - Architecture: developer_guide/architecture.md
+      - Rank Straggler Policy: developer_guide/rank-straggler-policy.md
       - Extending TraceML: developer_guide/extending.md
       - Contributing: developer_guide/contributing.md

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -133,6 +133,19 @@ visible_r = backward_r              # DDP/default
 visible_r = forward_r + backward_r  # FSDP
 ```
 
+Only ranks with measured visible-phase anchors and a measured step envelope are
+eligible:
+
+```text
+DDP/default: backward_r > 0 and step_time_r > 0
+FSDP:        forward_r > 0 and backward_r > 0 and step_time_r > 0
+```
+
+If fewer than two ranks are eligible, TraceML does not report a rank straggler.
+Missing visible instrumentation causes this rule to abstain instead of treating
+zero as a fast rank. `input_wait == 0` and `h2d == 0` remain valid component
+values.
+
 The culprit rank is the rank with the minimum visible value. This is the rank
 that likely arrived late and therefore waited least in the visible phase. The
 victim rank is the upper actual median rank by visible value.
@@ -150,6 +163,9 @@ input_excess = input_wait_culprit - input_wait_victim
 h2d_excess = h2d_culprit - h2d_victim
 forward_excess = forward_culprit - forward_victim  # DDP/default only
 ```
+
+DDP/default compute attribution requires measured forward time on both the
+culprit and victim ranks.
 
 The largest material positive excess becomes `INPUT_STRAGGLER`,
 `H2D_STRAGGLER`, or, for DDP/default only, `COMPUTE_STRAGGLER`. If no such

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -65,11 +65,14 @@ Training-step timing.
 - `NO_DATA`: no usable step-time data.
 - `WARMUP`: some data exists, but not enough for diagnosis.
 - `BALANCED`: no clear timing bottleneck or rank straggler.
-- `STRAGGLER`: one rank has a mixed clean-step straggler signal.
-- `INPUT_STRAGGLER`: one rank has materially higher selected-clock input wait.
-- `COMPUTE_STRAGGLER`: one rank has materially higher clean compute time.
-- `H2D_STRAGGLER`: one rank has materially higher host-to-device transfer time.
-- `RESIDUAL_STRAGGLER`: one rank has materially higher residual `residual_proxy`.
+- `STRAGGLER`: visible rank skew exists, but input wait, H2D, and DDP forward
+  do not explain the likely culprit.
+- `INPUT_STRAGGLER`: the culprit rank has materially higher selected-clock
+  input wait than the victim rank.
+- `COMPUTE_STRAGGLER`: in DDP/default strategy, the culprit rank has
+  materially higher forward time than the victim rank.
+- `H2D_STRAGGLER`: the culprit rank has materially higher host-to-device
+  transfer time than the victim rank.
 - `INPUT_BOUND`: selected-clock input wait dominates iteration time.
 - `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical step.
 - `RESIDUAL_HEAVY`: unattributed residual time is a material share of the step.
@@ -105,10 +108,10 @@ When runtime environment metadata is available, Step Time diagnosis also
 receives an advisory training strategy such as `ddp` or `fsdp`. This context is
 used only to choose diagnosis attribution behavior; it is not a public Step
 Time metric. Missing or unrecognized strategy metadata defaults to `ddp` to
-preserve the current straggler behavior. DDP remains eligible for critical
-Step Time diagnoses once thresholds and confidence gates are met. FSDP Step
-Time diagnoses are capped at warning because collective masking can make
-attribution under-confident.
+preserve the DDP/default visible-backward straggler behavior. DDP remains
+eligible for critical Step Time diagnoses once thresholds and confidence gates
+are met. FSDP Step Time diagnoses are capped at warning because collective
+masking can make attribution under-confident.
 
 `RESIDUAL_HEAVY` is not a communication diagnosis. `residual_ms` is residual
 unattributed step time averaged from per-step clamped residuals:
@@ -122,22 +125,36 @@ residual_ms = average(max(0, traced_step_ms - known_step_ms))
 total_step_ms = CPU dataloader_ms + CPU step envelope timing
 ```
 
-Rank-local stragglers use clean-step evidence. TraceML first discounts backward
-time that can be explained by another rank's non-backward work:
+Rank stragglers use culprit/victim evidence from selected-clock timing. TraceML
+first chooses one visible synchronization phase:
 
 ```text
-residual_r = residual_proxy_r
-non_bwd_r = input_wait_r + h2d_r + forward_r + optimizer_r + residual_r
-clean_bwd_r = max(0, backward_r - max(0, max(non_bwd) - non_bwd_r))
-clean_compute_r = forward_r + clean_bwd_r + optimizer_r
-clean_step_r = input_wait_r + h2d_r + clean_compute_r + residual_r
-score = (max(clean_step) - median(clean_step)) / median(actual_step)
+visible_r = backward_r              # DDP/default
+visible_r = forward_r + backward_r  # FSDP
 ```
 
-If `score < 0.10`, TraceML does not report a rank-local straggler. Otherwise it
-blames the largest worst-rank excess over peer median among input wait, clean
-compute, H2D, and residual. The largest excess must dominate the next-largest
-excess by `1.25x`; otherwise the diagnosis stays mixed `STRAGGLER`.
+The culprit rank is the rank with the minimum visible value. This is the rank
+that likely arrived late and therefore waited least in the visible phase. The
+victim rank is the upper actual median rank by visible value.
+
+```text
+denom = input_wait_victim + step_time_victim
+score = (visible_victim - visible_culprit) / denom
+```
+
+If `score < 0.10`, TraceML does not report a rank straggler. Otherwise it
+compares the culprit directly with the victim:
+
+```text
+input_excess = input_wait_culprit - input_wait_victim
+h2d_excess = h2d_culprit - h2d_victim
+forward_excess = forward_culprit - forward_victim  # DDP/default only
+```
+
+The largest material positive excess becomes `INPUT_STRAGGLER`,
+`H2D_STRAGGLER`, or, for DDP/default only, `COMPUTE_STRAGGLER`. If no such
+excess explains the visible wait cost, the diagnosis stays `STRAGGLER` with a
+sync-or-unattributed component.
 
 It can include validation, checkpointing, logging, framework orchestration, CPU
 stalls, unobserved transfer stalls, or other work inside the timed step but

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -24,6 +24,7 @@ from ..common import (
 )
 from .context import (
     build_step_time_context,
+    compute_rank_values_from_components,
     metric_median_total,
     metric_skew,
     metric_total,
@@ -44,7 +45,6 @@ DiagnosisKind = Literal[
     "INPUT_STRAGGLER",
     "COMPUTE_STRAGGLER",
     "H2D_STRAGGLER",
-    "RESIDUAL_STRAGGLER",
     "INPUT_BOUND",
     "COMPUTE_BOUND",
     "RESIDUAL_HEAVY",
@@ -58,7 +58,6 @@ _STATUS_BY_KIND: dict[DiagnosisKind, str] = {
     "INPUT_STRAGGLER": "INPUT STRAGGLER",
     "COMPUTE_STRAGGLER": "COMPUTE STRAGGLER",
     "H2D_STRAGGLER": "H2D STRAGGLER",
-    "RESIDUAL_STRAGGLER": "RESIDUAL STRAGGLER",
     "INPUT_BOUND": "INPUT-BOUND",
     "COMPUTE_BOUND": "COMPUTE-BOUND",
     "RESIDUAL_HEAVY": "RESIDUAL-HEAVY",
@@ -69,7 +68,6 @@ _PRIMARY_KIND_PRIORITY: dict[str, int] = {
     "INPUT_STRAGGLER": 40,
     "COMPUTE_STRAGGLER": 40,
     "H2D_STRAGGLER": 40,
-    "RESIDUAL_STRAGGLER": 40,
     "INPUT_BOUND": 30,
     "RESIDUAL_HEAVY": 20,
     "COMPUTE_BOUND": 10,
@@ -428,7 +426,6 @@ def build_step_diagnosis_result(
         "INPUT_STRAGGLER",
         "COMPUTE_STRAGGLER",
         "H2D_STRAGGLER",
-        "RESIDUAL_STRAGGLER",
     }:
         worst_rank = primary_issue.ranks[0] if primary_issue.ranks else None
         primary = _mk_diag(
@@ -514,20 +511,9 @@ def build_step_diagnosis_result(
             ),
         )
 
-    fwd_rank_values = context.rank_values.get("forward", {})
-    bwd_rank_values = context.rank_values.get("backward", {})
-    opt_rank_values = context.rank_values.get("optimizer_step", {})
-    compute_rank_values = context.clean_rank_values.get("clean_compute", {})
-    if not compute_rank_values:
-        compute_rank_values = {}
-        for rank in sorted(
-            set(fwd_rank_values) | set(bwd_rank_values) | set(opt_rank_values)
-        ):
-            compute_rank_values[int(rank)] = (
-                non_negative_finite(fwd_rank_values.get(rank, 0.0))
-                + non_negative_finite(bwd_rank_values.get(rank, 0.0))
-                + non_negative_finite(opt_rank_values.get(rank, 0.0))
-            )
+    compute_rank_values = compute_rank_values_from_components(
+        context.rank_values
+    )
     (
         compute_median_ms,
         compute_worst_ms,
@@ -555,7 +541,7 @@ def build_step_diagnosis_result(
         "forward": _metric_attribution_entry(
             metric=context.forward_metric,
             metric_key="forward",
-            rank_values=fwd_rank_values,
+            rank_values=context.rank_values.get("forward", {}),
             step_total=context.step_total,
             single_rank=context.single_rank,
             phase="forward",
@@ -563,7 +549,7 @@ def build_step_diagnosis_result(
         "backward": _metric_attribution_entry(
             metric=context.backward_metric,
             metric_key="backward",
-            rank_values=bwd_rank_values,
+            rank_values=context.rank_values.get("backward", {}),
             step_total=context.step_total,
             single_rank=context.single_rank,
             phase="backward",
@@ -571,7 +557,7 @@ def build_step_diagnosis_result(
         "optimizer_step": _metric_attribution_entry(
             metric=context.optimizer_metric,
             metric_key="optimizer_step",
-            rank_values=opt_rank_values,
+            rank_values=context.rank_values.get("optimizer_step", {}),
             step_total=context.step_total,
             single_rank=context.single_rank,
             phase="optimizer",
@@ -594,7 +580,7 @@ def build_step_diagnosis_result(
         ),
         "compute": {
             "metric": "compute",
-            "phase": "clean_compute",
+            "phase": "compute",
             "median_total_ms": compute_median_ms,
             "worst_total_ms": compute_worst_ms,
             "worst_rank": compute_worst_rank,

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -39,10 +39,31 @@ class ComputeSignal:
 
 
 @dataclass(frozen=True)
-class _CleanStragglerEvidence:
+class _RankStragglerPair:
     """
-    Rank-local straggler evidence after discounting backward delay that can be
-    explained by non-backward rank skew.
+    Culprit/victim pair for visible distributed rank skew.
+
+    The culprit is the rank with the smallest visible synchronization phase:
+    it likely arrived late and therefore waited least. The victim is the upper
+    actual median rank by that same visible phase, representing a real rank
+    that paid typical waiting cost.
+    """
+
+    culprit_rank: int
+    victim_rank: int
+    culprit_value_ms: float
+    victim_value_ms: float
+    cost_ms: float
+
+
+@dataclass(frozen=True)
+class _RankStragglerEvidence:
+    """
+    Culprit-first rank straggler evidence.
+
+    The score is visible wait cost paid by the victim rank, normalized by that
+    victim's selected-clock iteration time. Component attribution compares the
+    culprit's own input/H2D/forward values against the victim rank.
     """
 
     kind: str
@@ -51,13 +72,13 @@ class _CleanStragglerEvidence:
     metric: str
     phase: str
     score: float
-    worst_rank: Optional[int]
-    clean_step_median_ms: float
-    clean_step_worst_ms: float
-    clean_step_slack_ms: float
-    typical_step_ms: float
-    top_excess_ms: float
-    second_excess_ms: float
+    culprit_rank: int
+    victim_rank: int
+    visible_metric: str
+    visible_culprit_ms: float
+    visible_victim_ms: float
+    visible_cost_ms: float
+    iteration_time_ms: float
     component_excesses_ms: Dict[str, float]
 
 
@@ -104,8 +125,7 @@ class StepTimeAnalysisContext:
     largest_compute: Optional[ComputeSignal]
 
     rank_values: Dict[str, Dict[int, float]]
-    clean_rank_values: Dict[str, Dict[int, float]]
-    clean_straggler: Optional[_CleanStragglerEvidence]
+    rank_straggler: Optional[_RankStragglerEvidence]
 
 
 def non_negative_finite(value: float) -> float:
@@ -249,180 +269,167 @@ def metric_excess(metric: Optional[StepCombinedTimeMetric]) -> float:
     return max(0.0, metric_worst_total(metric) - metric_median_total(metric))
 
 
-def _clean_rank_timings(
-    per_rank_timing: Dict[int, Dict[str, float]],
-) -> Dict[str, Dict[int, float]]:
+def _rank_straggler_pair(
+    visible_values: Dict[int, float],
+) -> Optional[_RankStragglerPair]:
     """
-    Return clean rank-local timings used for straggler diagnosis.
+    Return the culprit and victim ranks for visible synchronization skew.
 
-    The policy discounts backward time that can be explained by another rank's
-    non-backward work in the same averaged/aligned window:
-
-        residual_r = current residual_proxy_r
-        non_bwd_r = INPUT_WAIT_r + H2D_r + FWD_r + OPT_r + RESIDUAL_r
-        clean_bwd_r = max(0, BWD_r - max(0, max(non_bwd) - non_bwd_r))
-        clean_compute_r = FWD_r + clean_bwd_r + OPT_r
-        clean_step_r = INPUT_WAIT_r + H2D_r + clean_compute_r + RESIDUAL_r
-        score = (max(clean_step) - median(clean_step)) / median(actual_step)
+    The culprit is the rank with the smallest visible phase. The victim is the
+    upper actual median rank by that same phase. Both are real observed ranks,
+    which keeps two-rank and even-world-size comparisons easy to explain.
     """
-    if not per_rank_timing:
-        return {}
-
-    ranks = sorted(int(rank) for rank in per_rank_timing)
-    non_bwd = {
-        rank: (
-            non_negative_finite(per_rank_timing[rank].get("input_wait", 0.0))
-            + non_negative_finite(per_rank_timing[rank].get("h2d", 0.0))
-            + non_negative_finite(per_rank_timing[rank].get("forward", 0.0))
-            + non_negative_finite(
-                per_rank_timing[rank].get("optimizer_step", 0.0)
-            )
-            + non_negative_finite(
-                per_rank_timing[rank].get("residual_proxy", 0.0)
-            )
-        )
-        for rank in ranks
-    }
-    non_bwd_max = max(non_bwd.values()) if non_bwd else 0.0
-
-    out = {
-        "input_wait": {},
-        "h2d": {},
-        "forward": {},
-        "backward": {},
-        "optimizer_step": {},
-        "residual_proxy": {},
-        "total_step": {},
-        "non_backward": {},
-        "clean_backward": {},
-        "clean_compute": {},
-        "clean_step": {},
-    }
-    for rank in ranks:
-        values = per_rank_timing[rank]
-        input_wait = non_negative_finite(values.get("input_wait", 0.0))
-        h2d = non_negative_finite(values.get("h2d", 0.0))
-        forward = non_negative_finite(values.get("forward", 0.0))
-        backward = non_negative_finite(values.get("backward", 0.0))
-        optimizer = non_negative_finite(values.get("optimizer_step", 0.0))
-        residual = non_negative_finite(values.get("residual_proxy", 0.0))
-        total_step = non_negative_finite(values.get("total_step", 0.0))
-
-        explained_bwd_delay = max(0.0, non_bwd_max - non_bwd[rank])
-        clean_backward = max(0.0, backward - explained_bwd_delay)
-        clean_compute = forward + clean_backward + optimizer
-        clean_step = input_wait + h2d + clean_compute + residual
-
-        out["input_wait"][rank] = input_wait
-        out["h2d"][rank] = h2d
-        out["forward"][rank] = forward
-        out["backward"][rank] = backward
-        out["optimizer_step"][rank] = optimizer
-        out["residual_proxy"][rank] = residual
-        out["total_step"][rank] = total_step
-        out["non_backward"][rank] = non_bwd[rank]
-        out["clean_backward"][rank] = clean_backward
-        out["clean_compute"][rank] = clean_compute
-        out["clean_step"][rank] = clean_step
-
-    return out
-
-
-def _clean_straggler_evidence(
-    *,
-    clean_rank_values: Dict[str, Dict[int, float]],
-    score_threshold: float,
-    dominance_tolerance: float,
-) -> Optional[_CleanStragglerEvidence]:
-    """Return rank-local clean-step straggler evidence, if material."""
-    clean_steps = clean_rank_values.get("clean_step", {})
-    actual_steps = clean_rank_values.get("total_step", {})
-    if len(clean_steps) <= 1 or not actual_steps:
+    if len(visible_values) <= 1:
         return None
 
-    median_clean, worst_clean, worst_rank, clean_slack = _rank_stats(
-        clean_steps
+    clean = {
+        int(rank): non_negative_finite(value)
+        for rank, value in visible_values.items()
+    }
+    ordered = sorted(clean, key=lambda rank: (clean[rank], int(rank)))
+    if len(ordered) <= 1:
+        return None
+
+    culprit_rank = int(ordered[0])
+    victim_rank = int(ordered[len(ordered) // 2])
+    culprit_value = clean[culprit_rank]
+    victim_value = clean[victim_rank]
+    return _RankStragglerPair(
+        culprit_rank=culprit_rank,
+        victim_rank=victim_rank,
+        culprit_value_ms=culprit_value,
+        victim_value_ms=victim_value,
+        cost_ms=max(0.0, victim_value - culprit_value),
     )
-    typical_step = _median(tuple(actual_steps.values()))
-    if typical_step <= 0.0:
+
+
+def _rank_metric_value(
+    per_rank_timing: Dict[int, Dict[str, float]],
+    rank: int,
+    metric: str,
+) -> float:
+    """Return a safe metric value for one rank."""
+    return non_negative_finite(
+        per_rank_timing.get(int(rank), {}).get(str(metric), 0.0)
+    )
+
+
+def _build_rank_straggler_evidence(
+    *,
+    per_rank_timing: Dict[int, Dict[str, float]],
+    score_threshold: float,
+    training_strategy: str,
+) -> Optional[_RankStragglerEvidence]:
+    """
+    Build culprit/victim rank straggler evidence for distributed runs.
+
+    DDP/default uses backward as the visible synchronization phase. FSDP uses
+    forward + backward because FSDP can communicate on both sides of module
+    execution. Component attribution compares the culprit rank directly to the
+    victim rank and only emits a subtype for material positive excess.
+    """
+    if len(per_rank_timing) <= 1:
         return None
 
-    score = clean_slack / typical_step
-    if score < non_negative_finite(score_threshold):
-        return None
-    if worst_rank is None:
+    strategy = normalize_training_strategy(training_strategy)
+    visible_metric = "forward_backward" if strategy == "fsdp" else "backward"
+    visible_values = {
+        int(rank): (
+            _rank_metric_value(per_rank_timing, int(rank), "forward")
+            + _rank_metric_value(per_rank_timing, int(rank), "backward")
+            if strategy == "fsdp"
+            else _rank_metric_value(per_rank_timing, int(rank), "backward")
+        )
+        for rank in per_rank_timing
+    }
+    pair = _rank_straggler_pair(visible_values)
+    if pair is None:
         return None
 
+    culprit = pair.culprit_rank
+    victim = pair.victim_rank
+    iteration_time = _rank_metric_value(
+        per_rank_timing, victim, "input_wait"
+    ) + _rank_metric_value(per_rank_timing, victim, "step_time")
+    if iteration_time <= 0.0:
+        return None
+
+    score = pair.cost_ms / iteration_time
+    threshold = non_negative_finite(score_threshold)
+    if score < threshold:
+        return None
+
+    input_excess = max(
+        0.0,
+        _rank_metric_value(per_rank_timing, culprit, "input_wait")
+        - _rank_metric_value(per_rank_timing, victim, "input_wait"),
+    )
+    h2d_excess = max(
+        0.0,
+        _rank_metric_value(per_rank_timing, culprit, "h2d")
+        - _rank_metric_value(per_rank_timing, victim, "h2d"),
+    )
+    if strategy == "fsdp":
+        # FSDP interleaves collectives with forward/backward, so without
+        # explicit collective timing this rule should not emit compute
+        # stragglers from forward excess.
+        forward_excess = 0.0
+    else:
+        forward_excess = max(
+            0.0,
+            _rank_metric_value(per_rank_timing, culprit, "forward")
+            - _rank_metric_value(per_rank_timing, victim, "forward"),
+        )
+
+    component_excesses = {
+        "input": input_excess,
+        "h2d": h2d_excess,
+        "compute": forward_excess,
+    }
     components = {
-        "input": (
-            "INPUT_STRAGGLER",
-            "INPUT STRAGGLER",
-            "input_wait",
-            "input",
-        ),
+        "input": ("INPUT_STRAGGLER", "INPUT STRAGGLER", "input_wait", "input"),
+        "h2d": ("H2D_STRAGGLER", "H2D STRAGGLER", "h2d", "h2d"),
         "compute": (
             "COMPUTE_STRAGGLER",
             "COMPUTE STRAGGLER",
-            "compute",
-            "compute",
+            "forward",
+            "forward",
         ),
-        "h2d": ("H2D_STRAGGLER", "H2D STRAGGLER", "h2d", "h2d"),
-        "residual": (
-            "RESIDUAL_STRAGGLER",
-            "RESIDUAL STRAGGLER",
-            "residual_proxy",
-            "residual",
-        ),
-    }
-    source_by_component = {
-        "input": clean_rank_values.get("input_wait", {}),
-        "compute": clean_rank_values.get("clean_compute", {}),
-        "h2d": clean_rank_values.get("h2d", {}),
-        "residual": clean_rank_values.get("residual_proxy", {}),
-    }
-    component_excesses = {
-        name: max(
-            0.0,
-            non_negative_finite(values.get(worst_rank, 0.0))
-            - _median(tuple(values.values())),
-        )
-        for name, values in source_by_component.items()
     }
     ordered = sorted(
         component_excesses.items(),
-        key=lambda item: (item[1], item[0]),
-        reverse=True,
+        key=lambda item: (
+            -item[1],
+            ("input", "h2d", "compute").index(item[0]),
+        ),
     )
     top_component, top_excess = ordered[0]
-    second_excess = ordered[1][1] if len(ordered) > 1 else 0.0
-
-    tolerance = max(1.0, non_negative_finite(dominance_tolerance))
-    if top_excess <= 0.0 or top_excess < tolerance * second_excess:
+    if top_excess > 0.0 and (top_excess / iteration_time) >= threshold:
+        kind, status, metric, phase = components[top_component]
+        component = top_component
+    else:
         kind, status, metric, phase = (
             "STRAGGLER",
             "STRAGGLER",
-            "step_time",
-            "mixed",
+            visible_metric,
+            "sync",
         )
-        component = "mixed"
-    else:
-        kind, status, metric, phase = components[top_component]
-        component = top_component
+        component = "sync_or_unattributed"
 
-    return _CleanStragglerEvidence(
+    return _RankStragglerEvidence(
         kind=kind,
         status=status,
         component=component,
         metric=metric,
         phase=phase,
         score=score,
-        worst_rank=worst_rank,
-        clean_step_median_ms=median_clean,
-        clean_step_worst_ms=worst_clean,
-        clean_step_slack_ms=clean_slack,
-        typical_step_ms=typical_step,
-        top_excess_ms=top_excess,
-        second_excess_ms=second_excess,
+        culprit_rank=culprit,
+        victim_rank=victim,
+        visible_metric=visible_metric,
+        visible_culprit_ms=pair.culprit_value_ms,
+        visible_victim_ms=pair.victim_value_ms,
+        visible_cost_ms=pair.cost_ms,
+        iteration_time_ms=iteration_time,
         component_excesses_ms=component_excesses,
     )
 
@@ -487,6 +494,25 @@ def rank_values_from_metric(
         return {}
 
     return {int(rank): metric_worst_total(metric)}
+
+
+def compute_rank_values_from_components(
+    rank_values: Dict[str, Dict[int, float]],
+) -> Dict[int, float]:
+    """
+    Return rank -> forward + backward + optimizer_step from rank-value maps.
+    """
+    forward = rank_values.get("forward", {})
+    backward = rank_values.get("backward", {})
+    optimizer = rank_values.get("optimizer_step", {})
+    out: Dict[int, float] = {}
+    for rank in sorted(set(forward) | set(backward) | set(optimizer)):
+        out[int(rank)] = (
+            non_negative_finite(forward.get(rank, 0.0))
+            + non_negative_finite(backward.get(rank, 0.0))
+            + non_negative_finite(optimizer.get(rank, 0.0))
+        )
+    return out
 
 
 def build_step_time_context(
@@ -607,14 +633,13 @@ def build_step_time_context(
         if single_rank or input_wait_median <= 0.0
         else input_slack / input_wait_median
     )
-    clean_rank_values = _clean_rank_timings(local_per_rank_timing)
-    clean_straggler = _clean_straggler_evidence(
-        clean_rank_values=clean_rank_values,
+    rank_straggler = _build_rank_straggler_evidence(
+        per_rank_timing=local_per_rank_timing,
         score_threshold=thresholds.straggler_score_warn,
-        dominance_tolerance=thresholds.straggler_dominance_tolerance,
+        training_strategy=training_strategy,
     )
-    clean_compute_values = clean_rank_values.get("clean_compute", {})
-    _compute_median, _, _, _compute_slack = _rank_stats(clean_compute_values)
+    compute_rank_values = compute_rank_values_from_components(rank_values)
+    _compute_median, _, _, _compute_slack = _rank_stats(compute_rank_values)
     compute_skew_value = (
         (_compute_slack / _compute_median) if _compute_median > 0.0 else 0.0
     )
@@ -649,8 +674,7 @@ def build_step_time_context(
         iteration_time_total=iteration_time_total,
         largest_compute=largest_compute,
         rank_values=rank_values,
-        clean_rank_values=clean_rank_values,
-        clean_straggler=clean_straggler,
+        rank_straggler=rank_straggler,
     )
 
 
@@ -659,6 +683,7 @@ __all__ = [
     "StepTimeAnalysisContext",
     "build_step_time_context",
     "compute_total",
+    "compute_rank_values_from_components",
     "largest_compute_phase",
     "metric_median_total",
     "metric_excess",

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -325,22 +325,37 @@ def _build_rank_straggler_evidence(
 
     DDP/default uses backward as the visible synchronization phase. FSDP uses
     forward + backward because FSDP can communicate on both sides of module
-    execution. Component attribution compares the culprit rank directly to the
-    victim rank and only emits a subtype for material positive excess.
+    execution. Only ranks with measured visible-phase anchors and a measured
+    step envelope are eligible. Component attribution compares the culprit rank
+    directly to the victim rank and only emits a subtype for material positive
+    excess.
     """
     if len(per_rank_timing) <= 1:
         return None
 
     strategy = normalize_training_strategy(training_strategy)
     visible_metric = "forward_backward" if strategy == "fsdp" else "backward"
+    eligible_ranks = []
+    for rank in sorted(int(rank) for rank in per_rank_timing):
+        forward = _rank_metric_value(per_rank_timing, rank, "forward")
+        backward = _rank_metric_value(per_rank_timing, rank, "backward")
+        step_time = _rank_metric_value(per_rank_timing, rank, "step_time")
+        if step_time <= 0.0 or backward <= 0.0:
+            continue
+        if strategy == "fsdp" and forward <= 0.0:
+            continue
+        eligible_ranks.append(rank)
+    if len(eligible_ranks) <= 1:
+        return None
+
     visible_values = {
         int(rank): (
-            _rank_metric_value(per_rank_timing, int(rank), "forward")
-            + _rank_metric_value(per_rank_timing, int(rank), "backward")
+            _rank_metric_value(per_rank_timing, rank, "forward")
+            + _rank_metric_value(per_rank_timing, rank, "backward")
             if strategy == "fsdp"
-            else _rank_metric_value(per_rank_timing, int(rank), "backward")
+            else _rank_metric_value(per_rank_timing, rank, "backward")
         )
-        for rank in per_rank_timing
+        for rank in eligible_ranks
     }
     pair = _rank_straggler_pair(visible_values)
     if pair is None:
@@ -351,8 +366,6 @@ def _build_rank_straggler_evidence(
     iteration_time = _rank_metric_value(
         per_rank_timing, victim, "input_wait"
     ) + _rank_metric_value(per_rank_timing, victim, "step_time")
-    if iteration_time <= 0.0:
-        return None
 
     score = pair.cost_ms / iteration_time
     threshold = non_negative_finite(score_threshold)
@@ -375,10 +388,14 @@ def _build_rank_straggler_evidence(
         # stragglers from forward excess.
         forward_excess = 0.0
     else:
-        forward_excess = max(
-            0.0,
-            _rank_metric_value(per_rank_timing, culprit, "forward")
-            - _rank_metric_value(per_rank_timing, victim, "forward"),
+        culprit_forward = _rank_metric_value(
+            per_rank_timing, culprit, "forward"
+        )
+        victim_forward = _rank_metric_value(per_rank_timing, victim, "forward")
+        forward_excess = (
+            max(0.0, culprit_forward - victim_forward)
+            if culprit_forward > 0.0 and victim_forward > 0.0
+            else 0.0
         )
 
     component_excesses = {

--- a/src/traceml_ai/diagnostics/step_time/formatters.py
+++ b/src/traceml_ai/diagnostics/step_time/formatters.py
@@ -27,7 +27,6 @@ def _styled_status(diagnosis: StepDiagnosis) -> str:
         "INPUT_STRAGGLER",
         "COMPUTE_STRAGGLER",
         "H2D_STRAGGLER",
-        "RESIDUAL_STRAGGLER",
         "STRAGGLER",
         "RESIDUAL_HEAVY",
     }:

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -26,7 +26,6 @@ class DiagnosisThresholds:
 
     straggler_score_warn: float = 0.10
     straggler_score_crit: float = 0.20
-    straggler_dominance_tolerance: float = 1.25
 
     input_share_warn: float = 0.10
     input_share_crit: float = 0.20

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -60,7 +60,7 @@ class _BaseStepTimeRule(DiagnosticRule[StepTimeAnalysisContext]):
         ranks: Sequence[Optional[int]] = (),
         evidence: Optional[Dict[str, Any]] = None,
     ) -> DiagnosticIssue:
-        clean_ranks: Tuple[int, ...] = tuple(
+        issue_ranks: Tuple[int, ...] = tuple(
             int(rank) for rank in ranks if rank is not None
         )
         return DiagnosticIssue(
@@ -80,18 +80,18 @@ class _BaseStepTimeRule(DiagnosticRule[StepTimeAnalysisContext]):
             skew_pct=(
                 non_negative_finite(skew_pct) if skew_pct is not None else None
             ),
-            ranks=clean_ranks,
+            ranks=issue_ranks,
             evidence=evidence or {},
         )
 
 
 @dataclass(frozen=True)
-class CleanStragglerRule(_BaseStepTimeRule):
+class RankStragglerRule(_BaseStepTimeRule):
     """
-    Detect rank-local clean-step stragglers and classify the dominant cause.
+    Detect visible rank stragglers and classify the likely culprit cause.
     """
 
-    name: str = "clean_straggler"
+    name: str = "rank_straggler"
 
     def evaluate(
         self,
@@ -100,29 +100,36 @@ class CleanStragglerRule(_BaseStepTimeRule):
         if context.single_rank:
             return None
 
-        evidence = context.clean_straggler
+        evidence = context.rank_straggler
         if evidence is None:
             return None
 
-        rank = evidence.worst_rank
+        rank = evidence.culprit_rank
         component_label = {
             "input": "input wait",
-            "compute": "clean compute",
+            "compute": "forward compute",
             "h2d": "H2D",
-            "residual": "residual",
-            "mixed": "multiple components",
+            "sync_or_unattributed": "sync or unattributed work",
         }.get(evidence.component, evidence.component)
         if evidence.kind == "STRAGGLER":
-            summary = (
-                f"{_rank_str(rank)} is slower after backward-delay discount "
-                f"(~{_pct(evidence.score)} of a typical step); no component "
-                "dominates."
+            explanation = (
+                "no input or H2D excess explains it"
+                if context.training_strategy == "fsdp"
+                else "no input, H2D, or DDP-forward excess explains it"
             )
-            action = "Inspect input, H2D, compute, and residual time on the slow rank."
+            summary = (
+                f"{_rank_str(rank)} appears to be the culprit rank "
+                f"(~{_pct(evidence.score)} victim wait cost); "
+                f"{explanation}."
+            )
+            action = (
+                "Inspect synchronization, collectives, and unattributed work "
+                f"around {_rank_str(rank)}."
+            )
         else:
             summary = (
                 f"{_rank_str(rank)} has excess {component_label} burden "
-                f"(~{_pct(evidence.score)} of a typical step)."
+                f"explaining ~{_pct(evidence.score)} victim wait cost."
             )
             action = f"Inspect {component_label} on {_rank_str(rank)}."
 
@@ -138,20 +145,17 @@ class CleanStragglerRule(_BaseStepTimeRule):
             metric=evidence.metric,
             phase=evidence.phase,
             score=evidence.score,
-            skew_pct=(
-                evidence.clean_step_slack_ms / evidence.clean_step_median_ms
-                if evidence.clean_step_median_ms > 0.0
-                else 0.0
-            ),
+            skew_pct=evidence.score,
             ranks=(rank,),
             evidence={
                 "component": evidence.component,
-                "clean_step_median_ms": evidence.clean_step_median_ms,
-                "clean_step_worst_ms": evidence.clean_step_worst_ms,
-                "clean_step_slack_ms": evidence.clean_step_slack_ms,
-                "typical_step_ms": evidence.typical_step_ms,
-                "top_excess_ms": evidence.top_excess_ms,
-                "second_excess_ms": evidence.second_excess_ms,
+                "culprit_rank": evidence.culprit_rank,
+                "victim_rank": evidence.victim_rank,
+                "visible_metric": evidence.visible_metric,
+                "visible_culprit_ms": evidence.visible_culprit_ms,
+                "visible_victim_ms": evidence.visible_victim_ms,
+                "visible_cost_ms": evidence.visible_cost_ms,
+                "iteration_time_ms": evidence.iteration_time_ms,
                 "component_excesses_ms": evidence.component_excesses_ms,
             },
         )
@@ -253,7 +257,7 @@ class ComputeBoundRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
-        if context.clean_straggler is not None:
+        if context.rank_straggler is not None:
             return None
         if context.compute_share < context.thresholds.compute_bound_share_warn:
             return None
@@ -291,7 +295,7 @@ class ComputeBoundRule(_BaseStepTimeRule):
 DEFAULT_STEP_TIME_RULES: Tuple[
     DiagnosticRule[StepTimeAnalysisContext], ...
 ] = (
-    CleanStragglerRule(),
+    RankStragglerRule(),
     InputBoundRule(),
     ResidualHeavyRule(),
     ComputeBoundRule(),
@@ -318,9 +322,9 @@ def run_step_time_rules(
 
 __all__ = [
     "DEFAULT_STEP_TIME_RULES",
-    "CleanStragglerRule",
     "ComputeBoundRule",
     "InputBoundRule",
+    "RankStragglerRule",
     "ResidualHeavyRule",
     "run_step_time_rules",
 ]

--- a/src/traceml_ai/diagnostics/step_time/trend.py
+++ b/src/traceml_ai/diagnostics/step_time/trend.py
@@ -124,10 +124,7 @@ def build_step_trend_note(
                 f"{step_state} ({format_trend_pct(step_tr, deadband_pct=cfg.deadband_pct)})."
             )
 
-        if (
-            diagnosis_kind in {"RESIDUAL_HEAVY", "RESIDUAL_STRAGGLER"}
-            and residual_state
-        ):
+        if diagnosis_kind == "RESIDUAL_HEAVY" and residual_state:
             return (
                 "Trend: residual time is "
                 f"{residual_state} ({format_trend_pct(residual_tr, deadband_pct=cfg.deadband_pct)})."

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -73,9 +73,8 @@ section diagnoses.
 
 Selection policy:
 
-- `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`, `H2D_STRAGGLER`,
-  `RESIDUAL_STRAGGLER`, and `STRAGGLER` use rank-comparison evidence and are
-  promoted from `step_time.diagnosis`.
+- `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`, `H2D_STRAGGLER`, and `STRAGGLER`
+  use rank-comparison evidence and are promoted from `step_time.diagnosis`.
 - `RESIDUAL_HEAVY`, `INPUT_BOUND`, and `COMPUTE_BOUND` use phase-share evidence
   and are promoted from `step_time.diagnosis`.
 - `LOW_GPU_UTILIZATION_UNEXPLAINED` appears only when Step Time is `BALANCED`
@@ -144,10 +143,9 @@ other phase-share percentages use `step_time_ms`.
 ```
 
 `rank_comparison` is used for `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`,
-`H2D_STRAGGLER`, `RESIDUAL_STRAGGLER`, and `STRAGGLER`. Values come from
-`step_time.global.median[metric]` and
-`step_time.global.worst[metric]`. Generic `STRAGGLER` may contain a
-`comparisons` array instead of a single metric comparison.
+`H2D_STRAGGLER`, and `STRAGGLER`. Values come from `step_time.global` rank
+summaries. Generic `STRAGGLER` may contain a `comparisons` array instead of a
+single metric comparison.
 
 Fallback evidence types are:
 

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -26,7 +26,7 @@ Primary diagnosis policy
 ------------------------
 1. Step-time rank-skew findings become primary performance findings:
    ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``, ``H2D_STRAGGLER``,
-   ``RESIDUAL_STRAGGLER``, ``STRAGGLER``.
+   ``STRAGGLER``.
 2. Step-time phase-share findings become primary performance findings:
    ``RESIDUAL_HEAVY``, ``INPUT_BOUND``, ``COMPUTE_BOUND``.
 3. If Step Time is ``BALANCED`` and System reports low or moderate GPU
@@ -54,9 +54,8 @@ Evidence policy
 
 ``rank_comparison``
     Used for ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``,
-    ``H2D_STRAGGLER``, ``RESIDUAL_STRAGGLER``, and ``STRAGGLER``. Values come
-    from ``step_time.global.median[metric]`` and
-    ``step_time.global.worst[metric]`` because the diagnosis compares ranks.
+    ``H2D_STRAGGLER``, and ``STRAGGLER``. Values come from step-time rank
+    summaries because the diagnosis compares ranks.
 
 ``utilization_fallback``
     Used only when Step Time is balanced and System GPU utilization is low or
@@ -86,7 +85,6 @@ STRAGGLER_KINDS = {
     "INPUT_STRAGGLER",
     "COMPUTE_STRAGGLER",
     "H2D_STRAGGLER",
-    "RESIDUAL_STRAGGLER",
     "STRAGGLER",
 }
 INSUFFICIENT_STEP_TIME_KINDS = {"NO_DATA", "WARMUP"}
@@ -286,8 +284,6 @@ def _metric_for_step_time_issue(issue: Mapping[str, Any]) -> Optional[str]:
         return "compute_ms"
     if kind == "H2D_STRAGGLER":
         return "h2d_ms"
-    if kind == "RESIDUAL_STRAGGLER":
-        return "residual_ms"
     return None
 
 
@@ -305,8 +301,6 @@ def _metric_for_primary_diagnosis(
         return "compute_ms"
     if kind == "H2D_STRAGGLER":
         return "h2d_ms"
-    if kind == "RESIDUAL_STRAGGLER":
-        return "residual_ms"
     return None
 
 
@@ -477,7 +471,7 @@ def _rank_comparison_summary(
 ) -> str:
     """Return a concise primary summary for rank-comparison diagnoses."""
     if kind == "STRAGGLER":
-        return "Multiple clean-step components varied across ranks."
+        return "Visible rank skew was sync-bound or unattributed."
 
     metric = str(evidence.get("metric") or "step_time")
     phase = str(evidence.get("phase") or metric.replace("_ms", ""))

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -363,17 +363,8 @@ def _step_time_card_reason(
             f"{_global_rank_label(stats.h2d.worst_global_rank)} H2D was "
             f"slower than median global rank ({evidence})."
         )
-    if kind == "RESIDUAL_STRAGGLER":
-        evidence = _format_ms_pair(
-            stats.residual.worst_ms,
-            stats.residual.median_ms,
-        )
-        return (
-            f"{_global_rank_label(stats.residual.worst_global_rank)} residual "
-            f"time was higher than median global rank ({evidence})."
-        )
     if kind == "STRAGGLER":
-        return "Multiple clean-step components varied across ranks."
+        return "Visible rank skew was sync-bound or unattributed."
     if kind == "INPUT_BOUND":
         issue = _issue_by_kind(issues, "INPUT_BOUND")
         evidence_reason = _input_bound_evidence_reason(issue or diagnosis)

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -15,10 +15,8 @@ from traceml_ai.diagnostics.step_time.api import (
 from traceml_ai.diagnostics.step_time.context import build_step_time_context
 from traceml_ai.diagnostics.step_time.policy import SUMMARY_STEP_TIME_POLICY
 from traceml_ai.diagnostics.step_time.rules import (
-    ComputeBoundRule,
     InputBoundRule,
     RankStragglerRule,
-    ResidualHeavyRule,
 )
 from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeCoverage,
@@ -260,125 +258,6 @@ def _single_rank_step_metrics(
     )
 
 
-def test_step_time_rules_trigger_and_no_trigger_cases() -> None:
-    input_ctx = _rank_context(
-        {
-            0: _timing_row(
-                dataloader=100.0,
-                forward=20.0,
-                backward=20.0,
-                optimizer=0.0,
-            ),
-            1: _timing_row(
-                dataloader=0.0,
-                forward=20.0,
-                backward=120.0,
-                optimizer=0.0,
-            ),
-        }
-    )
-    assert RankStragglerRule().evaluate(input_ctx).kind == "INPUT_STRAGGLER"
-    assert (
-        RankStragglerRule().evaluate(
-            _time_context(*_single_rank_step_metrics())
-        )
-        is None
-    )
-
-    compute_ctx = _rank_context(
-        {
-            0: _timing_row(forward=100.0, backward=20.0, optimizer=0.0),
-            1: _timing_row(forward=20.0, backward=120.0, optimizer=0.0),
-        }
-    )
-    assert RankStragglerRule().evaluate(compute_ctx).kind == (
-        "COMPUTE_STRAGGLER"
-    )
-
-    input_bound = _time_context(
-        *_single_rank_step_metrics(
-            step=100.0,
-            dataloader=35.0,
-            forward=20.0,
-            backward=30.0,
-            optimizer=5.0,
-            residual=10.0,
-        ),
-        per_rank_timing={
-            0: _timing_row(
-                dataloader=35.0,
-                forward=20.0,
-                backward=30.0,
-                optimizer=5.0,
-                residual=10.0,
-                input_wait_gpu=35.0,
-                step_time_gpu=100.0,
-            )
-        },
-        diagnosis_clock="gpu",
-    )
-    issue = InputBoundRule().evaluate(input_bound)
-    assert issue is not None
-    assert issue.kind == "INPUT_BOUND"
-    assert issue.metric == "input_wait"
-    assert issue.phase == "input"
-    assert issue.evidence["diagnosis_clock"] == "gpu"
-    assert (
-        InputBoundRule().evaluate(
-            _time_context(
-                *_single_rank_step_metrics(dataloader=50.0),
-                per_rank_timing={
-                    0: _timing_row(
-                        dataloader=50.0,
-                        input_wait_gpu=5.0,
-                        step_time_gpu=100.0,
-                    )
-                },
-            )
-        )
-        is None
-    )
-
-    assert (
-        ResidualHeavyRule()
-        .evaluate(_time_context(*_single_rank_step_metrics(residual=20.0)))
-        .kind
-        == "RESIDUAL_HEAVY"
-    )
-    assert (
-        ResidualHeavyRule().evaluate(
-            _time_context(*_single_rank_step_metrics(residual=5.0))
-        )
-        is None
-    )
-
-    assert (
-        ComputeBoundRule()
-        .evaluate(
-            _time_context(
-                *_single_rank_step_metrics(dataloader=2.0, residual=3.0)
-            )
-        )
-        .kind
-        == "COMPUTE_BOUND"
-    )
-    assert (
-        ComputeBoundRule().evaluate(
-            _time_context(
-                *_single_rank_step_metrics(dataloader=5.0, residual=3.0),
-                per_rank_timing={
-                    0: _timing_row(
-                        dataloader=5.0,
-                        input_wait_cpu=35.0,
-                        step_time_cpu=100.0,
-                    )
-                },
-            )
-        )
-        is None
-    )
-
-
 def test_diagnosis_clock_selection_prefers_gpu_then_cpu() -> None:
     events = {
         "_traceml_internal:dataloader_next": {
@@ -513,41 +392,25 @@ def test_input_bound_rule_uses_input_wait_skew() -> None:
     assert InputBoundRule().evaluate(ctx) is None
 
 
-def test_rank_straggler_identifies_input_culprit_from_visible_wait() -> None:
-    per_rank = {
-        0: _timing_row(
-            dataloader=100.0,
-            forward=20.0,
-            backward=20.0,
-            optimizer=0.0,
-            total_step=140.0,
-        ),
-        1: _timing_row(
-            dataloader=0.0,
-            forward=20.0,
-            backward=120.0,
-            optimizer=0.0,
-            total_step=140.0,
-        ),
-    }
-    ctx = _rank_context(per_rank)
-    issue = RankStragglerRule().evaluate(ctx)
-
-    assert ctx.rank_straggler is not None
-    assert ctx.rank_straggler.culprit_rank == 0
-    assert ctx.rank_straggler.victim_rank == 1
-    assert ctx.rank_straggler.visible_cost_ms == pytest.approx(100.0)
-    assert issue is not None
-    assert issue.kind == "INPUT_STRAGGLER"
-    assert issue.ranks == (0,)
-    assert issue.evidence["component_excesses_ms"]["input"] == pytest.approx(
-        100.0
-    )
-
-
 @pytest.mark.parametrize(
     ("per_rank", "expected_kind", "expected_phase"),
     [
+        (
+            {
+                0: _timing_row(
+                    dataloader=100.0,
+                    backward=20.0,
+                    optimizer=0.0,
+                ),
+                1: _timing_row(
+                    dataloader=0.0,
+                    backward=120.0,
+                    optimizer=0.0,
+                ),
+            },
+            "INPUT_STRAGGLER",
+            "input",
+        ),
         (
             {
                 0: _timing_row(h2d=80.0, backward=20.0, optimizer=0.0),
@@ -670,58 +533,90 @@ def test_rank_straggler_not_emitted_below_visible_wait_threshold() -> None:
     assert RankStragglerRule().evaluate(ctx) is None
 
 
-def test_rank_straggler_excludes_rank_with_missing_backward() -> None:
-    per_rank = {
-        0: _timing_row(dataloader=200.0, backward=0.0, step_time=200.0),
-        1: _timing_row(dataloader=80.0, backward=20.0, step_time=100.0),
-        2: _timing_row(dataloader=0.0, backward=120.0, step_time=140.0),
-    }
-    ctx = _rank_context(per_rank)
+@pytest.mark.parametrize(
+    ("training_strategy", "per_rank", "expected"),
+    [
+        (
+            "ddp",
+            {
+                0: _timing_row(
+                    dataloader=200.0,
+                    backward=0.0,
+                    step_time=200.0,
+                ),
+                1: _timing_row(
+                    dataloader=80.0,
+                    backward=20.0,
+                    step_time=100.0,
+                ),
+                2: _timing_row(
+                    dataloader=0.0,
+                    backward=120.0,
+                    step_time=140.0,
+                ),
+            },
+            ("INPUT_STRAGGLER", 1, 2),
+        ),
+        (
+            "ddp",
+            {
+                0: _timing_row(backward=0.0, step_time=100.0),
+                1: _timing_row(backward=0.0, step_time=120.0),
+            },
+            None,
+        ),
+        (
+            "ddp",
+            {
+                0: _timing_row(
+                    dataloader=200.0,
+                    backward=1.0,
+                    step_time=0.0,
+                ),
+                1: _timing_row(
+                    dataloader=80.0,
+                    backward=20.0,
+                    step_time=100.0,
+                ),
+                2: _timing_row(
+                    dataloader=0.0,
+                    backward=120.0,
+                    step_time=140.0,
+                ),
+            },
+            ("INPUT_STRAGGLER", 1, 2),
+        ),
+        (
+            "fsdp",
+            {
+                0: _timing_row(dataloader=200.0, forward=0.0, backward=1.0),
+                1: _timing_row(dataloader=160.0, forward=10.0, backward=0.0),
+                2: _timing_row(dataloader=80.0, forward=20.0, backward=20.0),
+                3: _timing_row(dataloader=0.0, forward=80.0, backward=80.0),
+            },
+            ("INPUT_STRAGGLER", 2, 3),
+        ),
+    ],
+)
+def test_rank_straggler_uses_only_valid_visible_ranks(
+    training_strategy: str,
+    per_rank: dict[int, dict[str, float]],
+    expected: tuple[str, int, int] | None,
+) -> None:
+    ctx = _rank_context(per_rank, training_strategy=training_strategy)
+    issue = RankStragglerRule().evaluate(ctx)
 
+    if expected is None:
+        assert ctx.rank_straggler is None
+        assert issue is None
+        return
+
+    expected_kind, expected_culprit, expected_victim = expected
     assert ctx.rank_straggler is not None
-    assert ctx.rank_straggler.culprit_rank == 1
-    assert ctx.rank_straggler.victim_rank == 2
-    assert RankStragglerRule().evaluate(ctx).kind == "INPUT_STRAGGLER"
-
-
-def test_rank_straggler_abstains_when_all_backward_missing() -> None:
-    per_rank = {
-        0: _timing_row(backward=0.0, step_time=100.0),
-        1: _timing_row(backward=0.0, step_time=120.0),
-    }
-    ctx = _rank_context(per_rank)
-
-    assert ctx.rank_straggler is None
-    assert RankStragglerRule().evaluate(ctx) is None
-
-
-def test_rank_straggler_excludes_rank_with_missing_step_time() -> None:
-    per_rank = {
-        0: _timing_row(dataloader=200.0, backward=1.0, step_time=0.0),
-        1: _timing_row(dataloader=80.0, backward=20.0, step_time=100.0),
-        2: _timing_row(dataloader=0.0, backward=120.0, step_time=140.0),
-    }
-    ctx = _rank_context(per_rank)
-
-    assert ctx.rank_straggler is not None
-    assert ctx.rank_straggler.culprit_rank == 1
-    assert ctx.rank_straggler.victim_rank == 2
-    assert RankStragglerRule().evaluate(ctx).kind == "INPUT_STRAGGLER"
-
-
-def test_fsdp_rank_straggler_excludes_missing_visible_constituents() -> None:
-    per_rank = {
-        0: _timing_row(dataloader=200.0, forward=0.0, backward=1.0),
-        1: _timing_row(dataloader=160.0, forward=10.0, backward=0.0),
-        2: _timing_row(dataloader=80.0, forward=20.0, backward=20.0),
-        3: _timing_row(dataloader=0.0, forward=80.0, backward=80.0),
-    }
-    ctx = _rank_context(per_rank, training_strategy="fsdp")
-
-    assert ctx.rank_straggler is not None
-    assert ctx.rank_straggler.culprit_rank == 2
-    assert ctx.rank_straggler.victim_rank == 3
-    assert RankStragglerRule().evaluate(ctx).kind == "INPUT_STRAGGLER"
+    assert ctx.rank_straggler.culprit_rank == expected_culprit
+    assert ctx.rank_straggler.victim_rank == expected_victim
+    assert issue is not None
+    assert issue.kind == expected_kind
 
 
 def test_ddp_missing_forward_does_not_emit_compute_straggler() -> None:

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -670,6 +670,75 @@ def test_rank_straggler_not_emitted_below_visible_wait_threshold() -> None:
     assert RankStragglerRule().evaluate(ctx) is None
 
 
+def test_rank_straggler_excludes_rank_with_missing_backward() -> None:
+    per_rank = {
+        0: _timing_row(dataloader=200.0, backward=0.0, step_time=200.0),
+        1: _timing_row(dataloader=80.0, backward=20.0, step_time=100.0),
+        2: _timing_row(dataloader=0.0, backward=120.0, step_time=140.0),
+    }
+    ctx = _rank_context(per_rank)
+
+    assert ctx.rank_straggler is not None
+    assert ctx.rank_straggler.culprit_rank == 1
+    assert ctx.rank_straggler.victim_rank == 2
+    assert RankStragglerRule().evaluate(ctx).kind == "INPUT_STRAGGLER"
+
+
+def test_rank_straggler_abstains_when_all_backward_missing() -> None:
+    per_rank = {
+        0: _timing_row(backward=0.0, step_time=100.0),
+        1: _timing_row(backward=0.0, step_time=120.0),
+    }
+    ctx = _rank_context(per_rank)
+
+    assert ctx.rank_straggler is None
+    assert RankStragglerRule().evaluate(ctx) is None
+
+
+def test_rank_straggler_excludes_rank_with_missing_step_time() -> None:
+    per_rank = {
+        0: _timing_row(dataloader=200.0, backward=1.0, step_time=0.0),
+        1: _timing_row(dataloader=80.0, backward=20.0, step_time=100.0),
+        2: _timing_row(dataloader=0.0, backward=120.0, step_time=140.0),
+    }
+    ctx = _rank_context(per_rank)
+
+    assert ctx.rank_straggler is not None
+    assert ctx.rank_straggler.culprit_rank == 1
+    assert ctx.rank_straggler.victim_rank == 2
+    assert RankStragglerRule().evaluate(ctx).kind == "INPUT_STRAGGLER"
+
+
+def test_fsdp_rank_straggler_excludes_missing_visible_constituents() -> None:
+    per_rank = {
+        0: _timing_row(dataloader=200.0, forward=0.0, backward=1.0),
+        1: _timing_row(dataloader=160.0, forward=10.0, backward=0.0),
+        2: _timing_row(dataloader=80.0, forward=20.0, backward=20.0),
+        3: _timing_row(dataloader=0.0, forward=80.0, backward=80.0),
+    }
+    ctx = _rank_context(per_rank, training_strategy="fsdp")
+
+    assert ctx.rank_straggler is not None
+    assert ctx.rank_straggler.culprit_rank == 2
+    assert ctx.rank_straggler.victim_rank == 3
+    assert RankStragglerRule().evaluate(ctx).kind == "INPUT_STRAGGLER"
+
+
+def test_ddp_missing_forward_does_not_emit_compute_straggler() -> None:
+    per_rank = {
+        0: _timing_row(forward=100.0, backward=20.0, optimizer=0.0),
+        1: _timing_row(forward=0.0, backward=120.0, optimizer=0.0),
+    }
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+    )
+
+    assert result.primary.kind == "STRAGGLER"
+    assert result.issues[0].phase == "sync"
+    assert result.issues[0].evidence["component"] == "sync_or_unattributed"
+
+
 def test_rank_straggler_uses_actual_upper_median_victim_rank() -> None:
     per_rank = {
         0: _timing_row(backward=10.0, forward=10.0, optimizer=0.0),

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -15,9 +15,9 @@ from traceml_ai.diagnostics.step_time.api import (
 from traceml_ai.diagnostics.step_time.context import build_step_time_context
 from traceml_ai.diagnostics.step_time.policy import SUMMARY_STEP_TIME_POLICY
 from traceml_ai.diagnostics.step_time.rules import (
-    CleanStragglerRule,
     ComputeBoundRule,
     InputBoundRule,
+    RankStragglerRule,
     ResidualHeavyRule,
 )
 from traceml_ai.renderers.step_time.schema import (
@@ -173,12 +173,16 @@ def _metrics_from_per_rank_timing(
     return tuple(metrics)
 
 
-def _clean_context(
+def _rank_context(
     per_rank_timing: dict[int, dict[str, float]],
+    *,
+    training_strategy: str = "ddp",
 ):
-    return _time_context(
-        *_metrics_from_per_rank_timing(per_rank_timing),
+    return build_step_time_context(
+        metrics=_metrics_from_per_rank_timing(per_rank_timing),
+        thresholds=DEFAULT_THRESHOLDS,
         per_rank_timing=per_rank_timing,
+        training_strategy=training_strategy,
     )
 
 
@@ -257,27 +261,37 @@ def _single_rank_step_metrics(
 
 
 def test_step_time_rules_trigger_and_no_trigger_cases() -> None:
-    input_ctx = _clean_context(
+    input_ctx = _rank_context(
         {
-            0: _timing_row(dataloader=10.0),
-            1: _timing_row(dataloader=90.0),
+            0: _timing_row(
+                dataloader=100.0,
+                forward=20.0,
+                backward=20.0,
+                optimizer=0.0,
+            ),
+            1: _timing_row(
+                dataloader=0.0,
+                forward=20.0,
+                backward=120.0,
+                optimizer=0.0,
+            ),
         }
     )
-    assert CleanStragglerRule().evaluate(input_ctx).kind == "INPUT_STRAGGLER"
+    assert RankStragglerRule().evaluate(input_ctx).kind == "INPUT_STRAGGLER"
     assert (
-        CleanStragglerRule().evaluate(
+        RankStragglerRule().evaluate(
             _time_context(*_single_rank_step_metrics())
         )
         is None
     )
 
-    compute_ctx = _clean_context(
+    compute_ctx = _rank_context(
         {
-            0: _timing_row(forward=20.0, backward=30.0),
-            1: _timing_row(forward=90.0, backward=30.0),
+            0: _timing_row(forward=100.0, backward=20.0, optimizer=0.0),
+            1: _timing_row(forward=20.0, backward=120.0, optimizer=0.0),
         }
     )
-    assert CleanStragglerRule().evaluate(compute_ctx).kind == (
+    assert RankStragglerRule().evaluate(compute_ctx).kind == (
         "COMPUTE_STRAGGLER"
     )
 
@@ -480,7 +494,7 @@ def test_input_bound_rule_ignores_duration_without_explicit_clocks() -> None:
 
 
 def test_input_bound_rule_uses_input_wait_skew() -> None:
-    ctx = _clean_context(
+    ctx = _rank_context(
         {
             0: _timing_row(
                 dataloader=10.0,
@@ -499,7 +513,7 @@ def test_input_bound_rule_uses_input_wait_skew() -> None:
     assert InputBoundRule().evaluate(ctx) is None
 
 
-def test_clean_backward_discount_removes_telescoped_delay_from_peer() -> None:
+def test_rank_straggler_identifies_input_culprit_from_visible_wait() -> None:
     per_rank = {
         0: _timing_row(
             dataloader=100.0,
@@ -516,18 +530,18 @@ def test_clean_backward_discount_removes_telescoped_delay_from_peer() -> None:
             total_step=140.0,
         ),
     }
-    ctx = _clean_context(per_rank)
-    issue = CleanStragglerRule().evaluate(ctx)
+    ctx = _rank_context(per_rank)
+    issue = RankStragglerRule().evaluate(ctx)
 
-    assert ctx.clean_rank_values["clean_backward"][1] == pytest.approx(20.0)
-    assert ctx.clean_rank_values["clean_compute"][0] == pytest.approx(40.0)
-    assert ctx.clean_rank_values["clean_compute"][1] == pytest.approx(40.0)
-    assert ctx.clean_rank_values["clean_step"][0] == pytest.approx(140.0)
+    assert ctx.rank_straggler is not None
+    assert ctx.rank_straggler.culprit_rank == 0
+    assert ctx.rank_straggler.victim_rank == 1
+    assert ctx.rank_straggler.visible_cost_ms == pytest.approx(100.0)
     assert issue is not None
     assert issue.kind == "INPUT_STRAGGLER"
     assert issue.ranks == (0,)
     assert issue.evidence["component_excesses_ms"]["input"] == pytest.approx(
-        50.0
+        100.0
     )
 
 
@@ -536,39 +550,31 @@ def test_clean_backward_discount_removes_telescoped_delay_from_peer() -> None:
     [
         (
             {
-                0: _timing_row(forward=20.0),
-                1: _timing_row(forward=100.0),
-            },
-            "COMPUTE_STRAGGLER",
-            "compute",
-        ),
-        (
-            {
-                0: _timing_row(h2d=0.0),
-                1: _timing_row(h2d=80.0),
+                0: _timing_row(h2d=80.0, backward=20.0, optimizer=0.0),
+                1: _timing_row(h2d=0.0, backward=120.0, optimizer=0.0),
             },
             "H2D_STRAGGLER",
             "h2d",
         ),
         (
             {
-                0: _timing_row(residual=0.0),
-                1: _timing_row(residual=80.0),
+                0: _timing_row(forward=100.0, backward=20.0, optimizer=0.0),
+                1: _timing_row(forward=20.0, backward=120.0, optimizer=0.0),
             },
-            "RESIDUAL_STRAGGLER",
-            "residual",
+            "COMPUTE_STRAGGLER",
+            "forward",
         ),
         (
             {
-                0: _timing_row(dataloader=10.0, forward=20.0),
-                1: _timing_row(dataloader=60.0, forward=40.0),
+                0: _timing_row(forward=20.0, backward=20.0, optimizer=0.0),
+                1: _timing_row(forward=20.0, backward=120.0, optimizer=0.0),
             },
             "STRAGGLER",
-            "mixed",
+            "sync",
         ),
     ],
 )
-def test_clean_straggler_classifies_component_excess(
+def test_rank_straggler_classifies_culprit_excess(
     per_rank: dict[int, dict[str, float]],
     expected_kind: str,
     expected_phase: str,
@@ -579,17 +585,112 @@ def test_clean_straggler_classifies_component_excess(
     )
 
     assert result.primary.kind == expected_kind
-    assert result.primary.worst_rank == 1
+    assert result.primary.worst_rank == 0
     assert result.issues[0].phase == expected_phase
-    assert result.issues[0].evidence["clean_step_slack_ms"] > 0.0
+    assert result.issues[0].evidence["culprit_rank"] == 0
+    assert result.issues[0].evidence["victim_rank"] == 1
+    assert result.issues[0].evidence["visible_cost_ms"] > 0.0
 
 
-def test_step_time_primary_prefers_clean_straggler_over_residual_heavy() -> (
+@pytest.mark.parametrize(
+    ("per_rank", "expected_kind", "expected_phase"),
+    [
+        (
+            {
+                0: _timing_row(
+                    dataloader=100.0,
+                    forward=20.0,
+                    backward=20.0,
+                    optimizer=0.0,
+                ),
+                1: _timing_row(
+                    dataloader=0.0,
+                    forward=80.0,
+                    backward=80.0,
+                    optimizer=0.0,
+                ),
+            },
+            "INPUT_STRAGGLER",
+            "input",
+        ),
+        (
+            {
+                0: _timing_row(
+                    h2d=80.0,
+                    forward=20.0,
+                    backward=20.0,
+                    optimizer=0.0,
+                ),
+                1: _timing_row(
+                    h2d=0.0,
+                    forward=80.0,
+                    backward=80.0,
+                    optimizer=0.0,
+                ),
+            },
+            "H2D_STRAGGLER",
+            "h2d",
+        ),
+        (
+            {
+                0: _timing_row(forward=100.0, backward=20.0, optimizer=0.0),
+                1: _timing_row(forward=20.0, backward=200.0, optimizer=0.0),
+            },
+            "STRAGGLER",
+            "sync",
+        ),
+    ],
+)
+def test_fsdp_rank_straggler_uses_input_h2d_or_unattributed(
+    per_rank: dict[int, dict[str, float]],
+    expected_kind: str,
+    expected_phase: str,
+) -> None:
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+        training_strategy="fsdp",
+    )
+
+    assert result.primary.kind == expected_kind
+    assert result.primary.worst_rank == 0
+    assert result.issues[0].phase == expected_phase
+    if expected_kind == "STRAGGLER":
+        assert result.issues[0].evidence["component"] == "sync_or_unattributed"
+
+
+def test_rank_straggler_not_emitted_below_visible_wait_threshold() -> None:
+    per_rank = {
+        0: _timing_row(backward=115.0),
+        1: _timing_row(backward=120.0),
+    }
+    ctx = _rank_context(per_rank)
+
+    assert ctx.rank_straggler is None
+    assert RankStragglerRule().evaluate(ctx) is None
+
+
+def test_rank_straggler_uses_actual_upper_median_victim_rank() -> None:
+    per_rank = {
+        0: _timing_row(backward=10.0, forward=10.0, optimizer=0.0),
+        1: _timing_row(backward=20.0, forward=10.0, optimizer=0.0),
+        2: _timing_row(backward=30.0, forward=10.0, optimizer=0.0),
+        3: _timing_row(backward=40.0, forward=10.0, optimizer=0.0),
+    }
+    ctx = _rank_context(per_rank)
+
+    assert ctx.rank_straggler is not None
+    assert ctx.rank_straggler.culprit_rank == 0
+    assert ctx.rank_straggler.victim_rank == 2
+    assert ctx.rank_straggler.visible_victim_ms == pytest.approx(30.0)
+
+
+def test_step_time_primary_prefers_rank_straggler_over_residual_heavy() -> (
     None
 ):
     per_rank = {
-        0: _timing_row(dataloader=10.0, residual=80.0),
-        1: _timing_row(dataloader=110.0, residual=80.0),
+        0: _timing_row(dataloader=110.0, backward=20.0, residual=80.0),
+        1: _timing_row(dataloader=10.0, backward=120.0, residual=80.0),
     }
 
     result = build_step_diagnosis_result(

--- a/tests/reporting/summary/test_primary_diagnosis.py
+++ b/tests/reporting/summary/test_primary_diagnosis.py
@@ -211,23 +211,6 @@ def test_h2d_straggler_uses_rank_comparison_evidence() -> None:
     assert primary["evidence"]["phase"] == "h2d"
 
 
-def test_residual_straggler_uses_rank_comparison_evidence() -> None:
-    primary = _primary(
-        _step_time(
-            "RESIDUAL_STRAGGLER",
-            status="RESIDUAL STRAGGLER",
-            phase="residual",
-        )
-    )
-
-    assert primary["kind"] == "RESIDUAL_STRAGGLER"
-    assert primary["summary"] == (
-        "Rank r2 residual time was 70.0ms vs median rank r0 at 20.0ms."
-    )
-    assert primary["evidence"]["metric"] == "residual_ms"
-    assert primary["evidence"]["phase"] == "residual"
-
-
 def test_straggler_includes_input_and_compute_comparisons() -> None:
     issues = [
         {

--- a/tests/reporting/summary/test_primary_diagnosis.py
+++ b/tests/reporting/summary/test_primary_diagnosis.py
@@ -150,65 +150,55 @@ def test_compute_bound_uses_neutral_compute_phase_share() -> None:
     assert primary["evidence"]["shares"]["compute_pct"] == 75.0
 
 
-def test_input_straggler_uses_rank_comparison_evidence() -> None:
-    primary = _primary(
-        _step_time(
+@pytest.mark.parametrize(
+    (
+        "kind",
+        "phase",
+        "expected_metric",
+        "expected_summary",
+    ),
+    [
+        (
             "INPUT_STRAGGLER",
-            status="INPUT STRAGGLER",
-            phase="dataloader",
-        )
-    )
-
-    assert primary["kind"] == "INPUT_STRAGGLER"
-    assert primary["summary"] == (
-        "Rank r2 input wait was 120.0ms vs median rank r0 at 8.0ms."
-    )
-    assert primary["evidence"] == {
-        "type": "rank_comparison",
-        "steps_analyzed": 256,
-        "gpu_util_avg_percent": 87.0,
-        "metric": "input_wait_ms",
-        "phase": "dataloader",
-        "median": {"rank": 0, "value_ms": 8.0},
-        "worst": {"rank": 2, "value_ms": 120.0},
-        "delta_ms": 112.0,
-        "ratio": 15.0,
-    }
-
-
-def test_compute_straggler_uses_diagnosed_compute_phase() -> None:
-    primary = _primary(
-        _step_time(
+            "dataloader",
+            "input_wait_ms",
+            "Rank r2 input wait was 120.0ms vs median rank r0 at 8.0ms.",
+        ),
+        (
             "COMPUTE_STRAGGLER",
-            status="COMPUTE STRAGGLER",
-            phase="optimizer",
-        )
-    )
-
-    assert primary["kind"] == "COMPUTE_STRAGGLER"
-    assert primary["evidence"]["metric"] == "optimizer_ms"
-    assert primary["evidence"]["phase"] == "optimizer"
-    assert primary["evidence"]["median"] == {"rank": 3, "value_ms": 10.0}
-    assert primary["evidence"]["worst"] == {"rank": 2, "value_ms": 90.0}
-    assert primary["evidence"]["delta_ms"] == 80.0
-    assert primary["evidence"]["ratio"] == 9.0
-
-
-def test_h2d_straggler_uses_rank_comparison_evidence() -> None:
+            "optimizer",
+            "optimizer_ms",
+            None,
+        ),
+        (
+            "H2D_STRAGGLER",
+            "h2d",
+            "h2d_ms",
+            "Rank r2 h2d was 40.0ms vs median rank r1 at 10.0ms.",
+        ),
+    ],
+)
+def test_rank_stragglers_use_rank_comparison_evidence(
+    kind: str,
+    phase: str,
+    expected_metric: str,
+    expected_summary: str | None,
+) -> None:
     primary = _primary(
         _step_time(
-            "H2D_STRAGGLER",
-            status="H2D STRAGGLER",
-            phase="h2d",
+            kind,
+            status=kind.replace("_", " "),
+            phase=phase,
         )
     )
 
-    assert primary["kind"] == "H2D_STRAGGLER"
-    assert primary["summary"] == (
-        "Rank r2 h2d was 40.0ms vs median rank r1 at 10.0ms."
-    )
-    assert primary["evidence"]["metric"] == "h2d_ms"
-    assert primary["evidence"]["phase"] == "h2d"
+    assert primary["kind"] == kind
+    assert primary["evidence"]["type"] == "rank_comparison"
+    assert primary["evidence"]["metric"] == expected_metric
+    assert primary["evidence"]["phase"] == phase
+    assert primary["evidence"]["worst"]["rank"] == 2
+    if expected_summary is not None:
+        assert primary["summary"] == expected_summary
 
 
 def test_straggler_includes_input_and_compute_comparisons() -> None:


### PR DESCRIPTION
## What changed

This simplifies Step Time rank-straggler attribution for distributed training.

- Replaces the old clean-step/worst-vs-median attribution with culprit/victim attribution based on visible rank skew.
- Uses backward time as the visible skew anchor for DDP/default strategy, and  forward + backward for FSDP.
- Identifies the culprit as the rank that waited least in the visible phase and  the victim/reference rank as the upper actual median rank by visible phase.
- Attributes material culprit excess to input wait, H2D, or DDP forward time.
- Falls back to generic `STRAGGLER` when visible skew is sync-bound or  unattributed.
- Removes `RESIDUAL_STRAGGLER` from the rank-skew diagnosis set; residual  behavior remains covered by `RESIDUAL_HEAVY`.
- Abstains from rank-straggler diagnosis when visible-phase anchors or step  envelopes are missing, instead of treating missing instrumentation as a fast  rank.
- Updates final-summary primary diagnosis, Step Time report text, schema docs,  user docs, and developer docs to match the new attribution language.

## Why

The previous clean-step policy was hard to explain and could blur true culpritwork with synchronization wait observed on peer ranks. The new policy makes therank-skew story more direct:

- first detect visible wait cost,
- then name the likely culprit and victim/reference rank,
- then attribute only material culprit-side excess,
- otherwise leave the result as sync-bound or unattributed.

This also makes the FSDP behavior more honest. FSDP forward and backward caninclude sharding communication, so TraceML avoids emitting `COMPUTE STRAGGLER`from this policy without explicit collective timing.

## Markdown/docs delta vs `version_0.3.5`

Tracked Markdown files changed in the committed branch diff:

- `docs/developer_guide/architecture.md`
- `docs/guides/ddp-slow-training-rank-straggler.md`
- `docs/guides/low-gpu-utilization-pytorch.md`
- `docs/guides/slow-pytorch-training.md`
- `docs/user_guide/faq.md`
- `docs/user_guide/reading-output.md`
- `src/traceml_ai/diagnostics/DIAGNOSIS.md`
- `src/traceml_ai/reporting/SCHEMA.md`

The docs now consistently use culprit/victim/reference language, remove`RESIDUAL_STRAGGLER`, describe DDP vs FSDP attribution separately, and explain generic `STRAGGLER` as sync-bound or unattributed rank skew.

`mkdocs.yml` also adds a Developer Guide nav entry for`docs/developer_guide/rank-straggler-policy.md`. That file exists in the local worktree but is currently untracked, so include it when preparing the PR orremove the nav entry before publishing.

## How I tested

Focused tests for the changed Step Time and primary-diagnosis behavior:

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/diagnostics/test_step_time.py \
  tests/reporting/summary/test_primary_diagnosis.py \
  -q
```

Result:

```text
34 passed in 0.23s
```

- [x] Tests added or updated
- [x] Existing focused tests run
- [ ] Manual smoke test
- [ ] Not run; reason:

## Runtime impact

- [x] No training-path instrumentation impact
- [x] May affect live output, final summaries, reports, and diagnosis labels
- [ ] May affect telemetry collection or storage
- [ ] Not sure

Notes:

This changes diagnosis policy and presentation, not sampler timing collection. Existing telemetry can classify differently because rank-skew attribution no longer uses clean-step residual attribution and no longer emits `RESIDUAL_STRAGGLER`.
