### PR TITLE
docs: add CodeRabbit config for automated PR review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+tone_instructions: >-
+  TraceML instruments PyTorch training in-process. Flag anything that could
+  block the training thread, raise instead of degrading, or swallow a user
+  exception. Be direct and specific; skip generic praise.
+
+reviews:
+  profile: chill
+  high_level_summary: true
+  poem: false
+
+  path_filters:
+    - "!uv.lock"
+    - "!docs/assets/**"
+    - "!**/*.ipynb"
+
+  path_instructions:
+    - path: "src/**/*.py"
+      instructions: |
+        This is instrumentation code that runs inside a user's training loop.
+        Check that:
+        - Any code that touches torch internals or I/O is wrapped in
+          try/except, reports via sys.stderr with a "[TraceML]" prefix, and
+          never blocks or raises into the user's training process.
+        - Changes to the wire format or the final_summary schema keep
+          backward compatibility or come with a migration note.
+
+  tools:
+    ruff:
+      enabled: true
+    shellcheck:
+      enabled: true
+    markdownlint:
+      enabled: true
+    gitleaks:
+      enabled: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+
+chat:
+  auto_reply: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,10 @@ For code extension points, see
 - Run basic training loops to verify no regressions
 - Performance-sensitive changes should include a short explanation
 
+CodeRabbit reviews every pull request automatically and leaves inline comments.
+Treat it like a first-pass reviewer: worth reading, not a blocker. A maintainer
+still reviews and merges every PR.
+
 ---
 
 ## What We Are Not Looking For (Yet)


### PR DESCRIPTION
## Summary

Add a `.coderabbit.yaml` config so CodeRabbit reviews are scoped to this repo's conventions from day one, plus a short note in `CONTRIBUTING.md` so a first-time contributor isn't surprised by an automated review comment on their PR.

CodeRabbit's Pro tier is free for public repositories with no PR/review cap (only hourly rate limits), so this adds no cost.

## What this does not do

This PR only adds config. Turning CodeRabbit on for this repo also requires installing the CodeRabbit GitHub App at the organization level, which needs org-owner permissions. That step is separate and not part of this PR.

## Config choices

- `profile: chill` - first-pass reviewer tone, not a blocking gate.
- `path_filters` skips `uv.lock`, `docs/assets/**` (binary images/GIFs), and notebooks - none of these benefit from line-level review.
- One `path_instructions` rule on `src/**/*.py` naming the two things a well-intentioned PR is most likely to miss: instrumentation code must stay non-blocking and fail via try/except, and wire-format/`final_summary` schema changes need backward compatibility or a migration note.
- `tools`: `ruff` (matches the project's actual linter/line-length), `shellcheck` (repo has real `.sh` scripts), `markdownlint`, and `gitleaks` for commit-time secret scanning.
- `auto_review.drafts: false` so draft PRs aren't reviewed prematurely.

## Acceptance

- `.coderabbit.yaml` is valid YAML at the repo root.
- Once the GitHub App is installed, PRs against `main` get an automatic CodeRabbit review using this config.
