### PR TITLE
feat: move TCP telemetry export to a dedicated exporter thread

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+tone_instructions: >-
+  TraceML instruments PyTorch training in-process. Flag anything that could
+  block the training thread, raise instead of degrading, or swallow a user
+  exception. Be direct and specific; skip generic praise.
+
+reviews:
+  profile: chill
+  high_level_summary: true
+  poem: false
+
+  path_filters:
+    - "!uv.lock"
+    - "!docs/assets/**"
+    - "!**/*.ipynb"
+
+  path_instructions:
+    - path: "src/**/*.py"
+      instructions: |
+        This is instrumentation code that runs inside a user's training loop.
+        Check that:
+        - Any code that touches torch internals or I/O is wrapped in
+          try/except, reports via sys.stderr with a "[TraceML]" prefix, and
+          never blocks or raises into the user's training process.
+        - Changes to the wire format or the final_summary schema keep
+          backward compatibility or come with a migration note.
+
+  tools:
+    ruff:
+      enabled: true
+    shellcheck:
+      enabled: true
+    markdownlint:
+      enabled: true
+    gitleaks:
+      enabled: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+
+chat:
+  auto_reply: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,10 @@ For code extension points, see
 - Run basic training loops to verify no regressions
 - Performance-sensitive changes should include a short explanation
 
