### PR TITLE
Abhinav/issue236

### DIFF
--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -162,6 +162,8 @@ What to do next:
 Meaning:
 
 - input wait is taking a large share of iteration time
+- TraceML uses the median per-rank input share, so one unusually slow rank
+  does not hide a broad input bottleneck
 
 Common causes:
 
@@ -190,6 +192,7 @@ What to do next:
 Meaning:
 
 - model compute dominates the typical step
+- this is informational when no material input or residual overhead is visible
 
 In practice this means most step time is going into:
 
@@ -365,6 +368,11 @@ In TraceML:
 - `compute = forward + backward + optimizer`
 - `residual = step_time - h2d - compute`
 - `total_step = input_wait + step_time`
+
+TraceML evaluates residual as the median per-rank share of selected-clock
+iteration time (`input_wait + step_time`). Input and residual findings warn at
+10% and are critical at 20%; rank skew is supporting evidence rather than a
+gate that hides a typical bottleneck.
 
 This is residual unattributed time inside the traced step, not direct
 collective, NCCL, or all-reduce timing.

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -73,9 +73,11 @@ Training-step timing.
   materially higher forward time than the victim rank.
 - `H2D_STRAGGLER`: the culprit rank has materially higher host-to-device
   transfer time than the victim rank.
-- `INPUT_BOUND`: selected-clock input wait dominates iteration time.
-- `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical step.
-- `RESIDUAL_HEAVY`: unattributed residual time is a material share of the step.
+- `INPUT_BOUND`: selected-clock input wait is a material typical iteration cost.
+- `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical step;
+  this is informational when no material overhead is visible.
+- `RESIDUAL_HEAVY`: unattributed residual time is a material typical iteration
+  cost.
 
 Step-time diagnosis uses one selected clock for the analyzed window. It uses
 GPU event timing when every rank/step has GPU timing for the step envelope,
@@ -92,12 +94,19 @@ display or diagnosis. In the final text report, most selected-clock phase
 shares are divided by `step_time_ms`; CPU compatibility rows are labeled
 separately.
 
