### PR TITLE
fix(transport): guard SO_REUSEPORT so the aggregator can start on Windows

### DIFF
--- a/src/traceml_ai/transport/tcp_transport.py
+++ b/src/traceml_ai/transport/tcp_transport.py
@@ -48,7 +48,10 @@ class TCPServer:
     def start(self) -> None:
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        # SO_REUSEPORT is POSIX-only; Windows has no equivalent and the
+        # constant is absent there, so setting it unconditionally raises.
+        if hasattr(socket, "SO_REUSEPORT"):
+            self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         self._sock.bind((self.cfg.host, self.cfg.port))
         self._port = int(self._sock.getsockname()[1])
         self._sock.listen(self.cfg.backlog)

--- a/src/traceml_ai/transport/tcp_transport.py
+++ b/src/traceml_ai/transport/tcp_transport.py
@@ -48,10 +48,20 @@ class TCPServer:
     def start(self) -> None:
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        # SO_REUSEPORT is POSIX-only; Windows has no equivalent and the
-        # constant is absent there, so setting it unconditionally raises.
-        if hasattr(socket, "SO_REUSEPORT"):
-            self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        # SO_REUSEPORT is best-effort: it is absent on Windows, and even
+        # where the constant exists the kernel can still reject it (Python
+        # picks it up from build-time headers). Only SO_REUSEADDR above is
+        # required, so never fail startup over it.
+        reuseport = getattr(socket, "SO_REUSEPORT", None)
+        if reuseport is not None:
+            try:
+                self._sock.setsockopt(socket.SOL_SOCKET, reuseport, 1)
+            except OSError as exc:
+                self.logger.warning(
+                    "[TraceML] SO_REUSEPORT unavailable (%s); "
+                    "continuing without it.",
+                    exc,
+                )
         self._sock.bind((self.cfg.host, self.cfg.port))
         self._port = int(self._sock.getsockname()[1])
         self._sock.listen(self.cfg.backlog)

--- a/tests/runtime/test_tcp_transport.py
+++ b/tests/runtime/test_tcp_transport.py
@@ -41,3 +41,19 @@ def test_tcp_server_exposes_actual_port_for_dynamic_bind(monkeypatch) -> None:
     finally:
         server.stop()
     assert fake.closed
+
+
+def test_tcp_server_starts_without_so_reuseport(monkeypatch) -> None:
+    # Uses a real socket: _FakeSocket swallows setsockopt, so only a
+    # genuine bind proves the Windows path (no SO_REUSEPORT) works.
+    monkeypatch.delattr(
+        "traceml_ai.transport.tcp_transport.socket.SO_REUSEPORT",
+        raising=False,
+    )
+
+    server = TCPServer(TCPConfig(host="127.0.0.1", port=0))
+    server.start()
+    try:
+        assert server.port > 0
+    finally:
+        server.stop()

--- a/tests/runtime/test_tcp_transport.py
+++ b/tests/runtime/test_tcp_transport.py
@@ -1,3 +1,5 @@
+import socket
+
 from traceml_ai.transport.tcp_transport import TCPConfig, TCPServer
 
 
@@ -55,5 +57,37 @@ def test_tcp_server_starts_without_so_reuseport(monkeypatch) -> None:
     server.start()
     try:
         assert server.port > 0
+    finally:
+        server.stop()
+
+
+def test_tcp_server_starts_when_so_reuseport_is_rejected(
+    monkeypatch,
+) -> None:
+    # A kernel older than the headers Python was built against exposes the
+    # constant but rejects the option, so presence alone is not enough.
+    monkeypatch.setattr(
+        "traceml_ai.transport.tcp_transport.socket.SO_REUSEPORT",
+        15,
+        raising=False,
+    )
+
+    class _RejectingSocket(_FakeSocket):
+        def setsockopt(self, _level, option, _value):
+            if option == socket.SO_REUSEPORT:
+                raise OSError(92, "Protocol not available")
+            return None
+
+    fake = _RejectingSocket()
+    monkeypatch.setattr(
+        "traceml_ai.transport.tcp_transport.socket.socket",
+        lambda *_args, **_kwargs: fake,
+    )
+
+    server = TCPServer(TCPConfig(host="127.0.0.1", port=0))
+    server.start()
+    try:
+        assert fake.bound_to == ("127.0.0.1", 0)
+        assert server.port == 54321
     finally:
         server.stop()


### PR DESCRIPTION
## Problem

`TCPServer.start()` sets `SO_REUSEPORT` unconditionally. That option is POSIX-only — on Windows `socket.SO_REUSEPORT` does not exist, so the call raises before `bind()` is ever reached:

```
File "traceml_ai/transport/tcp_transport.py", line 51, in start
    self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
AttributeError: module 'socket' has no attribute 'SO_REUSEPORT'

[TraceML] ERROR: aggregator was not reachable at 127.0.0.1:29765 (exit=1).
```

The aggregator dies before it starts listening, so **every** `traceml run` fails on Windows, in every mode. `docs/developer_guide/architecture.md` lists a "Linux/macOS/Windows launcher" under Portability, so this reads as an oversight rather than a deliberate scoping decision.

Present on `main`, `version_0.3.5` and `version_0.3.6`.

## Fix

Apply `SO_REUSEPORT` only where the constant exists. `SO_REUSEADDR` is still set unconditionally and already provides the rebind behaviour TraceML relies on, so POSIX behaviour is completely unchanged.

## Why the existing test didn't catch it

`tests/runtime/test_tcp_transport.py` binds through `_FakeSocket`, whose `setsockopt` swallows every option — so it passes on Linux and is structurally unable to see this. (On Windows that same test fails on `main` today.)

The added test deletes `socket.SO_REUSEPORT` with `monkeypatch.delattr(..., raising=False)` and binds a **real** socket on port 0. That reproduces the Windows condition on any platform, so Linux CI will guard the regression from now on.

## Verification

Windows 11, Python 3.11, CPU-only:

- On `main`: the existing transport test fails with the `AttributeError` above, and `traceml run` exits 1 with `aggregator was not reachable`.
- On this branch: `pytest tests/runtime` → **121 passed, 1 skipped**, and `traceml run` now reaches `[TraceML] Aggregator ready on 127.0.0.1:29765 (... ui=summary)`.
- `black --check`, `ruff check` and `isort --check-only` are clean on both touched files.

One caveat I'd rather state than overclaim: I could not drive the demo all the way to completion on this machine. Once the aggregator is up, `torch.distributed.run` fails in `TCPStore` with `use_libuv was requested but PyTorch was built without libuv support`. That is a property of the local `torch 2.13.0+cpu` Windows wheel and happens well downstream of the code this PR touches, but it does mean a full Windows end-to-end run is still unproven — it likely needs a libuv-enabled torch build. Flagging it in case it's a second Windows papercut worth a separate issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TCP server startup behavior on platforms where `SO_REUSEPORT` is missing or not permitted.
  - The server now continues to start and bind to an available port even when the reuse-port socket option is unavailable or rejected.

- **Tests**
  - Added runtime test coverage for TCP server startup when `SO_REUSEPORT` is absent and when it raises an error during socket setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->