### PR TITLE
Abhinav/issue239

### DIFF
--- a/docs/developer_guide/architecture.md
+++ b/docs/developer_guide/architecture.md
@@ -103,7 +103,7 @@ Architectural risks and known structural debt. Day-to-day bugs live in the issue
 | Phase | A timed part of a step: input wait, H2D, forward, backward, or optimizer. |
 | Step / trace_step | A training iteration; `with trace_step(model)` marks the boundary that phase timing is computed against. |
 | Residual (residual_proxy) | Residual step time, `max(0, step - h2d - forward - backward - optimizer)`. |
-| INPUT_BOUND / COMPUTE_BOUND | Input wait dominates iteration time, or compute dominates the traced step. |
+| INPUT_BOUND / COMPUTE_BOUND | Input wait is material, or compute reaches 90% of typical selected-clock iteration time. |
 | INPUT_STRAGGLER / COMPUTE_STRAGGLER / H2D_STRAGGLER / STRAGGLER | Visible rank skew exists; the label names the culprit's material input, DDP-forward, or H2D excess, or `STRAGGLER` when the skew is sync-bound or unattributed. |
 | RESIDUAL_HEAVY | A large window-wide share of step time is unattributed residual time. |
 | HIGH_PRESSURE / IMBALANCE | GPU memory is near capacity, or uneven across ranks. |

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -113,6 +113,17 @@ contrast, `H2D_STRAGGLER` identifies one rank's excess H2D time.
 `COMPUTE_BOUND` remains an informational finding when compute dominates the
 traced step and no material input, H2D, or residual overhead is visible.
 
+Step Time uses `DiagnosticIssue.score` as normalized iteration impact for
+`INPUT_BOUND`, `H2D_BOUND`, `RESIDUAL_HEAVY`, and all rank-straggler findings.
+Typical findings use the median per-rank share above; stragglers use the
+culprit/victim score below. `COMPUTE_BOUND` has no score because its
+informational 85% gate remains compute divided by step time.
+
+When several Step Time findings qualify, TraceML orders them by severity, then
+score. A rank straggler wins only an exact severity-and-score tie with a
+typical finding; ties within the same scope preserve rule order. The primary
+diagnosis is always the first ordered issue.
+
 Shared Step Time diagnosis needs at least 2 steps to emit warning-only
 bottleneck diagnoses. Critical diagnoses are allowed once the window has at
 least 20 steps. Live and summary use the same diagnosis gates; they differ by

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -111,14 +111,16 @@ critical at 20%. `H2D_BOUND` requires GPU-selected timing, so asynchronous CPU
 host-call duration is not reported as transfer cost. Cross-rank skew remains
 evidence in a typical-bottleneck finding, but does not suppress one. In
 contrast, `H2D_STRAGGLER` identifies one rank's excess H2D time.
-`COMPUTE_BOUND` remains an informational finding when compute dominates the
-traced step and no material input, H2D, or residual overhead is visible.
+`COMPUTE_BOUND` remains an informational finding when the median per-rank
+compute share reaches 90% of selected-clock iteration time and no material
+input, H2D, or residual overhead is visible. Built-in live and summary policies
+use this same threshold; their analyzed window sizes differ.
 
 Step Time uses `DiagnosticIssue.score` as normalized iteration impact for
 `INPUT_BOUND`, `H2D_BOUND`, `RESIDUAL_HEAVY`, and all rank-straggler findings.
 Typical findings use the median per-rank share above; stragglers use the
 culprit/victim score below. `COMPUTE_BOUND` has no score because its
-informational 85% gate remains compute divided by step time.
+informational context is excluded from impact-based primary ordering.
 
 When several Step Time findings qualify, TraceML orders them by severity, then
 score. A rank straggler wins only an exact severity-and-score tie with a

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -94,7 +94,8 @@ These compatibility fields are not selected-clock phase-share denominators.
 `duration_ms` stays stored compatibility timing and is not used for Step Time
 display or diagnosis. In the final text report, selected-clock phase shares
 are divided by `input_wait_ms + step_time_ms`; CPU compatibility rows are
-labeled separately.
+labeled separately. These report-table shares are observational and do not
+replace the median per-rank diagnosis score.
 
 Typical overhead diagnoses use selected-clock per-rank iteration shares:
 
@@ -123,6 +124,10 @@ When several Step Time findings qualify, TraceML orders them by severity, then
 score. A rank straggler wins only an exact severity-and-score tie with a
 typical finding; ties within the same scope preserve rule order. The primary
 diagnosis is always the first ordered issue.
+
+The Step Time summary card reuses the selected issue summary for its reason
+text. It does not recompute phase shares or rank-straggler attribution from
+display rollups.
 
 Shared Step Time diagnosis needs at least 2 steps to emit warning-only
 bottleneck diagnoses. Critical diagnoses are allowed once the window has at

--- a/src/traceml_ai/diagnostics/common.py
+++ b/src/traceml_ai/diagnostics/common.py
@@ -108,25 +108,6 @@ def severity_rank(severity: Severity) -> int:
     return {"crit": 2, "warn": 1, "info": 0}.get(severity, 0)
 
 
-def sort_issues(
-    issues: Sequence[DiagnosticIssue],
-) -> Tuple[DiagnosticIssue, ...]:
-    """
-    Return issues sorted by severity, score, and attribution breadth.
-    """
-    return tuple(
-        sorted(
-            issues,
-            key=lambda item: (
-                severity_rank(item.severity),
-                float(item.score or 0.0),
-                len(item.ranks),
-            ),
-            reverse=True,
-        )
-    )
-
-
 def validate_confidence(confidence: Optional[float]) -> None:
     """
     Validate an optional confidence value.
@@ -223,7 +204,6 @@ __all__ = [
     "DiagnosticResult",
     "DiagnosticRule",
     "severity_rank",
-    "sort_issues",
     "validate_confidence",
     "diagnosis_to_issue",
     "ensure_primary_issue",

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -19,7 +19,6 @@ from ..common import (
     DiagnosticResult,
     Severity,
     severity_rank,
-    sort_issues,
     validate_confidence,
 )
 from .context import (
@@ -65,16 +64,14 @@ _STATUS_BY_KIND: dict[DiagnosisKind, str] = {
     "RESIDUAL_HEAVY": "RESIDUAL-HEAVY",
 }
 
-_PRIMARY_KIND_PRIORITY: dict[str, int] = {
-    "STRAGGLER": 50,
-    "INPUT_STRAGGLER": 40,
-    "COMPUTE_STRAGGLER": 40,
-    "H2D_STRAGGLER": 40,
-    "INPUT_BOUND": 30,
-    "H2D_BOUND": 30,
-    "RESIDUAL_HEAVY": 20,
-    "COMPUTE_BOUND": 10,
-}
+_RANK_STRAGGLER_KINDS = frozenset(
+    {
+        "STRAGGLER",
+        "INPUT_STRAGGLER",
+        "COMPUTE_STRAGGLER",
+        "H2D_STRAGGLER",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -175,11 +172,15 @@ def _severity(value: float, crit_threshold: float) -> Severity:
     return "crit" if non_negative_finite(value) >= crit_threshold else "warn"
 
 
-def _primary_issue_rank(issue: DiagnosticIssue) -> int:
-    """
-    Rank contributor issues for primary-diagnosis selection.
-    """
-    return _PRIMARY_KIND_PRIORITY.get(issue.kind, 0)
+def _step_time_issue_sort_key(
+    issue: DiagnosticIssue,
+) -> tuple[int, float, int]:
+    """Order Step Time findings by severity, impact, then rank-local scope."""
+    return (
+        severity_rank(issue.severity),
+        non_negative_finite(issue.score or 0.0),
+        int(issue.kind in _RANK_STRAGGLER_KINDS),
+    )
 
 
 def _cap_issue_severity(
@@ -282,25 +283,6 @@ def _metric_attribution_entry(
         ),
         "top_ranks": _top_rank_entries(rank_values),
     }
-
-
-def _select_primary_issue(
-    issues: Sequence[DiagnosticIssue],
-) -> Optional[DiagnosticIssue]:
-    """
-    Return the strongest atomic issue candidate.
-    """
-    if not issues:
-        return None
-    ranked = sorted(
-        issues,
-        key=lambda issue: (
-            _primary_issue_rank(issue),
-            float(issue.score or 0.0),
-        ),
-        reverse=True,
-    )
-    return ranked[0]
 
 
 def _apply_trend_note(
@@ -421,8 +403,10 @@ def build_step_diagnosis_result(
             _cap_issue_severity(issue, "warn") for issue in issue_list
         ]
 
-    issues = sort_issues(issue_list)
-    primary_issue = _select_primary_issue(issues)
+    issues = tuple(
+        sorted(issue_list, key=_step_time_issue_sort_key, reverse=True)
+    )
+    primary_issue = issues[0] if issues else None
 
     if primary_issue is not None and primary_issue.kind in {
         "STRAGGLER",

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -622,6 +622,13 @@ def build_step_time_context(
         int(rank): {str(k): non_negative_finite(v) for k, v in values.items()}
         for rank, values in (per_rank_timing or {}).items()
     }
+    for values in local_per_rank_timing.values():
+        if {"forward", "backward", "optimizer_step"}.issubset(values):
+            values["compute"] = (
+                values["forward"]
+                + values["backward"]
+                + values["optimizer_step"]
+            )
     if local_per_rank_timing:
         rank_values = {
             "input_wait": {
@@ -716,7 +723,10 @@ def build_step_time_context(
             local_per_rank_timing,
             "residual_proxy",
         ),
-        compute_share=share(compute_total_value, step_total),
+        compute_share=_median_iteration_component_share(
+            local_per_rank_timing,
+            "compute",
+        ),
         input_bound_share=_median_iteration_component_share(
             local_per_rank_timing,
             "input_wait",

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -10,15 +10,16 @@ class DiagnosisThresholds:
     """
     Thresholds used by the shared step-time rules.
 
