### PR TITLE
fix(deps): allow NumPy 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "rich>=12.0.0",
     "psutil>=5.0.0",
     "nvidia-ml-py",
-    "numpy>=1.24",
+    "numpy>=1.26",
     "msgspec",
     "pyyaml>=6.0",
     "nicegui",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "rich>=12.0.0",
     "psutil>=5.0.0",
     "nvidia-ml-py",
-    "numpy<2",
+    "numpy>=1.24",
     "msgspec",
     "pyyaml>=6.0",
     "nicegui",


### PR DESCRIPTION
Closes #263.

## Problem

`numpy<2` forces a downgrade on any environment that already has NumPy 2, which today is most of the scientific Python stack. As @GANs-and-roses notes in #263, resolvers that won't downgrade NumPy don't report the conflict — `uv` silently installs `traceml-ai==0.1.3` instead, so users get a two-year-old release with no indication why.

There's a second consequence that isn't in the issue: **the cap makes TraceML uninstallable on Python 3.13**, which `ci.yml` covers in the `test-core` matrix on `main`. The last NumPy 1.x release (1.26.4) publishes no 3.13 wheels — per PyPI its classifiers stop at 3.12 — and 3.13 support begins in NumPy 2.1. So `numpy<2` and Python 3.13 have no valid resolution.

## Why the cap looks unintentional

It was introduced in cb46d9e, which flipped `numpy>=2.0.0` → `numpy<2` as an incidental part of an unrelated GPU fix (commit message: "changed on gpu"). The project was on NumPy 2 before that.

Nothing in the codebase actually requires NumPy 1.x. Only ten modules import it, and they use long-stable APIs — `asarray`, `isfinite`, `mean`, `median`, `polyfit`, `arange`, `argmax`, `empty`, `float64`. Grepping `src/` and `tests/` for NumPy 2.0-removed aliases (`np.float_`, `np.NaN`, `np.infty`, `np.in1d`, `np.row_stack`, `np.trapz`, `np.product`, `np.alltrue`, …) returns nothing.

## Change

`numpy<2` → `numpy>=1.24`. The floor keeps existing NumPy 1.x users working instead of forcing an upgrade in the opposite direction, so this is strictly a widening of the supported range.

## Verification

Ran the full suite twice on the same machine and same commit, changing only the installed NumPy:

| | NumPy 1.26.4 | NumPy 2.2.6 |
|---|---|---|
| `pytest tests` | 25 failed, 639 passed, 4 skipped | 25 failed, 639 passed, 4 skipped |

The two `FAILED` lists are **identical** — I diffed them, and the diff is empty. Those 25 are pre-existing failures of my Windows/CPU-only box (CUDA paths, `socket.SO_REUSEPORT`, subprocess launcher), unrelated to this change and unaffected by it. NumPy 2 introduces no regression.

Narrower runs, also on both majors:
- The exact set `ci.yml` gates on (`tests/core`, `tests/diagnostics/test_bands.py`, `tests/diagnostics/test_common.py`, `tests/telemetry/{test_distributed,test_msgpack,test_sender_sequence}.py`): **43 passed** under NumPy 2.
- The NumPy-heavy modules (`tests/diagnostics`, `tests/renderers`, covering `step_memory/trend.py`, `renderers/step_memory/common.py`, `renderers/system/dashboard_compute.py`): 4 failed / 155 passed under **both** majors, same 4 in each.

Also confirmed a clean-room `pip install .` in an empty venv resolves to NumPy 2.4.6 with no conflict, and that the `torch` ↔ NumPy 2 bridge works (`torch.from_numpy` on a float64 array) with `torch 2.13.0+cpu`.

One thing I could not check: whether the original GPU environment behind cb46d9e had a CUDA/torch build that genuinely needed NumPy 1.x. I have no GPU here. If that constraint is still real, it likely belongs on the `torch` extra with a comment rather than on the core dependency, and I'm happy to rework it that way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the supported NumPy dependency constraint by changing it to `numpy>=1.26` (previously restricted with `numpy<2`).
  * Adjusted version compatibility guidance to focus on NumPy 1.26 and later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->