### PR TITLE
Abhinav/issue237

### DIFF
--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -162,6 +162,8 @@ What to do next:
 Meaning:
 
 - input wait is taking a large share of iteration time
+- TraceML uses the median per-rank input share, so one unusually slow rank
+  does not hide a broad input bottleneck
 
 Common causes:
 
@@ -190,6 +192,7 @@ What to do next:
 Meaning:
 
 - model compute dominates the typical step
+- this is informational when no material input or residual overhead is visible
 
 In practice this means most step time is going into:
 
@@ -365,6 +368,11 @@ In TraceML:
 - `compute = forward + backward + optimizer`
 - `residual = step_time - h2d - compute`
 - `total_step = input_wait + step_time`
+
+TraceML evaluates residual as the median per-rank share of selected-clock
+iteration time (`input_wait + step_time`). Input and residual findings warn at
+10% and are critical at 20%; rank skew is supporting evidence rather than a
+gate that hides a typical bottleneck.
 
 This is residual unattributed time inside the traced step, not direct
 collective, NCCL, or all-reduce timing.

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -175,7 +175,7 @@ Common causes:
 What to look at:
 
 - `Input Wait`
-- its share of the step
+- its share of iteration time
 - whether the issue is broad or rank-specific
 
 What to do next:
@@ -184,6 +184,30 @@ What to do next:
 - reduce preprocessing cost
 - improve storage throughput
 - inspect batch construction
+
+---
+
+### `H2D-BOUND`
+
+Meaning:
+
+- host-to-device transfer is taking a large share of typical iteration time
+- TraceML uses the median per-rank H2D share, so one unusually slow rank does
+  not hide a broad transfer bottleneck
+- this diagnosis requires GPU-selected timing; CPU host-call duration is not
+  treated as transfer cost
+
+TraceML reports a warning at 10% of iteration time and critical severity at
+20%.
+
+What to do next:
+
+- use pinned host memory where appropriate
+- inspect batch transfer placement and non-blocking copies
+- reduce transferred batch size or unnecessary host-to-device copies
+
+`H2D-BOUND` describes broad transfer cost. `H2D STRAGGLER` instead describes
+one rank with excess transfer time.
 
 ---
 
@@ -748,6 +772,7 @@ Use these as context cards:
 | Diagnosis | Good next step |
 |---|---|
 | `INPUT-BOUND` | inspect input loading, preprocessing, and storage |
+| `H2D-BOUND` | inspect pinned memory, batch transfer, and host-to-device copies |
 | `COMPUTE-BOUND` | inspect forward/backward/optimizer cost |
 | `INPUT STRAGGLER` | inspect input path on the culprit rank |
 | `COMPUTE STRAGGLER` | inspect DDP forward work on the culprit rank |

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -74,6 +74,8 @@ Training-step timing.
 - `H2D_STRAGGLER`: the culprit rank has materially higher host-to-device
   transfer time than the victim rank.
 - `INPUT_BOUND`: selected-clock input wait is a material typical iteration cost.
+- `H2D_BOUND`: selected-clock GPU H2D transfer is a material typical iteration
+  cost.
 - `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical step;
   this is informational when no material overhead is visible.
 - `RESIDUAL_HEAVY`: unattributed residual time is a material typical iteration
@@ -90,9 +92,9 @@ The compatibility `dataloader_ms` field remains CPU dataloader fetch time, and
 `total_step_ms` remains CPU dataloader fetch plus CPU step envelope timing.
 These compatibility fields are not selected-clock phase-share denominators.
 `duration_ms` stays stored compatibility timing and is not used for Step Time
-display or diagnosis. In the final text report, most selected-clock phase
-shares are divided by `step_time_ms`; CPU compatibility rows are labeled
-separately.
+display or diagnosis. In the final text report, selected-clock phase shares
+are divided by `input_wait_ms + step_time_ms`; CPU compatibility rows are
+labeled separately.
 
 Typical overhead diagnoses use selected-clock per-rank iteration shares:
 
@@ -102,11 +104,14 @@ component_share_r = component_r / iteration_r
 typical_component_share = median(component_share_r across ranks)
 ```
 
-`INPUT_BOUND` uses `input_wait` and `RESIDUAL_HEAVY` uses residual as the
-component. Both warn at 10% and are critical at 20%. Cross-rank skew remains
-evidence in the finding, but does not suppress a bottleneck affecting typical
-ranks. `COMPUTE_BOUND` remains an informational finding when compute dominates
-the traced step and no material input or residual overhead is visible.
+`INPUT_BOUND` uses `input_wait`, `H2D_BOUND` uses H2D transfer, and
+`RESIDUAL_HEAVY` uses residual as the component. They warn at 10% and are
+critical at 20%. `H2D_BOUND` requires GPU-selected timing, so asynchronous CPU
+host-call duration is not reported as transfer cost. Cross-rank skew remains
+evidence in a typical-bottleneck finding, but does not suppress one. In
+contrast, `H2D_STRAGGLER` identifies one rank's excess H2D time.
+`COMPUTE_BOUND` remains an informational finding when compute dominates the
+traced step and no material input, H2D, or residual overhead is visible.
 
 Shared Step Time diagnosis needs at least 2 steps to emit warning-only
 bottleneck diagnoses. Critical diagnoses are allowed once the window has at

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -73,9 +73,11 @@ Training-step timing.
   materially higher forward time than the victim rank.
 - `H2D_STRAGGLER`: the culprit rank has materially higher host-to-device
   transfer time than the victim rank.
-- `INPUT_BOUND`: selected-clock input wait dominates iteration time.
-- `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical step.
-- `RESIDUAL_HEAVY`: unattributed residual time is a material share of the step.
+- `INPUT_BOUND`: selected-clock input wait is a material typical iteration cost.
+- `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical step;
+  this is informational when no material overhead is visible.
+- `RESIDUAL_HEAVY`: unattributed residual time is a material typical iteration
+  cost.
 
 Step-time diagnosis uses one selected clock for the analyzed window. It uses
 GPU event timing when every rank/step has GPU timing for the step envelope,
@@ -92,12 +94,19 @@ display or diagnosis. In the final text report, most selected-clock phase
 shares are divided by `step_time_ms`; CPU compatibility rows are labeled
 separately.
 