-    Live and summary policies may choose different values, but they still run
-    the same rules and produce the same diagnosis vocabulary. Live and summary
-    differ by the selected timing window, not by extra diagnosis gates.
+    Built-in live and summary policies share these values and differ only by
+    their selected timing windows. Explicit callers may still supply a custom
+    policy.
 
     Typical overhead diagnoses use selected-clock per-rank iteration shares.
     The context takes the median of those shares across ranks, where
     ``iteration_time_ms = input_wait_ms + step_time_ms``. The shared overhead
     thresholds are the future configuration surface for input, residual, and
-    H2D policies.
+    H2D policies. Compute-bound uses the same denominator and a separate
+    informational dominance threshold.
 
     ``min_steps_for_warning_diag`` is the minimum window size for warning-only
     bottleneck diagnoses. ``min_steps_for_confident_diag`` is the minimum window
@@ -33,7 +34,7 @@ class DiagnosisThresholds:
     overhead_share_warn: float = 0.10
     overhead_share_crit: float = 0.20
 
-    compute_bound_share_warn: float = 0.85
+    compute_bound_share_warn: float = 0.90
 
     min_steps_for_warning_diag: int = 2
     min_steps_for_confident_diag: int = 20
@@ -49,24 +50,17 @@ class StepTimeDiagnosisPolicy:
     )
 
 
+DEFAULT_THRESHOLDS = DiagnosisThresholds()
+
 LIVE_STEP_TIME_POLICY = StepTimeDiagnosisPolicy(
     name="live",
-    thresholds=DiagnosisThresholds(),
+    thresholds=DEFAULT_THRESHOLDS,
 )
 
 SUMMARY_STEP_TIME_POLICY = StepTimeDiagnosisPolicy(
     name="summary",
-    thresholds=DiagnosisThresholds(
-        straggler_score_warn=0.10,
-        straggler_score_crit=0.20,
-        overhead_share_warn=0.10,
-        overhead_share_crit=0.20,
-        compute_bound_share_warn=0.88,
-        min_steps_for_confident_diag=20,
-    ),
+    thresholds=DEFAULT_THRESHOLDS,
 )
-
-DEFAULT_THRESHOLDS = LIVE_STEP_TIME_POLICY.thresholds
 
 
 __all__ = [

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -197,6 +197,7 @@ class InputBoundRule(_BaseStepTimeRule):
             action="Increase workers, prefetch, or storage throughput.",
             metric="input_wait",
             phase="input",
+            score=context.input_bound_share,
             share_pct=context.input_bound_share,
             skew_pct=context.input_bound_skew,
             ranks=(context.input_bound_worst_rank,),
@@ -243,6 +244,7 @@ class H2DBoundRule(_BaseStepTimeRule):
             ),
             metric="h2d",
             phase="h2d",
+            score=context.h2d_share,
             share_pct=context.h2d_share,
             skew_pct=metric_skew(
                 context.h2d_metric,
@@ -292,6 +294,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
             ),
             metric="residual_proxy",
             phase="residual",
