### PR TITLE
fix: don't compute a percentage overhead against a near-zero phase baseline

### DIFF
--- a/benchmarking/perf_benchmark/common/stats.py
+++ b/benchmarking/perf_benchmark/common/stats.py
@@ -72,12 +72,37 @@ def baseline_noise_floor(base_stats: dict[str, Any]) -> float | None:
     return max(float(std), abs(float(p95) - float(median)))
 
 
+# A never_init baseline below this is treated as too small for a
+# percentage to be meaningful, regardless of how precisely it was
+# measured: dividing by a sub-50-microsecond denominator turns a small,
+# real, absolute overhead (e.g. ~0.08ms of trace-context bookkeeping)
+# into a five-figure percentage that reads as a regression it isn't. See
+# traceml issue #233 (median trace_context_enter/exit_ms baselines of
+# ~0.005-0.006ms produced 1,500-5,100% "overhead" for ~0.08-0.3ms of
+# real, fixed instrumentation cost). This is a fixed floor, not a
+# noise-floor comparison, since a tiny baseline can still be measured
+# with a tight noise floor (as it is here) and the problem is scale, not
+# measurement reliability.
+MIN_BASELINE_MS_FOR_PCT = 0.05
+
+
+def baseline_too_small_for_pct(base_median: float | None) -> bool:
+    """A percentage computed against a near-zero baseline is meaningless."""
+    return (
+        base_median is not None
+        and float(base_median) < MIN_BASELINE_MS_FOR_PCT
+    )
+
+
 def overhead_label(row: dict[str, Any]) -> str:
     delta = row.get("overhead_median_ms")
     noise = row.get("baseline_noise_floor_ms")
     pct_value = row.get("overhead_median_pct")
+    base_median = row.get("baseline_median_ms")
     if delta is None:
         return "baseline"
     if row.get("within_baseline_noise"):
         return f"within noise (|delta| <= {fmt(noise)} ms)"
+    if baseline_too_small_for_pct(base_median):
+        return f"{fmt(delta)} ms (baseline too small for a reliable %)"
     return f"{fmt(delta)} ms / {fmt(pct_value, 2)}%"


### PR DESCRIPTION
Fixes the reporting bug from #233: `overhead_label()` in `common/stats.py` unconditionally showed a percentage for every phase, even when the `never_init` baseline was near-zero (e.g. `trace_context_enter_ms` ≈ 0.005ms). Dividing a small-but-real absolute overhead by a near-zero denominator produced meaningless five-figure percentages (1,500-5,100% in a clean, gil_probe-off validation run — see #233 for the full evidence, including confirmation this reproduces independent of the GIL-probe contamination in the original report).

## What changed

`overhead_label()` now checks whether the baseline's median falls below a fixed floor (`MIN_BASELINE_MS_FOR_PCT = 0.05`) before computing a percentage. Below that floor, it reports the absolute ms delta only, labeled as "baseline too small for a reliable %", instead of a percentage.

Deliberately **not** a noise-floor comparison — a near-zero baseline can still be measured with a tight noise floor (it is, in the evidence above), so the problem is absolute scale, not measurement reliability. The raw `overhead_median_pct` value is untouched in `summary.json`/`summary.csv` for anyone who wants it; only the human-readable `report.md` label changes.

`0.05ms` is a judgment call, not derived from anything — happy to change it if you'd rather use a different floor or the total-step-relative-percentage approach from the original issue instead.

## Verified

Regenerated a real clean-campaign report (`aws_clean_phase_mode_20260722_191149`, phase timing mode, gil_probe off, bs=256) with this fix:

- `trace_context_enter_ms` (trace_auto): `0.0785 ms (baseline too small for a reliable %)` — was `0.0785 ms / 1519.83%`
- `trace_context_exit_ms` (trace_auto): `0.3236 ms (baseline too small for a reliable %)` — was `0.3236 ms / 5119.93%`
- `forward_ms` (trace_auto, a normal-sized baseline): still shows `0.0828 ms / 31.96%` unchanged — confirms the fix doesn't suppress legitimate percentages.

Closes #233 once merged.