-`INPUT_BOUND` uses selected-clock
-`input_wait_ms / iteration_time_ms`, where
-`iteration_time_ms = input_wait_ms + step_time_ms`. This compares pre-step
-input wait with the full selected-clock iteration time while leaving
-`step_time_ms` as the traced step envelope. Live and summary diagnosis both
-warn at 10% and are critical at 20%.
+Typical overhead diagnoses use selected-clock per-rank iteration shares:
+
+```text
+iteration_r = input_wait_r + step_time_r
+component_share_r = component_r / iteration_r
+typical_component_share = median(component_share_r across ranks)
+```
+
+`INPUT_BOUND` uses `input_wait` and `RESIDUAL_HEAVY` uses residual as the
+component. Both warn at 10% and are critical at 20%. Cross-rank skew remains
+evidence in the finding, but does not suppress a bottleneck affecting typical
+ranks. `COMPUTE_BOUND` remains an informational finding when compute dominates
+the traced step and no material input or residual overhead is visible.
 
 Shared Step Time diagnosis needs at least 2 steps to emit warning-only
 bottleneck diagnoses. Critical diagnoses are allowed once the window has at

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -324,8 +324,8 @@ def _apply_trend_note(
             input_wait_metric=input_wait_metric,
             residual_share=residual_share,
             input_bound_share=input_bound_share,
-            residual_warn_threshold=thresholds.residual_share_warn,
-            input_warn_threshold=thresholds.input_share_warn,
+            residual_warn_threshold=thresholds.overhead_share_warn,
+            input_warn_threshold=thresholds.overhead_share_warn,
             cfg=DEFAULT_STEP_TREND_HEURISTICS,
         )
         if not trend_note:

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -46,6 +46,7 @@ DiagnosisKind = Literal[
     "COMPUTE_STRAGGLER",
     "H2D_STRAGGLER",
     "INPUT_BOUND",
+    "H2D_BOUND",
     "COMPUTE_BOUND",
     "RESIDUAL_HEAVY",
 ]
@@ -59,6 +60,7 @@ _STATUS_BY_KIND: dict[DiagnosisKind, str] = {
     "COMPUTE_STRAGGLER": "COMPUTE STRAGGLER",
     "H2D_STRAGGLER": "H2D STRAGGLER",
     "INPUT_BOUND": "INPUT-BOUND",
+    "H2D_BOUND": "H2D-BOUND",
     "COMPUTE_BOUND": "COMPUTE-BOUND",
     "RESIDUAL_HEAVY": "RESIDUAL-HEAVY",
 }
@@ -69,6 +71,7 @@ _PRIMARY_KIND_PRIORITY: dict[str, int] = {
     "COMPUTE_STRAGGLER": 40,
     "H2D_STRAGGLER": 40,
     "INPUT_BOUND": 30,
+    "H2D_BOUND": 30,
     "RESIDUAL_HEAVY": 20,
     "COMPUTE_BOUND": 10,
 }
