### PR TITLE
Guard runtime dependencies against undocumented upper bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install pytest
+          # tomli backports tomllib to 3.10 for the packaging guard.
+          pip install pytest 'tomli; python_version < "3.11"'
       - name: Run core tests
         run: |
           pytest \
@@ -129,7 +130,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install --no-cache-dir --upgrade --upgrade-strategy eager \
             -e ".[torch]"
-          pip install pytest
+          # tomli backports tomllib to 3.10 for the packaging guard.
+          pip install pytest 'tomli; python_version < "3.11"'
       - name: Report the resolved environment
         run: pip list
       - name: Run core tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,12 +107,20 @@ jobs:
     # environment (issue #263). A resolution check must resolve for real.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    # This job resolves and builds dependency versions that did not exist
+    # when the commit was written, so it executes third-party build code by
+    # design. Give it read-only scope and keep the checkout token out of the
+    # git config that build code could read.
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.13"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
       - '*.md'
       - '.gitignore'
   workflow_dispatch:
+  schedule:
+    # Weekly early warning that the newest published dependencies still work.
+    - cron: '0 6 * * 1'
 
 concurrency:
   group: ci-${{ github.head_ref || github.run_id }}
@@ -90,6 +93,46 @@ jobs:
             tests/runtime/test_telemetry_publisher.py \
             tests/reporting/compare \
             tests/reporting/html \
+            -q
+
+  test-latest-deps:
+    name: Latest Dependencies (early warning)
+    # Not a pull-request gate. A brand new release of a dependency must not
+    # block contributors, but we want to hear about it before users do.
+    #
+    # Deliberately runs without setup-python's pip cache. The cache once
+    # held a locally source-built numpy-1.26.4-cp313-cp313-linux_x86_64
+    # wheel, which kept the `numpy<2` cap green on Python 3.13 in CI long
+    # after it had become uninstallable for anyone starting from a clean
+    # environment (issue #263). A resolution check must resolve for real.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install with the newest resolvable dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-cache-dir --upgrade --upgrade-strategy eager \
+            -e ".[torch]"
+          pip install pytest
+      - name: Report the resolved environment
+        run: pip list
+      - name: Run core tests
+        run: |
+          pytest \
+            tests/core \
+            tests/diagnostics/test_bands.py \
+            tests/diagnostics/test_common.py \
+            tests/telemetry/test_distributed.py \
+            tests/telemetry/test_msgpack.py \
+            tests/telemetry/test_sender_sequence.py \
             -q
 
   smoke-test-install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
     "pytest-cov>=7.0.0",
     "datasets",
     "transformers",
