### PR TITLE
Automate PyPI releases via Trusted Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,29 @@ jobs:
             tests/reporting/compare \
             tests/reporting/html \
             -q
+
+  smoke-test-install:
+    name: Clean-install Smoke Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Build the wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel
+      - name: Install the built wheel into a clean environment
+        run: |
+          python -m venv /tmp/smoke-env
+          /tmp/smoke-env/bin/pip install --upgrade pip
+          /tmp/smoke-env/bin/pip install dist/*.whl
+      - name: Assert documented CLI surface is installed
+        run: |
+          /tmp/smoke-env/bin/traceml --help | grep -q 'view' || \
+            (echo "::error::traceml --help is missing the documented 'view' subcommand" && exit 1)
+          /tmp/smoke-env/bin/traceml run --help | grep -q 'html-report' || \
+            (echo "::error::traceml run --help is missing the documented '--html-report' flag" && exit 1)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+      - name: Build sdist and wheel
+        run: python -m build
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dist/
 *.egg
 pip-wheel-metadata/
 src/traceml_ai.egg-info/
+src/traceml_ai/_version.py
 
 
 # Test / coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to TraceML are documented here. This file follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions here
+should match the tags on [GitHub Releases](https://github.com/traceopt-ai/traceml/releases),
+which carry the full historical notes for versions predating this file.
+
+## [Unreleased]
+
+- Package version is now derived from the git tag (`setuptools-scm`)
+  instead of a hand-edited string in `pyproject.toml`.
+- Releases publish to PyPI automatically on a `v*` tag push, via PyPI
+  Trusted Publishing (OIDC, no stored token).
+- CI now smoke-tests a clean install of the built wheel against the
+  documented CLI surface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "traceml-ai"
-version = "0.3.4"
+dynamic = ["version"]
 
 description = "TraceML: Lightweight runtime bottleneck diagnostics for PyTorch training."
 authors = [{ name = "OptAI UG (haftungsbeschränkt)", email = "support@traceopt.ai" }]
@@ -118,3 +122,9 @@ where = ["src"]
 # Offline-bundled dashboard fonts must ship in the wheel (served at runtime by
 # the NiceGUI driver); without this they fall back to the system font stack.
 traceml_ai = ["aggregator/display_drivers/assets/fonts/*.woff2"]
+
+[tool.setuptools_scm]
+# Version is derived from the nearest git tag (e.g. v0.3.4) instead of a
+# hand-maintained string, so a release tag and the built package can no
+# longer drift apart. Written to a generated file read by __init__.py.
+version_file = "src/traceml_ai/_version.py"

--- a/src/traceml_ai/__init__.py
+++ b/src/traceml_ai/__init__.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.3.4"
+try:
+    from traceml_ai._version import __version__
+except ImportError:
+    # Editable/source installs without a git-derived _version.py (e.g. a
+    # shallow checkout with no tags reachable).
+    __version__ = "0.0.0+unknown"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
Closes #171.

Version, PyPI publish, and the CI safety net that catches drift between them, in one PR.

## What changes

- **Version comes from the git tag.** `setuptools-scm` replaces the hand-edited `version = "0.3.4"` in `pyproject.toml`. `main` and a release can no longer share a version number while their feature sets differ, which is exactly how #171 happened: a dev install one commit ahead of `main` reports `0.3.5.dev3+g7e6d6773d` instead of a stale `0.3.4`.
- **Tag push publishes to PyPI.** New `.github/workflows/publish.yml`, triggered on `v*` tags: builds the sdist and wheel, then publishes via PyPI Trusted Publishing (OIDC). No stored PyPI token in the repo.
- **CI catches the drift even on a manual release.** New `smoke-test-install` job in `ci.yml`: builds the wheel, installs it into a clean venv, and asserts the documented CLI surface (`view` subcommand, `--html-report` flag) is actually present. This is the check that would have caught the original #171 report before a release shipped.
- **CHANGELOG.md**, with an Unreleased section going forward. Existing release notes stay on GitHub Releases; this file doesn't duplicate them.

## Verified locally

- `uv build --wheel` resolves the version from the tag: `0.3.5.dev3+g7e6d6773d.d20260723` (3 commits past `v0.3.4`, correctly marked as a dev build, not a release).
- Installed the built wheel into a clean venv: `traceml_ai.__version__` matches, `traceml --help` lists `view`, `traceml run --help` lists `--html-report`, and the bundled dashboard fonts are still present in the wheel.
- `black`, `ruff`, `isort`, and the pre-commit `check-yaml` / `check-toml` checks all pass on the changed files.

## Before this can go live

Two one-time steps outside this repo, need a maintainer with the right access:

1. **Register PyPI Trusted Publishing** on the `traceml-ai` project (pypi.org project settings): owner GitHub org `traceopt-ai`, repo `traceml`, workflow `publish.yml`, environment `pypi`. Needs a PyPI project owner.
2. **Create the `pypi` GitHub Environment** on this repo (Settings > Environments), matching the name above. Optionally add required reviewers for extra protection on publish. Needs repo admin; I only have maintain.

Until both are done, a `v*` tag push will build successfully and fail at the publish step, not do anything unsafe.

## Not in this PR

Cutting the next release itself. Once the two steps above are done, the first tag push exercises the full pipeline end to end.