@@ -445,6 +448,17 @@ def build_step_diagnosis_result(
             steps_used=context.steps_used,
             worst_rank=(
                 None if context.single_rank else context.input_bound_worst_rank
+            ),
+        )
+    elif primary_issue is not None and primary_issue.kind == "H2D_BOUND":
+        primary = _mk_diag(
+            kind="H2D_BOUND",
+            severity=primary_issue.severity,
+            reason=primary_issue.summary,
+            action=primary_issue.action,
+            steps_used=context.steps_used,
+            worst_rank=(
+                primary_issue.ranks[0] if primary_issue.ranks else None
             ),
         )
     elif primary_issue is not None and primary_issue.kind == "RESIDUAL_HEAVY":

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -532,6 +532,29 @@ def compute_rank_values_from_components(
     return out
 
 
+def _median_iteration_component_share(
+    per_rank_timing: Dict[int, Dict[str, float]],
+    component: str,
+) -> float:
+    """Return the median selected-clock iteration share for one component."""
+    shares = []
+    for values in per_rank_timing.values():
+        if not {
+            "input_wait",
+            "step_time",
+            component,
+        }.issubset(values):
+            continue
+        iteration = non_negative_finite(
+            values["input_wait"]
+        ) + non_negative_finite(values["step_time"])
+        if iteration > 0.0:
+            shares.append(
+                share(non_negative_finite(values[component]), iteration)
+            )
+    return _median(shares)
+
+
 def build_step_time_context(
     *,
     metrics: Sequence[StepCombinedTimeMetric],
@@ -677,9 +700,15 @@ def build_step_time_context(
         step_total=step_total,
         residual_total=residual_total,
         compute_total=compute_total_value,
-        residual_share=share(residual_total, step_total),
+        residual_share=_median_iteration_component_share(
+            local_per_rank_timing,
+            "residual_proxy",
+        ),
         compute_share=share(compute_total_value, step_total),
-        input_bound_share=share(input_wait_total, iteration_time_total),
+        input_bound_share=_median_iteration_component_share(
+            local_per_rank_timing,
+            "input_wait",
+        ),
         input_bound_skew=input_bound_skew,
         compute_skew=compute_skew_value,
         input_bound_worst_rank=input_wait_worst_rank,

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -113,6 +113,7 @@ class StepTimeAnalysisContext:
     residual_share: float
     compute_share: float
     input_bound_share: float
+    h2d_share: float
 
     input_bound_skew: float
     compute_skew: float
@@ -708,6 +709,10 @@ def build_step_time_context(
         input_bound_share=_median_iteration_component_share(
             local_per_rank_timing,
             "input_wait",
+        ),
+        h2d_share=_median_iteration_component_share(
+            local_per_rank_timing,
+            "h2d",
         ),
         input_bound_skew=input_bound_skew,
         compute_skew=compute_skew_value,

--- a/src/traceml_ai/diagnostics/step_time/formatters.py
+++ b/src/traceml_ai/diagnostics/step_time/formatters.py
@@ -23,6 +23,8 @@ def _styled_status(diagnosis: StepDiagnosis) -> str:
         style = "bold bright_black"
     elif diagnosis.kind == "INPUT_BOUND":
         style = "bold yellow"
+    elif diagnosis.kind == "H2D_BOUND":
+        style = "bold red" if diagnosis.severity == "crit" else "bold yellow"
     elif diagnosis.kind in {
         "INPUT_STRAGGLER",
         "COMPUTE_STRAGGLER",

--- a/src/traceml_ai/diagnostics/step_time/formatters.py
+++ b/src/traceml_ai/diagnostics/step_time/formatters.py
@@ -21,7 +21,7 @@ def _styled_status(diagnosis: StepDiagnosis) -> str:
         style = "bold green"
     elif diagnosis.kind in {"NO_DATA", "WARMUP"}:
         style = "bold bright_black"
-    elif diagnosis.kind in {"INPUT_BOUND", "COMPUTE_BOUND"}:
+    elif diagnosis.kind == "INPUT_BOUND":
         style = "bold yellow"
     elif diagnosis.kind in {
         "INPUT_STRAGGLER",

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -14,10 +14,11 @@ class DiagnosisThresholds:
     the same rules and produce the same diagnosis vocabulary. Live and summary
     differ by the selected timing window, not by extra diagnosis gates.
 
-    INPUT_BOUND uses selected-clock ``input_wait_ms / iteration_time_ms``,
-    where ``iteration_time_ms = input_wait_ms + step_time_ms``. This keeps the
-    traced step envelope stable while measuring input wait against the full
-    selected-clock iteration time.
+    Typical overhead diagnoses use selected-clock per-rank iteration shares.
+    The context takes the median of those shares across ranks, where
+    ``iteration_time_ms = input_wait_ms + step_time_ms``. The shared overhead
+    thresholds are the future configuration surface for input, residual, and
+    H2D policies.
 
     ``min_steps_for_warning_diag`` is the minimum window size for warning-only
     bottleneck diagnoses. ``min_steps_for_confident_diag`` is the minimum window
@@ -27,17 +28,10 @@ class DiagnosisThresholds:
     straggler_score_warn: float = 0.10
     straggler_score_crit: float = 0.20
 
-    input_share_warn: float = 0.10
-    input_share_crit: float = 0.20
-
-    residual_share_warn: float = 0.15
-    residual_share_crit: float = 0.25
-
-    input_bound_max_skew: float = 0.06
-    compute_bound_max_skew: float = 0.06
+    overhead_share_warn: float = 0.10
+    overhead_share_crit: float = 0.20
 
     compute_bound_share_warn: float = 0.85
-    compute_bound_share_crit: float = 0.92
 
     min_steps_for_warning_diag: int = 2
     min_steps_for_confident_diag: int = 20
@@ -63,14 +57,9 @@ SUMMARY_STEP_TIME_POLICY = StepTimeDiagnosisPolicy(
     thresholds=DiagnosisThresholds(
         straggler_score_warn=0.10,
         straggler_score_crit=0.20,
-        input_share_warn=0.10,
-        input_share_crit=0.20,
-        residual_share_warn=0.18,
-        residual_share_crit=0.28,
-        input_bound_max_skew=0.05,
-        compute_bound_max_skew=0.05,
+        overhead_share_warn=0.10,
+        overhead_share_crit=0.20,
         compute_bound_share_warn=0.88,
-        compute_bound_share_crit=0.94,
         min_steps_for_confident_diag=20,
     ),
 )

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -12,7 +12,13 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Sequence, Tuple
 
 from ..common import DiagnosticIssue, DiagnosticRule
-from .context import StepTimeAnalysisContext, non_negative_finite
+from .context import (
+    StepTimeAnalysisContext,
+    metric_skew,
+    metric_total,
+    metric_worst_rank,
+    non_negative_finite,
+)
 
 
 def _severity(value: float, crit_threshold: float) -> str:
@@ -204,6 +210,56 @@ class InputBoundRule(_BaseStepTimeRule):
 
 
 @dataclass(frozen=True)
+class H2DBoundRule(_BaseStepTimeRule):
+    """Detect broad H2D transfer cost from GPU-selected timing."""
+
+    name: str = "h2d_bound"
+
+    def evaluate(
+        self,
+        context: StepTimeAnalysisContext,
+    ) -> Optional[DiagnosticIssue]:
+        if context.diagnosis_clock != "gpu":
+            return None
+        if context.h2d_share < context.thresholds.overhead_share_warn:
+            return None
+        worst_rank = metric_worst_rank(context.h2d_metric)
+
+        return self._issue(
+            kind="H2D_BOUND",
+            status="H2D-BOUND",
+            severity=_severity(
+                context.h2d_share,
+                context.thresholds.overhead_share_crit,
+            ),
+            summary=(
+                f"H2D transfer is {_pct(context.h2d_share)} of the "
+                "typical GPU iteration time."
+            ),
+            action=(
+                "Inspect pinned memory, batch transfer, and host-to-device "
+                "copies."
+            ),
+            metric="h2d",
+            phase="h2d",
+            share_pct=context.h2d_share,
+            skew_pct=metric_skew(
+                context.h2d_metric,
+                single_rank=context.single_rank,
+            ),
+            ranks=(worst_rank,) if worst_rank is not None else (),
+            evidence={
+                "h2d_ms": metric_total(
+                    context.h2d_metric,
+                    single_rank=context.single_rank,
+                ),
+                "h2d_share": context.h2d_share,
+                "diagnosis_clock": context.diagnosis_clock,
+            },
+        )
+
+
+@dataclass(frozen=True)
 class ResidualHeavyRule(_BaseStepTimeRule):
     """
     Detect windows dominated by residual time rather than traced local work.
@@ -256,6 +312,11 @@ class ComputeBoundRule(_BaseStepTimeRule):
             return None
         if context.input_bound_share >= context.thresholds.overhead_share_warn:
             return None
+        if (
+            context.diagnosis_clock == "gpu"
+            and context.h2d_share >= context.thresholds.overhead_share_warn
+        ):
+            return None
         if context.residual_share >= context.thresholds.overhead_share_warn:
             return None
 
@@ -283,6 +344,7 @@ DEFAULT_STEP_TIME_RULES: Tuple[
 ] = (
     RankStragglerRule(),
     InputBoundRule(),
+    H2DBoundRule(),
     ResidualHeavyRule(),
     ComputeBoundRule(),
 )
@@ -309,6 +371,7 @@ def run_step_time_rules(
 __all__ = [
     "DEFAULT_STEP_TIME_RULES",
     "ComputeBoundRule",
+    "H2DBoundRule",
     "InputBoundRule",
     "RankStragglerRule",
     "ResidualHeavyRule",

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -173,12 +173,7 @@ class InputBoundRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
-        if context.input_bound_share < context.thresholds.input_share_warn:
-            return None
-
-        if not context.single_rank and (
-            context.input_bound_skew > context.thresholds.input_bound_max_skew
-        ):
+        if context.input_bound_share < context.thresholds.overhead_share_warn:
             return None
 
         return self._issue(
@@ -186,7 +181,7 @@ class InputBoundRule(_BaseStepTimeRule):
             status="INPUT-BOUND",
             severity=_severity(
                 context.input_bound_share,
-                context.thresholds.input_share_crit,
+                context.thresholds.overhead_share_crit,
             ),
             summary=(
                 f"Input wait is {_pct(context.input_bound_share)} of the "
@@ -220,7 +215,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
-        if context.residual_share < context.thresholds.residual_share_warn:
+        if context.residual_share < context.thresholds.overhead_share_warn:
             return None
 
         return self._issue(
@@ -228,7 +223,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
             status="RESIDUAL-HEAVY",
             severity=_severity(
                 context.residual_share,
-                context.thresholds.residual_share_crit,
+                context.thresholds.overhead_share_crit,
             ),
             summary=(
                 f"Residual time is {_pct(context.residual_share)} of the "
@@ -248,7 +243,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
 @dataclass(frozen=True)
 class ComputeBoundRule(_BaseStepTimeRule):
     """
-    Detect windows dominated by compute without a strong cross-rank straggler.
+    Report dominant compute as informational context.
     """
 
     name: str = "compute_bound"
@@ -257,17 +252,11 @@ class ComputeBoundRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
-        if context.rank_straggler is not None:
-            return None
         if context.compute_share < context.thresholds.compute_bound_share_warn:
             return None
-        if context.input_bound_share >= context.thresholds.input_share_warn:
+        if context.input_bound_share >= context.thresholds.overhead_share_warn:
             return None
-        if context.residual_share >= context.thresholds.residual_share_warn:
-            return None
-        if not context.single_rank and (
-            context.compute_skew > context.thresholds.compute_bound_max_skew
-        ):
+        if context.residual_share >= context.thresholds.overhead_share_warn:
             return None
 
         label = (
@@ -278,10 +267,7 @@ class ComputeBoundRule(_BaseStepTimeRule):
         return self._issue(
             kind="COMPUTE_BOUND",
             status="COMPUTE-BOUND",
-            severity=_severity(
-                context.compute_share,
-                context.thresholds.compute_bound_share_crit,
-            ),
+            severity="info",
             summary=f"Compute-bound; {label.lower()} is the largest phase.",
             action="Optimize model compute or reduce step cost.",
             metric="compute",

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -75,8 +75,8 @@ Selection policy:
 
 - `INPUT_STRAGGLER`, `COMPUTE_STRAGGLER`, `H2D_STRAGGLER`, and `STRAGGLER`
   use rank-comparison evidence and are promoted from `step_time.diagnosis`.
-- `RESIDUAL_HEAVY`, `INPUT_BOUND`, and `COMPUTE_BOUND` use phase-share evidence
-  and are promoted from `step_time.diagnosis`.
+- `RESIDUAL_HEAVY`, `INPUT_BOUND`, `H2D_BOUND`, and `COMPUTE_BOUND` use
+  phase-share evidence and are promoted from `step_time.diagnosis`.
 - `LOW_GPU_UTILIZATION_UNEXPLAINED` appears only when Step Time is `BALANCED`
   and System reports `LOW_GPU_UTILIZATION` or `MODERATE_GPU_UTILIZATION`.
 - `NO_CLEAR_PERFORMANCE_BOTTLENECK` appears when Step Time is `BALANCED` and
@@ -115,18 +115,17 @@ Primary diagnosis evidence uses a small union:
   "residual_ms": 39.6,
   "shares": {
     "input_wait_pct": 33.3,
-    "h2d_pct": 0.3,
-    "compute_pct": 75.0,
-    "residual_pct": 24.8
+    "h2d_pct": 0.2,
+    "compute_pct": 50.0,
+    "residual_pct": 16.5
   },
   "gpu_util_avg_percent": 37.8
 }
 ```
 
-`phase_share` is used for `INPUT_BOUND`, `RESIDUAL_HEAVY`, and `COMPUTE_BOUND`.
-Values come from `step_time.global.average`. For `INPUT_BOUND`,
-`input_wait_pct` uses `iteration_time_ms = input_wait_ms + step_time_ms`;
-other phase-share percentages use `step_time_ms`.
+`phase_share` is used for `INPUT_BOUND`, `H2D_BOUND`, `RESIDUAL_HEAVY`, and
+`COMPUTE_BOUND`. Values come from `step_time.global.average`. All phase-share
+percentages use `iteration_time_ms = input_wait_ms + step_time_ms`.
 
 ```json
 {
@@ -329,9 +328,8 @@ The public `dataloader_ms` key is kept for compatibility and represents CPU
 dataloader fetch wall time.
 The public `total_step_ms` key is also CPU-clocked for compatibility; it is
 not the denominator for selected-clock phase shares. The final text report
-uses selected-clock `step_time_ms` for most phase shares and labels CPU
-compatibility rows separately. `INPUT_BOUND` input-wait share uses derived
-`iteration_time_ms = input_wait_ms + step_time_ms`.
+uses derived `iteration_time_ms = input_wait_ms + step_time_ms` for every
+selected-clock phase share and labels CPU compatibility rows separately.
 
 `residual_ms` is residual unattributed step time. It is averaged from
 per-step clamped residuals, not recomputed from already-averaged phase totals:

--- a/src/traceml_ai/reporting/final.py
+++ b/src/traceml_ai/reporting/final.py
@@ -603,11 +603,11 @@ def _append_step_time_evidence_single(
 ) -> None:
     """Append selected-clock average/share Step Time evidence."""
     widths = (16, 16, 12)
-    share_total = _average_value(step_time_summary, "step_time_ms")
+    step_time = _average_value(step_time_summary, "step_time_ms")
     input_wait = _average_value(step_time_summary, "input_wait_ms")
     iteration_time = (
-        input_wait + share_total
-        if input_wait is not None and share_total is not None
+        input_wait + step_time
+        if input_wait is not None and step_time is not None
         else None
     )
     lines.append(row("Step Time Evidence", width=SUMMARY_WIDTH))
@@ -622,14 +622,10 @@ def _append_step_time_evidence_single(
         value = _average_value(step_time_summary, metric)
         if metric in _STEP_TIME_CPU_COMPAT_METRICS:
             # These fields stay CPU-clocked for compatibility; selected-clock
-            # phase shares generally use step_time_ms as the denominator.
+            # phase shares use selected-clock iteration time as the denominator.
             share = "compat"
-        elif metric == "input_wait_ms":
-            share = _format_share(value, iteration_time)
-        elif metric == "step_time_ms":
-            share = "100.0%"
         else:
-            share = _format_share(value, share_total)
+            share = _format_share(value, iteration_time)
         lines.append(
             row(
                 _table_line(

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -28,7 +28,7 @@ Primary diagnosis policy
    ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``, ``H2D_STRAGGLER``,
    ``STRAGGLER``.
 2. Step-time phase-share findings become primary performance findings:
-   ``RESIDUAL_HEAVY``, ``INPUT_BOUND``, ``COMPUTE_BOUND``.
+   ``RESIDUAL_HEAVY``, ``INPUT_BOUND``, ``H2D_BOUND``, ``COMPUTE_BOUND``.
 3. If Step Time is ``BALANCED`` and System reports low or moderate GPU
    utilization, the primary becomes ``LOW_GPU_UTILIZATION_UNEXPLAINED``.
    GPU utilization is treated as a symptom or fallback, not root-cause proof.
@@ -48,9 +48,9 @@ primary.
 Evidence policy
 ---------------
 ``phase_share``
-    Used for ``INPUT_BOUND``, ``RESIDUAL_HEAVY``, and ``COMPUTE_BOUND``. Values
-    come from ``step_time.global.average`` because the diagnosis describes
-    where the average step time went.
+    Used for ``INPUT_BOUND``, ``H2D_BOUND``, ``RESIDUAL_HEAVY``, and
+    ``COMPUTE_BOUND``. Values come from ``step_time.global.average`` because
+    the diagnosis describes where the average step time went.
 
 ``rank_comparison``
     Used for ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``,
@@ -80,7 +80,12 @@ JsonDict = Dict[str, Any]
 STEP_TIME_SECTION = "step_time"
 PERFORMANCE_SCOPE = "performance"
 
-PHASE_SHARE_KINDS = {"INPUT_BOUND", "RESIDUAL_HEAVY", "COMPUTE_BOUND"}
+PHASE_SHARE_KINDS = {
+    "INPUT_BOUND",
+    "H2D_BOUND",
+    "RESIDUAL_HEAVY",
+    "COMPUTE_BOUND",
+}
 STRAGGLER_KINDS = {
     "INPUT_STRAGGLER",
     "COMPUTE_STRAGGLER",
@@ -222,9 +227,8 @@ def _phase_share_evidence(
     *,
     step_time_summary: Mapping[str, Any],
     system_summary: Mapping[str, Any],
-    include_iteration_time: bool = False,
 ) -> JsonDict:
-    """Build evidence for diagnoses based on average step-time shares."""
+    """Build evidence with selected-clock iteration-time phase shares."""
     average = _global_average(step_time_summary)
     total_ms = _float_or_none(average.get("total_step_ms"))
     step_time_ms = _float_or_none(average.get("step_time_ms"))
@@ -234,7 +238,6 @@ def _phase_share_evidence(
         if input_wait_ms is not None and step_time_ms is not None
         else None
     )
-    denominator_ms = step_time_ms or total_ms
     window = _global_window(step_time_summary)
     evidence: JsonDict = {
         "type": "phase_share",
@@ -245,8 +248,7 @@ def _phase_share_evidence(
         "diagnosis_clock": window.get("diagnosis_clock"),
         "dataloader_ms": _round(_float_or_none(average.get("dataloader_ms"))),
     }
-    if include_iteration_time:
-        evidence["iteration_time_ms"] = _round(iteration_time_ms)
+    evidence["iteration_time_ms"] = _round(iteration_time_ms)
 
     for metric in PHASE_METRICS:
         evidence[metric] = _round(_float_or_none(average.get(metric)))
@@ -255,15 +257,12 @@ def _phase_share_evidence(
     for metric in PHASE_METRICS:
         value = _float_or_none(average.get(metric))
         key = metric.replace("_ms", "_pct")
-        metric_denominator_ms = (
-            iteration_time_ms if metric == "input_wait_ms" else denominator_ms
-        )
         shares[key] = (
-            _round(100.0 * value / metric_denominator_ms)
+            _round(100.0 * value / iteration_time_ms)
             if (
                 value is not None
-                and metric_denominator_ms
-                and metric_denominator_ms > 0.0
+                and iteration_time_ms
+                and iteration_time_ms > 0.0
             )
             else None
         )
@@ -446,6 +445,15 @@ def _phase_share_summary(kind: str, evidence: Mapping[str, Any]) -> str:
                 f"{iteration_time:.1f}ms iteration time."
             )
         return "Input wait took a large share of iteration time."
+    if kind == "H2D_BOUND":
+        value = _float_or_none(evidence.get("h2d_ms"))
+        iteration_time = _float_or_none(evidence.get("iteration_time_ms"))
+        if value is not None and iteration_time is not None:
+            return (
+                f"H2D transfer took {value:.1f}ms of "
+                f"{iteration_time:.1f}ms iteration time."
+            )
+        return "H2D transfer took a large share of iteration time."
     if kind == "RESIDUAL_HEAVY":
         value = _float_or_none(evidence.get("residual_ms"))
         if value is not None and total is not None:
@@ -512,7 +520,6 @@ def _promote_step_time_primary(
         evidence = _phase_share_evidence(
             step_time_summary=step_time_summary,
             system_summary=system_summary,
-            include_iteration_time=(kind == "INPUT_BOUND"),
         )
         summary = _phase_share_summary(kind, evidence)
     else:

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -373,6 +373,12 @@ def _step_time_card_reason(
         return str(
             getattr(diagnosis, "reason", "") or "Input wait was high."
         ).strip()
+    if kind == "H2D_BOUND":
+        evidence = (
+            f"{format_ms(stats.h2d.worst_ms)}/"
+            f"{format_ms(stats.total_step.worst_ms)}"
+        )
+        return f"H2D transfer was high inside the total step ({evidence})."
     if kind == "RESIDUAL_HEAVY":
         evidence = (
             f"{format_ms(stats.residual.worst_ms)}/"

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -6,16 +6,21 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import pytest
 
 from traceml_ai.diagnostics.step_time.api import (
     DEFAULT_THRESHOLDS,
+    StepDiagnosis,
     build_step_diagnosis_result,
 )
 from traceml_ai.diagnostics.step_time.context import build_step_time_context
+from traceml_ai.diagnostics.step_time.formatters import format_cli_diagnosis
 from traceml_ai.diagnostics.step_time.policy import SUMMARY_STEP_TIME_POLICY
 from traceml_ai.diagnostics.step_time.rules import (
     ComputeBoundRule,
+    H2DBoundRule,
     InputBoundRule,
     RankStragglerRule,
     ResidualHeavyRule,
@@ -177,12 +182,14 @@ def _rank_context(
     per_rank_timing: dict[int, dict[str, float]],
     *,
     training_strategy: str = "ddp",
+    diagnosis_clock: str = "cpu",
 ):
     return build_step_time_context(
         metrics=_metrics_from_per_rank_timing(per_rank_timing),
         thresholds=DEFAULT_THRESHOLDS,
         per_rank_timing=per_rank_timing,
         training_strategy=training_strategy,
+        diagnosis_clock=diagnosis_clock,
     )
 
 
@@ -425,6 +432,98 @@ def test_input_bound_uses_iteration_share_thresholds(
 
 
 @pytest.mark.parametrize(
+    ("h2d", "expected_severity"),
+    [(10.0, "warn"), (20.0, "crit")],
+)
+def test_h2d_bound_uses_gpu_iteration_share_thresholds(
+    h2d: float,
+    expected_severity: str,
+) -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=h2d,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    issue = H2DBoundRule().evaluate(
+        _rank_context(per_rank, diagnosis_clock="gpu")
+    )
+
+    assert issue is not None
+    assert issue.metric == "h2d"
+    assert issue.phase == "h2d"
+    assert issue.share_pct == pytest.approx(h2d / 100.0)
+    assert issue.severity == expected_severity
+
+
+def test_h2d_bound_abstains_below_warning_threshold() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=9.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    assert (
+        H2DBoundRule().evaluate(_rank_context(per_rank, diagnosis_clock="gpu"))
+        is None
+    )
+
+
+def test_h2d_bound_requires_gpu_selected_timing() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=80.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    assert H2DBoundRule().evaluate(_rank_context(per_rank)) is None
+
+
+def test_h2d_bound_keeps_skew_as_evidence() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=10.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=0.0,
+            h2d=90.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+    }
+
+    issue = H2DBoundRule().evaluate(
+        _rank_context(per_rank, diagnosis_clock="gpu")
+    )
+
+    assert issue is not None
+    assert issue.skew_pct is not None
+    assert issue.ranks == (1,)
+
+
+@pytest.mark.parametrize(
     ("residual", "expected_severity"),
     [(10.0, "warn"), (20.0, "crit")],
 )
@@ -488,6 +587,89 @@ def test_compute_bound_requires_existing_dominance_threshold() -> None:
     }
 
     assert ComputeBoundRule().evaluate(_rank_context(per_rank)) is None
+
+
+def test_compute_bound_abstains_for_material_h2d() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=10.0,
+            forward=90.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    assert (
+        ComputeBoundRule().evaluate(
+            _rank_context(per_rank, diagnosis_clock="gpu")
+        )
+        is None
+    )
+
+
+def test_cpu_h2d_does_not_suppress_compute_bound() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=80.0,
+            forward=90.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    issue = ComputeBoundRule().evaluate(_rank_context(per_rank))
+
+    assert issue is not None
+    assert issue.kind == "COMPUTE_BOUND"
+
+
+def test_input_bound_remains_primary_when_h2d_is_also_material() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=20.0,
+            h2d=20.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+        diagnosis_clock="gpu",
+    )
+
+    assert result.primary.kind == "INPUT_BOUND"
+    assert {issue.kind for issue in result.issues} >= {
+        "INPUT_BOUND",
+        "H2D_BOUND",
+    }
+
+
+@pytest.mark.parametrize(
+    ("severity", "style"),
+    [("warn", "bold yellow"), ("crit", "bold red")],
+)
+def test_h2d_bound_cli_style_matches_severity(
+    severity: Literal["warn", "crit"],
+    style: str,
+) -> None:
+    diagnosis = StepDiagnosis(
+        kind="H2D_BOUND",
+        status="H2D-BOUND",
+        severity=severity,
+        reason="H2D transfer is material.",
+        action="Inspect transfers.",
+        steps_used=64,
+    )
+
+    assert f"[{style}]H2D-BOUND[/{style}]" in format_cli_diagnosis(diagnosis)
 
 
 def test_compute_bound_is_secondary_to_rank_straggler() -> None:
@@ -881,6 +1063,7 @@ def _event_stats(
 def _summary_step_events(
     *,
     input_wait_gpu: float | None,
+    h2d: float = 0.0,
     step_time_gpu: float = 60.0,
     steps: int = 60,
 ) -> dict[int, dict]:
@@ -888,7 +1071,7 @@ def _summary_step_events(
     for step in range(steps):
         events = {
             "_traceml_internal:dataloader_next": _event_stats(cpu_ms=5.0),
-            "_traceml_internal:h2d_time": _event_stats(cpu_ms=0.0),
+            "_traceml_internal:h2d_time": _event_stats(cpu_ms=h2d),
             "_traceml_internal:forward_time": _event_stats(cpu_ms=20.0),
             "_traceml_internal:backward_time": _event_stats(cpu_ms=30.0),
             "_traceml_internal:optimizer_step": _event_stats(cpu_ms=10.0),
@@ -899,7 +1082,7 @@ def _summary_step_events(
                 "_traceml_internal:dataloader_next": _event_stats(
                     gpu_ms=input_wait_gpu
                 ),
-                "_traceml_internal:h2d_time": _event_stats(gpu_ms=0.0),
+                "_traceml_internal:h2d_time": _event_stats(gpu_ms=h2d),
                 "_traceml_internal:forward_time": _event_stats(gpu_ms=20.0),
                 "_traceml_internal:backward_time": _event_stats(gpu_ms=30.0),
                 "_traceml_internal:optimizer_step": _event_stats(gpu_ms=10.0),
@@ -928,6 +1111,28 @@ def test_summary_input_bound_uses_explicit_input_clocks() -> None:
     assert high_wait.issues[0].evidence["iteration_time_ms"] == pytest.approx(
         85.0
     )
+
+
+def test_summary_h2d_bound_uses_gpu_selected_h2d_timing() -> None:
+    result = _diagnose_summary_events(
+        {0: _summary_step_events(input_wait_gpu=0.0, h2d=12.0)},
+        max_rows=100,
+    )
+
+    assert result.primary.kind == "H2D_BOUND"
+    issue = next(issue for issue in result.issues if issue.kind == "H2D_BOUND")
+    assert issue.severity == "crit"
+    assert issue.evidence["diagnosis_clock"] == "gpu"
+    assert issue.share_pct == pytest.approx(12.0 / 60.0)
+
+
+def test_summary_h2d_bound_ignores_cpu_selected_h2d_timing() -> None:
+    result = _diagnose_summary_events(
+        {0: _summary_step_events(input_wait_gpu=None, h2d=80.0)},
+        max_rows=100,
+    )
+
+    assert all(issue.kind != "H2D_BOUND" for issue in result.issues)
 
 
 def test_summary_input_bound_trend_uses_selected_input_wait_series() -> None:

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -15,8 +15,10 @@ from traceml_ai.diagnostics.step_time.api import (
 from traceml_ai.diagnostics.step_time.context import build_step_time_context
 from traceml_ai.diagnostics.step_time.policy import SUMMARY_STEP_TIME_POLICY
 from traceml_ai.diagnostics.step_time.rules import (
+    ComputeBoundRule,
     InputBoundRule,
     RankStragglerRule,
+    ResidualHeavyRule,
 )
 from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeCoverage,
@@ -372,7 +374,7 @@ def test_input_bound_rule_ignores_duration_without_explicit_clocks() -> None:
     assert InputBoundRule().evaluate(ctx) is None
 
 
-def test_input_bound_rule_uses_input_wait_skew() -> None:
+def test_input_bound_uses_median_per_rank_iteration_share() -> None:
     ctx = _rank_context(
         {
             0: _timing_row(
@@ -388,8 +390,138 @@ def test_input_bound_rule_uses_input_wait_skew() -> None:
         }
     )
 
-    assert ctx.input_bound_share == pytest.approx(35.0 / 135.0)
-    assert InputBoundRule().evaluate(ctx) is None
+    expected = ((10.0 / 110.0) + (60.0 / 160.0)) / 2.0
+
+    assert ctx.input_bound_share == pytest.approx(expected)
+    assert ctx.input_bound_share != pytest.approx(35.0 / 135.0)
+
+    issue = InputBoundRule().evaluate(ctx)
+    assert issue is not None
+    assert issue.severity == "crit"
+    assert issue.skew_pct is not None
+
+
+@pytest.mark.parametrize(
+    ("input_wait", "step_time", "expected_severity"),
+    [(10.0, 90.0, "warn"), (20.0, 80.0, "crit")],
+)
+def test_input_bound_uses_iteration_share_thresholds(
+    input_wait: float,
+    step_time: float,
+    expected_severity: str,
+) -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=input_wait,
+            step_time=step_time,
+        )
+    }
+
+    issue = InputBoundRule().evaluate(_rank_context(per_rank))
+
+    assert issue is not None
+    assert issue.share_pct == pytest.approx(input_wait / 100.0)
+    assert issue.severity == expected_severity
+
+
+@pytest.mark.parametrize(
+    ("residual", "expected_severity"),
+    [(10.0, "warn"), (20.0, "crit")],
+)
+def test_residual_heavy_uses_iteration_share_thresholds(
+    residual: float,
+    expected_severity: str,
+) -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            residual=residual,
+            step_time=100.0,
+        )
+    }
+
+    issue = ResidualHeavyRule().evaluate(_rank_context(per_rank))
+
+    assert issue is not None
+    assert issue.share_pct == pytest.approx(residual / 100.0)
+    assert issue.severity == expected_severity
+
+
+def test_compute_bound_is_informational_despite_compute_skew() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            forward=90.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=0.0,
+            forward=150.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=160.0,
+        ),
+    }
+
+    issue = ComputeBoundRule().evaluate(_rank_context(per_rank))
+
+    assert issue is not None
+    assert issue.severity == "info"
+    assert issue.skew_pct is not None
+
+
+def test_compute_bound_requires_existing_dominance_threshold() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            h2d=20.0,
+            forward=80.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    assert ComputeBoundRule().evaluate(_rank_context(per_rank)) is None
+
+
+def test_compute_bound_is_secondary_to_rank_straggler() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            forward=90.0,
+            backward=10.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=0.0,
+            forward=90.0,
+            backward=30.0,
+            optimizer=0.0,
+            step_time=120.0,
+        ),
+    }
+
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+    )
+
+    assert result.primary.kind == "STRAGGLER"
+    assert {issue.kind for issue in result.issues} >= {
+        "STRAGGLER",
+        "COMPUTE_BOUND",
+    }
+    compute_issue = next(
+        issue for issue in result.issues if issue.kind == "COMPUTE_BOUND"
+    )
+    assert compute_issue.severity == "info"
 
 
 @pytest.mark.parametrize(

--- a/tests/reporting/summary/test_final.py
+++ b/tests/reporting/summary/test_final.py
@@ -233,7 +233,7 @@ def test_final_text_uses_single_process_average_layout():
     assert "Total             139.1ms           compat" in text
     assert "Input Wait        130.8ms           48.5%" in text
     assert "Dataloader        120.0ms           compat" in text
-    assert "Step Time         139.1ms           100.0%" in text
+    assert "Step Time         139.1ms           51.5%" in text
     assert "Median" not in text
     assert "Worst" not in text
     assert "Skew" not in text
@@ -274,10 +274,49 @@ def test_final_text_uses_selected_step_time_for_phase_shares():
     text = payload["text"]
     assert "Total             10.5ms            compat" in text
     assert "Dataloader        0.5ms             compat" in text
-    assert "Step Time         50.0ms            100.0%" in text
-    assert "Compute           48.0ms            96.0%" in text
+    assert "Step Time         50.0ms            96.2%" in text
+    assert "Compute           48.0ms            92.3%" in text
     assert "457.1%" not in text
     assert "476.2%" not in text
+
+
+def test_final_text_includes_h2d_bound_diagnosis():
+    step_time = _payload(
+        metadata={"global_ranks_used": 1},
+        diagnosis=_diagnosis(
+            "H2D_BOUND",
+            "H2D-BOUND",
+            severity="crit",
+            action="Inspect pinned memory and batch transfers.",
+        ),
+        global_summary={
+            "window": {"steps_analyzed": 60, "diagnosis_clock": "gpu"},
+            "average": {
+                "total_step_ms": 150.0,
+                "dataloader_ms": 40.0,
+                "input_wait_ms": 40.0,
+                "step_time_ms": 100.0,
+                "h2d_ms": 20.0,
+                "compute_ms": 70.0,
+                "residual_ms": 10.0,
+            },
+        },
+    )
+
+    payload = build_summary_payload(
+        "fake.db",
+        generator=_generator(
+            _PayloadSection("system", _status_payload("NORMAL")),
+            _PayloadSection("process", _status_payload("NORMAL")),
+            _PayloadSection("step_time", step_time),
+            _PayloadSection("step_memory", _status_payload("BALANCED")),
+        ),
+    )
+
+    assert "TraceML Verdict: H2D-BOUND / CRITICAL" in payload["text"]
+    assert "Why: H2D transfer took 20.0ms of 140.0ms iteration time." in (
+        payload["text"]
+    )
 
 
 def test_final_text_uses_multi_process_comparison_layout():

--- a/tests/reporting/summary/test_primary_diagnosis.py
+++ b/tests/reporting/summary/test_primary_diagnosis.py
@@ -121,11 +121,28 @@ def test_input_bound_uses_phase_share_evidence() -> None:
         "residual_ms": 20.0,
         "shares": {
             "input_wait_pct": 33.333,
-            "h2d_pct": 6.25,
-            "compute_pct": 75.0,
-            "residual_pct": 12.5,
+            "h2d_pct": 4.167,
+            "compute_pct": 50.0,
+            "residual_pct": 8.333,
         },
         "gpu_util_avg_percent": 38.0,
+    }
+
+
+def test_h2d_bound_uses_iteration_phase_share_evidence() -> None:
+    primary = _primary(_step_time("H2D_BOUND", status="H2D-BOUND"))
+
+    assert primary["kind"] == "H2D_BOUND"
+    assert primary["summary"] == (
+        "H2D transfer took 10.0ms of 240.0ms iteration time."
+    )
+    assert primary["evidence"]["type"] == "phase_share"
+    assert primary["evidence"]["iteration_time_ms"] == 240.0
+    assert primary["evidence"]["shares"] == {
+        "input_wait_pct": 33.333,
+        "h2d_pct": 4.167,
+        "compute_pct": 50.0,
+        "residual_pct": 8.333,
     }
 
 
@@ -137,7 +154,7 @@ def test_residual_heavy_uses_residual_phase_share() -> None:
         "Residual time took 20.0ms of a 160.0ms average step."
     )
     assert primary["evidence"]["type"] == "phase_share"
-    assert primary["evidence"]["shares"]["residual_pct"] == 12.5
+    assert primary["evidence"]["shares"]["residual_pct"] == 8.333
 
 
 def test_compute_bound_uses_neutral_compute_phase_share() -> None:
@@ -147,7 +164,7 @@ def test_compute_bound_uses_neutral_compute_phase_share() -> None:
     assert primary["summary"] == (
         "Model compute took 120.0ms of a 160.0ms average step."
     )
-    assert primary["evidence"]["shares"]["compute_pct"] == 75.0
+    assert primary["evidence"]["shares"]["compute_pct"] == 50.0
 
 
 @pytest.mark.parametrize(

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -147,6 +147,7 @@ def _input_bound_step_metrics(
     step_time_cpu: float = 90.0,
     input_wait_gpu: float,
     step_time_gpu: float,
+    h2d_gpu: float = 0.0,
     steps: int = 64,
 ) -> dict[int, dict]:
     return {
@@ -154,6 +155,7 @@ def _input_bound_step_metrics(
             "_traceml_internal:dataloader_next": _event_stats(
                 cpu_ms=dataloader_cpu, gpu_ms=input_wait_gpu
             ),
+            "_traceml_internal:h2d_time": _event_stats(gpu_ms=h2d_gpu),
             "_traceml_internal:step_time": _event_stats(
                 cpu_ms=step_time_cpu,
                 gpu_ms=step_time_gpu,
@@ -311,6 +313,40 @@ def test_step_time_input_bound_card_uses_short_reason() -> None:
     assert (
         "- Why: Input wait was 40.0ms of 140.0ms gpu iteration time."
         in payload["card"]
+    )
+    _assert_compact_card(payload["card"])
+
+
+def test_step_time_h2d_bound_card_uses_short_reason() -> None:
+    payload = _summary(
+        {
+            0: _rank(
+                dataloader=12.0,
+                h2d=20.0,
+                forward=20.0,
+                backward=35.0,
+                optimizer=5.0,
+                step_cpu=100.0,
+            )
+        },
+        per_rank_steps={
+            0: _input_bound_step_metrics(
+                input_wait_gpu=0.0,
+                h2d_gpu=20.0,
+                step_time_cpu=100.0,
+                step_time_gpu=100.0,
+            )
+        },
+    )
+
+    assert payload["diagnosis"] == payload["issues"][0]
+    assert payload["diagnosis"]["status"] == "H2D-BOUND"
+    assert payload["diagnosis"]["metric"] == "h2d"
+    assert payload["diagnosis"]["phase"] == "h2d"
+    assert payload["diagnosis"]["evidence"]["h2d_ms"] == 20.0
+    assert payload["diagnosis"]["evidence"]["diagnosis_clock"] == "gpu"
+    assert (
+        "- Why: H2D transfer was high inside the total step" in payload["card"]
     )
     _assert_compact_card(payload["card"])
 

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -214,17 +214,19 @@ def test_step_time_balanced_card_is_compact() -> None:
         {
             0: _rank(
                 dataloader=5.0,
+                h2d=15.0,
                 forward=20.0,
                 backward=35.0,
                 optimizer=5.0,
-                step_cpu=70.0,
+                step_cpu=75.0,
             ),
             1: _rank(
                 dataloader=5.0,
+                h2d=15.0,
                 forward=21.0,
                 backward=34.0,
                 optimizer=5.0,
-                step_cpu=70.0,
+                step_cpu=75.0,
             ),
         }
     )
@@ -388,6 +390,7 @@ def test_step_time_input_straggler_card_shows_rank_evidence() -> None:
     )
     assert "issues" not in payload["groups"]["rows"]["1"]
     assert {issue["kind"] for issue in payload["issues"]} == {
-        "INPUT_STRAGGLER"
+        "INPUT_STRAGGLER",
+        "INPUT_BOUND",
     }
     _assert_compact_card(payload["card"])


### PR DESCRIPTION
## Summary

Build on `abhinav/issue236` by adding `H2D_BOUND` for broad host-to-device transfer cost and using one selected-clock iteration denominator throughout public phase-share evidence and final text output.

This PR reuses the rank-aligned selected-clock share policy introduced by `abhinav/issue236`; it does not change input or residual diagnosis behavior.

## What Changed

- Reuse the existing per-rank selected-clock iteration-share calculation for  H2D:

  ```text
  iteration_r = input_wait_r + step_time_r
  component_share_r = component_r / iteration_r
  typical_component_share = median(component_share_r across ranks)
  ```

- Reuse the existing shared 10% warning and 20% critical overhead thresholds.
- Add `H2D_BOUND` when the median per-rank H2D iteration share is material. It requires GPU-selected timing, so asynchronous CPU host-call duration is  never reported as transfer cost.
- Preserve `H2D_STRAGGLER`; it may coexist with `H2D_BOUND` because the two findings describe broad cost and rank-local excess respectively.
- Keep `COMPUTE_BOUND` informational and suppress it when a material GPU H2D share is already explained. CPU-selected H2D cannot suppress compute-bound.
- Add H2D support to the diagnosis API, CLI formatter, Step Time card, run-level primary diagnosis, JSON, final text, schema documentation, and user guide.
- Use `input_wait_ms + step_time_ms` as the denominator for every selected-clock phase share in primary evidence and the final text table.

## Why

H2D needs a separate typical-bottleneck diagnosis because a widespread transfer cost and a single-rank transfer outlier require different fixes.

The public report must use the same iteration denominator for every selected phase; otherwise the displayed percentages depend on which diagnosis happened to be primary.

## Scope

- No instrumentation, telemetry, transport, SQLite, dashboard plumbing, or YAML configuration changes.
- No changes to existing `H2D_STRAGGLER` attribution behavior.
- The existing 85% `COMPUTE_BOUND` diagnostic gate remains step-time based and informational. This PR only normalizes public phase-share reporting to the iteration denominator.
- Normalized impact-based primary selection and straggler cause-coverage  policy remain follow-up work.

## Verification

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/diagnostics/test_step_time.py \
  tests/renderers/test_step_time_compute.py \
  tests/renderers/test_step_time_renderer.py \
  tests/reporting/summary/test_step_time.py \
  tests/reporting/summary/test_step_time_card.py \
  tests/reporting/summary/test_primary_diagnosis.py \
  tests/reporting/summary/test_final.py \
  -q
```

Result: `77 passed`.

Focused coverage includes:

- 9%, 10%, and 20% H2D boundaries;
- GPU-only `H2D_BOUND` and CPU-selected timing protection;
- skew retained as H2D evidence without suppressing the finding;
- coexistence with `H2D_STRAGGLER` and input-primary ordering;
- compute-bound suppression only for material GPU H2D;
- CLI styling, Step Time card, primary JSON evidence, and final text output;
- one common iteration denominator for all public selected-clock phase shares.

`git diff --check` passes.

