### PR TITLE
feat: add a CPU-only devcontainer for one-click contributor setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "TraceML",
+  "image": "mcr.microsoft.com/devcontainers/python:3.10",
+  "postCreateCommand": "pip install -e '.[dev,torch]' && pre-commit install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff"
+      ]
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,14 @@ Requirements:
 - PyTorch 2.5+ for Torch-backed examples and tests
 - CUDA enabled GPU for GPU/distributed changes. Many docs, reporting, CLI, and CPU smoke-test changes can be developed without a GPU.
 
+### Develop in a container
+
+If you use VS Code with the Dev Containers extension (or GitHub Codespaces),
+open the repository in the provided dev container. It installs an editable
+`.[dev,torch]` build and enables the pre-commit hooks for you, so the
+environment matches what CI expects. The container is CPU-only; GPU work still
+needs a local CUDA setup.
+
 ---
 
 ## Open tasks for first contributors


### PR DESCRIPTION
## What changed

Adds `.devcontainer/devcontainer.json`: the standard `mcr.microsoft.com/devcontainers/python:3.10` image, CPU-only, single variant, with a `postCreateCommand` that installs an editable `.[dev,torch]` build and runs `pre-commit install`. Also adds a short "Develop in a container" note to CONTRIBUTING.md.

Closes #246.

## Why

Gives VS Code and Codespaces users a working, hook-enabled dev environment in one click instead of assembling the editable install and hooks by hand.

## How I tested

Validated the JSON with `jq` and confirmed the `3.10` tag exists on MCR. The extras (`dev`, `torch`) and `.pre-commit-config.yaml` the config references are already on this branch. I don't have a local Dev Containers setup, so the in-container `pytest tests/core -q` acceptance check still needs a Codespaces run.

- [ ] Tests added or updated
- [ ] Existing tests run
- [ ] Manual smoke test
- [x] Not run; reason: needs a Dev Containers/Codespaces build; config only references extras and hooks that already exist on this branch

## Runtime impact

- [x] No training-path impact
- [ ] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes:

## Docs

- [x] Updated
- [ ] Not needed

## Extra context

Based on `version_0.3.5` as requested in the issue. Kept out of scope: CUDA variant, changes to the #223 demo Dockerfile, prebuilt images.