+    'tomli; python_version < "3.11"',
 ]
 
 hf = [

--- a/tests/core/test_packaging_constraints.py
+++ b/tests/core/test_packaging_constraints.py
@@ -13,9 +13,13 @@ Upper bounds remain allowed, but they must be listed in
 ALLOWED_UPPER_BOUNDS with a reason, so the decision is explicit and
 reviewable rather than incidental.
 
-This parses pyproject.toml directly rather than using tomllib, which is
-absent on Python 3.10, the version CI runs for pull requests. A skipped
-guard on the one leg that always runs would defeat the purpose.
+The manifest is read with a real TOML parser. An earlier revision matched
+quoted strings with a regex, which dropped a dependency whose URL carried
+a ``#`` fragment and then swallowed the following entry along with it. A
+guard that silently omits a dependency is the failure it exists to catch,
+so the parse is never approximated. ``tomllib`` covers 3.11 and newer and
+``tomli`` covers 3.10; if neither is importable the guard fails rather
+than skipping.
 """
 
 from __future__ import annotations
@@ -25,6 +29,14 @@ from pathlib import Path
 
 import pytest
 
+try:  # Python 3.11+
+    import tomllib as _toml
+except ModuleNotFoundError:  # Python 3.10
+    try:
+        import tomli as _toml  # type: ignore[no-redef]
+    except ModuleNotFoundError:  # pragma: no cover - environment error
+        _toml = None  # type: ignore[assignment]
+
 PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
 
 # Dependency name -> reason the upper bound is justified.
@@ -32,33 +44,29 @@ PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
 ALLOWED_UPPER_BOUNDS: dict[str, str] = {}
 
 _UPPER_BOUND_PATTERN = re.compile(r"(<=|<|==|~=)\s*[0-9]")
-_DEPENDENCIES_BLOCK = re.compile(
-    r"^dependencies\s*=\s*\[(?P<body>.*?)\]", re.MULTILINE | re.DOTALL
-)
-# TOML allows both basic ("...") and literal ('...') strings. Matching only
-# one style would drop a requirement from the guard entirely, which would let
-# an upper bound through silently.
-_TOML_STRING = re.compile(r"\"([^\"]*)\"|'([^']*)'")
 
 
 def _parse_dependencies(text: str) -> list[str]:
-    """Extract the [project] dependencies array from pyproject.toml text."""
-    match = _DEPENDENCIES_BLOCK.search(text)
-    if match is None:
+    """Return the [project] dependencies array from pyproject.toml text."""
+    if _toml is None:
         raise AssertionError(
-            "could not locate the [project] dependencies array"
+            "no TOML parser available. Install tomli on Python 3.10 "
+            "(pip install \"tomli; python_version < '3.11'\") so this "
+            "guard can read pyproject.toml."
         )
 
-    body = match.group("body")
-    # Drop comments so a quoted string inside one is not read as a
-    # requirement.
-    body = "\n".join(line.split("#", 1)[0] for line in body.splitlines())
+    data = _toml.loads(text)
+    try:
+        dependencies = data["project"]["dependencies"]
+    except KeyError as exc:
+        raise AssertionError(
+            f"could not locate [project].dependencies: missing {exc}"
+        ) from None
 
-    return [
-        basic or literal
-        for basic, literal in _TOML_STRING.findall(body)
-        if (basic or literal).strip()
-    ]
+    if not isinstance(dependencies, list):
+        raise AssertionError("[project].dependencies is not an array")
+
+    return [str(item) for item in dependencies]
 
 
 def _runtime_dependencies() -> list[str]:
@@ -68,7 +76,7 @@ def _runtime_dependencies() -> list[str]:
 
 def _requirement_name(requirement: str) -> str:
     """Return the bare distribution name from a requirement string."""
-    name = re.split(r"[\[(;<>=!~ ]", requirement.strip(), maxsplit=1)[0]
+    name = re.split(r"[\[(;<>=!~ @]", requirement.strip(), maxsplit=1)[0]
     return name.strip().lower()
 
 
@@ -77,42 +85,45 @@ def _version_specifier(requirement: str) -> str:
     return requirement.split(";")[0]
 
 
-def test_parser_reads_both_toml_string_styles() -> None:
-    """A requirement must not vanish because of how it is quoted.
+def test_parser_handles_quote_styles_comments_and_url_fragments() -> None:
+    """No dependency may disappear because of how it is written.
 
-    A dependency the parser cannot see is a dependency the guard cannot
-    check, so the bound would ship unnoticed.
+    A dependency the parser cannot see is one the guard cannot check, so
+    the bound would ship unnoticed. The URL fragment is the case that
+    broke an earlier regex version: the ``#`` ended the string early and
+    the entry after it was lost too.
     """
     text = """
 [project]
 dependencies = [
     "double>=1.0",
-    'literal<3',  # a comment mentioning "quoted" text
-    "spans-comment",
+    'literal<3',
+    "fragment @ https://example.com/pkg-1.0.whl#sha256=deadbeef",
+    "capped<2",
 ]
 """
 
     assert _parse_dependencies(text) == [
         "double>=1.0",
         "literal<3",
-        "spans-comment",
+        "fragment @ https://example.com/pkg-1.0.whl#sha256=deadbeef",
+        "capped<2",
     ]
 
 
-def test_parser_catches_an_upper_bound_in_a_literal_string() -> None:
-    """The upper-bound check must fire regardless of quote style."""
+def test_upper_bound_is_detected_in_every_quote_style() -> None:
+    """The upper-bound check must fire regardless of how a dep is quoted."""
     text = """
 [project]
-dependencies = ['capped<2']
+dependencies = ["basic<2", 'literal<=3']
 """
 
-    (requirement,) = _parse_dependencies(text)
-
-    assert _UPPER_BOUND_PATTERN.search(requirement) is not None
+    for requirement in _parse_dependencies(text):
+        assert _UPPER_BOUND_PATTERN.search(requirement) is not None
 
 
 def test_runtime_dependencies_are_parsed() -> None:
-    """The parser must actually find dependencies, or the guard is inert."""
+    """The parser must find dependencies, or the guard is inert."""
     dependencies = _runtime_dependencies()
 
     assert dependencies, "no runtime dependencies parsed from pyproject.toml"

--- a/tests/core/test_packaging_constraints.py
+++ b/tests/core/test_packaging_constraints.py
@@ -35,18 +35,35 @@ _UPPER_BOUND_PATTERN = re.compile(r"(<=|<|==|~=)\s*[0-9]")
 _DEPENDENCIES_BLOCK = re.compile(
     r"^dependencies\s*=\s*\[(?P<body>.*?)\]", re.MULTILINE | re.DOTALL
 )
+# TOML allows both basic ("...") and literal ('...') strings. Matching only
+# one style would drop a requirement from the guard entirely, which would let
+# an upper bound through silently.
+_TOML_STRING = re.compile(r"\"([^\"]*)\"|'([^']*)'")
+
+
+def _parse_dependencies(text: str) -> list[str]:
+    """Extract the [project] dependencies array from pyproject.toml text."""
+    match = _DEPENDENCIES_BLOCK.search(text)
+    if match is None:
+        raise AssertionError(
+            "could not locate the [project] dependencies array"
+        )
+
+    body = match.group("body")
+    # Drop comments so a quoted string inside one is not read as a
+    # requirement.
+    body = "\n".join(line.split("#", 1)[0] for line in body.splitlines())
+
+    return [
+        basic or literal
+        for basic, literal in _TOML_STRING.findall(body)
+        if (basic or literal).strip()
+    ]
 
 
 def _runtime_dependencies() -> list[str]:
     """Return the [project] dependencies list from pyproject.toml."""
-    text = PYPROJECT.read_text(encoding="utf-8")
-    match = _DEPENDENCIES_BLOCK.search(text)
-    if match is None:
-        raise AssertionError(
-            "could not locate the [project] dependencies array in "
-            f"{PYPROJECT}"
-        )
-    return re.findall(r'"([^"]+)"', match.group("body"))
+    return _parse_dependencies(PYPROJECT.read_text(encoding="utf-8"))
 
 
 def _requirement_name(requirement: str) -> str:
@@ -58,6 +75,40 @@ def _requirement_name(requirement: str) -> str:
 def _version_specifier(requirement: str) -> str:
     """Return the requirement text with any environment marker removed."""
     return requirement.split(";")[0]
+
+
+def test_parser_reads_both_toml_string_styles() -> None:
+    """A requirement must not vanish because of how it is quoted.
+
+    A dependency the parser cannot see is a dependency the guard cannot
+    check, so the bound would ship unnoticed.
+    """
+    text = """
+[project]
+dependencies = [
+    "double>=1.0",
+    'literal<3',  # a comment mentioning "quoted" text
+    "spans-comment",
+]
+"""
+
+    assert _parse_dependencies(text) == [
+        "double>=1.0",
+        "literal<3",
+        "spans-comment",
+    ]
+
+
+def test_parser_catches_an_upper_bound_in_a_literal_string() -> None:
+    """The upper-bound check must fire regardless of quote style."""
+    text = """
+[project]
+dependencies = ['capped<2']
+"""
+
+    (requirement,) = _parse_dependencies(text)
+
+    assert _UPPER_BOUND_PATTERN.search(requirement) is not None
 
 
 def test_runtime_dependencies_are_parsed() -> None:

--- a/tests/core/test_packaging_constraints.py
+++ b/tests/core/test_packaging_constraints.py
@@ -1,0 +1,114 @@
+"""Guard the runtime dependency contract in pyproject.toml.
+
+An upper bound on a runtime dependency silently caps every downstream
+environment. The rest of the suite cannot catch it: CI resolves to
+whatever the bound allows and stays green forever, while users on a
+newer ecosystem get a downgrade or an unsolvable resolution.
+
+A ``numpy<2`` bound shipped this way. Installing traceml-ai downgraded
+NumPy 2 in place, and resolvers that refuse to downgrade backsolved to a
+two-year-old release instead (issue #263).
+
+Upper bounds remain allowed, but they must be listed in
+ALLOWED_UPPER_BOUNDS with a reason, so the decision is explicit and
+reviewable rather than incidental.
+
+This parses pyproject.toml directly rather than using tomllib, which is
+absent on Python 3.10, the version CI runs for pull requests. A skipped
+guard on the one leg that always runs would defeat the purpose.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+# Dependency name -> reason the upper bound is justified.
+# Add an entry only for a concrete, current incompatibility.
+ALLOWED_UPPER_BOUNDS: dict[str, str] = {}
+
+_UPPER_BOUND_PATTERN = re.compile(r"(<=|<|==|~=)\s*[0-9]")
+_DEPENDENCIES_BLOCK = re.compile(
+    r"^dependencies\s*=\s*\[(?P<body>.*?)\]", re.MULTILINE | re.DOTALL
+)
+
+
+def _runtime_dependencies() -> list[str]:
+    """Return the [project] dependencies list from pyproject.toml."""
+    text = PYPROJECT.read_text(encoding="utf-8")
+    match = _DEPENDENCIES_BLOCK.search(text)
+    if match is None:
+        raise AssertionError(
+            "could not locate the [project] dependencies array in "
+            f"{PYPROJECT}"
+        )
+    return re.findall(r'"([^"]+)"', match.group("body"))
+
+
+def _requirement_name(requirement: str) -> str:
+    """Return the bare distribution name from a requirement string."""
+    name = re.split(r"[\[(;<>=!~ ]", requirement.strip(), maxsplit=1)[0]
+    return name.strip().lower()
+
+
+def _version_specifier(requirement: str) -> str:
+    """Return the requirement text with any environment marker removed."""
+    return requirement.split(";")[0]
+
+
+def test_runtime_dependencies_are_parsed() -> None:
+    """The parser must actually find dependencies, or the guard is inert."""
+    dependencies = _runtime_dependencies()
+
+    assert dependencies, "no runtime dependencies parsed from pyproject.toml"
+    assert any(
+        _requirement_name(item) == "numpy" for item in dependencies
+    ), "expected numpy among the runtime dependencies"
+
+
+@pytest.mark.parametrize("requirement", _runtime_dependencies())
+def test_runtime_dependency_has_no_undocumented_upper_bound(
+    requirement: str,
+) -> None:
+    """Fail when a runtime dependency caps the version a user may install."""
+    name = _requirement_name(requirement)
+    specifier = _version_specifier(requirement)
+
+    operators = {
+        match.group(1) for match in _UPPER_BOUND_PATTERN.finditer(specifier)
+    }
+    if not operators:
+        return
+
+    if name in ALLOWED_UPPER_BOUNDS:
+        assert ALLOWED_UPPER_BOUNDS[
+            name
+        ].strip(), f"{name} is allowlisted but records no reason"
+        return
+
+    pytest.fail(
+        f"Runtime dependency {requirement!r} carries an upper bound "
+        f"({', '.join(sorted(operators))}). An upper bound caps every "
+        "downstream environment and cannot be caught by the rest of the "
+        "suite. Remove it, or add an entry to ALLOWED_UPPER_BOUNDS in "
+        f"{Path(__file__).name} recording the concrete incompatibility "
+        "that justifies it."
+    )
+
+
+def test_numpy_is_not_capped_below_version_2() -> None:
+    """Regression guard for issue #263."""
+    for requirement in _runtime_dependencies():
+        if _requirement_name(requirement) != "numpy":
+            continue
+
+        specifier = _version_specifier(requirement).replace(" ", "")
+
+        assert "<2" not in specifier, (
+            f"numpy is capped below 2 by {requirement!r}. This downgrades "
+            "NumPy in place for every user on a modern scientific stack."
+        )


### PR DESCRIPTION
## What changed

Adds two guardrails for the class of defect behind #263, now that #265 has fixed the instance.

1. `tests/core/test_packaging_constraints.py` fails when a runtime dependency in `pyproject.toml` carries an upper bound that is not recorded in an allowlist with a reason. It also keeps a named regression check for the NumPy cap specifically.
2. A scheduled `test-latest-deps` CI job resolves the newest published dependencies and runs the core suite.

## Why a guardrail rather than just the fix

`numpy<2` was introduced in cb46d9e by flipping `numpy>=2.0.0`, as an incidental part of an unrelated change, and it shipped for seven months. Nothing in the suite could object, because the manifest under test is also the manifest that drives resolution: whatever the cap allows is what CI installs, so CI stays green while users get a downgrade.

There is a live example of that masking in this repository. `numpy<2` is unresolvable on Python 3.13, since NumPy 1.26.4 publishes no cp313 wheels and 3.13 support starts in NumPy 2.1. The `test-core` 3.13 leg passed anyway, because `cache: "pip"` was serving a locally source-built wheel:

```
Collecting numpy<2 (from traceml-ai==...)
  Using cached numpy-1.26.4-cp313-cp313-linux_x86_64.whl
```

That `linux_x86_64` tag is not a PyPI wheel. CI built it once and reused it, so an install failure that any user would hit stayed invisible in CI for as long as the cache survived. The new job therefore installs with `--no-cache-dir`, and the reason is recorded in a comment next to it.

The scheduled job is deliberately not a pull-request gate. A fresh release of a dependency should not block a contributor, but we should hear about it before a user does.

## Verification

The guard passes against `main` as it stands after #265:

```
$ pytest tests/core/test_packaging_constraints.py -q
10 passed
```

Reintroducing the cap makes it fail, which is the behaviour that matters:

```
$ # with "numpy<2" restored in pyproject.toml
FAILED tests/core/test_packaging_constraints.py::test_runtime_dependency_has_no_undocumented_upper_bound[numpy<2]
FAILED tests/core/test_packaging_constraints.py::test_numpy_is_not_capped_below_version_2
2 failed, 8 passed
```

Confirmed the guard runs rather than skips on Python 3.10, the version pull requests are gated on, by running it in a clean `python:3.10-slim` container: `10 passed`. The test parses `pyproject.toml` directly instead of using `tomllib`, which is absent on 3.10, so the guard stays active on the one version every pull request runs.

Also checked that `.github/workflows/ci.yml` still parses and that the job list is `lint`, `test-core`, `test-integration`, `test-latest-deps`, `smoke-test-install`.

## Note on timing

`version_0.3.5` still carries `numpy<2` and has commits that are not on `main`. When that branch merges forward, a conflict resolved the wrong way would put the cap back. Landing this guard first makes that failure loud instead of silent.

## Runtime impact

- [x] No training-path impact

## Docs

- [x] Not needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened runtime dependency contract checks by parsing `pyproject.toml` with the appropriate TOML parser per Python version and failing when parsing support is unavailable.
  * Added coverage to detect and enforce upper-bound specifier allowlisting (with justification) across multiple TOML quoting/comment/URL fragment variants, plus a NumPy cap regression.

* **Chores**
  * Extended CI to include a weekly scheduled run and manual trigger for “latest dependencies” compatibility checks on Python 3.10 and 3.13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->