+            score=context.residual_share,
             share_pct=context.residual_share,
             ranks=(context.overall_worst_rank,),
         )

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -122,9 +122,11 @@ class RankStragglerRule(_BaseStepTimeRule):
         )
         if evidence.kind == "STRAGGLER":
             summary = (
-                f"{_rank_str(rank)} appears to be the culprit rank "
+                f"{_rank_str(rank)} is slower than victim "
+                f"{_rank_str(evidence.victim_rank)} "
                 f"(~{_pct(evidence.score)} impact); no measured component "
-                f"explains {_pct(context.thresholds.straggler_cause_coverage_min)} "
+                "explains "
+                f"{_pct(context.thresholds.straggler_cause_coverage_min)} "
                 "of visible wait cost."
             )
             action = (
@@ -134,6 +136,7 @@ class RankStragglerRule(_BaseStepTimeRule):
         else:
             summary = (
                 f"{_rank_str(rank)} has excess {component_label} burden "
+                f"relative to victim {_rank_str(evidence.victim_rank)} "
                 f"(~{_pct(evidence.score)} impact; "
                 f"~{_pct(cause_coverage)} of visible wait cost)."
             )
@@ -286,7 +289,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
             ),
             summary=(
                 f"Residual time is {_pct(context.residual_share)} of the "
-                "typical step."
+                f"typical {context.diagnosis_clock} iteration time."
             ),
             action=(
                 "Inspect work outside traced phases, CPU stalls, logging, "

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -249,6 +249,9 @@ Fallback evidence types are:
 - `status` is the user-facing display label.
 - `summary` is the short explanation. Older `reason` fields should be treated
   as pre-`1.4` input, not the current final-summary contract.
+- `score` is an optional section-specific ranking signal. In Step Time, scored
+  typical bottlenecks use median per-rank iteration impact and stragglers use
+  visible wait cost divided by victim iteration time.
 - Section-specific details such as `scope`, `samples_used`, `steps_used`,
   `note`, and `confidence` belong in `evidence`.
 - `groups.rows` contains row data only: `identity` and `metrics`.

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -113,19 +113,18 @@ Primary diagnosis evidence uses a small union:
   "h2d_ms": 0.4,
   "compute_ms": 120.0,
   "residual_ms": 39.6,
-  "shares": {
-    "input_wait_pct": 33.3,
-    "h2d_pct": 0.2,
-    "compute_pct": 50.0,
-    "residual_pct": 16.5
-  },
+  "score": 0.333,
+  "score_basis": "median_per_rank_iteration_share",
+  "score_denominator": "input_wait_ms + step_time_ms per rank",
   "gpu_util_avg_percent": 37.8
 }
 ```
 
 `phase_share` is used for `INPUT_BOUND`, `H2D_BOUND`, `RESIDUAL_HEAVY`, and
-`COMPUTE_BOUND`. Values come from `step_time.global.average`. All phase-share
-percentages use `iteration_time_ms = input_wait_ms + step_time_ms`.
+`COMPUTE_BOUND`. Millisecond values come from `step_time.global.average` and
+are supporting observations only. For scored typical bottlenecks, `score` is
+the authoritative median per-rank iteration-impact fraction. Informational
+`COMPUTE_BOUND` has no fabricated iteration-impact score.
 
 ```json
 {
@@ -333,6 +332,8 @@ The public `total_step_ms` key is also CPU-clocked for compatibility; it is
 not the denominator for selected-clock phase shares. The final text report
 uses derived `iteration_time_ms = input_wait_ms + step_time_ms` for every
 selected-clock phase share and labels CPU compatibility rows separately.
+Those table shares are observational averages and may differ from the
+authoritative median per-rank diagnosis `score`.
 
 `residual_ms` is residual unattributed step time. It is averaged from
 per-step clamped residuals, not recomputed from already-averaged phase totals:

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -124,7 +124,10 @@ Primary diagnosis evidence uses a small union:
 `COMPUTE_BOUND`. Millisecond values come from `step_time.global.average` and
 are supporting observations only. For scored typical bottlenecks, `score` is
 the authoritative median per-rank iteration-impact fraction. Informational
-`COMPUTE_BOUND` has no fabricated iteration-impact score.
+`COMPUTE_BOUND` uses the median per-rank
+`(forward_ms + backward_ms + optimizer_ms) / iteration_time_ms` share with a
+90% threshold, but has no score because it is excluded from impact-based
+primary ordering.
 
 ```json
 {

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -382,6 +382,36 @@ def _rank_comparison_evidence(
     return evidence
 
 
+def _step_time_score_evidence(
+    *,
+    kind: str,
+    diagnosis: Mapping[str, Any],
+) -> JsonDict:
+    """Return the exact policy score and denominator for a promoted finding."""
+    score = _float_or_none(diagnosis.get("score"))
+    if score is None:
+        return {}
+
+    if kind in PHASE_SHARE_KINDS:
+        return {
+            "score": score,
+            "score_basis": "median_per_rank_iteration_share",
+            "score_denominator": "input_wait_ms + step_time_ms per rank",
+        }
+
+    issue_evidence = _mapping(diagnosis.get("evidence"))
+    return {
+        "score": score,
+        "score_basis": "visible_cost_ms / victim_iteration_time_ms",
+        "score_numerator_ms": _float_or_none(
+            issue_evidence.get("visible_cost_ms")
+        ),
+        "score_denominator_ms": _float_or_none(
+            issue_evidence.get("iteration_time_ms")
+        ),
+    }
+
+
 def _straggler_comparisons(
     *,
     step_time_summary: Mapping[str, Any],
@@ -529,6 +559,7 @@ def _promote_step_time_primary(
             diagnosis=diagnosis,
         )
         summary = _rank_comparison_summary(kind, evidence)
+    evidence.update(_step_time_score_evidence(kind=kind, diagnosis=diagnosis))
 
     return _primary_payload(
         kind=kind,

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -49,13 +49,15 @@ Evidence policy
 ---------------
 ``phase_share``
     Used for ``INPUT_BOUND``, ``H2D_BOUND``, ``RESIDUAL_HEAVY``, and
-    ``COMPUTE_BOUND``. Values come from ``step_time.global.average`` because
-    the diagnosis describes where the average step time went.
+    ``COMPUTE_BOUND``. Raw timing values from ``step_time.global.average`` are
+    supporting observations; the promoted diagnosis keeps the policy score
+    emitted by Step Time.
 
 ``rank_comparison``
     Used for ``INPUT_STRAGGLER``, ``COMPUTE_STRAGGLER``,
-    ``H2D_STRAGGLER``, and ``STRAGGLER``. Values come from step-time rank
-    summaries because the diagnosis compares ranks.
+    ``H2D_STRAGGLER``, and ``STRAGGLER``. Rank summaries are supporting
+    observations; culprit, victim, impact, and attribution remain owned by
+    the Step Time diagnosis.
 
 ``utilization_fallback``
     Used only when Step Time is balanced and System GPU utilization is low or
@@ -228,7 +230,7 @@ def _phase_share_evidence(
     step_time_summary: Mapping[str, Any],
     system_summary: Mapping[str, Any],
 ) -> JsonDict:
-    """Build evidence with selected-clock iteration-time phase shares."""
+    """Build supporting average phase observations for a Step Time finding."""
     average = _global_average(step_time_summary)
     total_ms = _float_or_none(average.get("total_step_ms"))
     step_time_ms = _float_or_none(average.get("step_time_ms"))
@@ -253,20 +255,6 @@ def _phase_share_evidence(
     for metric in PHASE_METRICS:
         evidence[metric] = _round(_float_or_none(average.get(metric)))
 
-    shares: JsonDict = {}
-    for metric in PHASE_METRICS:
-        value = _float_or_none(average.get(metric))
-        key = metric.replace("_ms", "_pct")
-        shares[key] = (
-            _round(100.0 * value / iteration_time_ms)
-            if (
-                value is not None
-                and iteration_time_ms
-                and iteration_time_ms > 0.0
-            )
-            else None
-        )
-    evidence["shares"] = shares
     evidence["gpu_util_avg_percent"] = _round(_gpu_util_avg(system_summary))
     return evidence
 
@@ -461,83 +449,6 @@ def _straggler_comparisons(
     ]
 
 
-def _phase_share_summary(kind: str, evidence: Mapping[str, Any]) -> str:
-    """Return a concise primary summary for phase-share diagnoses."""
-    total = _float_or_none(evidence.get("step_time_ms")) or _float_or_none(
-        evidence.get("total_step_ms")
-    )
-    if kind == "INPUT_BOUND":
-        value = _float_or_none(evidence.get("input_wait_ms"))
-        iteration_time = _float_or_none(evidence.get("iteration_time_ms"))
-        if value is not None and iteration_time is not None:
-            return (
-                f"Input wait was {value:.1f}ms of "
-                f"{iteration_time:.1f}ms iteration time."
-            )
-        return "Input wait took a large share of iteration time."
-    if kind == "H2D_BOUND":
-        value = _float_or_none(evidence.get("h2d_ms"))
-        iteration_time = _float_or_none(evidence.get("iteration_time_ms"))
-        if value is not None and iteration_time is not None:
-            return (
-                f"H2D transfer took {value:.1f}ms of "
-                f"{iteration_time:.1f}ms iteration time."
-            )
-        return "H2D transfer took a large share of iteration time."
-    if kind == "RESIDUAL_HEAVY":
-        value = _float_or_none(evidence.get("residual_ms"))
-        if value is not None and total is not None:
-            return (
-                f"Residual time took {value:.1f}ms of a "
-                f"{total:.1f}ms average step."
-            )
-        return "Residual time took a large share of step time."
-    if kind == "COMPUTE_BOUND":
-        value = _float_or_none(evidence.get("compute_ms"))
-        if value is not None and total is not None:
-            return (
-                f"Model compute took {value:.1f}ms of a "
-                f"{total:.1f}ms average step."
-            )
-        return "Most step time was model compute."
-    return "Step time was dominated by one phase."
-
-
-def _rank_comparison_summary(
-    kind: str,
-    evidence: Mapping[str, Any],
-) -> str:
-    """Return a concise primary summary for rank-comparison diagnoses."""
-    if kind == "STRAGGLER":
-        return "Visible rank skew was sync-bound or unattributed."
-
-    metric = str(evidence.get("metric") or "step_time")
-    phase = str(evidence.get("phase") or metric.replace("_ms", ""))
-    phase_label = {
-        "dataloader": "input wait",
-        "input": "input wait",
-        "residual": "residual time",
-    }.get(phase, phase)
-    median = _mapping(evidence.get("median"))
-    worst = _mapping(evidence.get("worst"))
-    worst_rank = _int_or_none(worst.get("rank"))
-    median_rank = _int_or_none(median.get("rank"))
-    worst_value = _float_or_none(worst.get("value_ms"))
-    median_value = _float_or_none(median.get("value_ms"))
-
-    if (
-        worst_rank is not None
-        and median_rank is not None
-        and worst_value is not None
-        and median_value is not None
-    ):
-        return (
-            f"Rank r{worst_rank} {phase_label} was {worst_value:.1f}ms "
-            f"vs median rank r{median_rank} at {median_value:.1f}ms."
-        )
-    return "One rank was materially slower than its peers."
-
-
 def _promote_step_time_primary(
     *,
     kind: str,
@@ -551,14 +462,12 @@ def _promote_step_time_primary(
             step_time_summary=step_time_summary,
             system_summary=system_summary,
         )
-        summary = _phase_share_summary(kind, evidence)
     else:
         evidence = _rank_comparison_evidence(
             step_time_summary=step_time_summary,
             system_summary=system_summary,
             diagnosis=diagnosis,
         )
-        summary = _rank_comparison_summary(kind, evidence)
     evidence.update(_step_time_score_evidence(kind=kind, diagnosis=diagnosis))
 
     return _primary_payload(
@@ -566,7 +475,7 @@ def _promote_step_time_primary(
         status=_diag_field(diagnosis, "status", kind),
         severity=_diag_field(diagnosis, "severity", "info"),
         section=STEP_TIME_SECTION,
-        summary=summary or _diag_field(diagnosis, "summary", ""),
+        summary=_diag_field(diagnosis, "summary", ""),
         action=_diag_field(diagnosis, "action", ""),
         evidence=evidence,
     )

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -232,173 +232,6 @@ def _format_card_ranks(stats: StepTimeCardStats) -> Optional[str]:
     )
 
 
-def _largest_compute_phase(
-    summary: Optional[RankStepSummary],
-) -> Optional[str]:
-    """Return the largest compute bucket for one rank summary."""
-    if summary is None:
-        return None
-    values = {
-        "forward": finite_float(summary.avg_forward_ms),
-        "backward": finite_float(summary.avg_backward_ms),
-        "optimizer": finite_float(summary.avg_optimizer_ms),
-    }
-    return max(values, key=values.get) if values else None
-
-
-def _issue_by_kind(issues: tuple[Any, ...], kind: str) -> Optional[Any]:
-    """Return the first issue with the requested kind."""
-    for issue in issues:
-        if str(getattr(issue, "kind", "") or "") == kind:
-            return issue
-    return None
-
-
-def _diagnosis_evidence(diagnosis: Any) -> Dict[str, Any]:
-    """Return diagnosis evidence as a plain mapping."""
-    evidence = getattr(diagnosis, "evidence", None)
-    return evidence if isinstance(evidence, dict) else {}
-
-
-def _input_bound_evidence_reason(diagnosis: Any) -> Optional[str]:
-    """Build a short input-bound reason from selected-clock evidence."""
-    evidence = _diagnosis_evidence(diagnosis)
-    input_wait_ms = evidence.get("input_wait_ms")
-    step_time_ms = evidence.get("step_time_ms")
-    iteration_time_ms = evidence.get("iteration_time_ms")
-    diagnosis_clock = str(evidence.get("diagnosis_clock") or "").lower()
-    if input_wait_ms is None or step_time_ms is None:
-        return None
-    if iteration_time_ms is None:
-        try:
-            iteration_time_ms = float(input_wait_ms) + float(step_time_ms)
-        except Exception:
-            return None
-    clock_text = (
-        f" {diagnosis_clock}" if diagnosis_clock in {"cpu", "gpu"} else ""
-    )
-    return (
-        f"Input wait was {format_ms(input_wait_ms)} of "
-        f"{format_ms(iteration_time_ms)}{clock_text} iteration time."
-    )
-
-
-def _compute_phase_pair_from_rank_values(
-    phase: str,
-    per_global_rank_summary: Dict[int, RankStepSummary],
-) -> StepTimeMetricPair:
-    """Return median/worst timing values for one compute phase."""
-    phase_key = str(phase or "").lower()
-    field_by_phase = {
-        "forward": "avg_forward_ms",
-        "backward": "avg_backward_ms",
-        "optimizer": "avg_optimizer_ms",
-    }
-    field_name = field_by_phase.get(phase_key)
-    if field_name is None:
-        return StepTimeMetricPair(None, None, None, None)
-
-    return _metric_pair_from_rank_values(
-        {
-            int(rank): finite_float(getattr(summary, field_name))
-            for rank, summary in per_global_rank_summary.items()
-        }
-    )
-
-
-def _step_time_card_reason(
-    diagnosis: Any,
-    *,
-    stats: Optional[StepTimeCardStats],
-    per_global_rank_summary: Dict[int, RankStepSummary],
-    issues: tuple[Any, ...] = (),
-) -> str:
-    """Build the short `Why` line used only by the human card."""
-    kind = str(getattr(diagnosis, "kind", "") or "")
-    if kind == "NO_DATA":
-        return "Need more step-time samples."
-    if kind == "WARMUP":
-        return str(getattr(diagnosis, "reason", "") or "").strip()
-    if stats is None:
-        return str(getattr(diagnosis, "reason", "") or "n/a")
-
-    if kind == "BALANCED":
-        return "No clear timing bottleneck."
-    if kind == "INPUT_STRAGGLER":
-        evidence = _format_ms_pair(stats.input.worst_ms, stats.input.median_ms)
-        return (
-            f"{_global_rank_label(stats.input.worst_global_rank)} input was "
-            f"slower than median global rank ({evidence})."
-        )
-    if kind == "COMPUTE_STRAGGLER":
-        issue = _issue_by_kind(issues, "COMPUTE_STRAGGLER")
-        phase = str(getattr(issue, "phase", "") or "").lower()
-        phase_stats = _compute_phase_pair_from_rank_values(
-            phase,
-            per_global_rank_summary,
-        )
-        if phase_stats.worst_ms is not None:
-            ranks = tuple(getattr(issue, "ranks", ()) or ())
-            rank = int(ranks[0]) if ranks else phase_stats.worst_global_rank
-            evidence = _format_ms_pair(
-                phase_stats.worst_ms,
-                phase_stats.median_ms,
-            )
-            return (
-                f"{_global_rank_label(rank)} {phase} was slower than "
-                f"peer median ({evidence})."
-            )
-
-        evidence = _format_ms_pair(
-            stats.compute.worst_ms,
-            stats.compute.median_ms,
-        )
-        return (
-            f"{_global_rank_label(stats.compute.worst_global_rank)} compute "
-            f"was slower than median global rank ({evidence})."
-        )
-    if kind == "H2D_STRAGGLER":
-        evidence = _format_ms_pair(stats.h2d.worst_ms, stats.h2d.median_ms)
-        return (
-            f"{_global_rank_label(stats.h2d.worst_global_rank)} H2D was "
-            f"slower than median global rank ({evidence})."
-        )
-    if kind == "STRAGGLER":
-        return "Visible rank skew was sync-bound or unattributed."
-    if kind == "INPUT_BOUND":
-        issue = _issue_by_kind(issues, "INPUT_BOUND")
-        evidence_reason = _input_bound_evidence_reason(issue or diagnosis)
-        if evidence_reason:
-            return evidence_reason
-        return str(
-            getattr(diagnosis, "reason", "") or "Input wait was high."
-        ).strip()
-    if kind == "H2D_BOUND":
-        evidence = (
-            f"{format_ms(stats.h2d.worst_ms)}/"
-            f"{format_ms(stats.total_step.worst_ms)}"
-        )
-        return f"H2D transfer was high inside the total step ({evidence})."
-    if kind == "RESIDUAL_HEAVY":
-        evidence = (
-            f"{format_ms(stats.residual.worst_ms)}/"
-            f"{format_ms(stats.total_step.worst_ms)}"
-        )
-        return f"Residual time was high inside the total step ({evidence})."
-    if kind == "COMPUTE_BOUND":
-        summary = per_global_rank_summary.get(stats.compute.worst_global_rank)
-        phase = _largest_compute_phase(summary)
-        suffix = f"; {phase} was largest" if phase else ""
-        evidence = (
-            f"{format_ms(stats.compute.worst_ms)}/"
-            f"{format_ms(stats.total_step.worst_ms)}"
-        )
-        return f"Compute dominated ({evidence}){suffix}."
-
-    reason = str(getattr(diagnosis, "reason", "") or "").strip()
-    return reason or "No clear timing bottleneck."
-
-
 def _global_rank_entry_to_json(
     global_rank: int,
     summary: RankStepSummary,
@@ -456,6 +289,7 @@ def build_step_time_payload(
     summary_diag = diagnosis_result.primary
     issues = diagnosis_result.issues
     diagnosis_json, issues_json = diagnostic_result_to_json(diagnosis_result)
+    primary_issue = issues[0]
 
     global_rollup = build_global_rollup(
         per_global_rank_summary=rank_summary,
@@ -471,12 +305,11 @@ def build_step_time_payload(
     )
     lines = [title, "Step Time"]
     diagnosis_status = summary_diag.status
-    diagnosis_why = _step_time_card_reason(
-        summary_diag,
-        stats=card_stats,
-        per_global_rank_summary=rank_summary,
-        issues=tuple(issues),
-    )
+    diagnosis_why = str(
+        primary_issue.summary
+        or summary_diag.reason
+        or "No clear timing bottleneck."
+    ).strip()
 
     if not rank_summary:
         latest_step_text = (

--- a/tests/diagnostics/test_common.py
+++ b/tests/diagnostics/test_common.py
@@ -6,7 +6,6 @@ from traceml_ai.diagnostics.common import (
     DiagnosticResult,
     diagnosis_to_issue,
     ensure_primary_issue,
-    sort_issues,
 )
 from traceml_ai.reporting.summaries.issue_summary import (
     diagnostic_result_to_json,
@@ -137,39 +136,3 @@ def test_diagnostic_result_json_uses_first_issue_as_diagnosis() -> None:
 
     assert diagnosis == issues[0]
     assert diagnosis["kind"] == "HIGH_CPU"
-
-
-def test_sort_issues_orders_by_severity_score_and_rank_breadth() -> None:
-    low = DiagnosticIssue(
-        kind="LOW",
-        status="LOW",
-        severity="info",
-        summary="low",
-        action="none",
-        score=1.0,
-        ranks=(0, 1),
-    )
-    high_low_score = DiagnosticIssue(
-        kind="HIGH_LOW_SCORE",
-        status="HIGH LOW SCORE",
-        severity="crit",
-        summary="high",
-        action="none",
-        score=0.1,
-        ranks=(0,),
-    )
-    high_high_score = DiagnosticIssue(
-        kind="HIGH_HIGH_SCORE",
-        status="HIGH HIGH SCORE",
-        severity="crit",
-        summary="high",
-        action="none",
-        score=0.9,
-        ranks=(0,),
-    )
-
-    assert sort_issues((low, high_low_score, high_high_score)) == (
-        high_high_score,
-        high_low_score,
-        low,
-    )

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -31,6 +31,9 @@ from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeSeries,
     StepCombinedTimeSummary,
 )
+from traceml_ai.reporting.summaries.issue_summary import (
+    diagnostic_result_to_json,
+)
 from traceml_ai.utils.step_time_window import (
     build_step_time_window_from_events,
     diagnose_step_time_window,
@@ -367,6 +370,7 @@ def test_input_bound_rule_uses_cpu_clock_when_gpu_is_absent() -> None:
     assert issue.metric == "input_wait"
     assert issue.phase == "input"
     assert issue.share_pct == pytest.approx(35.0 / 135.0)
+    assert issue.score == issue.share_pct
     assert issue.evidence["diagnosis_clock"] == "cpu"
     assert issue.evidence["input_wait_ms"] == pytest.approx(35.0)
     assert issue.evidence["step_time_ms"] == pytest.approx(100.0)
@@ -458,6 +462,7 @@ def test_h2d_bound_uses_gpu_iteration_share_thresholds(
     assert issue.metric == "h2d"
     assert issue.phase == "h2d"
     assert issue.share_pct == pytest.approx(h2d / 100.0)
+    assert issue.score == issue.share_pct
     assert issue.severity == expected_severity
 
 
@@ -546,6 +551,7 @@ def test_residual_heavy_uses_iteration_share_thresholds(
 
     assert issue is not None
     assert issue.share_pct == pytest.approx(residual / 100.0)
+    assert issue.score == issue.share_pct
     assert issue.severity == expected_severity
 
 
@@ -571,6 +577,7 @@ def test_compute_bound_is_informational_despite_compute_skew() -> None:
 
     assert issue is not None
     assert issue.severity == "info"
+    assert issue.score is None
     assert issue.skew_pct is not None
 
 
@@ -650,6 +657,139 @@ def test_input_bound_remains_primary_when_h2d_is_also_material() -> None:
         "INPUT_BOUND",
         "H2D_BOUND",
     }
+
+
+def test_step_time_primary_orders_by_severity_before_impact() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=20.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            residual=30.0,
+            step_time=100.0,
+        )
+    }
+
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+    )
+
+    assert result.primary.kind == "RESIDUAL_HEAVY"
+    assert [issue.kind for issue in result.issues[:2]] == [
+        "RESIDUAL_HEAVY",
+        "INPUT_BOUND",
+    ]
+    assert result.issues[0].severity == "crit"
+    assert result.issues[1].severity == "warn"
+
+
+def test_step_time_primary_orders_equal_severity_by_impact() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=15.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            residual=19.0,
+            step_time=100.0,
+        )
+    }
+
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank),
+        per_rank_timing=per_rank,
+    )
+
+    assert result.primary.kind == "RESIDUAL_HEAVY"
+    assert [issue.kind for issue in result.issues[:2]] == [
+        "RESIDUAL_HEAVY",
+        "INPUT_BOUND",
+    ]
+    assert result.issues[0].severity == result.issues[1].severity == "warn"
+    assert result.issues[0].score > result.issues[1].score
+
+
+def test_rank_straggler_wins_only_an_exact_impact_tie() -> None:
+    tied = {
+        0: _timing_row(
+            dataloader=20.0,
+            forward=0.0,
+            backward=20.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=20.0,
+            forward=0.0,
+            backward=40.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+    }
+    higher_typical = {
+        0: _timing_row(
+            dataloader=20.0,
+            forward=0.0,
+            backward=20.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=20.0,
+            forward=0.0,
+            backward=35.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+    }
+
+    tied_result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(tied),
+        per_rank_timing=tied,
+    )
+    typical_result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(higher_typical),
+        per_rank_timing=higher_typical,
+    )
+
+    assert tied_result.primary.kind == "STRAGGLER"
+    assert [issue.kind for issue in tied_result.issues[:2]] == [
+        "STRAGGLER",
+        "INPUT_BOUND",
+    ]
+    assert tied_result.issues[0].score == tied_result.issues[1].score
+
+    assert typical_result.primary.kind == "INPUT_BOUND"
+    assert [issue.kind for issue in typical_result.issues[:2]] == [
+        "INPUT_BOUND",
+        "STRAGGLER",
+    ]
+    assert typical_result.issues[0].score > typical_result.issues[1].score
+
+
+def test_step_time_primary_uses_capped_severity_before_impact() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=20.0,
+            forward=0.0,
+            backward=0.0,
+            optimizer=0.0,
+            residual=30.0,
+            step_time=100.0,
+        )
+    }
+
+    result = build_step_diagnosis_result(
+        _metrics_from_per_rank_timing(per_rank, steps=5),
+        per_rank_timing=per_rank,
+    )
+    diagnosis_json, issues_json = diagnostic_result_to_json(result)
+
+    assert result.primary.kind == "RESIDUAL_HEAVY"
+    assert all(issue.severity == "warn" for issue in result.issues)
+    assert diagnosis_json == issues_json[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -1097,6 +1097,11 @@ def test_rank_straggler_coverage_changes_attribution_not_severity() -> None:
     assert named.kind == "INPUT_STRAGGLER"
     assert generic.score == named.score == pytest.approx(1.0)
     assert generic.severity == named.severity == "crit"
+    assert "r0 is slower than victim r1" in generic.summary
+    assert "r0 has excess input wait burden relative to victim r1" in (
+        named.summary
+    )
+    assert "~80.0% of visible wait cost" in named.summary
 
 
 def test_rank_straggler_component_coverage_is_bounded() -> None:

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -17,7 +17,10 @@ from traceml_ai.diagnostics.step_time.api import (
 )
 from traceml_ai.diagnostics.step_time.context import build_step_time_context
 from traceml_ai.diagnostics.step_time.formatters import format_cli_diagnosis
-from traceml_ai.diagnostics.step_time.policy import SUMMARY_STEP_TIME_POLICY
+from traceml_ai.diagnostics.step_time.policy import (
+    LIVE_STEP_TIME_POLICY,
+    SUMMARY_STEP_TIME_POLICY,
+)
 from traceml_ai.diagnostics.step_time.rules import (
     ComputeBoundRule,
     H2DBoundRule,
@@ -581,6 +584,57 @@ def test_compute_bound_is_informational_despite_compute_skew() -> None:
     assert issue.skew_pct is not None
 
 
+@pytest.mark.parametrize(
+    ("compute", "expected"),
+    [(89.9, False), (90.0, True)],
+)
+def test_compute_bound_uses_iteration_share_threshold(
+    compute: float,
+    expected: bool,
+) -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            forward=compute,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        )
+    }
+
+    issue = ComputeBoundRule().evaluate(_rank_context(per_rank))
+
+    assert (issue is not None) is expected
+    if issue is not None:
+        assert issue.share_pct == pytest.approx(0.90)
+        assert issue.score is None
+
+
+def test_compute_share_is_median_of_per_rank_iteration_shares() -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=0.0,
+            forward=100.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+        1: _timing_row(
+            dataloader=100.0,
+            forward=80.0,
+            backward=0.0,
+            optimizer=0.0,
+            step_time=100.0,
+        ),
+    }
+
+    context = _rank_context(per_rank)
+
+    assert context.compute_share == pytest.approx(0.70)
+    aggregate_median_ratio = 90.0 / (50.0 + 100.0)
+    assert context.compute_share != pytest.approx(aggregate_median_ratio)
+
+
 def test_compute_bound_requires_existing_dominance_threshold() -> None:
     per_rank = {
         0: _timing_row(
@@ -614,6 +668,31 @@ def test_compute_bound_abstains_for_material_h2d() -> None:
         )
         is None
     )
+
+
+@pytest.mark.parametrize(
+    ("input_wait", "residual", "step_time"),
+    [(10.0, 0.0, 90.0), (0.0, 10.0, 100.0)],
+)
+def test_compute_bound_abstains_for_material_iteration_overhead(
+    input_wait: float,
+    residual: float,
+    step_time: float,
+) -> None:
+    per_rank = {
+        0: _timing_row(
+            dataloader=input_wait,
+            forward=90.0,
+            backward=0.0,
+            optimizer=0.0,
+            residual=residual,
+            step_time=step_time,
+        )
+    }
+    context = _rank_context(per_rank)
+
+    assert context.compute_share == pytest.approx(0.90)
+    assert ComputeBoundRule().evaluate(context) is None
 
 
 def test_cpu_h2d_does_not_suppress_compute_bound() -> None:
@@ -1372,6 +1451,27 @@ def test_summary_step_time_window_uses_summary_policy_by_default() -> None:
 
     assert result is not None
     assert result.primary.steps_used == 60
+
+
+def test_builtin_live_and_summary_policies_use_identical_thresholds() -> None:
+    live_thresholds = LIVE_STEP_TIME_POLICY.thresholds
+    summary_thresholds = SUMMARY_STEP_TIME_POLICY.thresholds
+
+    assert live_thresholds is summary_thresholds
+    assert live_thresholds.compute_bound_share_warn == pytest.approx(0.90)
+
+    window = build_step_time_window_from_events(
+        {0: _summary_step_events(input_wait_gpu=None, steps=40)},
+        max_rows=100,
+    )
+    live = diagnose_step_time_window(window, policy=LIVE_STEP_TIME_POLICY)
+    summary = diagnose_step_time_window(
+        window,
+        policy=SUMMARY_STEP_TIME_POLICY,
+    )
+
+    assert live.primary == summary.primary
+    assert live.issues == summary.issues
 
 
 def _event_stats(

--- a/tests/reporting/summary/test_final.py
+++ b/tests/reporting/summary/test_final.py
@@ -178,6 +178,7 @@ def test_final_text_uses_single_process_average_layout():
         "INPUT_BOUND",
         "INPUT-BOUND",
         severity="crit",
+        summary="Input wait is 48.5% of the typical GPU iteration time.",
         action="Increase workers, prefetch, or storage throughput.",
     )
     step_time = _payload(
@@ -224,7 +225,9 @@ def test_final_text_uses_single_process_average_layout():
 
     text = payload["text"]
     assert "TraceML Verdict: INPUT-BOUND / CRITICAL" in text
-    assert "Why: Input wait was 130.8ms of 269.9ms iteration time." in text
+    assert (
+        "Why: Input wait is 48.5% of the typical GPU iteration time." in text
+    )
     assert "Next: Increase workers, prefetch, or storage throughput." in text
     assert "System Evidence" in text
     assert "Metric            Average" in text
@@ -287,6 +290,7 @@ def test_final_text_includes_h2d_bound_diagnosis():
             "H2D_BOUND",
             "H2D-BOUND",
             severity="crit",
+            summary="H2D transfer is 14.3% of the typical GPU iteration time.",
             action="Inspect pinned memory and batch transfers.",
         ),
         global_summary={
@@ -314,7 +318,7 @@ def test_final_text_includes_h2d_bound_diagnosis():
     )
 
     assert "TraceML Verdict: H2D-BOUND / CRITICAL" in payload["text"]
-    assert "Why: H2D transfer took 20.0ms of 140.0ms iteration time." in (
+    assert "Why: H2D transfer is 14.3% of the typical GPU iteration time." in (
         payload["text"]
     )
 
@@ -324,6 +328,10 @@ def test_final_text_uses_multi_process_comparison_layout():
         "INPUT_STRAGGLER",
         "INPUT STRAGGLER",
         severity="crit",
+        summary=(
+            "r0 has excess input wait burden relative to victim r1 "
+            "(~82.6% impact; ~100.0% of visible wait cost)."
+        ),
         phase="input",
         action=(
             "Inspect input wait, collate_fn, preprocessing, and storage "
@@ -406,9 +414,11 @@ def test_final_text_uses_multi_process_comparison_layout():
 
     text = payload["text"]
     assert "TraceML Verdict: INPUT STRAGGLER / CRITICAL" in text
-    assert (
-        "Rank r0 input wait was 264.5ms vs median rank r1 at 13.8ms." in text
+    assert payload["primary_diagnosis"]["summary"] == (
+        "r0 has excess input wait burden relative to victim r1 "
+        "(~82.6% impact; ~100.0% of visible wait cost)."
     )
+    assert "Why: r0 has excess input wait burden relative to victim r1" in text
     assert (
         "Metric          Median        Worst         Skew        Scope" in text
     )

--- a/tests/reporting/summary/test_primary_diagnosis.py
+++ b/tests/reporting/summary/test_primary_diagnosis.py
@@ -146,6 +146,48 @@ def test_h2d_bound_uses_iteration_phase_share_evidence() -> None:
     }
 
 
+def test_phase_share_primary_keeps_the_diagnosis_impact_score() -> None:
+    step_time = _step_time("H2D_BOUND", status="H2D-BOUND")
+    step_time["diagnosis"].update(
+        {
+            "score": 0.23125,
+            "evidence": {"h2d_share": 0.23125},
+        }
+    )
+
+    primary = _primary(step_time)
+
+    assert primary["evidence"]["score"] == 0.23125
+    assert primary["evidence"]["score_basis"] == (
+        "median_per_rank_iteration_share"
+    )
+    assert primary["evidence"]["score_denominator"] == (
+        "input_wait_ms + step_time_ms per rank"
+    )
+
+
+def test_straggler_primary_keeps_the_diagnosis_impact_score() -> None:
+    step_time = _step_time("STRAGGLER", status="STRAGGLER")
+    step_time["diagnosis"].update(
+        {
+            "score": 0.23,
+            "evidence": {
+                "visible_cost_ms": 23.0,
+                "iteration_time_ms": 100.0,
+            },
+        }
+    )
+
+    primary = _primary(step_time)
+
+    assert primary["evidence"]["score"] == 0.23
+    assert primary["evidence"]["score_basis"] == (
+        "visible_cost_ms / victim_iteration_time_ms"
+    )
+    assert primary["evidence"]["score_numerator_ms"] == 23.0
+    assert primary["evidence"]["score_denominator_ms"] == 100.0
+
+
 def test_residual_heavy_uses_residual_phase_share() -> None:
     primary = _primary(_step_time("RESIDUAL_HEAVY", status="RESIDUAL-HEAVY"))
 

--- a/tests/reporting/summary/test_primary_diagnosis.py
+++ b/tests/reporting/summary/test_primary_diagnosis.py
@@ -37,6 +37,7 @@ def _step_time(
     kind: str,
     *,
     status: str | None = None,
+    summary: str = "step-time summary",
     phase: str | None = None,
     issues: list[dict] | None = None,
 ) -> dict:
@@ -44,7 +45,7 @@ def _step_time(
         "kind": kind,
         "status": status or kind.replace("_", "-"),
         "severity": "warn",
-        "summary": "step-time summary",
+        "summary": summary,
         "action": "step-time action",
         "metric": None,
         "phase": phase,
@@ -96,7 +97,11 @@ def _primary(step_time: dict, system: dict | None = None) -> dict:
 
 def test_input_bound_uses_phase_share_evidence() -> None:
     primary = _primary(
-        _step_time("INPUT_BOUND", status="INPUT-BOUND"),
+        _step_time(
+            "INPUT_BOUND",
+            status="INPUT-BOUND",
+            summary="Input wait is 33.3% of the typical GPU iteration time.",
+        ),
         _system(gpu_util=38.0),
     )
 
@@ -104,7 +109,7 @@ def test_input_bound_uses_phase_share_evidence() -> None:
     assert primary["section"] == "step_time"
     assert primary["scope"] == "performance"
     assert primary["summary"] == (
-        "Input wait was 80.0ms of 240.0ms iteration time."
+        "Input wait is 33.3% of the typical GPU iteration time."
     )
     assert primary["evidence"] == {
         "type": "phase_share",
@@ -119,31 +124,26 @@ def test_input_bound_uses_phase_share_evidence() -> None:
         "h2d_ms": 10.0,
         "compute_ms": 120.0,
         "residual_ms": 20.0,
-        "shares": {
-            "input_wait_pct": 33.333,
-            "h2d_pct": 4.167,
-            "compute_pct": 50.0,
-            "residual_pct": 8.333,
-        },
         "gpu_util_avg_percent": 38.0,
     }
 
 
 def test_h2d_bound_uses_iteration_phase_share_evidence() -> None:
-    primary = _primary(_step_time("H2D_BOUND", status="H2D-BOUND"))
+    primary = _primary(
+        _step_time(
+            "H2D_BOUND",
+            status="H2D-BOUND",
+            summary="H2D transfer is 23.1% of the typical GPU iteration time.",
+        )
+    )
 
     assert primary["kind"] == "H2D_BOUND"
     assert primary["summary"] == (
-        "H2D transfer took 10.0ms of 240.0ms iteration time."
+        "H2D transfer is 23.1% of the typical GPU iteration time."
     )
     assert primary["evidence"]["type"] == "phase_share"
     assert primary["evidence"]["iteration_time_ms"] == 240.0
-    assert primary["evidence"]["shares"] == {
-        "input_wait_pct": 33.333,
-        "h2d_pct": 4.167,
-        "compute_pct": 50.0,
-        "residual_pct": 8.333,
-    }
+    assert "shares" not in primary["evidence"]
 
 
 def test_phase_share_primary_keeps_the_diagnosis_impact_score() -> None:
@@ -158,12 +158,16 @@ def test_phase_share_primary_keeps_the_diagnosis_impact_score() -> None:
     primary = _primary(step_time)
 
     assert primary["evidence"]["score"] == 0.23125
+    assert primary["evidence"]["h2d_ms"] == 10.0
+    assert primary["evidence"]["iteration_time_ms"] == 240.0
+    assert primary["evidence"]["score"] != pytest.approx(10.0 / 240.0)
     assert primary["evidence"]["score_basis"] == (
         "median_per_rank_iteration_share"
     )
     assert primary["evidence"]["score_denominator"] == (
         "input_wait_ms + step_time_ms per rank"
     )
+    assert "shares" not in primary["evidence"]
 
 
 def test_straggler_primary_keeps_the_diagnosis_impact_score() -> None:
@@ -189,24 +193,38 @@ def test_straggler_primary_keeps_the_diagnosis_impact_score() -> None:
 
 
 def test_residual_heavy_uses_residual_phase_share() -> None:
-    primary = _primary(_step_time("RESIDUAL_HEAVY", status="RESIDUAL-HEAVY"))
+    primary = _primary(
+        _step_time(
+            "RESIDUAL_HEAVY",
+            status="RESIDUAL-HEAVY",
+            summary=(
+                "Residual time is 21.0% of the typical GPU iteration time."
+            ),
+        )
+    )
 
     assert primary["kind"] == "RESIDUAL_HEAVY"
     assert primary["summary"] == (
-        "Residual time took 20.0ms of a 160.0ms average step."
+        "Residual time is 21.0% of the typical GPU iteration time."
     )
     assert primary["evidence"]["type"] == "phase_share"
-    assert primary["evidence"]["shares"]["residual_pct"] == 8.333
+    assert "shares" not in primary["evidence"]
 
 
 def test_compute_bound_uses_neutral_compute_phase_share() -> None:
-    primary = _primary(_step_time("COMPUTE_BOUND", status="COMPUTE-BOUND"))
+    primary = _primary(
+        _step_time(
+            "COMPUTE_BOUND",
+            status="COMPUTE-BOUND",
+            summary="Compute-bound; backward is the largest phase.",
+        )
+    )
 
     assert primary["kind"] == "COMPUTE_BOUND"
-    assert primary["summary"] == (
-        "Model compute took 120.0ms of a 160.0ms average step."
+    assert (
+        primary["summary"] == "Compute-bound; backward is the largest phase."
     )
-    assert primary["evidence"]["shares"]["compute_pct"] == 50.0
+    assert "shares" not in primary["evidence"]
 
 
 @pytest.mark.parametrize(
@@ -214,26 +232,22 @@ def test_compute_bound_uses_neutral_compute_phase_share() -> None:
         "kind",
         "phase",
         "expected_metric",
-        "expected_summary",
     ),
     [
         (
             "INPUT_STRAGGLER",
             "dataloader",
             "input_wait_ms",
-            "Rank r2 input wait was 120.0ms vs median rank r0 at 8.0ms.",
         ),
         (
             "COMPUTE_STRAGGLER",
             "optimizer",
             "optimizer_ms",
-            None,
         ),
         (
             "H2D_STRAGGLER",
             "h2d",
             "h2d_ms",
-            "Rank r2 h2d was 40.0ms vs median rank r1 at 10.0ms.",
         ),
     ],
 )
@@ -241,7 +255,6 @@ def test_rank_stragglers_use_rank_comparison_evidence(
     kind: str,
     phase: str,
     expected_metric: str,
-    expected_summary: str | None,
 ) -> None:
     primary = _primary(
         _step_time(
@@ -256,8 +269,7 @@ def test_rank_stragglers_use_rank_comparison_evidence(
     assert primary["evidence"]["metric"] == expected_metric
     assert primary["evidence"]["phase"] == phase
     assert primary["evidence"]["worst"]["rank"] == 2
-    if expected_summary is not None:
-        assert primary["summary"] == expected_summary
+    assert primary["summary"] == "step-time summary"
 
 
 def test_straggler_includes_input_and_compute_comparisons() -> None:

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -148,6 +148,7 @@ def _input_bound_step_metrics(
     input_wait_gpu: float,
     step_time_gpu: float,
     h2d_gpu: float = 0.0,
+    compute_gpu: float = 0.0,
     steps: int = 64,
 ) -> dict[int, dict]:
     return {
@@ -156,6 +157,7 @@ def _input_bound_step_metrics(
                 cpu_ms=dataloader_cpu, gpu_ms=input_wait_gpu
             ),
             "_traceml_internal:h2d_time": _event_stats(gpu_ms=h2d_gpu),
+            "_traceml_internal:forward_time": _event_stats(gpu_ms=compute_gpu),
             "_traceml_internal:step_time": _event_stats(
                 cpu_ms=step_time_cpu,
                 gpu_ms=step_time_gpu,
@@ -286,6 +288,7 @@ def test_step_time_input_bound_card_uses_short_reason() -> None:
             0: _input_bound_step_metrics(
                 input_wait_gpu=40.0,
                 step_time_gpu=100.0,
+                compute_gpu=90.0,
             )
         },
     )
@@ -333,6 +336,7 @@ def test_step_time_h2d_bound_card_uses_short_reason() -> None:
             0: _input_bound_step_metrics(
                 input_wait_gpu=0.0,
                 h2d_gpu=20.0,
+                compute_gpu=70.0,
                 step_time_cpu=100.0,
                 step_time_gpu=100.0,
             )

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -209,7 +209,7 @@ def test_step_time_no_data_card_is_compact() -> None:
     assert payload["diagnosis"]["kind"] == "NO_DATA"
     assert "- Diagnosis: NO DATA" in payload["card"]
     assert "- Stats: n/a" in payload["card"]
-    assert "- Why: Need more step-time samples." in payload["card"]
+    assert "- Why: step_time metric is missing." in payload["card"]
     _assert_compact_card(payload["card"])
 
 
@@ -242,7 +242,10 @@ def test_step_time_balanced_card_is_compact() -> None:
     assert "- Residual: median/worst" in payload["card"]
     assert "- Ranks: median/worst |" in payload["card"]
     assert "- Residual ranks: median/worst" in payload["card"]
-    assert "- Why: No clear timing bottleneck." in payload["card"]
+    assert (
+        "- Why: No dominant bottleneck is visible in this window."
+        in payload["card"]
+    )
     _assert_compact_card(payload["card"])
 
 
@@ -267,7 +270,7 @@ def test_step_time_compute_bound_card_uses_short_reason() -> None:
     )
     assert "- Residual: 5.0ms" in payload["card"]
     assert (
-        "- Why: Compute dominated (90.0ms/97.0ms); backward was largest."
+        "- Why: Compute-bound; backward is the largest phase."
         in payload["card"]
     )
     _assert_compact_card(payload["card"])
@@ -314,7 +317,7 @@ def test_step_time_input_bound_card_uses_short_reason() -> None:
     assert row_metrics["total_step_ms"] == 102.0
     _assert_public_step_metrics_keep_dataloader(payload)
     assert (
-        "- Why: Input wait was 40.0ms of 140.0ms gpu iteration time."
+        "- Why: Input wait is 28.6% of the typical gpu iteration time."
         in payload["card"]
     )
     _assert_compact_card(payload["card"])
@@ -350,7 +353,8 @@ def test_step_time_h2d_bound_card_uses_short_reason() -> None:
     assert payload["diagnosis"]["evidence"]["h2d_ms"] == 20.0
     assert payload["diagnosis"]["evidence"]["diagnosis_clock"] == "gpu"
     assert (
-        "- Why: H2D transfer was high inside the total step" in payload["card"]
+        "- Why: H2D transfer is 20.0% of the typical GPU iteration time."
+        in payload["card"]
     )
     _assert_compact_card(payload["card"])
 
@@ -371,10 +375,43 @@ def test_step_time_residual_heavy_card_uses_short_reason() -> None:
     assert payload["diagnosis"] == payload["issues"][0]
     assert payload["diagnosis"]["status"] == "RESIDUAL-HEAVY"
     assert (
-        "- Why: Residual time was high inside the total step (30.0ms/102.0ms)."
+        "- Why: Residual time is 29.4% of the typical cpu iteration time."
         in payload["card"]
     )
     _assert_compact_card(payload["card"])
+
+
+def test_step_time_card_uses_h2d_diagnosis_score_not_worst_rollups() -> None:
+    payload = _summary(
+        {
+            0: _rank(h2d=10.0, forward=90.0, backward=0.0, optimizer=0.0),
+            1: _rank(h2d=90.0, forward=10.0, backward=0.0, optimizer=0.0),
+        },
+        per_rank_steps={
+            0: _input_bound_step_metrics(
+                input_wait_gpu=0.0,
+                h2d_gpu=10.0,
+                compute_gpu=90.0,
+                step_time_cpu=300.0,
+                step_time_gpu=100.0,
+            ),
+            1: _input_bound_step_metrics(
+                input_wait_gpu=20.0,
+                h2d_gpu=90.0,
+                compute_gpu=10.0,
+                step_time_cpu=120.0,
+                step_time_gpu=100.0,
+            ),
+        },
+    )
+
+    assert payload["diagnosis"]["status"] == "H2D-BOUND"
+    assert payload["diagnosis"]["score"] == 0.425
+    assert (
+        "- Why: H2D transfer is 42.5% of the typical GPU iteration time."
+        in payload["card"]
+    )
+    assert "90.0ms/312.0ms" not in payload["card"]
 
 
 def test_step_time_residual_uses_average_of_per_step_clamps() -> None:
@@ -399,7 +436,8 @@ def test_step_time_residual_uses_average_of_per_step_clamps() -> None:
     )
     assert primary["kind"] == "RESIDUAL_HEAVY"
     assert primary["evidence"]["residual_ms"] == 25.0
-    assert primary["evidence"]["shares"]["residual_pct"] == 33.333
+    assert primary["evidence"]["score"] == payload["diagnosis"]["score"]
+    assert "shares" not in primary["evidence"]
 
 
 def test_step_time_input_straggler_card_shows_rank_evidence() -> None:
@@ -425,8 +463,8 @@ def test_step_time_input_straggler_card_shows_rank_evidence() -> None:
     _assert_public_step_metrics_keep_dataloader(payload)
     assert "- Ranks: median/worst |" in payload["card"]
     assert (
-        "- Why: r1 input was slower than median global rank (70.0/40.0ms)."
-        in payload["card"]
+        "- Why: r1 has excess input wait burden relative to victim r0 "
+        "(~24.0% impact; ~100.0% of visible wait cost)." in payload["card"]
     )
     assert "issues" not in payload["groups"]["rows"]["1"]
     assert {issue["kind"] for issue in payload["issues"]} == {
@@ -434,3 +472,18 @@ def test_step_time_input_straggler_card_shows_rank_evidence() -> None:
         "INPUT_BOUND",
     }
     _assert_compact_card(payload["card"])
+
+
+def test_step_time_generic_straggler_card_uses_canonical_summary() -> None:
+    payload = _summary(
+        {
+            0: _rank(backward=50.0),
+            1: _rank(backward=100.0),
+        }
+    )
+
+    assert payload["diagnosis"]["kind"] == "STRAGGLER"
+    assert (
+        "- Why: r0 is slower than victim r1 (~34.5% impact); no measured "
+        "component explains 80.0% of visible wait cost." in payload["card"]
+    )


### PR DESCRIPTION
# Normalize Step Time diagnosis by iteration impact

## Summary

This PR makes Step Time diagnosis consistent across CLI, dashboard, and final summary. Typical bottlenecks and rank stragglers now use selected-clock iteration impact, primary selection is based on severity and impact instead of a fixed diagnosis-kind table, and reporting reuses the canonical diagnosis object instead of rebuilding explanations from independent rollups.

This description covers the cumulative changes relative to `version_0.3.5`.

## Diagnosis Policy

Typical input, H2D, residual, and compute shares are calculated per rank:

```text
iteration_r = input_wait_r + step_time_r
component_share_r = component_r / iteration_r
typical_component_share = median(component_share_r across ranks)
```

- `INPUT_BOUND`, `H2D_BOUND`, and `RESIDUAL_HEAVY` warn at 10% and become   critical at 20%.
- `H2D_BOUND` requires GPU-selected timing so asynchronous CPU host-call  duration is not reported as transfer cost.
- Rank skew remains supporting evidence and no longer suppresses a qualifying  typical bottleneck.
- `COMPUTE_BOUND` is informational and requires a 90% median per-rank compute  iteration share:

  ```text
  compute_r = forward_r + backward_r + optimizer_r
  compute_share_r = compute_r / iteration_r
  ```

- Built-in live and summary policies share the same thresholds. Their analyzed   window sizes may differ.

## Rank-Straggler Policy

The existing DDP/FSDP visible-phase model is retained:

- DDP uses backward as the visible synchronization phase.
- FSDP uses forward plus backward.
- The culprit is the rank with the smallest visible phase.
- The victim is the upper-median observed rank by that phase.

Severity is based only on victim iteration impact:

```text
visible_cost = victim_visible_ms - culprit_visible_ms
impact = visible_cost / (victim_input_wait_ms + victim_step_time_ms)
```

Impact below 10% abstains, 10% warns, and 20% is critical, subject to existing
confidence and FSDP severity caps.

Attribution is a separate decision:

```text
component_coverage = min(1, component_excess_ms / visible_cost_ms)
```

Input, H2D, or DDP compute is named only when it explains at least 80% of the visible cost. Otherwise TraceML emits generic `STRAGGLER` with raw excess and coverage evidence. FSDP remains conservative and does not name compute without explicit collective timing.

## Primary Selection

- `INPUT_BOUND`, `H2D_BOUND`, and `RESIDUAL_HEAVY` expose their median   per-rank iteration share as `DiagnosticIssue.score`.
- Rank-straggler score remains visible cost divided by victim iteration time.
- Findings are ordered by severity, then score, then rank-local scope for an  exact tie.
- A rank straggler beats a typical bottleneck only when severity and score are  exactly equal.
- All qualifying findings remain in `issues`, and `diagnosis == issues[0]`.
- Informational `COMPUTE_BOUND` intentionally has no impact-ordering score.

## Reporting Consistency

- Add `H2D_BOUND` to diagnosis kinds, CLI formatting, dashboard status,   summary JSON/text, compact cards, and run-level primary promotion.
- Preserve the selected issue score and denominator in run-level primary  evidence instead of recomputing it from global averages.
- Remove the independently derived primary-evidence `shares` map.
- Make Step Time card `Why` text reuse `issues[0].summary`.
- Include culprit, victim, impact, and attribution coverage in canonical  straggler summaries.
- Keep aggregate phase values and rank rows as observational display data.

This removes the old fixed kind-priority table, duplicate summary formulas,
and card-specific bottleneck reconstruction.

## User-Visible Changes

- Typical input or residual bottlenecks can remain visible even when one rank   is more skewed.
- Broad GPU transfer cost can now appear as `H2D_BOUND`; rank-local transfer  skew remains `H2D_STRAGGLER`.
- A straggler may become generic when measured components explain less than  80% of its visible cost.
- The primary Step Time finding may change when another qualifying finding has  greater severity or iteration impact.
- Compute-bound is now a neutral informational result at 90% of iteration time,  rather than a warning/critical diagnosis based on traced-step share.

## Scope

- No telemetry collection, transport, SQLite, dashboard plumbing, or schema  version change.
- No YAML configuration or new public configuration surface.
- Existing selected-clock, warmup, minimum-step, confidence, and FSDP gates  remain in place.
- The broader refactor to compute one live `DiagnosticResult` and pass that  exact instance to every live consumer remains separate.

## Verification

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/diagnostics/test_step_time.py \
  tests/renderers/test_step_time_renderer.py \
  tests/reporting/summary/test_step_time_card.py \
  tests/reporting/summary/test_primary_diagnosis.py \
  tests/reporting/summary/test_final.py \
  tests/reporting/summary/test_fixtures.py -q
```

Result: `106 passed`.

Focused coverage includes:

- median-of-per-rank shares versus ratios of independent rollups;
- 10%/20% input, H2D, residual, and straggler boundaries;
- 89.9%/90% compute-bound boundary;
- GPU-only H2D-bound behavior;
- 79%/80% straggler attribution coverage;
- severity/score/scope primary ordering;
- canonical score propagation through cards, JSON, and final text;
- identical built-in live and summary thresholds.

`git diff --check` passes.

## Base

Comparison: `version_0.3.5...abhinav/issue239`