-`INPUT_BOUND` uses selected-clock
-`input_wait_ms / iteration_time_ms`, where
-`iteration_time_ms = input_wait_ms + step_time_ms`. This compares pre-step
-input wait with the full selected-clock iteration time while leaving
-`step_time_ms` as the traced step envelope. Live and summary diagnosis both
-warn at 10% and are critical at 20%.
+Typical overhead diagnoses use selected-clock per-rank iteration shares:
+
+```text
+iteration_r = input_wait_r + step_time_r
+component_share_r = component_r / iteration_r
+typical_component_share = median(component_share_r across ranks)
+```
+
+`INPUT_BOUND` uses `input_wait` and `RESIDUAL_HEAVY` uses residual as the
+component. Both warn at 10% and are critical at 20%. Cross-rank skew remains
+evidence in the finding, but does not suppress a bottleneck affecting typical
+ranks. `COMPUTE_BOUND` remains an informational finding when compute dominates
+the traced step and no material input or residual overhead is visible.
 
 Shared Step Time diagnosis needs at least 2 steps to emit warning-only
 bottleneck diagnoses. Critical diagnoses are allowed once the window has at

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -324,8 +324,8 @@ def _apply_trend_note(
             input_wait_metric=input_wait_metric,
             residual_share=residual_share,
             input_bound_share=input_bound_share,
-            residual_warn_threshold=thresholds.residual_share_warn,
-            input_warn_threshold=thresholds.input_share_warn,
+            residual_warn_threshold=thresholds.overhead_share_warn,
+            input_warn_threshold=thresholds.overhead_share_warn,
             cfg=DEFAULT_STEP_TREND_HEURISTICS,
         )
         if not trend_note:

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -532,6 +532,29 @@ def compute_rank_values_from_components(
     return out
 
 
+def _median_iteration_component_share(
+    per_rank_timing: Dict[int, Dict[str, float]],
+    component: str,
+) -> float:
+    """Return the median selected-clock iteration share for one component."""
+    shares = []
+    for values in per_rank_timing.values():
+        if not {
+            "input_wait",
+            "step_time",
+            component,
+        }.issubset(values):
+            continue
+        iteration = non_negative_finite(
+            values["input_wait"]
+        ) + non_negative_finite(values["step_time"])
+        if iteration > 0.0:
+            shares.append(
+                share(non_negative_finite(values[component]), iteration)
+            )
+    return _median(shares)
+
+
 def build_step_time_context(
     *,
     metrics: Sequence[StepCombinedTimeMetric],
@@ -677,9 +700,15 @@ def build_step_time_context(
         step_total=step_total,
         residual_total=residual_total,
         compute_total=compute_total_value,
-        residual_share=share(residual_total, step_total),
+        residual_share=_median_iteration_component_share(
+            local_per_rank_timing,
+            "residual_proxy",
+        ),
         compute_share=share(compute_total_value, step_total),
-        input_bound_share=share(input_wait_total, iteration_time_total),
+        input_bound_share=_median_iteration_component_share(
+            local_per_rank_timing,
+            "input_wait",
+        ),
         input_bound_skew=input_bound_skew,
         compute_skew=compute_skew_value,
         input_bound_worst_rank=input_wait_worst_rank,

--- a/src/traceml_ai/diagnostics/step_time/formatters.py
+++ b/src/traceml_ai/diagnostics/step_time/formatters.py
@@ -21,7 +21,7 @@ def _styled_status(diagnosis: StepDiagnosis) -> str:
         style = "bold green"
     elif diagnosis.kind in {"NO_DATA", "WARMUP"}:
         style = "bold bright_black"
-    elif diagnosis.kind in {"INPUT_BOUND", "COMPUTE_BOUND"}:
+    elif diagnosis.kind == "INPUT_BOUND":
         style = "bold yellow"
     elif diagnosis.kind in {
         "INPUT_STRAGGLER",

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -14,10 +14,11 @@ class DiagnosisThresholds:
     the same rules and produce the same diagnosis vocabulary. Live and summary
     differ by the selected timing window, not by extra diagnosis gates.
 
-    INPUT_BOUND uses selected-clock ``input_wait_ms / iteration_time_ms``,
-    where ``iteration_time_ms = input_wait_ms + step_time_ms``. This keeps the
-    traced step envelope stable while measuring input wait against the full
-    selected-clock iteration time.
+    Typical overhead diagnoses use selected-clock per-rank iteration shares.
+    The context takes the median of those shares across ranks, where
+    ``iteration_time_ms = input_wait_ms + step_time_ms``. The shared overhead
+    thresholds are the future configuration surface for input, residual, and
+    H2D policies.
 
     ``min_steps_for_warning_diag`` is the minimum window size for warning-only
     bottleneck diagnoses. ``min_steps_for_confident_diag`` is the minimum window
@@ -27,17 +28,10 @@ class DiagnosisThresholds:
     straggler_score_warn: float = 0.10
     straggler_score_crit: float = 0.20
 
-    input_share_warn: float = 0.10
-    input_share_crit: float = 0.20
-
-    residual_share_warn: float = 0.15
-    residual_share_crit: float = 0.25
-
-    input_bound_max_skew: float = 0.06
-    compute_bound_max_skew: float = 0.06
+    overhead_share_warn: float = 0.10
+    overhead_share_crit: float = 0.20
 
     compute_bound_share_warn: float = 0.85
-    compute_bound_share_crit: float = 0.92
 
     min_steps_for_warning_diag: int = 2
     min_steps_for_confident_diag: int = 20
@@ -63,14 +57,9 @@ SUMMARY_STEP_TIME_POLICY = StepTimeDiagnosisPolicy(
     thresholds=DiagnosisThresholds(
         straggler_score_warn=0.10,
         straggler_score_crit=0.20,
-        input_share_warn=0.10,
-        input_share_crit=0.20,
-        residual_share_warn=0.18,
-        residual_share_crit=0.28,
-        input_bound_max_skew=0.05,
-        compute_bound_max_skew=0.05,
+        overhead_share_warn=0.10,
+        overhead_share_crit=0.20,
         compute_bound_share_warn=0.88,
-        compute_bound_share_crit=0.94,
         min_steps_for_confident_diag=20,
     ),
 )

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -173,12 +173,7 @@ class InputBoundRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
-        if context.input_bound_share < context.thresholds.input_share_warn:
-            return None
-
-        if not context.single_rank and (
-            context.input_bound_skew > context.thresholds.input_bound_max_skew
-        ):
+        if context.input_bound_share < context.thresholds.overhead_share_warn:
             return None
 
         return self._issue(
@@ -186,7 +181,7 @@ class InputBoundRule(_BaseStepTimeRule):
             status="INPUT-BOUND",
             severity=_severity(
                 context.input_bound_share,
-                context.thresholds.input_share_crit,
+                context.thresholds.overhead_share_crit,
             ),
             summary=(
                 f"Input wait is {_pct(context.input_bound_share)} of the "
@@ -220,7 +215,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
-        if context.residual_share < context.thresholds.residual_share_warn:
+        if context.residual_share < context.thresholds.overhead_share_warn:
             return None
 
         return self._issue(
@@ -228,7 +223,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
             status="RESIDUAL-HEAVY",
             severity=_severity(
                 context.residual_share,
-                context.thresholds.residual_share_crit,
+                context.thresholds.overhead_share_crit,
             ),
             summary=(
                 f"Residual time is {_pct(context.residual_share)} of the "
@@ -248,7 +243,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
 @dataclass(frozen=True)
 class ComputeBoundRule(_BaseStepTimeRule):
     """
-    Detect windows dominated by compute without a strong cross-rank straggler.
+    Report dominant compute as informational context.
     """
 
     name: str = "compute_bound"
@@ -257,17 +252,11 @@ class ComputeBoundRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
-        if context.rank_straggler is not None:
-            return None
         if context.compute_share < context.thresholds.compute_bound_share_warn:
             return None
-        if context.input_bound_share >= context.thresholds.input_share_warn:
+        if context.input_bound_share >= context.thresholds.overhead_share_warn:
             return None
-        if context.residual_share >= context.thresholds.residual_share_warn:
-            return None
-        if not context.single_rank and (
-            context.compute_skew > context.thresholds.compute_bound_max_skew
-        ):
+        if context.residual_share >= context.thresholds.overhead_share_warn:
             return None
 
         label = (
@@ -278,10 +267,7 @@ class ComputeBoundRule(_BaseStepTimeRule):
         return self._issue(
             kind="COMPUTE_BOUND",
             status="COMPUTE-BOUND",
-            severity=_severity(
-                context.compute_share,
-                context.thresholds.compute_bound_share_crit,
-            ),
+            severity="info",
             summary=f"Compute-bound; {label.lower()} is the largest phase.",
             action="Optimize model compute or reduce step cost.",
             metric="compute",

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -15,8 +15,10 @@ from traceml_ai.diagnostics.step_time.api import (
 from traceml_ai.diagnostics.step_time.context import build_step_time_context
 from traceml_ai.diagnostics.step_time.policy import SUMMARY_STEP_TIME_POLICY
 from traceml_ai.diagnostics.step_time.rules import (
+    ComputeBoundRule,
     InputBoundRule,
     RankStragglerRule,
+    ResidualHeavyRule,
 )
 from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeCoverage,
@@ -372,7 +374,7 @@ def test_input_bound_rule_ignores_duration_without_explicit_clocks() -> None:
     assert InputBoundRule().evaluate(ctx) is None
 
 
-def test_input_bound_rule_uses_input_wait_skew() -> None:
+def test_input_bound_uses_median_per_rank_iteration_share() -> None:
     ctx = _rank_context(
         {
             0: _timing_row(
@@ -388,8 +390,138 @@ def test_input_bound_rule_uses_input_wait_skew() -> None:
         }
     )
 
-    assert ctx.input_bound_share == pytest.approx(35.0 / 135.0)
-    assert InputBoundRule().evaluate(ctx) is None
+    expected = ((10.0 / 110.0) + (60.0 / 160.0)) / 2.0
+
+    assert ctx.input_bound_share == pytest.approx(expected)
+    assert ctx.input_bound_share != pytest.approx(35.0 / 135.0)
+
+    issue = InputBoundRule().evaluate(ctx)
+    assert issue is not None
+    assert issue.severity == "crit"
+    assert issue.skew_pct is not None
+
+
+@pytest.mark.parametrize(
+    ("input_wait", "step_time", "expected_severity"),
+    [(10.0, 90.0, "warn"), (20.0, 80.0, "crit")],
+)
+def test_input_bound_uses_iteration_share_thresholds(
+    input_wait: float,
+    step_time: float,
+    expected_severity: str,
+) -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=input_wait,
+            step_time=step_time,
+        )
+    }
+
+    issue = InputBoundRule().evaluate(_rank_context(per_rank))
+
+    assert issue is not None
+    assert issue.share_pct == pytest.approx(input_wait / 100.0)
+    assert issue.severity == expected_severity
+
+
+@pytest.mark.parametrize(
+    ("residual", "expected_severity"),
+    [(10.0, "warn"), (20.0, "crit")],
+)
+def test_residual_heavy_uses_iteration_share_thresholds(
+    residual: float,
+    expected_severity: str,
+) -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            residual=residual,
+            step_time=100.0,
+        )
+    }
+
+    issue = ResidualHeavyRule().evaluate(_rank_context(per_rank))
+
+    assert issue is not None
+    assert issue.share_pct == pytest.approx(residual / 100.0)
+    assert issue.severity == expected_severity
+
+
+def test_compute_bound_is_informational_despite_compute_skew() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            forward=90.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=0.0,
+            forward=150.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=160.0,
+        ),
+    }
+
+    issue = ComputeBoundRule().evaluate(_rank_context(per_rank))
+
+    assert issue is not None
+    assert issue.severity == "info"
+    assert issue.skew_pct is not None
+
+
+def test_compute_bound_requires_existing_dominance_threshold() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=20.0,
+            forward=80.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    assert ComputeBoundRule().evaluate(_rank_context(per_rank)) is None
+
+
+def test_compute_bound_is_secondary_to_rank_straggler() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            forward=90.0,
+            backward=10.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=0.0,
+            forward=90.0,
+            backward=30.0,
+            optimizer=0.0,
+            step_time=120.0,
+        ),
+    }
+
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+    )
+
+    assert result.primary.kind == "STRAGGLER"
+    assert {issue.kind for issue in result.issues} >= {
+        "STRAGGLER",
+        "COMPUTE_BOUND",
+    }
+    compute_issue = next(
+        issue for issue in result.issues if issue.kind == "COMPUTE_BOUND"
+    )
+    assert compute_issue.severity == "info"
 
 
 @pytest.mark.parametrize(

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -214,17 +214,19 @@ def test_step_time_balanced_card_is_compact() -> None:
         {
             0: _rank(
                 dataloader=5.0,
+                h2d=15.0,
                 forward=20.0,
                 backward=35.0,
                 optimizer=5.0,
-                step_cpu=70.0,
+                step_cpu=75.0,
             ),
             1: _rank(
                 dataloader=5.0,
+                h2d=15.0,
                 forward=21.0,
                 backward=34.0,
                 optimizer=5.0,
-                step_cpu=70.0,
+                step_cpu=75.0,
             ),
         }
     )
@@ -388,6 +390,7 @@ def test_step_time_input_straggler_card_shows_rank_evidence() -> None:
     )
     assert "issues" not in payload["groups"]["rows"]["1"]
     assert {issue["kind"] for issue in payload["issues"]} == {
-        "INPUT_STRAGGLER"
+        "INPUT_STRAGGLER",
+        "INPUT_BOUND",
     }
     _assert_compact_card(payload["card"])


### PR DESCRIPTION
## Summary

Normalize Step Time typical-bottleneck diagnosis around rank-aligned, selected-clock iteration shares.

This fixes a correctness issue where typical input and residual shares could be derived from separate metric rollups rather than from each rank's actual iteration cost. It also makes compute-bound output informational and removesobsolete threshold knobs that no longer affect policy.

## What Changed

- Compute input and residual shares per rank using:

  ```text
  iteration_r = input_wait_r + step_time_r
  component_share_r = component_r / iteration_r
  typical_component_share = median(component_share_r across ranks)
  ```

- Use shared `overhead_share_warn` / `overhead_share_crit` policy fields at   10% / 20% for both `INPUT_BOUND` and `RESIDUAL_HEAVY`.
- Keep rank skew as evidence in findings, but stop using it to suppress a  typical bottleneck that affects the median rank.
- Keep the existing compute-dominance gate, but make `COMPUTE_BOUND`  informational when no material input or residual overhead is present.  It can appear as secondary context beside an actionable rank straggler.
- Remove obsolete policy fields and summary overrides that no longer affected  diagnosis behavior.
- Update canonical and user-facing Step Time documentation.

## Why

In distributed training, independently taking a median input time and a median step time can combine values from different ranks. That ratio does not represent a real rank's iteration share and can cross a diagnosis thresholdincorrectly.

The new policy measures each rank's observed overhead fraction first, then takes the median. This preserves the selected-clock model and makes the diagnosis explainable: a typical bottleneck is not hidden just because one rank has more skew.

`COMPUTE_BOUND` now describes productive work rather than an actionable warning. Input, residual, and rank-straggler findings remain the actionable signals.

## Scope

- No instrumentation, telemetry, SQLite, transport, dashboard, or schema   changes.
- No `H2D_BOUND` diagnosis in this PR; the rank-share helper is intentionally reusable for that follow-up.
- No YAML configuration is added yet. The shared `overhead_share_*` fields are the intended future configuration surface.

## Verification

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/diagnostics \
  tests/renderers/test_step_time_compute.py \
  tests/renderers/test_step_time_renderer.py \
  tests/reporting/summary/test_step_time.py \
  tests/reporting/summary/test_step_time_card.py \
  -q
```


Focused coverage includes:

- median-of-per-rank-shares versus ratio-of-rollups;
- input and residual 10% warning / 20% critical boundaries;
- skew no longer suppressing a typical bottleneck;
- informational compute-bound behavior and its coexistence with a straggler;
- selected-clock, warmup, FSDP, renderer, and final-summary paths.

