### PR TITLE
Create the GitHub Release when cutting a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,3 +67,12 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "v$VERSION" \
+            --generate-notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ which carry the full historical notes for versions predating this file.
 
 ## [Unreleased]
 
+- Cutting a release now also creates the GitHub Release entry, so a
+  published version is never missing its release notes.
+
+## [0.3.5] - 2026-07-26
+
+- DeepSpeed training is supported alongside DDP and FSDP.
+- Telemetry export moved to a dedicated exporter thread, keeping TCP
+  sends off the training thread's critical path.
+- Runtime metadata (training strategy, environment) is captured and
+  carried into the final summary.
+- Step Time diagnosis refinements across straggler, input-bound, and
+  H2D paths, including FSDP warm-step filtering.
 - Package version is now derived from the git tag (`setuptools-scm`)
   instead of a hand-edited string in `pyproject.toml`.
 - Releases publish to PyPI automatically on a `v*` tag push, via PyPI


### PR DESCRIPTION
The 0.3.5 release published to PyPI and pushed a `v0.3.5` tag, but no GitHub Release entry was created, so the Releases page still showed `v0.3.4` as Latest while `0.3.5` was live on PyPI. `release.yml` tags, builds, and publishes, but never called `gh release create`.

## What changes

- `release.yml` gains a final step that creates the GitHub Release for the tag it just pushed, using `--generate-notes` for the body.
- `CHANGELOG.md` gets a `## [0.3.5]` section (it was still sitting under `Unreleased`), plus an `Unreleased` entry for this change.

The new step uses the already-validated `$VERSION` env var rather than interpolating the workflow input into the shell, matching the convention the file's own comment sets out. It runs after the PyPI publish, so a publish failure won't leave a Release pointing at a version that never shipped.

## Verified

- `release.yml` parses as YAML and the job's step list is intact, with `Create the GitHub Release` last.
- `--generate-notes`, `--title`, and `--repo` all confirmed against `gh release create --help`.
- The `v0.3.5` Release was created by hand today to close the immediate gap, so this PR fixes the recurrence, not the current state.

## Note

`GH_TOKEN` uses `github.token`, which the job already has `contents: write` on for the tag push, so no new permission is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DeepSpeed training support alongside DDP and FSDP.
  * Release publishing now automatically creates a corresponding GitHub Release with generated notes.
  * Runtime metadata, including training strategy and environment details, is included in final summaries.

* **Performance & Diagnostics**
  * Telemetry exports now run separately to reduce impact on training.
  * Improved step-time diagnostics for stragglers, input-bound workloads, H2D transfers, and FSDP warm-up steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->