+CodeRabbit reviews every pull request automatically and leaves inline comments.
+Treat it like a first-pass reviewer: worth reading, not a blocker. A maintainer
+still reviews and merges every PR.
+
 ---
 
 ## What We Are Not Looking For (Yet)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 
 [![PyPI version](https://img.shields.io/pypi/v/traceml-ai.svg)](https://pypi.org/project/traceml-ai/)
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/traceml-ai?period=total&units=INTERNATIONAL_SYSTEM&left_color=grey&right_color=blue&left_text=downloads)](https://pepy.tech/projects/traceml-ai)
 [![CI](https://github.com/traceopt-ai/traceml/actions/workflows/ci.yml/badge.svg)](https://github.com/traceopt-ai/traceml/actions/workflows/ci.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](./LICENSE)

--- a/docs/user_guide/integrations/ray.md
+++ b/docs/user_guide/integrations/ray.md
@@ -203,7 +203,7 @@ TraceMLRayConfig(
     patch_h2d=None,
     logs_dir="./logs",
     session_id="",
-    sampler_interval_sec=1.0,
+    sampler_interval_sec=2.0,
     bind_host="0.0.0.0",
     port=0,
 )
@@ -212,6 +212,10 @@ TraceMLRayConfig(
 The default ``mode="summary"`` is recommended for Ray because distributed worker
 logs are noisy. Use ``mode="cli"`` only when you specifically want live terminal
 rendering from the aggregator actor.
+
+``sampler_interval_sec`` defaults to ``2.0`` seconds. It controls worker sampling
+and the aggregator actor's live UI refresh; incoming TCP telemetry is drained as
+soon as it arrives.
 
 ``init_mode`` is passed to ``traceml.init(mode="auto")`` inside each Ray
 worker. The Ray Data ``wrap_dataloader_fetch(...)`` pattern above works with

--- a/src/traceml_ai/aggregator/aggregator_main.py
+++ b/src/traceml_ai/aggregator/aggregator_main.py
@@ -39,6 +39,7 @@ from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
 from traceml_ai.runtime.lifecycle import start_aggregator
 from traceml_ai.runtime.settings import (
     DEFAULT_FINALIZE_TIMEOUT_SEC,
+    DEFAULT_INTERVAL_SEC,
     AggregatorTransportSettings,
     TraceMLSettings,
 )
@@ -109,7 +110,9 @@ def read_traceml_env() -> dict[str, Any]:
     return {
         "mode": ui_mode,
         "profile": os.environ.get("TRACEML_PROFILE", "run"),
-        "interval": float(os.environ.get("TRACEML_INTERVAL", "1.0")),
+        "interval": float(
+            os.environ.get("TRACEML_INTERVAL", str(DEFAULT_INTERVAL_SEC))
+        ),
         "enable_logging": os.environ.get("TRACEML_ENABLE_LOGGING", "0") == "1",
         "logs_dir": os.environ.get("TRACEML_LOGS_DIR", "./logs"),
         "aggregator_host": os.environ.get(

--- a/src/traceml_ai/config/yaml_loader.py
+++ b/src/traceml_ai/config/yaml_loader.py
@@ -20,7 +20,10 @@ import warnings
 from pathlib import Path
 from typing import Any, Mapping
 
-from traceml_ai.runtime.settings import DEFAULT_FINALIZE_TIMEOUT_SEC
+from traceml_ai.runtime.settings import (
+    DEFAULT_FINALIZE_TIMEOUT_SEC,
+    DEFAULT_INTERVAL_SEC,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -33,6 +36,8 @@ _MAX_WALK_LEVELS = 10
 # To add a setting: add here, add to BUILT_IN_DEFAULTS, add default=None in cli.py.
 YAML_KEY_SCHEMA: dict[str, tuple[str, type]] = {
     "mode": ("TRACEML_UI_MODE", str),
+    # This is the one public cadence control: sampler frequency on workers and
+    # UI refresh frequency on the aggregator. TCP ingestion remains event-driven.
     "interval": ("TRACEML_INTERVAL", float),
     "enable_logging": ("TRACEML_ENABLE_LOGGING", bool),
     "logs_dir": ("TRACEML_LOGS_DIR", str),
@@ -46,7 +51,7 @@ YAML_KEY_SCHEMA: dict[str, tuple[str, type]] = {
 # The launcher promotes mode to "summary" for multi-node runs.
 BUILT_IN_DEFAULTS: dict[str, Any] = {
     "mode": "dashboard",
-    "interval": 2.0,
+    "interval": DEFAULT_INTERVAL_SEC,
     "enable_logging": False,
     "logs_dir": "./logs",
     "history_enabled": True,

--- a/src/traceml_ai/integrations/ray.py
+++ b/src/traceml_ai/integrations/ray.py
@@ -24,6 +24,7 @@ from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
 from traceml_ai.runtime.lifecycle import RuntimeHandle, start_aggregator
 from traceml_ai.runtime.lifecycle import start_runtime as start_runtime_handle
 from traceml_ai.runtime.settings import (
+    DEFAULT_INTERVAL_SEC,
     AggregatorEndpoint,
     AggregatorTransportSettings,
     TraceMLSettings,
@@ -60,7 +61,8 @@ class TraceMLRayConfig:
         Optional explicit TraceML session id. If omitted, a unique Ray session
         id is generated for each ``fit()`` call.
     sampler_interval_sec:
-        Background sampler cadence in seconds.
+        Background sampler cadence in seconds. The aggregator actor uses the
+        same value for its live UI refresh cadence; TCP ingestion is immediate.
     summary_window_rows:
         Number of recent history rows used by final summary generation.
     bind_host:
@@ -81,7 +83,7 @@ class TraceMLRayConfig:
     patch_h2d: Optional[bool] = None
     logs_dir: str = "./logs"
     session_id: str = ""
-    sampler_interval_sec: float = 1.0
+    sampler_interval_sec: float = DEFAULT_INTERVAL_SEC
     summary_window_rows: int = DEFAULT_SUMMARY_WINDOW_ROWS
     bind_host: str = "0.0.0.0"
     port: int = 0
@@ -135,7 +137,7 @@ def _build_aggregator_settings(
     return TraceMLSettings(
         mode=str(config.mode),
         profile=str(config.profile),
-        sampler_interval_sec=float(config.sampler_interval_sec),
+        render_interval_sec=float(config.sampler_interval_sec),
         logs_dir=str(config.logs_dir),
         session_id=str(config.session_id),
         summary_window_rows=int(config.summary_window_rows),

--- a/src/traceml_ai/launcher/cli.py
+++ b/src/traceml_ai/launcher/cli.py
@@ -18,7 +18,10 @@ from traceml_ai.launcher.commands import (
     validate_launch_args,
 )
 from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
-from traceml_ai.runtime.settings import DEFAULT_FINALIZE_TIMEOUT_SEC
+from traceml_ai.runtime.settings import (
+    DEFAULT_FINALIZE_TIMEOUT_SEC,
+    DEFAULT_INTERVAL_SEC,
+)
 
 
 def _add_launch_args(parser: argparse.ArgumentParser) -> None:
@@ -44,7 +47,11 @@ def _add_launch_args(parser: argparse.ArgumentParser) -> None:
         "--interval",
         type=float,
         default=None,
-        help="Polling interval in seconds.",
+        help=(
+            "Worker sampler interval and live UI refresh interval in seconds "
+            f"(default: {DEFAULT_INTERVAL_SEC:g}). TCP ingestion is "
+            "event-driven."
+        ),
     )
     parser.add_argument(
         "--enable-logging",

--- a/src/traceml_ai/runtime/executor.py
+++ b/src/traceml_ai/runtime/executor.py
@@ -24,6 +24,7 @@ from traceml_ai.runtime.lifecycle import start_runtime as start_runtime_handle
 from traceml_ai.runtime.runtime import TraceMLRuntime
 from traceml_ai.runtime.settings import (
     DEFAULT_FINALIZE_TIMEOUT_SEC,
+    DEFAULT_INTERVAL_SEC,
     AggregatorTransportSettings,
     TraceMLSettings,
 )
@@ -35,7 +36,6 @@ DEFAULT_AGGREGATOR_BIND_HOST = "127.0.0.1"
 DEFAULT_AGGREGATOR_PORT = 29765
 DEFAULT_PROFILE = "run"
 DEFAULT_UI_MODE = "cli"
-DEFAULT_INTERVAL_SEC = 1.0
 USER_ERROR_LOG_NAME = "torchrun_error.log"
 RUNTIME_ERROR_LOG_NAME = "runtime_error.log"
 

--- a/src/traceml_ai/runtime/exporter.py
+++ b/src/traceml_ai/runtime/exporter.py
@@ -58,7 +58,7 @@ class TelemetryExporter:
 
     @property
     def dropped_count(self) -> int:
-        """Number of payload batches dropped on queue overflow."""
+        """Number of payload batches dropped on overflow or shutdown."""
         with self._cond:
             return self._dropped
 
@@ -116,6 +116,9 @@ class TelemetryExporter:
 
     def _enqueue(self, batch: List[Any]) -> None:
         with self._cond:
+            if self._stopped:
+                self._dropped += 1
+                return
             if len(self._queue) >= self._max_queue_size:
                 self._queue.popleft()  # drop oldest
                 self._dropped += 1
@@ -150,6 +153,19 @@ class TelemetryExporter:
             if batch is None:
                 return
             self._send(batch)
+
+        with self._cond:
+            remaining = len(self._queue)
+            if remaining:
+                self._queue.clear()
+                self._dropped += remaining
+
+        if remaining:
+            self._logger.error(
+                "[TraceML] exporter shutdown dropped %d queued payload batches "
+                "after drain timeout",
+                remaining,
+            )
 
     def _send(self, batch: List[Any]) -> None:
         # Network send runs outside the queue lock so enqueue never blocks.

--- a/src/traceml_ai/runtime/exporter.py
+++ b/src/traceml_ai/runtime/exporter.py
@@ -1,0 +1,175 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Background TCP exporter that drains queued payload batches off a dedicated
+thread, isolating the sampler thread from a slow or unreachable aggregator."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from typing import Any, Deque, List, Optional
+
+from traceml_ai.loggers.error_log import get_error_logger
+
+DEFAULT_EXPORT_QUEUE_SIZE = 2048
+DEFAULT_EXPORT_DRAIN_TIMEOUT_SEC = 2.0
+_EXPORT_POLL_INTERVAL_SEC = 0.5
+
+
+class TelemetryExporter:
+    """
+    Async, thread-backed stand-in for the TCPClient send surface.
+
+    Exposes send/send_batch/close so it can replace the TCP client the
+    publisher holds, but enqueues onto a bounded queue instead of sending
+    inline. One background thread drains the queue via TCPClient.send_batch.
+    """
+
+    def __init__(
+        self,
+        *,
+        tcp_client: Any,
+        max_queue_size: int = DEFAULT_EXPORT_QUEUE_SIZE,
+        drain_timeout_sec: float = DEFAULT_EXPORT_DRAIN_TIMEOUT_SEC,
+        poll_interval_sec: float = _EXPORT_POLL_INTERVAL_SEC,
+        logger: Optional[Any] = None,
+    ) -> None:
+        self._tcp_client = tcp_client
+        self._max_queue_size = max(1, int(max_queue_size))
+        self._drain_timeout_sec = max(0.0, float(drain_timeout_sec))
+        self._poll_interval_sec = max(0.01, float(poll_interval_sec))
+        self._logger = logger or get_error_logger("TelemetryExporter")
+
+        self._queue: Deque[List[Any]] = deque()
+        self._cond = threading.Condition()
+        self._stop_event = threading.Event()
+        self._dropped = 0
+        self._stopped = False
+        self._thread = threading.Thread(
+            target=self._run,
+            name="TraceMLExporter",
+            daemon=True,
+        )
+
+    @property
+    def dropped_count(self) -> int:
+        """Number of payload batches dropped on queue overflow."""
+        with self._cond:
+            return self._dropped
+
+    @property
+    def queue_size(self) -> int:
+        """Current number of queued payload batches."""
+        with self._cond:
+            return len(self._queue)
+
+    def start(self) -> None:
+        """Start the exporter thread."""
+        self._thread.start()
+
+    def send_batch(self, batch: List[Any]) -> None:
+        """Enqueue a collected payload batch. Never blocks on the network."""
+        if not batch:
+            return
+        self._enqueue(list(batch))
+
+    def send(self, payload: Any) -> None:
+        """Enqueue a single payload as a one-item batch (used for control)."""
+        if not payload:
+            return
+        self._enqueue([payload])
+
+    def close(self) -> None:
+        """TCPClient.close parity. Stops with the configured drain budget."""
+        self.stop()
+
+    def stop(self, timeout_sec: Optional[float] = None) -> None:
+        """Signal stop, let the thread do a bounded final drain, then close."""
+        with self._cond:
+            if self._stopped:
+                return
+            self._stopped = True
+            if timeout_sec is not None:
+                self._drain_timeout_sec = max(0.0, float(timeout_sec))
+            self._stop_event.set()
+            self._cond.notify_all()
+
+        if self._thread.is_alive():
+            self._thread.join(
+                timeout=self._drain_timeout_sec + self._poll_interval_sec + 1.0
+            )
+
+        if self._dropped:
+            self._logger.error(
+                f"[TraceML] exporter dropped {self._dropped} payload batches"
+            )
+
+        try:
+            self._tcp_client.close()
+        except Exception as exc:
+            self._log_exception("TCPClient.close failed", exc)
+
+    def _enqueue(self, batch: List[Any]) -> None:
+        with self._cond:
+            if len(self._queue) >= self._max_queue_size:
+                self._queue.popleft()  # drop oldest
+                self._dropped += 1
+            self._queue.append(batch)
+            self._cond.notify()
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            batch = self._take_next()
+            if batch is not None:
+                self._send(batch)
+        self._final_drain()
+
+    def _take_next(self) -> Optional[List[Any]]:
+        with self._cond:
+            if not self._queue and not self._stop_event.is_set():
+                self._cond.wait(timeout=self._poll_interval_sec)
+            if self._queue:
+                return self._queue.popleft()
+            return None
+
+    def _pop_nowait(self) -> Optional[List[Any]]:
+        with self._cond:
+            if self._queue:
+                return self._queue.popleft()
+            return None
+
+    def _final_drain(self) -> None:
+        deadline = time.monotonic() + self._drain_timeout_sec
+        while time.monotonic() < deadline:
+            batch = self._pop_nowait()
+            if batch is None:
+                return
+            self._send(batch)
+
+    def _send(self, batch: List[Any]) -> None:
+        # Network send runs outside the queue lock so enqueue never blocks.
+        try:
+            self._tcp_client.send_batch(batch)
+        except Exception as exc:
+            self._log_exception("TCPClient.send_batch failed", exc)
+
+    def _log_exception(self, label: str, exc: Exception) -> None:
+        log = getattr(self._logger, "exception", None)
+        if callable(log):
+            log("[TraceML] %s: %s", label, exc)
+            return
+        fallback = getattr(self._logger, "error", None)
+        if callable(fallback):
+            fallback(f"[TraceML] {label}: {exc}")
+
+
+__all__ = [
+    "DEFAULT_EXPORT_QUEUE_SIZE",
+    "DEFAULT_EXPORT_DRAIN_TIMEOUT_SEC",
+    "TelemetryExporter",
+]

--- a/src/traceml_ai/runtime/exporter.py
+++ b/src/traceml_ai/runtime/exporter.py
@@ -18,7 +18,7 @@ from traceml_ai.loggers.error_log import get_error_logger
 
 DEFAULT_EXPORT_QUEUE_SIZE = 2048
 DEFAULT_EXPORT_DRAIN_TIMEOUT_SEC = 2.0
-_EXPORT_POLL_INTERVAL_SEC = 0.5
+_EXPORT_POLL_INTERVAL_SEC = 1.0
 
 
 class TelemetryExporter:

--- a/src/traceml_ai/runtime/runtime.py
+++ b/src/traceml_ai/runtime/runtime.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, List, Optional
 
 from traceml_ai.loggers.error_log import get_error_logger, setup_error_logger
 from traceml_ai.runtime.config import config
+from traceml_ai.runtime.exporter import TelemetryExporter
 from traceml_ai.runtime.identity import resolve_runtime_identity
 from traceml_ai.runtime.sampler_registry import build_samplers
 from traceml_ai.runtime.sender import SenderIdentity, TelemetryPublisher
@@ -80,8 +81,14 @@ class TraceMLRuntime:
                 port=int(self._settings.aggregator.port),
             )
         )
-        self._publisher = TelemetryPublisher(
+        # Exporter owns all TCP send/connect work on its own thread. The
+        # publisher enqueues batches into it instead of sending inline.
+        self._exporter = TelemetryExporter(
             tcp_client=self._tcp_client,
+            logger=self._logger,
+        )
+        self._publisher = TelemetryPublisher(
+            tcp_client=self._exporter,
             identity=SenderIdentity(
                 global_rank=self.identity.global_rank,
                 local_rank=self.identity.local_rank,
@@ -189,7 +196,8 @@ class TraceMLRuntime:
 
         Start order:
         1) enable stdout/stderr capture (CLI mode only, dashboard no need)
-        2) start sampler thread
+        2) start exporter thread
+        3) start sampler thread
         """
         if self.mode == "cli":
             _safe(
@@ -197,6 +205,9 @@ class TraceMLRuntime:
                 "Stdout/stderr capture enable failed",
                 StreamCapture.redirect_to_capture,
             )
+
+        # Exporter must be running before samplers start enqueuing batches.
+        self._exporter.start()
 
         try:
             self._sampler_thread.start()
@@ -210,8 +221,8 @@ class TraceMLRuntime:
 
         - Signals the sampler thread to stop
         - Joins the sampler thread
-        - Sends a rank-finished control message for aggregator finalization
-        - Closes TCP client
+        - Enqueues a final telemetry batch and a rank-finished control message
+        - Drains the export queue and closes the TCP client (bounded)
         - Restores stdout/stderr (CLI mode only)
         """
         self._stop_event.set()
@@ -236,8 +247,8 @@ class TraceMLRuntime:
             )
         )
 
-        # close client last
-        self._publisher.close()
+        # drain the export queue and close the client last
+        self._exporter.stop()
 
         # restore stdout/stderr
         if self.mode == "cli":

--- a/src/traceml_ai/runtime/settings.py
+++ b/src/traceml_ai/runtime/settings.py
@@ -21,6 +21,9 @@ from typing import Optional
 from traceml_ai.reporting.config import DEFAULT_SUMMARY_WINDOW_ROWS
 
 DEFAULT_FINALIZE_TIMEOUT_SEC = 300.0
+# The public ``interval`` setting uses this value unless explicitly overridden
+# through the CLI, environment, YAML, or an integration-specific config.
+DEFAULT_INTERVAL_SEC = 2.0
 
 
 @dataclass(frozen=True)
@@ -54,8 +57,9 @@ class TraceMLSettings:
     High-level TraceML settings shared across runtime and aggregator.
 
     Notes:
-    - `sampler_interval_sec` controls sampling cadence (all ranks).
-    - `render_interval_sec` controls UI cadence (aggregator only).
+    - `sampler_interval_sec` controls worker sampling cadence (all ranks).
+    - `render_interval_sec` controls aggregator UI cadence only; TCP telemetry
+      is drained as soon as data arrives.
     - `mode` selects display backend and capture behavior ("cli" | "summary" | "dashboard").
     - `summary` mode disables live rendering and prints only the final
       end-of-run summary.
@@ -65,8 +69,8 @@ class TraceMLSettings:
 
     profile: str = "run"
     mode: str = "cli"
-    sampler_interval_sec: float = 1.0
-    render_interval_sec: float = 1.0
+    sampler_interval_sec: float = DEFAULT_INTERVAL_SEC
+    render_interval_sec: float = DEFAULT_INTERVAL_SEC
     logs_dir: str = "./logs"
     enable_logging: bool = False
     dashboard_port: int = 8765

--- a/tests/aggregator/test_aggregator_main_env.py
+++ b/tests/aggregator/test_aggregator_main_env.py
@@ -8,9 +8,11 @@ from traceml_ai.aggregator.aggregator_main import read_traceml_env
 def test_read_traceml_env_dashboard_defaults(monkeypatch) -> None:
     monkeypatch.delenv("TRACEML_DASHBOARD_PORT", raising=False)
     monkeypatch.delenv("TRACEML_DASHBOARD_AUTO_OPEN", raising=False)
+    monkeypatch.delenv("TRACEML_INTERVAL", raising=False)
     cfg = read_traceml_env()
     assert cfg["dashboard_port"] == 8765
     assert cfg["dashboard_auto_open"] is True
+    assert cfg["interval"] == 2.0
 
 
 def test_read_traceml_env_dashboard_from_env(monkeypatch) -> None:

--- a/tests/integrations/test_ray.py
+++ b/tests/integrations/test_ray.py
@@ -32,6 +32,7 @@ def test_normalize_config_generates_session_id():
     assert config.session_id.startswith("ray_")
     assert config.mode == "summary"
     assert config.port == 0
+    assert config.sampler_interval_sec == 2.0
 
 
 def test_normalize_config_preserves_explicit_session_id():
@@ -67,6 +68,7 @@ def test_aggregator_settings_use_actor_node_as_connect_host():
     assert settings.aggregator.connect_host == "10.0.0.9"
     assert settings.aggregator.bind_host == "0.0.0.0"
     assert settings.aggregator.port == 0
+    assert settings.render_interval_sec == 2.0
 
 
 def test_worker_settings_connect_to_actor_endpoint():

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -39,6 +39,7 @@ from traceml_ai.runtime.executor import (  # noqa: E402
 )
 from traceml_ai.runtime.settings import (
     DEFAULT_FINALIZE_TIMEOUT_SEC,
+    TraceMLSettings,
 )  # noqa: E402
 
 
@@ -143,6 +144,20 @@ def test_read_traceml_env_parses_trace_max_steps(monkeypatch):
     assert cfg["trace_max_steps"] == 123
     assert cfg["finalize_timeout_sec"] == 42.5
     assert cfg["expected_world_size"] == 8
+
+
+def test_read_traceml_env_defaults_to_two_second_interval(monkeypatch):
+    monkeypatch.setenv("TRACEML_SCRIPT_PATH", "train.py")
+    monkeypatch.delenv("TRACEML_INTERVAL", raising=False)
+
+    assert read_traceml_env()["interval"] == 2.0
+
+
+def test_trace_settings_default_to_two_second_cadences():
+    settings = TraceMLSettings()
+
+    assert settings.sampler_interval_sec == 2.0
+    assert settings.render_interval_sec == 2.0
 
 
 def test_build_runtime_settings_carries_trace_max_steps():

--- a/tests/runtime/test_exporter.py
+++ b/tests/runtime/test_exporter.py
@@ -1,0 +1,191 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+import time
+
+from traceml_ai.runtime.exporter import TelemetryExporter
+from traceml_ai.runtime.sender import SenderIdentity, TelemetryPublisher
+
+
+class _FakeLogger:
+    def __init__(self) -> None:
+        self.exceptions: list[str] = []
+        self.errors: list[str] = []
+
+    def exception(self, message: str, *args: object) -> None:
+        self.exceptions.append(message % args if args else message)
+
+    def error(self, message: str, *args: object) -> None:
+        self.errors.append(message % args if args else message)
+
+
+class _FakeClient:
+    """Records send_batch calls; can be told to raise or sleep."""
+
+    def __init__(
+        self,
+        *,
+        raise_on_send: bool = False,
+        send_delay: float = 0.0,
+    ) -> None:
+        self._lock = threading.Lock()
+        self.batches: list[list] = []
+        self.send_calls = 0
+        self.closed = False
+        self._raise_on_send = raise_on_send
+        self._send_delay = send_delay
+
+    def send_batch(self, batch: list) -> None:
+        with self._lock:
+            self.send_calls += 1
+        if self._send_delay:
+            time.sleep(self._send_delay)
+        if self._raise_on_send:
+            raise RuntimeError("send failed")
+        with self._lock:
+            self.batches.append(batch)
+
+    def send(self, payload: object) -> None:
+        self.send_batch([payload])
+
+    def close(self) -> None:
+        with self._lock:
+            self.closed = True
+
+    def snapshot(self) -> list[list]:
+        with self._lock:
+            return list(self.batches)
+
+    @property
+    def call_count(self) -> int:
+        with self._lock:
+            return self.send_calls
+
+
+class _FakeSender:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+        self.sender = None
+        self.identity = None
+
+    def collect_payload(self) -> object:
+        return self.payload
+
+
+class _FakeSampler:
+    def __init__(self, name: str, *, sender: _FakeSender) -> None:
+        self.sampler_name = name
+        self.sender = sender
+        self.db = None
+
+
+def _wait_until(pred, timeout: float = 2.0, interval: float = 0.01) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return True
+        time.sleep(interval)
+    return pred()
+
+
+def test_normal_enqueue_and_export() -> None:
+    client = _FakeClient()
+    exporter = TelemetryExporter(tcp_client=client, logger=_FakeLogger())
+    exporter.start()
+    try:
+        exporter.send_batch([{"id": 1}])
+        assert _wait_until(lambda: client.snapshot() == [[{"id": 1}]])
+    finally:
+        exporter.stop()
+    assert client.closed is True
+
+
+def test_drop_oldest_when_full() -> None:
+    client = _FakeClient()
+    exporter = TelemetryExporter(
+        tcp_client=client,
+        max_queue_size=2,
+        logger=_FakeLogger(),
+    )
+    # Thread not started, so nothing drains and the queue fills.
+    exporter.send_batch([{"id": 1}])
+    exporter.send_batch([{"id": 2}])
+    exporter.send_batch([{"id": 3}])  # drops the oldest ([{"id": 1}])
+
+    assert exporter.queue_size == 2
+    assert exporter.dropped_count == 1
+
+    # The newest two survive, in order.
+    exporter.start()
+    try:
+        assert _wait_until(
+            lambda: client.snapshot() == [[{"id": 2}], [{"id": 3}]]
+        )
+    finally:
+        exporter.stop()
+    assert exporter.dropped_count == 1
+
+
+def test_aggregator_unavailable_does_not_block_or_crash() -> None:
+    logger = _FakeLogger()
+    client = _FakeClient(raise_on_send=True)
+    exporter = TelemetryExporter(tcp_client=client, logger=logger)
+    exporter.start()
+    try:
+        # Enqueue must return immediately and never raise.
+        for i in range(5):
+            exporter.send_batch([{"id": i}])
+        # The exporter thread keeps attempting sends and swallows failures.
+        assert _wait_until(lambda: client.call_count >= 5)
+        assert exporter.dropped_count == 0
+        assert len(logger.exceptions) >= 5
+    finally:
+        exporter.stop()
+
+
+def test_shutdown_drain_timeout_is_bounded() -> None:
+    client = _FakeClient(send_delay=2.0)
+    exporter = TelemetryExporter(
+        tcp_client=client,
+        drain_timeout_sec=0.2,
+        poll_interval_sec=0.1,
+        logger=_FakeLogger(),
+    )
+    exporter.start()
+    for i in range(10):
+        exporter.send_batch([{"id": i}])
+
+    start = time.monotonic()
+    exporter.stop()
+    elapsed = time.monotonic() - start
+
+    # Must return before a single slow send completes, not after draining all.
+    assert elapsed < 2.0
+
+
+def test_tick_enqueues_and_does_not_send_inline() -> None:
+    client = _FakeClient()
+    exporter = TelemetryExporter(tcp_client=client, logger=_FakeLogger())
+    publisher = TelemetryPublisher(
+        tcp_client=exporter,
+        identity=SenderIdentity(global_rank=0, local_rank=0),
+        logger=_FakeLogger(),
+    )
+    sampler = _FakeSampler("A", sender=_FakeSender(payload={"rows": [1]}))
+
+    # Exporter thread not started: publish must only enqueue, never send.
+    publisher.publish([sampler])
+    assert client.call_count == 0
+    assert exporter.queue_size == 1
+
+    # Once the exporter runs, the batch is sent.
+    exporter.start()
+    try:
+        assert _wait_until(lambda: client.call_count == 1)
+        assert client.snapshot() == [[{"rows": [1]}]]
+    finally:
+        exporter.stop()

--- a/tests/runtime/test_exporter.py
+++ b/tests/runtime/test_exporter.py
@@ -147,6 +147,19 @@ def test_aggregator_unavailable_does_not_block_or_crash() -> None:
         exporter.stop()
 
 
+def test_enqueue_after_stop_is_dropped() -> None:
+    client = _FakeClient()
+    exporter = TelemetryExporter(tcp_client=client, logger=_FakeLogger())
+    exporter.start()
+    exporter.stop()
+
+    exporter.send_batch([{"id": 1}])
+
+    assert exporter.queue_size == 0
+    assert exporter.dropped_count == 1
+    assert client.call_count == 0
+
+
 def test_shutdown_drain_timeout_is_bounded() -> None:
     client = _FakeClient(send_delay=2.0)
     exporter = TelemetryExporter(
@@ -165,6 +178,30 @@ def test_shutdown_drain_timeout_is_bounded() -> None:
 
     # Must return before a single slow send completes, not after draining all.
     assert elapsed < 2.0
+
+
+def test_shutdown_drain_timeout_counts_and_logs_remaining_batches() -> None:
+    logger = _FakeLogger()
+    client = _FakeClient(send_delay=0.2)
+    exporter = TelemetryExporter(
+        tcp_client=client,
+        drain_timeout_sec=0.0,
+        poll_interval_sec=0.01,
+        logger=logger,
+    )
+    exporter.start()
+    exporter.send_batch([{"id": 1}])
+    assert _wait_until(lambda: client.call_count == 1)
+    exporter.send_batch([{"id": 2}])
+    exporter.send_batch([{"id": 3}])
+
+    exporter.stop()
+
+    assert exporter.queue_size == 0
+    assert exporter.dropped_count == 2
+    assert any(
+        "shutdown dropped 2 queued payload batches" in e for e in logger.errors
+    )
 
 
 def test_tick_enqueues_and_does_not_send_inline() -> None:


### PR DESCRIPTION
## What changed

Moved TCP telemetry export off the sampler thread onto a dedicated exporter thread with a bounded in-memory handoff queue.

New flow: `sampler thread -> run samplers -> collect payload batch -> bounded export queue -> exporter thread -> TCP send to aggregator`

- New `TelemetryExporter` (`runtime/exporter.py`): owns all TCP send/connect work on its own daemon thread. Bounded queue (default `2048`); on overflow it drops the oldest batch and increments a drop counter. Enqueue is O(1) and the network send runs outside the queue lock, so producers never block on the network.
- `runtime.py`: the sampler thread now only collects and enqueues; the publisher hands batches to the exporter instead of sending inline. Shutdown does a bounded final drain (respecting a timeout) then closes the client, so export can never hang or crash training.

## Why

Closes #222. Previously the sampler thread performed TCP send inline, so a slow, stopped, or unreachable aggregator could stall sampling (sampler lag, queue pressure, telemetry drops, extra GIL/CPU contention). This is a backpressure isolation change: network trouble is now absorbed by the exporter thread, not the sampler thread.

## How I tested

- New `tests/runtime/test_exporter.py` covers the five issue scenarios: normal enqueue/export, drop-oldest-when-full, aggregator unavailable, bounded shutdown drain timeout, and sampler-tick-does-not-send-inline.
- Ran `pytest tests/runtime/ tests/telemetry/` — 127 passed, no regressions (existing publisher/runtime wiring unchanged).
- Manual smoke test: `traceml run examples/manual_custom_minimal.py --mode summary` — run finalized cleanly with the end-of-run summary; no `send_batch failed` / `exporter dropped` log lines against the local aggregator.

- [x] Tests added or updated
- [x] Existing tests run
- [x] Manual smoke test
- [ ] Not run; reason:

## Runtime impact

- [ ] No training-path impact
- [x] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes: Touches the worker transport path. Behavior is preserved by construction the publish path and msgpack wire format are unchanged, and the rank-finished control now travels as a one-item batch which the aggregator already parses (`_split_telemetry_payloads`). Telemetry is delivered slightly later (queue latency) but the aggregator's settle/drain logic waits for data, so nothing is lost. Worst-case added shutdown time is bounded (~3.5s) if the aggregator hangs; the exporter thread is a daemon, so it can never hang training.

## Docs

- [ ] Updated
- [x] Not needed

