### PR TITLE
Add a button-driven release workflow and document releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Cut a release
+
+# Manual, button-driven release: Actions tab -> "Cut a release" -> Run
+# workflow -> type the version. Tags, builds, and publishes to PyPI in one
+# run, so shipping a release doesn't depend on remembering the exact git
+# commands. Pushing a tag from a local checkout (git tag vX.Y.Z && git push)
+# still works too and is handled by publish.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, e.g. 0.3.5 (no leading v, no suffix)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  tag-build-publish:
+    name: Tag, build, and publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      # Read once into a shell-safe env var. Template substitution happens
+      # before the shell runs, so interpolating ${{ inputs.version }}
+      # directly into a run: script is not shell-safe even after the format
+      # check below; always go through "$VERSION" instead.
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate version format
+        run: |
+          echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' || {
+            echo "::error::Version must be X.Y.Z, e.g. 0.3.5 (no leading v, no suffix)"
+            exit 1
+          }
+
+      - name: Reject an already-existing tag
+        run: |
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag v$VERSION already exists"
+            exit 1
+          fi
+
+      - name: Create and push the release tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,31 @@ To keep the project focused, we are currently **not** accepting:
 
 ---
 
+## Releasing (maintainers)
+
+There is no version to edit anywhere in the repo. The package version comes
+from the git tag (`setuptools-scm`), and a tag is what starts a release.
+
+**Cut a release from the Actions tab:** go to Actions -> "Cut a release" ->
+Run workflow, type the version (e.g. `0.3.5`, no leading `v`). This tags,
+builds, and publishes to PyPI in one run. No git commands to remember.
+
+Pushing a tag from a local checkout still works too, if you'd rather:
+
+```bash
+git tag v0.3.5
+git push upstream v0.3.5
+```
+
+Either path publishes to PyPI automatically. From there, conda-forge's own
+bot picks up the new PyPI release and opens a version-bump PR on the
+`traceml-ai` feedstock. If the release only changed the version, that PR
+merges itself. If it added, dropped, or repinned a runtime dependency,
+someone edits the recipe in that bot PR by hand before it merges, since the
+bot only knows how to bump a version number.
+
+---
+
 ## Communication
 
 - Bugs and features: GitHub Issues


### PR DESCRIPTION
Follow-up to #249.

That PR moved the version off a hand-edited string and onto the git tag. It didn't leave anything in the repo telling a maintainer that a release now means pushing a tag, so the actual release step was still living in a chat thread, not the repo. This closes that gap two ways:

- **A button, not a memorized command.** `.github/workflows/release.yml`, triggered by `workflow_dispatch`: Actions tab, "Cut a release", Run workflow, type the version. It validates the format, tags, builds, and publishes to PyPI in one run.
- **Docs**, for the why and for anyone who'd rather push a tag from a local checkout, which still works unchanged (`publish.yml` is untouched).

## A note on the workflow file

The first draft interpolated `${{ inputs.version }}` directly into `run:` shell steps. That substitution happens before the shell runs, so it's not shell-safe regardless of quoting inside the script, even with the format check in an earlier step (each `run:` block gets substituted independently, not gated by a prior step). Fixed by reading the input once into `env: VERSION` at the job level and referencing `"$VERSION"` in every script instead, the standard safe pattern for workflow_dispatch inputs.

## Verified

- Both workflow YAML files parse and `release.yml`'s job structure matches `publish.yml`'s existing `pypi` environment and `id-token: write` scoping (already confirmed live and working via #249).
- Grepped the final file for any remaining raw `${{ inputs.version }}` inside a `run:` block: none.
- Did not trigger the workflow. Cutting an actual release, and picking the next real version number, isn't mine to decide.
