### PR TITLE
Preserve missing Step Time signals and gate diagnosis with INCOMPLETE_DATA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'version_*']
     paths-ignore:
       - 'docs/**'
       - '*.md'
       - '.gitignore'
   pull_request:
-    branches: [main]
+    branches: [main, 'version_*']
     paths-ignore:
       - 'docs/**'
       - '*.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
             tests/core \
             tests/diagnostics/test_bands.py \
             tests/diagnostics/test_common.py \
+            tests/diagnostics/test_step_time.py \
+            tests/diagnostics/test_step_time_missing_signals.py \
             tests/telemetry/test_distributed.py \
             tests/telemetry/test_msgpack.py \
             tests/telemetry/test_sender_sequence.py \

--- a/docs/developer_guide/rank-straggler-policy.md
+++ b/docs/developer_guide/rank-straggler-policy.md
@@ -40,18 +40,22 @@ visible_r = backward_r              # DDP / default
 visible_r = forward_r + backward_r  # FSDP
 ```
 
-Only ranks with a measured visible-phase anchor and a measured step envelope are
-eligible:
+Only ranks with a measured visible-phase anchor, a measured step envelope,
+and a measured input wait are eligible:
 
 ```text
-DDP / default: backward_r > 0 and step_time_r > 0
-FSDP:          forward_r > 0 and backward_r > 0 and step_time_r > 0
+DDP / default: input_wait measured and backward_r > 0 and step_time_r > 0
+FSDP:          input_wait measured and forward_r > 0 and backward_r > 0
+               and step_time_r > 0
 ```
 
 If fewer than two ranks are eligible, TraceML does not report a rank straggler.
-Missing visible instrumentation makes the rule abstain rather than treat a
-zero as a fast rank. Component values of `input_wait == 0` and `h2d == 0` are
-still valid measurements and are kept.
+Missing instrumentation makes the rule abstain rather than treat a zero as a
+fast rank; when that abstention leaves the whole window without any finding,
+Step Time reports `INCOMPLETE_DATA` with the missing signal names instead of
+`BALANCED`. Component values of `input_wait == 0` and `h2d == 0` are still
+valid measurements and are kept: a metric measured somewhere in the window is
+never confused with one that was never measured at all.
 
 ## Culprit and victim selection
 
@@ -84,7 +88,8 @@ the victim to explain the visible wait:
 
 ```text
 input_excess   = input_wait_culprit - input_wait_victim
-h2d_excess     = h2d_culprit - h2d_victim
+h2d_excess     = h2d_culprit - h2d_victim           # only when H2D is
+                                                    # measured on both ranks
 forward_excess = forward_culprit - forward_victim   # DDP / default only
 ```
 
@@ -96,11 +101,14 @@ cause_coverage = min(1, component_excess / visible_cost)
 
 The component with the highest coverage names `INPUT_STRAGGLER`,
 `H2D_STRAGGLER`, or (DDP / default only) `COMPUTE_STRAGGLER` only when its
-coverage reaches 80%. DDP / default compute attribution requires measured
-forward time on both the culprit and victim. Otherwise the diagnosis stays
-`STRAGGLER` with a sync-or-unattributed component. The issue evidence includes
-both `component_excesses_ms` and `component_coverage`, keyed by `input`,
-`h2d`, and `compute`.
+coverage reaches 80%. Every candidate component must be measured on both the
+culprit and the victim rank: DDP / default compute attribution requires
+measured forward time on both, and H2D attribution requires measured H2D time
+on both, so an unmeasured phase can never name the cause. Otherwise the
+diagnosis stays `STRAGGLER` with a sync-or-unattributed component. The issue
+evidence includes both `component_excesses_ms` and `component_coverage`, keyed
+by `input`, `h2d`, and `compute`; components excluded for missing measurement
+are absent from both maps.
 
 Cause coverage chooses the diagnosis label. The straggler score above remains
 the sole source of warning or critical severity. Generic residual attribution

--- a/src/dev/demo/mlp_incomplete_signals.py
+++ b/src/dev/demo/mlp_incomplete_signals.py
@@ -1,0 +1,91 @@
+"""
+Incomplete-signals scenario for the Step Time INCOMPLETE_DATA diagnosis.
+
+This keeps the healthy single-process MLP loop shape but calls
+``model.forward(features)`` directly instead of ``model(features)``. The
+forward auto-timer hooks ``nn.Module.__call__`` only, so forward timing is
+never recorded: compute and residual become underivable and TraceML must
+report ``INCOMPLETE DATA`` naming ``forward`` - not a confident BALANCED or
+RESIDUAL-HEAVY verdict built on a fake zero.
+
+Control twin: ``mlp_ddp_healthy_baseline.py`` (fully instrumented; must not
+report INCOMPLETE DATA).
+
+Run on any machine (CPU is fine):
+
+    traceml run python -m dev.demo.mlp_incomplete_signals
+"""
+
+from __future__ import annotations
+
+import random
+
+import torch
+import torch.nn as nn
+from torch.optim import AdamW
+from torch.utils.data import DataLoader, TensorDataset
+
+import traceml_ai as traceml
+
+SEED = 42
+NUM_SAMPLES = 4096
+INPUT_DIM = 512
+HIDDEN_DIM = 1024
+NUM_CLASSES = 100
+
+BATCH_SIZE = 64
+EPOCHS = 2
+LR = 1e-4
+
+
+class BaselineMLP(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(INPUT_DIM, HIDDEN_DIM),
+            nn.ReLU(),
+            nn.Linear(HIDDEN_DIM, NUM_CLASSES),
+        )
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        return self.net(features)
+
+
+def main() -> None:
+    random.seed(SEED)
+    torch.manual_seed(SEED)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    traceml.init(mode="auto")
+
+    features = torch.randn(NUM_SAMPLES, INPUT_DIM)
+    labels = torch.randint(0, NUM_CLASSES, (NUM_SAMPLES,))
+    loader = DataLoader(
+        TensorDataset(features, labels),
+        batch_size=BATCH_SIZE,
+        shuffle=True,
+    )
+
+    model = BaselineMLP().to(device)
+    optimizer = AdamW(model.parameters(), lr=LR)
+    criterion = nn.CrossEntropyLoss()
+
+    model.train()
+    for _ in range(EPOCHS):
+        for batch_features, batch_labels in loader:
+            with traceml.trace_step(model):
+                batch_features = batch_features.to(device)
+                batch_labels = batch_labels.to(device)
+
+                optimizer.zero_grad(set_to_none=True)
+                # Deliberate: bypasses nn.Module.__call__, so forward
+                # timing is never recorded for this run.
+                logits = model.forward(batch_features)
+                loss = criterion(logits, batch_labels)
+                loss.backward()
+                optimizer.step()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_diagnostics_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_diagnostics_section.py
@@ -22,7 +22,7 @@ _SOURCE_NAMES = {
 # Color buckets come from the engine's own severity (info|warn|crit), already
 # present in the payload — never re-parsed from the status text. New diagnosis
 # kinds therefore color correctly with no change here (single source of truth).
-_NEUTRAL_KINDS = ("NO_DATA", "WARMUP", "NO_GPU")
+_NEUTRAL_KINDS = ("NO_DATA", "WARMUP", "NO_GPU", "INCOMPLETE_DATA")
 
 
 def _row_sev(item: Dict[str, Any]) -> str:

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -65,10 +65,10 @@ Training-step timing.
 - `NO_DATA`: no usable step-time data.
 - `WARMUP`: some data exists, but not enough for diagnosis.
 - `INCOMPLETE_DATA` with status `INCOMPLETE DATA`: timing exists, but one or
-  more phase signals were never measured in the window and no rule could
-  reach a reliable conclusion. The evidence lists `missing_signals` (metric
-  names) and per-signal `signal_coverage` (`measured ranks / observed
-  ranks`).
+  more phase signals were not measured on every observed rank and no rule
+  could reach a reliable conclusion. The evidence lists `missing_signals`
+  (metric names) and per-signal `signal_coverage` (`measured ranks /
+  observed ranks`).
 - `BALANCED`: no clear timing bottleneck or rank straggler.
 - `STRAGGLER`: visible rank skew exists, but input wait, H2D, and DDP forward
   do not explain the likely culprit.
@@ -91,19 +91,22 @@ was never observed in the window stays an absent metric (it is not converted
 to `0.0`), while a phase measured at `0.0` stays a valid zero. A metric
 measured in at least one aligned step of a rank's window is *available* for
 that rank; steps where an available metric is absent count as zero work (the
-optimizer under gradient accumulation is the canonical case). Derived
-metrics exist only when their inputs are available: `compute` needs forward,
-backward, and optimizer; `total_step` needs input wait plus the step
-envelope; `residual_proxy` needs the step envelope plus every compute phase,
-and on the gpu clock also H2D (on the cpu clock H2D cost is unmeasurable by
-design and contributes zero). Each rule abstains when its required signals
-are unavailable: input needs input wait + step time; H2D needs GPU H2D +
-input wait + step time; compute and residual need every compute phase +
-input wait + step time; rank stragglers need their visible-phase anchors +
-input wait + step time. Rules still fire from the ranks that measured their
-signals, so one dark rank does not silence an otherwise measured finding.
-When no rule fires and at least one abstained for missing signals, Step Time
-reports `INCOMPLETE_DATA` instead of `BALANCED`.
+optimizer under gradient accumulation is the canonical case). H2D is
+special: its events are occurrence-driven, so a fully instrumented run with
+no host-to-device copies emits none. An absent H2D therefore means "no
+observed transfers" and contributes zero to derived metrics; it is never
+reported as a missing signal. Derived metrics exist only when their inputs
+are available: `compute` needs forward, backward, and optimizer;
+`total_step` needs input wait plus the step envelope; `residual_proxy`
+needs the step envelope plus every compute phase. Each rule abstains when
+its required signals are unavailable: input needs input wait + step time;
+H2D needs GPU-clock H2D + input wait + step time; compute and residual need
+every compute phase + input wait + step time; rank stragglers need their
+visible-phase anchors + input wait + step time. Rules still fire from the
+ranks that measured their signals, so one dark rank does not silence an
+otherwise measured finding. When no rule fires and at least one abstained
+for missing signals, Step Time reports `INCOMPLETE_DATA` instead of
+`BALANCED`.
 
 Step-time diagnosis uses one selected clock for the analyzed window. It uses
 GPU event timing when every rank/step has GPU timing for the step envelope,

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -88,17 +88,23 @@ Training-step timing.
 
 Missing signals and measured zeros are different things. A timing event that
 was never observed in the window stays an absent metric (it is not converted
-to `0.0`), while a phase measured at `0.0` stays a valid zero. A metric
-measured in at least one aligned step of a rank's window is *available* for
-that rank; steps where an available metric is absent count as zero work (the
-optimizer under gradient accumulation is the canonical case). H2D is
-special: its events are occurrence-driven, so a fully instrumented run with
-no host-to-device copies emits none. An absent H2D therefore means "no
-observed transfers" and contributes zero to derived metrics; it is never
-reported as a missing signal. Derived metrics exist only when their inputs
-are available: `compute` needs forward, backward, and optimizer;
-`total_step` needs input wait plus the step envelope; `residual_proxy`
-needs the step envelope plus every compute phase. Each rule abstains when
+to `0.0`), while a phase measured at `0.0` stays a valid zero. Availability
+is metric-specific. Occurrence-driven metrics (`optimizer_step`, `h2d`)
+legitimately skip steps: the optimizer under gradient accumulation, and H2D
+when a step performs no host-to-device copies. They are available for a rank
+when measured in at least one aligned step, and their absent steps count as
+zero work. Every other metric (`input_wait`, `forward`, `backward`,
+`step_time`) must occur on every bracketed step, so it is available only
+when measured in every aligned step of the rank's window; intermittent
+presence means the instrumentation dropped out mid-window and drops
+availability instead of synthesizing zeros that would leak the missing work
+into the residual. An absent H2D means "no observed transfers", contributes
+zero to derived metrics, and is never reported as a missing signal. Derived
+metrics exist only when their inputs are available: `compute` needs forward,
+backward, and optimizer; `total_step` needs input wait plus the step
+envelope; `residual_proxy` needs the step envelope plus every compute
+phase. The public final-summary projection preserves absence rather than
+re-deriving declined values. Each rule abstains when
 its required signals are unavailable: input needs input wait + step time;
 H2D needs GPU-clock H2D + input wait + step time; compute and residual need
 every compute phase + input wait + step time; rank stragglers need their

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -64,6 +64,11 @@ Training-step timing.
 
 - `NO_DATA`: no usable step-time data.
 - `WARMUP`: some data exists, but not enough for diagnosis.
+- `INCOMPLETE_DATA` with status `INCOMPLETE DATA`: timing exists, but one or
+  more phase signals were never measured in the window and no rule could
+  reach a reliable conclusion. The evidence lists `missing_signals` (metric
+  names) and per-signal `signal_coverage` (`measured ranks / observed
+  ranks`).
 - `BALANCED`: no clear timing bottleneck or rank straggler.
 - `STRAGGLER`: visible rank skew exists, but input wait, H2D, and DDP forward
   do not explain the likely culprit.
@@ -80,6 +85,25 @@ Training-step timing.
   this is informational when no material overhead is visible.
 - `RESIDUAL_HEAVY`: unattributed residual time is a material typical iteration
   cost.
+
+Missing signals and measured zeros are different things. A timing event that
+was never observed in the window stays an absent metric (it is not converted
+to `0.0`), while a phase measured at `0.0` stays a valid zero. A metric
+measured in at least one aligned step of a rank's window is *available* for
+that rank; steps where an available metric is absent count as zero work (the
+optimizer under gradient accumulation is the canonical case). Derived
+metrics exist only when their inputs are available: `compute` needs forward,
+backward, and optimizer; `total_step` needs input wait plus the step
+envelope; `residual_proxy` needs the step envelope plus every compute phase,
+and on the gpu clock also H2D (on the cpu clock H2D cost is unmeasurable by
+design and contributes zero). Each rule abstains when its required signals
+are unavailable: input needs input wait + step time; H2D needs GPU H2D +
+input wait + step time; compute and residual need every compute phase +
+input wait + step time; rank stragglers need their visible-phase anchors +
+input wait + step time. Rules still fire from the ranks that measured their
+signals, so one dark rank does not silence an otherwise measured finding.
+When no rule fires and at least one abstained for missing signals, Step Time
+reports `INCOMPLETE_DATA` instead of `BALANCED`.
 
 Step-time diagnosis uses one selected clock for the analyzed window. It uses
 GPU event timing when every rank/step has GPU timing for the step envelope,
@@ -165,12 +189,13 @@ visible_r = backward_r              # DDP/default
 visible_r = forward_r + backward_r  # FSDP
 ```
 
-Only ranks with measured visible-phase anchors and a measured step envelope are
-eligible:
+Only ranks with measured visible-phase anchors, a measured step envelope, and
+a measured input wait are eligible:
 
 ```text
-DDP/default: backward_r > 0 and step_time_r > 0
-FSDP:        forward_r > 0 and backward_r > 0 and step_time_r > 0
+DDP/default: input_wait measured and backward_r > 0 and step_time_r > 0
+FSDP:        input_wait measured and forward_r > 0 and backward_r > 0
+             and step_time_r > 0
 ```
 
 If fewer than two ranks are eligible, TraceML does not report a rank straggler.
@@ -197,9 +222,11 @@ h2d_excess = h2d_culprit - h2d_victim
 forward_excess = forward_culprit - forward_victim  # DDP/default only
 ```
 
-DDP/default compute attribution requires measured forward time on both the
-culprit and victim ranks. A component names the cause only when it covers at
-least 80% of visible wait cost:
+Every candidate component must be measured on both the culprit and victim
+ranks: DDP/default compute attribution requires measured forward time on
+both, and H2D attribution requires measured H2D time on both, so an
+unmeasured phase can never name the cause. A component names the cause only
+when it covers at least 80% of visible wait cost:
 
 ```text
 component_coverage = min(1, component_excess / visible_cost)

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -39,6 +39,26 @@ from .policy import DEFAULT_THRESHOLDS, DiagnosisThresholds
 from .rules import run_step_time_rules
 from .trend import DEFAULT_STEP_TREND_HEURISTICS, build_step_trend_note
 
+
+def _overall_worst_rank(
+    per_rank_timing: Optional[Dict[int, Dict[str, float]]],
+    step_metric: StepCombinedTimeMetric,
+) -> Optional[int]:
+    """Return the run-level slowest rank by full iteration time.
+
+    The run-level worst rank is ranked by ``total_step`` (input wait +
+    step envelope), a separate value from any single metric's own worst
+    rank, so the step-time metric summary stays self-coherent. Callers
+    without per-rank timing fall back to the step-time metric's own
+    worst rank.
+    """
+    from traceml_ai.utils.step_time_window import worst_rank_by_total_step
+
+    if per_rank_timing:
+        return worst_rank_by_total_step(per_rank_timing)
+    return metric_worst_rank(step_metric)
+
+
 DiagnosisKind = Literal[
     "NO_DATA",
     "WARMUP",
@@ -437,7 +457,7 @@ def build_step_diagnosis_result(
     coverage = step_metric.coverage
     single_rank = (coverage.world_size <= 1) or (coverage.ranks_present <= 1)
     steps_used = int(step_metric.summary.steps_used)
-    overall_worst_rank = metric_worst_rank(step_metric)
+    overall_worst_rank = _overall_worst_rank(per_rank_timing, step_metric)
     step_total = metric_total(step_metric, single_rank=single_rank)
 
     if step_total <= 0.0:

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -335,7 +335,6 @@ def _apply_trend_note(
 
 _MISSING_SIGNAL_ORDER: tuple[str, ...] = (
     "input_wait",
-    "h2d",
     "forward",
     "backward",
     "optimizer_step",
@@ -349,10 +348,15 @@ def _missing_signal_report(
     """Return missing-signal names plus per-signal rank coverage.
 
     A signal is reported when an abstaining rule required it and it was
-    not measured on every observed rank. Abstentions caused purely by
-    the clock gate (H2D on the cpu clock) are not missing data.
+    not measured on every observed rank. H2D is never reported missing:
+    its events are occurrence-driven (a fully instrumented run with no
+    host-to-device copies emits none), so absence means no observed
+    transfers, not missing instrumentation. Without per-rank rows,
+    availability is unknowable, so nothing is reported missing either.
     """
     ranks = max(0, int(context.ranks_observed))
+    if ranks == 0:
+        return [], {}
     counts = context.signal_rank_counts or {}
     needed: set[str] = set()
 
@@ -361,8 +365,6 @@ def _missing_signal_report(
 
     if context.input_bound_share is None:
         _require(("input_wait", "step_time"))
-    if context.diagnosis_clock == "gpu" and context.h2d_share is None:
-        _require(("h2d", "input_wait", "step_time"))
     if context.compute_share is None:
         _require(
             (
@@ -383,8 +385,6 @@ def _missing_signal_report(
                 "step_time",
             )
         )
-        if context.diagnosis_clock == "gpu":
-            _require(("h2d",))
     if (
         not context.single_rank
         and context.rank_straggler is None
@@ -394,11 +394,10 @@ def _missing_signal_report(
         if context.training_strategy == "fsdp":
             _require(("forward",))
 
-    required_ranks = max(1, ranks)
     missing = [
         name
         for name in _MISSING_SIGNAL_ORDER
-        if name in needed and counts.get(name, 0) < required_ranks
+        if name in needed and counts.get(name, 0) < ranks
     ]
     coverage = {name: f"{counts.get(name, 0)}/{ranks}" for name in missing}
     return missing, coverage

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -9,15 +9,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Literal,
-    Optional,
-    Sequence,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Sequence, cast
 
 from traceml_ai.renderers.step_time.schema import StepCombinedTimeMetric
 

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -9,9 +9,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Any, Dict, Literal, Optional, Sequence, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Literal,
+    Optional,
+    Sequence,
+    cast,
+)
 
 from traceml_ai.renderers.step_time.schema import StepCombinedTimeMetric
+
+if TYPE_CHECKING:
+    from .context import StepTimeAnalysisContext
 
 from ..common import (
     BaseDiagnosis,
@@ -39,6 +50,7 @@ from .trend import DEFAULT_STEP_TREND_HEURISTICS, build_step_trend_note
 DiagnosisKind = Literal[
     "NO_DATA",
     "WARMUP",
+    "INCOMPLETE_DATA",
     "BALANCED",
     "STRAGGLER",
     "INPUT_STRAGGLER",
@@ -53,6 +65,7 @@ DiagnosisKind = Literal[
 _STATUS_BY_KIND: dict[DiagnosisKind, str] = {
     "NO_DATA": "NO DATA",
     "WARMUP": "WARMUP",
+    "INCOMPLETE_DATA": "INCOMPLETE DATA",
     "BALANCED": "BALANCED",
     "STRAGGLER": "STRAGGLER",
     "INPUT_STRAGGLER": "INPUT STRAGGLER",
@@ -320,6 +333,77 @@ def _apply_trend_note(
         return diagnosis
 
 
+_MISSING_SIGNAL_ORDER: tuple[str, ...] = (
+    "input_wait",
+    "h2d",
+    "forward",
+    "backward",
+    "optimizer_step",
+    "step_time",
+)
+
+
+def _missing_signal_report(
+    context: "StepTimeAnalysisContext",
+) -> tuple[list[str], Dict[str, str]]:
+    """Return missing-signal names plus per-signal rank coverage.
+
+    A signal is reported when an abstaining rule required it and it was
+    not measured on every observed rank. Abstentions caused purely by
+    the clock gate (H2D on the cpu clock) are not missing data.
+    """
+    ranks = max(0, int(context.ranks_observed))
+    counts = context.signal_rank_counts or {}
+    needed: set[str] = set()
+
+    def _require(signals: Sequence[str]) -> None:
+        needed.update(signals)
+
+    if context.input_bound_share is None:
+        _require(("input_wait", "step_time"))
+    if context.diagnosis_clock == "gpu" and context.h2d_share is None:
+        _require(("h2d", "input_wait", "step_time"))
+    if context.compute_share is None:
+        _require(
+            (
+                "forward",
+                "backward",
+                "optimizer_step",
+                "input_wait",
+                "step_time",
+            )
+        )
+    if context.residual_share is None:
+        _require(
+            (
+                "forward",
+                "backward",
+                "optimizer_step",
+                "input_wait",
+                "step_time",
+            )
+        )
+        if context.diagnosis_clock == "gpu":
+            _require(("h2d",))
+    if (
+        not context.single_rank
+        and context.rank_straggler is None
+        and context.straggler_eligible_ranks < 2
+    ):
+        _require(("backward", "input_wait", "step_time"))
+        if context.training_strategy == "fsdp":
+            _require(("forward",))
+
+    required_ranks = max(1, ranks)
+    missing = [
+        name
+        for name in _MISSING_SIGNAL_ORDER
+        if name in needed and counts.get(name, 0) < required_ranks
+    ]
+    coverage = {name: f"{counts.get(name, 0)}/{ranks}" for name in missing}
+    return missing, coverage
+
+
 def build_step_diagnosis_result(
     metrics: Sequence[StepCombinedTimeMetric],
     thresholds: DiagnosisThresholds = DEFAULT_THRESHOLDS,
@@ -471,16 +555,42 @@ def build_step_diagnosis_result(
             ),
         )
     else:
-        primary = _mk_diag(
-            kind="BALANCED",
-            severity="info",
-            reason="No dominant bottleneck is visible in this window.",
-            action="Focus on throughput only if overall speed is still low.",
-            steps_used=context.steps_used,
-            worst_rank=(
-                None if context.single_rank else context.overall_worst_rank
-            ),
-        )
+        missing_signals, signal_coverage = _missing_signal_report(context)
+        if missing_signals:
+            primary = _mk_diag(
+                kind="INCOMPLETE_DATA",
+                severity="info",
+                reason=(
+                    "Missing timing signals prevent a reliable diagnosis: "
+                    + ", ".join(missing_signals)
+                    + "."
+                ),
+                action=(
+                    "Instrument the missing phases (auto mode or the "
+                    "matching wrap_* helpers) to restore coverage."
+                ),
+                steps_used=context.steps_used,
+                worst_rank=(
+                    None if context.single_rank else context.overall_worst_rank
+                ),
+            )
+            incomplete_evidence = {
+                "missing_signals": list(missing_signals),
+                "signal_coverage": dict(signal_coverage),
+            }
+        else:
+            primary = _mk_diag(
+                kind="BALANCED",
+                severity="info",
+                reason="No dominant bottleneck is visible in this window.",
+                action=(
+                    "Focus on throughput only if overall speed is still low."
+                ),
+                steps_used=context.steps_used,
+                worst_rank=(
+                    None if context.single_rank else context.overall_worst_rank
+                ),
+            )
 
     primary = _apply_trend_note(
         primary,
@@ -488,8 +598,8 @@ def build_step_diagnosis_result(
         residual_metric=context.residual_metric,
         input_wait_metric=context.input_wait_metric,
         single_rank=context.single_rank,
-        residual_share=context.residual_share,
-        input_bound_share=context.input_bound_share,
+        residual_share=context.residual_share or 0.0,
+        input_bound_share=context.input_bound_share or 0.0,
         thresholds=thresholds,
     )
 
@@ -505,6 +615,11 @@ def build_step_diagnosis_result(
                     (primary.worst_rank,)
                     if primary.worst_rank is not None
                     else ()
+                ),
+                evidence=(
+                    incomplete_evidence
+                    if primary.kind == "INCOMPLETE_DATA"
+                    else {}
                 ),
             ),
         )

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -12,8 +12,8 @@ individual diagnosis rules can stay small and focused. The intent is:
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Optional, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple
 
 from traceml_ai.renderers.step_time.schema import StepCombinedTimeMetric
 from traceml_ai.utils.training_strategy import normalize_training_strategy
@@ -112,10 +112,10 @@ class StepTimeAnalysisContext:
     residual_total: float
     compute_total: float
 
-    residual_share: float
-    compute_share: float
-    input_bound_share: float
-    h2d_share: float
+    residual_share: Optional[float]
+    compute_share: Optional[float]
+    input_bound_share: Optional[float]
+    h2d_share: Optional[float]
 
     input_bound_skew: float
     compute_skew: float
@@ -129,6 +129,10 @@ class StepTimeAnalysisContext:
 
     rank_values: Dict[str, Dict[int, float]]
     rank_straggler: Optional[_RankStragglerEvidence]
+
+    ranks_observed: int = 0
+    signal_rank_counts: Dict[str, int] = field(default_factory=dict)
+    straggler_eligible_ranks: int = 0
 
 
 def non_negative_finite(value: float) -> float:
@@ -323,24 +327,32 @@ def _build_rank_straggler_evidence(
     score_threshold: float,
     cause_coverage_threshold: float,
     training_strategy: str,
-) -> Optional[_RankStragglerEvidence]:
+) -> Tuple[Optional[_RankStragglerEvidence], int]:
     """
     Build culprit/victim rank straggler evidence for distributed runs.
 
     DDP/default uses backward as the visible synchronization phase. FSDP uses
     forward + backward because FSDP can communicate on both sides of module
-    execution. Only ranks with measured visible-phase anchors and a measured
-    step envelope are eligible. Component attribution compares the culprit rank
-    directly to the victim rank and emits a subtype only when one component
-    explains enough of the visible cost.
+    execution. Only ranks with measured visible-phase anchors, a measured
+    step envelope, and a measured input wait are eligible. Component
+    attribution compares the culprit rank directly to the victim rank,
+    considers only components measured on both ranks, and emits a subtype
+    only when one component explains enough of the visible cost.
+
+    Returns the evidence (or ``None``) plus the eligible-rank count so
+    callers can distinguish a healthy abstention from a missing-signal
+    abstention.
     """
     if len(per_rank_timing) <= 1:
-        return None
+        return None, len(per_rank_timing)
 
     strategy = normalize_training_strategy(training_strategy)
     visible_metric = "forward_backward" if strategy == "fsdp" else "backward"
     eligible_ranks = []
     for rank in sorted(int(rank) for rank in per_rank_timing):
+        values = per_rank_timing.get(int(rank), {})
+        if "input_wait" not in values:
+            continue
         forward = _rank_metric_value(per_rank_timing, rank, "forward")
         backward = _rank_metric_value(per_rank_timing, rank, "backward")
         step_time = _rank_metric_value(per_rank_timing, rank, "step_time")
@@ -350,7 +362,7 @@ def _build_rank_straggler_evidence(
             continue
         eligible_ranks.append(rank)
     if len(eligible_ranks) <= 1:
-        return None
+        return None, len(eligible_ranks)
 
     visible_values = {
         int(rank): (
@@ -363,7 +375,7 @@ def _build_rank_straggler_evidence(
     }
     pair = _rank_straggler_pair(visible_values)
     if pair is None:
-        return None
+        return None, len(eligible_ranks)
 
     culprit = pair.culprit_rank
     victim = pair.victim_rank
@@ -374,39 +386,42 @@ def _build_rank_straggler_evidence(
     score = pair.cost_ms / iteration_time
     threshold = non_negative_finite(score_threshold)
     if score < threshold:
-        return None
+        return None, len(eligible_ranks)
 
-    input_excess = max(
-        0.0,
-        _rank_metric_value(per_rank_timing, culprit, "input_wait")
-        - _rank_metric_value(per_rank_timing, victim, "input_wait"),
-    )
-    h2d_excess = max(
-        0.0,
-        _rank_metric_value(per_rank_timing, culprit, "h2d")
-        - _rank_metric_value(per_rank_timing, victim, "h2d"),
-    )
-    if strategy == "fsdp":
+    def _measured_on_both(metric: str) -> bool:
+        return metric in per_rank_timing.get(
+            culprit, {}
+        ) and metric in per_rank_timing.get(victim, {})
+
+    # Eligibility guarantees input_wait on both ranks; H2D joins the
+    # candidate set only when measured on both, so an unmeasured
+    # transfer phase can never name the cause.
+    component_excesses = {
+        "input": max(
+            0.0,
+            _rank_metric_value(per_rank_timing, culprit, "input_wait")
+            - _rank_metric_value(per_rank_timing, victim, "input_wait"),
+        )
+    }
+    if _measured_on_both("h2d"):
+        component_excesses["h2d"] = max(
+            0.0,
+            _rank_metric_value(per_rank_timing, culprit, "h2d")
+            - _rank_metric_value(per_rank_timing, victim, "h2d"),
+        )
+    if strategy != "fsdp":
         # FSDP interleaves collectives with forward/backward, so without
         # explicit collective timing this rule should not emit compute
         # stragglers from forward excess.
-        forward_excess = 0.0
-    else:
         culprit_forward = _rank_metric_value(
             per_rank_timing, culprit, "forward"
         )
         victim_forward = _rank_metric_value(per_rank_timing, victim, "forward")
-        forward_excess = (
-            max(0.0, culprit_forward - victim_forward)
-            if culprit_forward > 0.0 and victim_forward > 0.0
-            else 0.0
-        )
+        if culprit_forward > 0.0 and victim_forward > 0.0:
+            component_excesses["compute"] = max(
+                0.0, culprit_forward - victim_forward
+            )
 
-    component_excesses = {
-        "input": input_excess,
-        "h2d": h2d_excess,
-        "compute": forward_excess,
-    }
     component_coverage = {
         component: min(1.0, excess / pair.cost_ms)
         for component, excess in component_excesses.items()
@@ -459,7 +474,7 @@ def _build_rank_straggler_evidence(
         iteration_time_ms=iteration_time,
         component_excesses_ms=component_excesses,
         component_coverage=component_coverage,
-    )
+    ), len(eligible_ranks)
 
 
 def largest_compute_phase(
@@ -529,12 +544,15 @@ def compute_rank_values_from_components(
 ) -> Dict[int, float]:
     """
     Return rank -> forward + backward + optimizer_step from rank-value maps.
+
+    Only ranks with all three compute phases measured are included, so a
+    missing phase cannot understate a rank's compute as a partial sum.
     """
     forward = rank_values.get("forward", {})
     backward = rank_values.get("backward", {})
     optimizer = rank_values.get("optimizer_step", {})
     out: Dict[int, float] = {}
-    for rank in sorted(set(forward) | set(backward) | set(optimizer)):
+    for rank in sorted(set(forward) & set(backward) & set(optimizer)):
         out[int(rank)] = (
             non_negative_finite(forward.get(rank, 0.0))
             + non_negative_finite(backward.get(rank, 0.0))
@@ -546,8 +564,13 @@ def compute_rank_values_from_components(
 def _median_iteration_component_share(
     per_rank_timing: Dict[int, Dict[str, float]],
     component: str,
-) -> float:
-    """Return the median selected-clock iteration share for one component."""
+) -> Optional[float]:
+    """Return the median selected-clock iteration share for one component.
+
+    Returns ``None`` when no rank measured the component together with
+    its iteration anchors; a measured-zero share stays ``0.0`` so rules
+    can distinguish "signal absent" from "signal present and small".
+    """
     shares = []
     for values in per_rank_timing.values():
         if not {
@@ -563,6 +586,8 @@ def _median_iteration_component_share(
             shares.append(
                 share(non_negative_finite(values[component]), iteration)
             )
+    if not shares:
+        return None
     return _median(shares)
 
 
@@ -631,34 +656,20 @@ def build_step_time_context(
             )
     if local_per_rank_timing:
         rank_values = {
-            "input_wait": {
-                rank: non_negative_finite(values.get("input_wait", 0.0))
+            metric_key: {
+                rank: non_negative_finite(values[metric_key])
                 for rank, values in local_per_rank_timing.items()
-            },
-            "h2d": {
-                rank: non_negative_finite(values.get("h2d", 0.0))
-                for rank, values in local_per_rank_timing.items()
-            },
-            "forward": {
-                rank: non_negative_finite(values.get("forward", 0.0))
-                for rank, values in local_per_rank_timing.items()
-            },
-            "backward": {
-                rank: non_negative_finite(values.get("backward", 0.0))
-                for rank, values in local_per_rank_timing.items()
-            },
-            "optimizer_step": {
-                rank: non_negative_finite(values.get("optimizer_step", 0.0))
-                for rank, values in local_per_rank_timing.items()
-            },
-            "step_time": {
-                rank: non_negative_finite(values.get("step_time", 0.0))
-                for rank, values in local_per_rank_timing.items()
-            },
-            "residual_proxy": {
-                rank: non_negative_finite(values.get("residual_proxy", 0.0))
-                for rank, values in local_per_rank_timing.items()
-            },
+                if metric_key in values
+            }
+            for metric_key in (
+                "input_wait",
+                "h2d",
+                "forward",
+                "backward",
+                "optimizer_step",
+                "step_time",
+                "residual_proxy",
+            )
         }
 
     input_candidates = {
@@ -691,12 +702,27 @@ def build_step_time_context(
         if single_rank or input_wait_median <= 0.0
         else input_slack / input_wait_median
     )
-    rank_straggler = _build_rank_straggler_evidence(
+    rank_straggler, straggler_eligible_ranks = _build_rank_straggler_evidence(
         per_rank_timing=local_per_rank_timing,
         score_threshold=thresholds.straggler_score_warn,
         cause_coverage_threshold=thresholds.straggler_cause_coverage_min,
         training_strategy=training_strategy,
     )
+    signal_rank_counts = {
+        metric_key: sum(
+            1
+            for values in local_per_rank_timing.values()
+            if metric_key in values
+        )
+        for metric_key in (
+            "input_wait",
+            "h2d",
+            "forward",
+            "backward",
+            "optimizer_step",
+            "step_time",
+        )
+    }
     compute_rank_values = compute_rank_values_from_components(rank_values)
     _compute_median, _, _, _compute_slack = _rank_stats(compute_rank_values)
     compute_skew_value = (
@@ -747,6 +773,9 @@ def build_step_time_context(
         largest_compute=largest_compute,
         rank_values=rank_values,
         rank_straggler=rank_straggler,
+        ranks_observed=len(local_per_rank_timing),
+        signal_rank_counts=signal_rank_counts,
+        straggler_eligible_ranks=straggler_eligible_ranks,
     )
 
 

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -409,10 +409,15 @@ def _build_rank_straggler_evidence(
             _rank_metric_value(per_rank_timing, culprit, "h2d")
             - _rank_metric_value(per_rank_timing, victim, "h2d"),
         )
-    if strategy != "fsdp":
+    if strategy == "fsdp":
         # FSDP interleaves collectives with forward/backward, so without
-        # explicit collective timing this rule should not emit compute
-        # stragglers from forward excess.
+        # explicit collective timing this rule never attributes compute
+        # from forward excess; the zero entry keeps the evidence shape.
+        component_excesses["compute"] = 0.0
+    elif _measured_on_both("forward"):
+        # A measured-zero forward stays in the maps with zero excess
+        # (matching the base attribution); only a forward that was never
+        # measured on either rank is excluded from attribution entirely.
         culprit_forward = _rank_metric_value(
             per_rank_timing, culprit, "forward"
         )
@@ -421,6 +426,8 @@ def _build_rank_straggler_evidence(
             component_excesses["compute"] = max(
                 0.0, culprit_forward - victim_forward
             )
+        else:
+            component_excesses["compute"] = 0.0
 
     component_coverage = {
         component: min(1.0, excess / pair.cost_ms)

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple
 
 from traceml_ai.renderers.step_time.schema import StepCombinedTimeMetric
+from traceml_ai.utils.step_time_window import worst_rank_by_total_step
 from traceml_ai.utils.training_strategy import normalize_training_strategy
 
 if TYPE_CHECKING:
@@ -622,7 +623,14 @@ def build_step_time_context(
     coverage = step_metric.coverage
     single_rank = (coverage.world_size <= 1) or (coverage.ranks_present <= 1)
     steps_used = int(step_metric.summary.steps_used)
-    overall_worst_rank = metric_worst_rank(step_metric)
+    # The run-level worst rank is ranked by full iteration time
+    # (total_step), kept distinct from the step-time metric's own
+    # self-coherent worst rank; metrics-only callers fall back to it.
+    overall_worst_rank = (
+        worst_rank_by_total_step(per_rank_timing)
+        if per_rank_timing
+        else metric_worst_rank(step_metric)
+    )
 
     step_total = metric_total(step_metric, single_rank=single_rank)
     residual_total = metric_total(residual_metric, single_rank=single_rank)

--- a/src/traceml_ai/diagnostics/step_time/formatters.py
+++ b/src/traceml_ai/diagnostics/step_time/formatters.py
@@ -19,7 +19,7 @@ def _styled_status(diagnosis: StepDiagnosis) -> str:
     """Render a colored status label for Rich CLI output."""
     if diagnosis.kind == "BALANCED":
         style = "bold green"
-    elif diagnosis.kind in {"NO_DATA", "WARMUP"}:
+    elif diagnosis.kind in {"NO_DATA", "WARMUP", "INCOMPLETE_DATA"}:
         style = "bold bright_black"
     elif diagnosis.kind == "INPUT_BOUND":
         style = "bold yellow"

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -183,6 +183,10 @@ class InputBoundRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
+        if context.input_bound_share is None:
+            # Input wait or the step envelope was never measured: abstain
+            # rather than diagnose from a fake zero.
+            return None
         if context.input_bound_share < context.thresholds.overhead_share_warn:
             return None
 
@@ -225,6 +229,9 @@ class H2DBoundRule(_BaseStepTimeRule):
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
         if context.diagnosis_clock != "gpu":
+            return None
+        if context.h2d_share is None:
+            # H2D, input wait, or the step envelope was never measured.
             return None
         if context.h2d_share < context.thresholds.overhead_share_warn:
             return None
@@ -277,6 +284,10 @@ class ResidualHeavyRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
+        if context.residual_share is None:
+            # The residual is underivable because a component phase was
+            # never measured: abstain instead of absorbing missing work.
+            return None
         if context.residual_share < context.thresholds.overhead_share_warn:
             return None
 
@@ -315,16 +326,29 @@ class ComputeBoundRule(_BaseStepTimeRule):
         self,
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
+        if context.compute_share is None:
+            # A compute phase, input wait, or the step envelope was never
+            # measured: dominance cannot be established.
+            return None
         if context.compute_share < context.thresholds.compute_bound_share_warn:
             return None
-        if context.input_bound_share >= context.thresholds.overhead_share_warn:
+        if (
+            context.input_bound_share is not None
+            and context.input_bound_share
+            >= context.thresholds.overhead_share_warn
+        ):
             return None
         if (
             context.diagnosis_clock == "gpu"
+            and context.h2d_share is not None
             and context.h2d_share >= context.thresholds.overhead_share_warn
         ):
             return None
-        if context.residual_share >= context.thresholds.overhead_share_warn:
+        if (
+            context.residual_share is not None
+            and context.residual_share
+            >= context.thresholds.overhead_share_warn
+        ):
             return None
 
         label = (

--- a/src/traceml_ai/renderers/step_time/compute.py
+++ b/src/traceml_ai/renderers/step_time/compute.py
@@ -161,13 +161,20 @@ class StepCombinedComputer:
 def _worst_rank_from_window(
     per_rank_timing: Dict[int, Dict[str, float]],
 ) -> Optional[int]:
-    """Return the slowest rank by selected average total step."""
-    if not per_rank_timing:
+    """Return the slowest rank by selected average total step.
+
+    Only ranks whose total step is measured compete; when none is (the
+    input wait was never measured anywhere), no rank is named rather
+    than defaulting every rank to a fake zero.
+    """
+    candidates = {
+        int(rank): float(values["total_step"])
+        for rank, values in per_rank_timing.items()
+        if "total_step" in values
+    }
+    if not candidates:
         return None
     return max(
-        per_rank_timing,
-        key=lambda rank: (
-            float(per_rank_timing.get(rank, {}).get("total_step", 0.0)),
-            -int(rank),
-        ),
+        candidates,
+        key=lambda rank: (candidates[rank], -rank),
     )

--- a/src/traceml_ai/reporting/compare/policy.py
+++ b/src/traceml_ai/reporting/compare/policy.py
@@ -32,6 +32,7 @@ _SIGNIFICANCE_ORDER = {
 _STEP_TIME_STATUS_RANK = {
     "NO DATA": 0,
     "WARMUP": 0,
+    "INCOMPLETE DATA": 0,
     "BALANCED": 1,
     "INPUT-BOUND": 2,
     "H2D-BOUND": 2,

--- a/src/traceml_ai/reporting/html/banner.py
+++ b/src/traceml_ai/reporting/html/banner.py
@@ -23,7 +23,7 @@ from .textutils import esc
 _SECTION_ORDER = ("step_time", "step_memory", "system", "process")
 _SEVERITY_RANK = {"crit": 3, "warn": 2, "info": 1}
 _HEALTHY_KINDS = {"BALANCED", "NORMAL"}
-_NEUTRAL_KINDS = {"NO_DATA", "WARMUP", "NO_GPU"}
+_NEUTRAL_KINDS = {"NO_DATA", "WARMUP", "NO_GPU", "INCOMPLETE_DATA"}
 _PRIMARY_SOURCE = "primary"
 
 

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -94,7 +94,7 @@ STRAGGLER_KINDS = {
     "H2D_STRAGGLER",
     "STRAGGLER",
 }
-INSUFFICIENT_STEP_TIME_KINDS = {"NO_DATA", "WARMUP"}
+INSUFFICIENT_STEP_TIME_KINDS = {"NO_DATA", "WARMUP", "INCOMPLETE_DATA"}
 LOW_GPU_UTIL_KINDS = {
     "LOW_GPU_UTILIZATION",
     "MODERATE_GPU_UTILIZATION",
@@ -494,16 +494,28 @@ def _insufficient_step_time_primary(
         "steps_analyzed": _steps_analyzed(step_time_summary),
         "gpu_util_avg_percent": _round(_gpu_util_avg(system_summary)),
     }
+    if _diag_field(diagnosis, "kind", "") == "INCOMPLETE_DATA":
+        summary = (
+            "Step timing is missing phase signals, so no reliable "
+            "performance diagnosis is available."
+        )
+        action = (
+            "Instrument the missing phases; the Step Time section lists "
+            "the missing signal names."
+        )
+    else:
+        summary = (
+            "Not enough completed step-time samples were available for a "
+            "stable performance diagnosis."
+        )
+        action = "Run for more steps or ensure step timing is recorded."
     return _primary_payload(
         kind="INSUFFICIENT_STEP_TIME_DATA",
         status="INSUFFICIENT STEP-TIME DATA",
         severity="info",
         section=STEP_TIME_SECTION,
-        summary=(
-            "Not enough completed step-time samples were available for a "
-            "stable performance diagnosis."
-        ),
-        action="Run for more steps or ensure step timing is recorded.",
+        summary=summary,
+        action=action,
         evidence=evidence,
     )
 

--- a/src/traceml_ai/utils/step_time_window.py
+++ b/src/traceml_ai/utils/step_time_window.py
@@ -208,6 +208,12 @@ def _metric_from_events(
 
 _COMPUTE_KEYS: tuple[str, ...] = ("forward", "backward", "optimizer_step")
 
+# Occurrence-driven metrics legitimately skip steps: the optimizer under
+# gradient accumulation and H2D when a step performs no transfers. Every
+# other selected metric must occur on every bracketed step, so partial
+# presence there means lost instrumentation, not measured zeros.
+_OCCURRENCE_METRICS: frozenset[str] = frozenset(("optimizer_step", "h2d"))
+
 
 def _rank_metric_availability(
     step_map: Mapping[int, Mapping[str, Any]],
@@ -215,30 +221,41 @@ def _rank_metric_availability(
     *,
     clock: DiagnosisClock,
 ) -> frozenset[str]:
-    """Return the metric keys measured in at least one aligned step.
+    """Return the metric keys considered measured for this rank's window.
 
-    A metric measured in some steps but not others stays available: the
-    absent steps are true zeros (e.g. the optimizer under gradient
-    accumulation). A metric never measured in the window is missing and
-    must not appear as a key at all.
+    Availability is metric-specific. Occurrence-driven metrics
+    (``optimizer_step``, ``h2d``) are available when measured in at
+    least one aligned step; their absent steps are true zeros. Every
+    other metric must be measured in every aligned step: intermittent
+    presence means the instrumentation dropped out mid-window, and
+    averaging the fragments would understate the phase and leak the
+    missing work into the residual.
     """
-    available: set[str] = set()
+    if not steps:
+        return frozenset()
+    seen_counts: Dict[str, int] = {}
     for step in steps:
         events = step_map.get(int(step), {})
         for metric_key in SELECTED_METRICS:
-            if metric_key in available:
-                continue
             if (
                 _metric_from_events(events, metric_key, clock=clock)
                 is not None
             ):
-                available.add(metric_key)
-        if DATALOADER_FETCH_KEY not in available:
-            if _event_cpu_ms(events, INPUT_WAIT_KEY) is not None:
-                available.add(DATALOADER_FETCH_KEY)
-        if STEP_TIME_CPU_KEY not in available:
-            if _event_cpu_ms(events, "step_time") is not None:
-                available.add(STEP_TIME_CPU_KEY)
+                seen_counts[metric_key] = seen_counts.get(metric_key, 0) + 1
+        if _event_cpu_ms(events, INPUT_WAIT_KEY) is not None:
+            seen_counts[DATALOADER_FETCH_KEY] = (
+                seen_counts.get(DATALOADER_FETCH_KEY, 0) + 1
+            )
+        if _event_cpu_ms(events, "step_time") is not None:
+            seen_counts[STEP_TIME_CPU_KEY] = (
+                seen_counts.get(STEP_TIME_CPU_KEY, 0) + 1
+            )
+    total = len(steps)
+    available = {
+        metric_key
+        for metric_key, count in seen_counts.items()
+        if count == total or metric_key in _OCCURRENCE_METRICS
+    }
     return frozenset(available)
 
 
@@ -384,7 +401,7 @@ def _metric_values(
     return out
 
 
-def _worst_rank_by_total_step(
+def worst_rank_by_total_step(
     per_rank_timing: Mapping[int, Mapping[str, float]],
 ) -> Optional[int]:
     candidates = _metric_values(per_rank_timing, "total_step")
@@ -405,13 +422,14 @@ def build_step_time_metrics(
     per_rank_step_timing: Optional[
         Mapping[int, Mapping[int, Mapping[str, float]]]
     ] = None,
-    worst_rank_override: Optional[int] = None,
 ) -> list[StepCombinedTimeMetric]:
     """Build selected-clock average metrics for diagnosis and display.
 
     A metric measured by no rank emits no entry at all; a metric
     measured by a subset of ranks builds its statistics over exactly
-    those ranks.
+    those ranks. Each summary's ``worst_total`` and ``worst_rank`` come
+    from one ordering: the rank named is always the rank that produced
+    the reported worst value for that same metric.
     """
     ranks = sorted(int(rank) for rank in per_rank_timing)
     if not ranks:
@@ -431,8 +449,6 @@ def build_step_time_metrics(
         worst_idx = int(np.argmax(arr))
         worst_total = float(arr[worst_idx])
         worst_rank = int(metric_ranks[worst_idx])
-        if metric_key == "step_time" and worst_rank_override is not None:
-            worst_rank = int(worst_rank_override)
 
         if coverage.ranks_present <= 1 or len(metric_ranks) <= 1:
             median_total = worst_total
@@ -555,14 +571,12 @@ def build_step_time_window_from_events(
         ranks_present=len(per_rank_step_timing),
         incomplete=(len(per_rank_step_timing) < len(expected)),
     )
-    worst_rank = _worst_rank_by_total_step(per_rank_timing)
     metrics = build_step_time_metrics(
         per_rank_timing,
         coverage=coverage,
         clock=clock,
         series_steps=steps,
         per_rank_step_timing=per_rank_step_timing,
-        worst_rank_override=worst_rank,
     )
     return StepTimeWindow(
         clock=clock,
@@ -598,32 +612,43 @@ def diagnose_step_time_window(
 
 def public_step_time_metric_values(
     timing: Mapping[str, float],
-) -> Dict[str, float]:
+) -> Dict[str, Optional[float]]:
     """Map window timing to stable final_summary metric names.
 
     Selected-clock fields expose diagnosis timing. Dataloader and total-step
     compatibility fields use explicit CPU timings retained by the window.
+    Every public key is always present; a metric whose signal was never
+    measured in the window is ``None``, while a measured zero stays ``0.0``.
     """
-    forward = float(timing.get("forward", 0.0))
-    backward = float(timing.get("backward", 0.0))
-    optimizer = float(timing.get("optimizer_step", 0.0))
-    compute = forward + backward + optimizer
-    input_wait = float(timing.get(INPUT_WAIT_KEY, 0.0))
-    step_time = float(timing.get("step_time", 0.0))
-    dataloader_fetch = float(timing.get(DATALOADER_FETCH_KEY, 0.0))
-    step_time_cpu = float(timing.get(STEP_TIME_CPU_KEY, 0.0))
-    h2d = float(timing.get("h2d", 0.0))
-    residual_value = timing.get("residual_proxy")
-    if residual_value is None:
-        residual = max(0.0, step_time - h2d - compute)
-    else:
-        residual = max(0.0, float(residual_value))
+
+    def _value(key: str) -> Optional[float]:
+        if key not in timing:
+            return None
+        return float(timing[key])
+
+    forward = _value("forward")
+    backward = _value("backward")
+    optimizer = _value("optimizer_step")
+    compute = (
+        forward + backward + optimizer
+        if None not in (forward, backward, optimizer)
+        else None
+    )
+    dataloader_fetch = _value(DATALOADER_FETCH_KEY)
+    step_time_cpu = _value(STEP_TIME_CPU_KEY)
+    total_step = (
+        dataloader_fetch + step_time_cpu
+        if None not in (dataloader_fetch, step_time_cpu)
+        else None
+    )
+    residual_value = _value("residual_proxy")
+    residual = max(0.0, residual_value) if residual_value is not None else None
     return {
-        "total_step_ms": dataloader_fetch + step_time_cpu,
+        "total_step_ms": total_step,
         "dataloader_ms": dataloader_fetch,
-        "input_wait_ms": input_wait,
-        "step_time_ms": step_time,
-        "h2d_ms": h2d,
+        "input_wait_ms": _value(INPUT_WAIT_KEY),
+        "step_time_ms": _value("step_time"),
+        "h2d_ms": _value("h2d"),
         "compute_ms": compute,
         "residual_ms": residual,
         "forward_ms": forward,
@@ -648,4 +673,5 @@ __all__ = [
     "build_step_time_window_from_events",
     "diagnose_step_time_window",
     "public_step_time_metric_values",
+    "worst_rank_by_total_step",
 ]

--- a/src/traceml_ai/utils/step_time_window.py
+++ b/src/traceml_ai/utils/step_time_window.py
@@ -201,53 +201,101 @@ def _metric_from_events(
     metric_key: str,
     *,
     clock: DiagnosisClock,
-) -> float:
+) -> Optional[float]:
+    """Return the selected-clock value for one metric, or None if missing."""
     value = (
         _event_gpu_ms(events, metric_key)
         if clock == "gpu"
         else _event_cpu_ms(events, metric_key)
     )
-    return float(value) if value is not None else 0.0
+    return float(value) if value is not None else None
 
 
-def _build_rank_timing(
+_COMPUTE_KEYS: tuple[str, ...] = ("forward", "backward", "optimizer_step")
+
+
+def _rank_metric_availability(
+    step_map: Mapping[int, Mapping[str, Any]],
+    steps: Sequence[int],
     *,
-    input_wait: float,
-    dataloader_fetch: float,
-    h2d: float,
-    forward: float,
-    backward: float,
-    optimizer: float,
-    step_time: float,
-    step_time_cpu: float,
-) -> Dict[str, float]:
-    residual = max(0.0, step_time - h2d - forward - backward - optimizer)
+    clock: DiagnosisClock,
+) -> frozenset[str]:
+    """Return the metric keys measured in at least one aligned step.
 
-    return {
-        INPUT_WAIT_KEY: float(input_wait),
-        DATALOADER_FETCH_KEY: float(dataloader_fetch),
-        "h2d": float(h2d),
-        "forward": float(forward),
-        "backward": float(backward),
-        "optimizer_step": float(optimizer),
-        "step_time": float(step_time),
-        STEP_TIME_CPU_KEY: float(step_time_cpu),
-        "residual_proxy": residual,
-        "total_step": input_wait + step_time,
-    }
+    A metric measured in some steps but not others stays available: the
+    absent steps are true zeros (e.g. the optimizer under gradient
+    accumulation). A metric never measured in the window is missing and
+    must not appear as a key at all.
+    """
+    available: set[str] = set()
+    for step in steps:
+        events = step_map.get(int(step), {})
+        for metric_key in SELECTED_METRICS:
+            if metric_key in available:
+                continue
+            if (
+                _metric_from_events(events, metric_key, clock=clock)
+                is not None
+            ):
+                available.add(metric_key)
+        if DATALOADER_FETCH_KEY not in available:
+            if _event_cpu_ms(events, INPUT_WAIT_KEY) is not None:
+                available.add(DATALOADER_FETCH_KEY)
+        if STEP_TIME_CPU_KEY not in available:
+            if _event_cpu_ms(events, "step_time") is not None:
+                available.add(STEP_TIME_CPU_KEY)
+    return frozenset(available)
+
+
+def _add_derived_step_metrics(
+    timing: Dict[str, float],
+    *,
+    available: frozenset[str],
+    clock: DiagnosisClock,
+) -> None:
+    """Attach derived metrics whose required inputs are available.
+
+    ``residual_proxy`` needs the step envelope plus every compute phase.
+    On the gpu clock it also needs H2D; on the cpu clock H2D cost is
+    unmeasurable by design, so an unavailable H2D contributes zero.
+    ``total_step`` needs the input wait plus the step envelope.
+    """
+    compute_available = all(key in available for key in _COMPUTE_KEYS)
+    h2d_ready = ("h2d" in available) or (clock == "cpu")
+    if "step_time" in available and compute_available and h2d_ready:
+        timing["residual_proxy"] = max(
+            0.0,
+            timing["step_time"]
+            - timing.get("h2d", 0.0)
+            - timing["forward"]
+            - timing["backward"]
+            - timing["optimizer_step"],
+        )
+    if INPUT_WAIT_KEY in available and "step_time" in available:
+        timing["total_step"] = timing[INPUT_WAIT_KEY] + timing["step_time"]
 
 
 def _average_rank_timing(
     per_rank_step_timing: Mapping[int, Mapping[int, Mapping[str, float]]],
     steps: Sequence[int],
 ) -> Dict[int, Dict[str, float]]:
+    """Average each rank's measured metrics over the aligned steps.
+
+    Only keys present in the rank's step rows are averaged, so a metric
+    missing from the whole window stays absent instead of averaging to a
+    fake zero. The divisor stays the full step count: an available
+    metric absent at one step did no work at that step.
+    """
     out: Dict[int, Dict[str, float]] = {}
     divisor = float(len(steps)) if steps else 1.0
     for rank, step_map in per_rank_step_timing.items():
-        totals = {metric_key: 0.0 for metric_key in WINDOW_AVERAGE_METRICS}
+        keys: set[str] = set()
+        for step in steps:
+            keys.update(step_map.get(int(step), {}).keys())
+        totals = {metric_key: 0.0 for metric_key in keys}
         for step in steps:
             metrics = step_map.get(int(step), {})
-            for metric_key in WINDOW_AVERAGE_METRICS:
+            for metric_key in keys:
                 value = _safe_non_negative_float(metrics.get(metric_key))
                 totals[metric_key] += (
                     float(value) if value is not None else 0.0
@@ -256,9 +304,6 @@ def _average_rank_timing(
             metric_key: float(value / divisor)
             for metric_key, value in totals.items()
         }
-        out[int(rank)]["total_step"] = out[int(rank)].get(
-            INPUT_WAIT_KEY, 0.0
-        ) + out[int(rank)].get("step_time", 0.0)
     return out
 
 
@@ -268,27 +313,33 @@ def _selected_step_timing_from_events(
     *,
     clock: DiagnosisClock,
 ) -> Dict[int, Dict[int, Dict[str, float]]]:
+    """Build sparse per-step timing rows from raw event payloads.
+
+    A metric key appears only when it was measured somewhere in the
+    rank's window; a measured zero stays ``0.0``.
+    """
     out: Dict[int, Dict[int, Dict[str, float]]] = {}
     for rank, step_map in per_rank_steps.items():
+        available = _rank_metric_availability(step_map, steps, clock=clock)
         rank_timing: Dict[int, Dict[str, float]] = {}
         for step in steps:
             events = step_map.get(int(step), {})
-            selected = {
-                metric_key: _metric_from_events(
-                    events, metric_key, clock=clock
+            timing: Dict[str, float] = {}
+            for metric_key in SELECTED_METRICS:
+                if metric_key not in available:
+                    continue
+                value = _metric_from_events(events, metric_key, clock=clock)
+                timing[metric_key] = float(value) if value is not None else 0.0
+            if DATALOADER_FETCH_KEY in available:
+                timing[DATALOADER_FETCH_KEY] = (
+                    _event_cpu_ms(events, INPUT_WAIT_KEY) or 0.0
                 )
-                for metric_key in SELECTED_METRICS
-            }
-            rank_timing[int(step)] = _build_rank_timing(
-                input_wait=selected.get(INPUT_WAIT_KEY, 0.0),
-                dataloader_fetch=_event_cpu_ms(events, INPUT_WAIT_KEY) or 0.0,
-                h2d=selected.get("h2d", 0.0),
-                forward=selected.get("forward", 0.0),
-                backward=selected.get("backward", 0.0),
-                optimizer=selected.get("optimizer_step", 0.0),
-                step_time=selected.get("step_time", 0.0),
-                step_time_cpu=_event_cpu_ms(events, "step_time") or 0.0,
-            )
+            if STEP_TIME_CPU_KEY in available:
+                timing[STEP_TIME_CPU_KEY] = (
+                    _event_cpu_ms(events, "step_time") or 0.0
+                )
+            _add_derived_step_metrics(timing, available=available, clock=clock)
+            rank_timing[int(step)] = timing
         out[int(rank)] = rank_timing
     return out
 
@@ -314,26 +365,30 @@ def _metric_values(
     per_rank_timing: Mapping[int, Mapping[str, float]],
     metric_key: str,
 ) -> Dict[int, float]:
-    return {
-        int(rank): (_safe_non_negative_float(values.get(metric_key)) or 0.0)
-        for rank, values in per_rank_timing.items()
-    }
+    """Return rank values for ranks that measured this metric.
+
+    Ranks without the key are excluded so a missing metric cannot enter
+    medians or worst-rank picks as a fake zero; a measured zero stays.
+    """
+    out: Dict[int, float] = {}
+    for rank, values in per_rank_timing.items():
+        if metric_key not in values:
+            continue
+        out[int(rank)] = (
+            _safe_non_negative_float(values.get(metric_key)) or 0.0
+        )
+    return out
 
 
 def _worst_rank_by_total_step(
     per_rank_timing: Mapping[int, Mapping[str, float]],
 ) -> Optional[int]:
-    if not per_rank_timing:
+    candidates = _metric_values(per_rank_timing, "total_step")
+    if not candidates:
         return None
     return max(
-        (int(rank) for rank in per_rank_timing),
-        key=lambda rank: (
-            _safe_non_negative_float(
-                per_rank_timing.get(rank, {}).get("total_step")
-            )
-            or 0.0,
-            -rank,
-        ),
+        candidates,
+        key=lambda rank: (candidates[rank], -rank),
     )
 
 
@@ -348,7 +403,12 @@ def build_step_time_metrics(
     ] = None,
     worst_rank_override: Optional[int] = None,
 ) -> list[StepCombinedTimeMetric]:
-    """Build selected-clock average metrics for diagnosis and display."""
+    """Build selected-clock average metrics for diagnosis and display.
+
+    A metric measured by no rank emits no entry at all; a metric
+    measured by a subset of ranks builds its statistics over exactly
+    those ranks.
+    """
     ranks = sorted(int(rank) for rank in per_rank_timing)
     if not ranks:
         return []
@@ -356,18 +416,21 @@ def build_step_time_metrics(
     metrics: list[StepCombinedTimeMetric] = []
     for metric_key in DISPLAY_METRICS:
         values = _metric_values(per_rank_timing, metric_key)
-        arr = np.asarray([values[rank] for rank in ranks], dtype=np.float64)
-        if arr.size == 0:
+        if not values:
             continue
+        metric_ranks = sorted(values)
+        arr = np.asarray(
+            [values[rank] for rank in metric_ranks], dtype=np.float64
+        )
 
         median_total = float(np.median(arr))
         worst_idx = int(np.argmax(arr))
         worst_total = float(arr[worst_idx])
-        worst_rank = int(ranks[worst_idx])
+        worst_rank = int(metric_ranks[worst_idx])
         if metric_key == "step_time" and worst_rank_override is not None:
             worst_rank = int(worst_rank_override)
 
-        if coverage.ranks_present <= 1:
+        if coverage.ranks_present <= 1 or len(metric_ranks) <= 1:
             median_total = worst_total
             skew_ratio = 0.0
             skew_pct = 0.0
@@ -393,7 +456,7 @@ def build_step_time_metrics(
                             .get(metric_key)
                         )
                         or 0.0
-                        for rank in ranks
+                        for rank in metric_ranks
                     ],
                     dtype=np.float64,
                 )
@@ -530,7 +593,7 @@ def diagnose_step_time_window(
 
 
 def public_step_time_metric_values(
-    timing: Mapping[str, float]
+    timing: Mapping[str, float],
 ) -> Dict[str, float]:
     """Map window timing to stable final_summary metric names.
 

--- a/src/traceml_ai/utils/step_time_window.py
+++ b/src/traceml_ai/utils/step_time_window.py
@@ -73,11 +73,6 @@ DISPLAY_METRICS: tuple[str, ...] = (
     "residual_proxy",
 )
 
-WINDOW_AVERAGE_METRICS: tuple[str, ...] = DISPLAY_METRICS + (
-    DATALOADER_FETCH_KEY,
-    STEP_TIME_CPU_KEY,
-)
-
 REQUIRED_GPU_METRICS: tuple[str, ...] = (INPUT_WAIT_KEY, "step_time")
 
 
@@ -256,13 +251,14 @@ def _add_derived_step_metrics(
     """Attach derived metrics whose required inputs are available.
 
     ``residual_proxy`` needs the step envelope plus every compute phase.
-    On the gpu clock it also needs H2D; on the cpu clock H2D cost is
-    unmeasurable by design, so an unavailable H2D contributes zero.
-    ``total_step`` needs the input wait plus the step envelope.
+    H2D events are occurrence-driven (a fully instrumented run with no
+    host-to-device copies emits none), so an unavailable H2D contributes
+    zero rather than blocking the residual. ``total_step`` needs the
+    input wait plus the step envelope.
     """
+    del clock
     compute_available = all(key in available for key in _COMPUTE_KEYS)
-    h2d_ready = ("h2d" in available) or (clock == "cpu")
-    if "step_time" in available and compute_available and h2d_ready:
+    if "step_time" in available and compute_available:
         timing["residual_proxy"] = max(
             0.0,
             timing["step_time"]
@@ -300,10 +296,18 @@ def _average_rank_timing(
                 totals[metric_key] += (
                     float(value) if value is not None else 0.0
                 )
-        out[int(rank)] = {
+        averaged = {
             metric_key: float(value / divisor)
             for metric_key, value in totals.items()
         }
+        if "total_step" in averaged:
+            # Re-derive from the averaged components so complete-data
+            # output stays bit-identical to the historical
+            # avg(input_wait) + avg(step_time) formulation.
+            averaged["total_step"] = averaged.get(
+                INPUT_WAIT_KEY, 0.0
+            ) + averaged.get("step_time", 0.0)
+        out[int(rank)] = averaged
     return out
 
 

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -314,7 +314,10 @@ def test_diagnosis_clock_selection_prefers_gpu_then_cpu() -> None:
     assert selected.clock == "gpu"
     assert selected.per_rank_timing[0]["input_wait"] == pytest.approx(4.0)
     assert selected.per_rank_timing[0]["step_time"] == pytest.approx(20.0)
-    assert selected.per_rank_timing[0]["residual_proxy"] == pytest.approx(5.0)
+    # optimizer_step and h2d were never measured: the residual must not
+    # silently absorb them as zeros.
+    assert "residual_proxy" not in selected.per_rank_timing[0]
+    assert "optimizer_step" not in selected.per_rank_timing[0]
     assert selected.per_rank_step_timing[0][1]["input_wait"] == pytest.approx(
         4.0
     )
@@ -332,7 +335,9 @@ def test_diagnosis_clock_selection_prefers_gpu_then_cpu() -> None:
     assert selected.clock == "cpu"
     assert selected.per_rank_timing[0]["input_wait"] == pytest.approx(12.0)
     assert selected.per_rank_timing[0]["step_time"] == pytest.approx(60.0)
-    assert selected.per_rank_timing[0]["residual_proxy"] == pytest.approx(10.0)
+    # optimizer_step was never measured, so compute and residual stay
+    # underivable on the cpu clock as well.
+    assert "residual_proxy" not in selected.per_rank_timing[0]
 
     duration_only_events = {
         "_traceml_internal:dataloader_next": {"cpu": {"duration_ms": 12.0}},
@@ -349,9 +354,10 @@ def test_diagnosis_clock_selection_prefers_gpu_then_cpu() -> None:
     )
 
     assert selected.clock == "cpu"
-    assert selected.per_rank_timing[0]["input_wait"] == pytest.approx(0.0)
-    assert selected.per_rank_timing[0]["step_time"] == pytest.approx(0.0)
-    assert selected.per_rank_timing[0]["residual_proxy"] == pytest.approx(0.0)
+    # duration-only stats carry no selected-clock timing at all: every
+    # metric is missing, not measured-as-zero.
+    assert selected.per_rank_timing[0] == {}
+    assert selected.metrics == []
 
 
 def test_input_bound_rule_uses_cpu_clock_when_gpu_is_absent() -> None:

--- a/tests/diagnostics/test_step_time_invariants.py
+++ b/tests/diagnostics/test_step_time_invariants.py
@@ -1,0 +1,280 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Executable invariants for the Step Time window (issue #257 review).
+
+These pin the *classes* of defect surfaced in review, not single
+instances, by fuzzing the dimension each rule quantifies over:
+
+- F1 availability is metric-specific: a required (non-occurrence) metric
+  present in only some steps drops availability instead of averaging a
+  fragment; an occurrence-driven metric stays available.
+- F2 a metric summary's ``worst_total`` and ``worst_rank`` always come
+  from one ordering: the named rank produced the reported worst value.
+- F3 the public projection preserves absence: a metric the window
+  declined to derive is ``None``, never a fabricated number.
+
+The drift guard fails when a new selected metric is added without a
+conscious occurrence-vs-required classification.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from traceml_ai.utils.step_time_window import (
+    _OCCURRENCE_METRICS,
+    SELECTED_METRICS,
+    build_step_time_window_from_events,
+    public_step_time_metric_values,
+)
+
+_EVENT_NAMES = {
+    "input_wait": "_traceml_internal:dataloader_next",
+    "h2d": "_traceml_internal:h2d_time",
+    "forward": "_traceml_internal:forward_time",
+    "backward": "_traceml_internal:backward_time",
+    "optimizer_step": "_traceml_internal:optimizer_step",
+    "step_time": "_traceml_internal:step_time",
+}
+
+_BASE_MS = {
+    "input_wait": 4.0,
+    "h2d": 1.0,
+    "forward": 20.0,
+    "backward": 30.0,
+    "optimizer_step": 10.0,
+    "step_time": 64.0,
+}
+
+# Every metric that is not occurrence-driven must be measured on every
+# aligned step to stay available.
+_REQUIRED_METRICS = tuple(
+    m for m in SELECTED_METRICS if m not in _OCCURRENCE_METRICS
+)
+
+_WINDOW = 6
+
+
+def _stat(value: float) -> dict:
+    return {
+        "cpu": {
+            "duration_ms": value,
+            "cpu_ms": value,
+            "gpu_ms": None,
+            "n_calls": 1,
+        }
+    }
+
+
+def _window_from_presence(present_steps: dict[str, set[int]]):
+    per_rank = {0: {}}
+    for step in range(_WINDOW):
+        events = {}
+        for metric, steps in present_steps.items():
+            if step in steps:
+                events[_EVENT_NAMES[metric]] = _stat(_BASE_MS[metric])
+        per_rank[0][step] = events
+    return build_step_time_window_from_events(per_rank, max_rows=_WINDOW)
+
+
+def _all_steps() -> dict[str, set[int]]:
+    return {m: set(range(_WINDOW)) for m in _EVENT_NAMES}
+
+
+# ---------------------------------------------------------------------------
+# Invariant helper reused across cases
+# ---------------------------------------------------------------------------
+
+
+def assert_metric_worst_is_self_consistent(window) -> None:
+    """F2: every metric's worst value and worst rank share one ordering."""
+    for metric in window.metrics:
+        worst_rank = metric.summary.worst_rank
+        if worst_rank is None:
+            continue
+        rank_row = window.per_rank_timing.get(worst_rank)
+        assert (
+            rank_row is not None
+        ), f"{metric.metric}: worst_rank {worst_rank} is not a window rank"
+        assert (
+            metric.metric in rank_row
+        ), f"{metric.metric}: worst_rank {worst_rank} never measured it"
+        assert rank_row[metric.metric] == pytest.approx(
+            metric.summary.worst_total
+        ), (
+            f"{metric.metric}: reported worst {metric.summary.worst_total} "
+            f"but rank {worst_rank} has {rank_row[metric.metric]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# F1: availability is metric-specific
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("metric", _REQUIRED_METRICS)
+@pytest.mark.parametrize("present_count", [1, _WINDOW // 2, _WINDOW - 1])
+def test_required_metric_partial_presence_drops_availability(
+    metric: str, present_count: int
+) -> None:
+    presence = _all_steps()
+    presence[metric] = set(range(present_count))  # present in a strict subset
+    window = _window_from_presence(presence)
+
+    assert metric not in window.per_rank_timing[0], (
+        f"{metric} present in {present_count}/{_WINDOW} steps must be "
+        "unavailable, not averaged from a fragment"
+    )
+    assert metric not in {m.metric for m in window.metrics}
+
+
+@pytest.mark.parametrize("metric", sorted(_OCCURRENCE_METRICS))
+@pytest.mark.parametrize("present_count", [1, _WINDOW // 2, _WINDOW - 1])
+def test_occurrence_metric_partial_presence_stays_available(
+    metric: str, present_count: int
+) -> None:
+    presence = _all_steps()
+    presence[metric] = set(range(present_count))
+    window = _window_from_presence(presence)
+
+    assert metric in window.per_rank_timing[0]
+    # Averaged over the whole window: absent steps are true zeros.
+    assert window.per_rank_timing[0][metric] == pytest.approx(
+        _BASE_MS[metric] * present_count / _WINDOW
+    )
+
+
+def test_required_metric_full_presence_is_available() -> None:
+    window = _window_from_presence(_all_steps())
+    for metric in _REQUIRED_METRICS:
+        assert metric in window.per_rank_timing[0]
+
+
+# ---------------------------------------------------------------------------
+# F2: worst value and worst rank come from one ordering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("slow_rank_lacks_input", [True, False])
+def test_worst_value_and_rank_are_self_consistent(
+    slow_rank_lacks_input: bool,
+) -> None:
+    # Two ranks, the slower one optionally missing input wait so its
+    # total_step is underivable. The step-time summary must never pair a
+    # value from one rank with a rank id from another.
+    def fill(target, rank, step_time, drop_input):
+        row = {}
+        for metric in _EVENT_NAMES:
+            if drop_input and metric == "input_wait":
+                continue
+            value = step_time if metric == "step_time" else _BASE_MS[metric]
+            row[_EVENT_NAMES[metric]] = _stat(value)
+        for step in range(_WINDOW):
+            target[rank][step] = dict(row)
+
+    per_rank = {0: {}, 1: {}}
+    fill(per_rank, 0, 100.0, False)
+    fill(per_rank, 1, 400.0, slow_rank_lacks_input)
+    window = build_step_time_window_from_events(per_rank, max_rows=_WINDOW)
+
+    assert_metric_worst_is_self_consistent(window)
+    step_metric = next(m for m in window.metrics if m.metric == "step_time")
+    assert step_metric.summary.worst_total == pytest.approx(400.0)
+    assert step_metric.summary.worst_rank == 1
+
+
+def test_self_consistency_holds_across_many_presence_patterns() -> None:
+    # Fuzz a two-rank window over which metrics each rank measures every
+    # step; the self-consistency invariant must hold for all of them.
+    metrics = list(_EVENT_NAMES)
+    checked = 0
+    for drop_a, drop_b in itertools.product(
+        [(), ("h2d",), ("forward",), ("input_wait",)],
+        [(), ("optimizer_step",), ("backward",), ("input_wait",)],
+    ):
+        per_rank = {0: {}, 1: {}}
+        for rank, dropped, scale in ((0, drop_a, 1.0), (1, drop_b, 1.7)):
+            for step in range(_WINDOW):
+                events = {}
+                for metric in metrics:
+                    if metric in dropped:
+                        continue
+                    events[_EVENT_NAMES[metric]] = _stat(
+                        _BASE_MS[metric] * scale
+                    )
+                per_rank[rank][step] = events
+        window = build_step_time_window_from_events(per_rank, max_rows=_WINDOW)
+        assert_metric_worst_is_self_consistent(window)
+        checked += 1
+    assert checked == 16
+
+
+# ---------------------------------------------------------------------------
+# F3: the public projection preserves absence
+# ---------------------------------------------------------------------------
+
+
+_COMPUTE_PUBLIC_KEY = {
+    "forward": "forward_ms",
+    "backward": "backward_ms",
+    "optimizer_step": "optimizer_ms",
+}
+
+
+@pytest.mark.parametrize("missing", sorted(_COMPUTE_PUBLIC_KEY))
+def test_projection_nulls_residual_when_compute_incomplete(
+    missing: str,
+) -> None:
+    presence = _all_steps()
+    del presence[missing]
+    window = _window_from_presence(presence)
+    public = public_step_time_metric_values(window.per_rank_timing[0])
+
+    assert public[_COMPUTE_PUBLIC_KEY[missing]] is None
+    assert public["compute_ms"] is None
+    assert public["residual_ms"] is None
+    # A measured metric on the same row stays a real number.
+    assert public["step_time_ms"] is not None
+
+
+def test_projection_keeps_measured_zero_distinct_from_absent() -> None:
+    measured_zero = public_step_time_metric_values(
+        {"h2d": 0.0, "input_wait": 4.0, "step_time": 64.0}
+    )
+    absent = public_step_time_metric_values(
+        {"input_wait": 4.0, "step_time": 64.0}
+    )
+
+    assert measured_zero["h2d_ms"] == 0.0
+    assert absent["h2d_ms"] is None
+
+
+# ---------------------------------------------------------------------------
+# Drift guard: a new metric forces a classification decision
+# ---------------------------------------------------------------------------
+
+
+def test_metric_partition_is_exhaustive_and_intended() -> None:
+    # Every selected metric is classified exactly once. Occurrence-driven
+    # metrics are the closed set below; adding a new selected metric
+    # without deciding its class fails here (the single-source guard).
+    assert _OCCURRENCE_METRICS <= set(SELECTED_METRICS)
+    assert _OCCURRENCE_METRICS == {"optimizer_step", "h2d"}
+    assert (
+        set(_REQUIRED_METRICS) == set(SELECTED_METRICS) - _OCCURRENCE_METRICS
+    )
+    # Every required metric has a partial-presence test above via
+    # parametrization over _REQUIRED_METRICS, so a new required metric is
+    # automatically covered by test_required_metric_partial_presence.
+    assert set(_REQUIRED_METRICS) == {
+        "input_wait",
+        "forward",
+        "backward",
+        "step_time",
+    }

--- a/tests/diagnostics/test_step_time_missing_signals.py
+++ b/tests/diagnostics/test_step_time_missing_signals.py
@@ -649,3 +649,95 @@ def test_fsdp_straggler_evidence_keeps_zero_compute_entry() -> None:
     # zero entry so the evidence shape matches complete-data output.
     assert issue.evidence["component_excesses_ms"]["compute"] == 0.0
     assert issue.evidence["component_coverage"]["compute"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Availability is metric-specific (review findings on the stack PR)
+# ---------------------------------------------------------------------------
+
+
+def test_intermittent_forward_drops_availability() -> None:
+    # forward measured in only 1 of 30 steps: the instrumentation dropped
+    # out mid-window. Averaging the fragment would understate compute and
+    # leak the missing work into the residual as a false RESIDUAL_HEAVY.
+    events = _step_events(
+        omit=("forward",),
+        input_wait=2.0,
+        backward=30.0,
+        optimizer_step=10.0,
+        step_time=100.0,
+    )
+    events[0][_EVENT_NAMES["forward"]] = _stats(40.0, gpu=False)
+
+    window = build_step_time_window_from_events({0: events}, max_rows=30)
+    assert "forward" not in window.per_rank_timing[0]
+    assert "residual_proxy" not in window.per_rank_timing[0]
+
+    result = diagnose_step_time_window(window, policy=SUMMARY_STEP_TIME_POLICY)
+    assert result.primary.kind == "INCOMPLETE_DATA"
+    assert "forward" in result.issues[0].evidence["missing_signals"]
+
+
+def test_every_step_forward_stays_available() -> None:
+    window = build_step_time_window_from_events(
+        {0: _step_events(**_BALANCED_RANK)}, max_rows=30
+    )
+
+    assert window.per_rank_timing[0]["forward"] == pytest.approx(30.0)
+    assert "residual_proxy" in window.per_rank_timing[0]
+
+
+def test_intermittent_optimizer_stays_available_occurrence_metric() -> None:
+    # The occurrence twin: sparse optimizer presence is gradient
+    # accumulation, not lost instrumentation (contrast with the
+    # intermittent-forward test above).
+    events = _step_events(omit=("optimizer_step",), steps=30)
+    events[0][_EVENT_NAMES["optimizer_step"]] = _stats(30.0, gpu=False)
+
+    window = build_step_time_window_from_events({0: events}, max_rows=30)
+
+    assert window.per_rank_timing[0]["optimizer_step"] == pytest.approx(1.0)
+    assert "residual_proxy" in window.per_rank_timing[0]
+
+
+def test_worst_value_and_rank_come_from_one_candidate_set() -> None:
+    # r1 is 4x slower but has no measured input wait: the step metric
+    # must not report r1's value with r0's rank.
+    window = build_step_time_window_from_events(
+        {
+            0: _step_events(step_time=100.0),
+            1: _step_events(
+                omit=("input_wait",),
+                **{
+                    key: value
+                    for key, value in dict(
+                        _DEFAULT_MS, step_time=400.0
+                    ).items()
+                    if key != "input_wait"
+                },
+            ),
+        },
+        max_rows=30,
+    )
+
+    step_metric = next(m for m in window.metrics if m.metric == "step_time")
+    assert step_metric.summary.worst_total == pytest.approx(400.0)
+    assert step_metric.summary.worst_rank == 1
+
+
+def test_public_projection_preserves_absence() -> None:
+    from traceml_ai.utils.step_time_window import (
+        public_step_time_metric_values,
+    )
+
+    # step envelope measured, input wait measured, compute never
+    # measured: the projection must not fabricate residual = step_time.
+    public = public_step_time_metric_values(
+        {"input_wait": 2.0, "step_time": 100.0, "step_time_cpu": 100.0}
+    )
+
+    assert public["input_wait_ms"] == 2.0
+    assert public["step_time_ms"] == 100.0
+    assert public["forward_ms"] is None
+    assert public["compute_ms"] is None
+    assert public["residual_ms"] is None

--- a/tests/diagnostics/test_step_time_missing_signals.py
+++ b/tests/diagnostics/test_step_time_missing_signals.py
@@ -1,0 +1,509 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Missing Step Time signals stay missing and gate diagnosis (issue #257).
+
+Every scenario runs the real event pipeline where possible:
+raw event payloads -> canonical window -> shared diagnosis. Each
+missing-signal test has a measured-zero or complete-data control twin so
+"absent" and "measured zero" stay distinguishable forever.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import pytest
+
+from traceml_ai.diagnostics.common import DiagnosticResult
+from traceml_ai.diagnostics.step_time.api import StepDiagnosis
+from traceml_ai.diagnostics.step_time.context import build_step_time_context
+from traceml_ai.diagnostics.step_time.formatters import format_cli_diagnosis
+from traceml_ai.diagnostics.step_time.policy import SUMMARY_STEP_TIME_POLICY
+from traceml_ai.diagnostics.step_time.rules import RankStragglerRule
+from traceml_ai.renderers.step_time.schema import (
+    StepCombinedTimeCoverage,
+    StepCombinedTimeMetric,
+    StepCombinedTimeSummary,
+)
+from traceml_ai.reporting.compare.policy import step_time_status_rank
+from traceml_ai.reporting.primary_diagnosis import build_primary_diagnosis
+from traceml_ai.reporting.summaries.issue_summary import (
+    diagnostic_result_to_json,
+)
+from traceml_ai.utils.step_time_window import (
+    build_step_time_window_from_events,
+    diagnose_step_time_window,
+)
+
+_EVENT_NAMES = {
+    "input_wait": "_traceml_internal:dataloader_next",
+    "h2d": "_traceml_internal:h2d_time",
+    "forward": "_traceml_internal:forward_time",
+    "backward": "_traceml_internal:backward_time",
+    "optimizer_step": "_traceml_internal:optimizer_step",
+    "step_time": "_traceml_internal:step_time",
+}
+
+_DEFAULT_MS = {
+    "input_wait": 5.0,
+    "h2d": 0.0,
+    "forward": 20.0,
+    "backward": 30.0,
+    "optimizer_step": 10.0,
+    "step_time": 62.0,
+}
+
+
+def _stats(value: float, *, gpu: bool) -> dict:
+    return {
+        "cpu": {
+            "duration_ms": value,
+            "cpu_ms": value,
+            "gpu_ms": value if gpu else None,
+            "n_calls": 1,
+        }
+    }
+
+
+def _step_events(
+    *,
+    omit: Iterable[str] = (),
+    gpu: bool = False,
+    steps: int = 30,
+    **values_ms: float,
+) -> dict[int, dict]:
+    """Build per-step event maps; metrics in ``omit`` are never emitted."""
+    values = dict(_DEFAULT_MS)
+    values.update(values_ms)
+    omitted = set(omit)
+    out: dict[int, dict] = {}
+    for step in range(steps):
+        out[step] = {
+            _EVENT_NAMES[key]: _stats(values[key], gpu=gpu)
+            for key in _EVENT_NAMES
+            if key not in omitted
+        }
+    return out
+
+
+def _diagnose(
+    per_rank_steps: dict[int, dict],
+    *,
+    training_strategy: str = "ddp",
+    max_rows: int = 30,
+) -> DiagnosticResult[StepDiagnosis]:
+    window = build_step_time_window_from_events(
+        per_rank_steps,
+        max_rows=max_rows,
+    )
+    return diagnose_step_time_window(
+        window,
+        policy=SUMMARY_STEP_TIME_POLICY,
+        training_strategy=training_strategy,
+    )
+
+
+def _step_metric(*, world_size: int = 2) -> StepCombinedTimeMetric:
+    return StepCombinedTimeMetric(
+        metric="step_time",
+        clock="cpu",
+        series=None,
+        summary=StepCombinedTimeSummary(
+            window_size=30,
+            steps_used=30,
+            median_total=100.0,
+            worst_total=100.0,
+            worst_rank=1,
+            skew_ratio=0.0,
+            skew_pct=0.0,
+        ),
+        coverage=StepCombinedTimeCoverage(
+            expected_steps=30,
+            steps_used=30,
+            completed_step=30,
+            world_size=world_size,
+            ranks_present=world_size,
+            incomplete=False,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Missing vs measured-zero stays distinguishable in the window
+# ---------------------------------------------------------------------------
+
+
+def test_window_keeps_measured_zero_and_drops_missing() -> None:
+    zero = build_step_time_window_from_events(
+        {0: _step_events(h2d=0.0)}, max_rows=30
+    )
+    missing = build_step_time_window_from_events(
+        {0: _step_events(omit=("h2d",))}, max_rows=30
+    )
+
+    assert zero.per_rank_timing[0]["h2d"] == pytest.approx(0.0)
+    assert "h2d" not in missing.per_rank_timing[0]
+    zero_metrics = {metric.metric for metric in zero.metrics}
+    missing_metrics = {metric.metric for metric in missing.metrics}
+    assert "h2d" in zero_metrics
+    assert "h2d" not in missing_metrics
+
+
+def test_grad_accum_sparse_optimizer_stays_available() -> None:
+    events = _step_events(omit=("optimizer_step",), steps=24)
+    for step in range(0, 24, 4):
+        events[step][_EVENT_NAMES["optimizer_step"]] = _stats(8.0, gpu=False)
+
+    window = build_step_time_window_from_events({0: events}, max_rows=24)
+
+    # Present in 6 of 24 steps: available, averaged over the full window.
+    assert window.per_rank_timing[0]["optimizer_step"] == pytest.approx(2.0)
+    assert "residual_proxy" in window.per_rank_timing[0]
+    result = diagnose_step_time_window(window, policy=SUMMARY_STEP_TIME_POLICY)
+    assert result.primary.kind != "INCOMPLETE_DATA"
+
+
+# ---------------------------------------------------------------------------
+# Missing compute phases cannot produce COMPUTE_BOUND / RESIDUAL_HEAVY
+# ---------------------------------------------------------------------------
+
+
+def test_missing_forward_blocks_compute_bound_and_reports_incomplete() -> None:
+    result = _diagnose(
+        {
+            0: _step_events(
+                omit=("forward",),
+                input_wait=2.0,
+                backward=60.0,
+                optimizer_step=10.0,
+                step_time=90.0,
+            )
+        }
+    )
+
+    assert result.primary.kind == "INCOMPLETE_DATA"
+    assert result.primary.status == "INCOMPLETE DATA"
+    assert result.primary.severity == "info"
+    assert result.issues[0].evidence["missing_signals"] == ["forward"]
+    assert result.issues[0].evidence["signal_coverage"] == {"forward": "0/1"}
+
+
+def test_complete_compute_dominance_still_reports_compute_bound() -> None:
+    result = _diagnose(
+        {
+            0: _step_events(
+                input_wait=2.0,
+                forward=60.0,
+                backward=20.0,
+                optimizer_step=8.0,
+                step_time=90.0,
+            )
+        }
+    )
+
+    assert result.primary.kind == "COMPUTE_BOUND"
+
+
+def test_missing_optimizer_blocks_residual_heavy() -> None:
+    result = _diagnose(
+        {
+            0: _step_events(
+                omit=("optimizer_step",),
+                input_wait=2.0,
+                forward=40.0,
+                backward=30.0,
+                step_time=100.0,
+            )
+        }
+    )
+
+    assert result.primary.kind == "INCOMPLETE_DATA"
+    assert result.issues[0].evidence["missing_signals"] == ["optimizer_step"]
+
+
+def test_measured_zero_optimizer_still_reports_residual_heavy() -> None:
+    result = _diagnose(
+        {
+            0: _step_events(
+                input_wait=2.0,
+                forward=40.0,
+                backward=30.0,
+                optimizer_step=0.0,
+                step_time=100.0,
+            )
+        }
+    )
+
+    assert result.primary.kind == "RESIDUAL_HEAVY"
+
+
+# ---------------------------------------------------------------------------
+# Missing input wait gates input-dependent rules
+# ---------------------------------------------------------------------------
+
+
+def test_missing_input_wait_reports_incomplete_data() -> None:
+    result = _diagnose(
+        {
+            0: _step_events(
+                omit=("input_wait",),
+                forward=30.0,
+                backward=30.0,
+                optimizer_step=10.0,
+                step_time=80.0,
+            )
+        }
+    )
+
+    assert result.primary.kind == "INCOMPLETE_DATA"
+    assert result.issues[0].evidence["missing_signals"] == ["input_wait"]
+
+
+def test_missing_h2d_still_emits_input_bound_on_gpu_clock() -> None:
+    result = _diagnose(
+        {
+            0: _step_events(
+                omit=("h2d",),
+                gpu=True,
+                input_wait=20.0,
+                forward=30.0,
+                backward=30.0,
+                optimizer_step=10.0,
+                step_time=80.0,
+            )
+        }
+    )
+
+    # H2D and the residual are unavailable, but the input finding's own
+    # inputs are complete, so it must still be emitted.
+    assert result.primary.kind == "INPUT_BOUND"
+
+
+# ---------------------------------------------------------------------------
+# Missing synchronization anchors cannot produce a rank straggler
+# ---------------------------------------------------------------------------
+
+_BALANCED_RANK = dict(
+    input_wait=4.0,
+    h2d=0.0,
+    forward=30.0,
+    backward=30.0,
+    optimizer_step=10.0,
+    step_time=76.0,
+)
+
+
+def test_missing_backward_blocks_ddp_straggler() -> None:
+    result = _diagnose(
+        {
+            0: _step_events(**_BALANCED_RANK),
+            1: _step_events(
+                omit=("backward",),
+                **{
+                    key: value
+                    for key, value in _BALANCED_RANK.items()
+                    if key != "backward"
+                },
+            ),
+        }
+    )
+
+    assert result.primary.kind == "INCOMPLETE_DATA"
+    assert "backward" in result.issues[0].evidence["missing_signals"]
+    assert result.issues[0].evidence["signal_coverage"]["backward"] == "1/2"
+
+
+def test_visible_backward_skew_still_reports_straggler() -> None:
+    slow = dict(_BALANCED_RANK, backward=60.0, step_time=106.0)
+    result = _diagnose(
+        {
+            0: _step_events(**_BALANCED_RANK),
+            1: _step_events(**slow),
+        }
+    )
+
+    assert result.primary.kind in {
+        "STRAGGLER",
+        "INPUT_STRAGGLER",
+        "COMPUTE_STRAGGLER",
+        "H2D_STRAGGLER",
+    }
+
+
+def test_missing_forward_blocks_fsdp_straggler() -> None:
+    slow = dict(_BALANCED_RANK, backward=60.0, step_time=106.0)
+    result = _diagnose(
+        {
+            0: _step_events(
+                omit=("forward",),
+                **{k: v for k, v in _BALANCED_RANK.items() if k != "forward"},
+            ),
+            1: _step_events(
+                omit=("forward",),
+                **{k: v for k, v in slow.items() if k != "forward"},
+            ),
+        },
+        training_strategy="fsdp",
+    )
+
+    assert result.primary.kind == "INCOMPLETE_DATA"
+    assert "forward" in result.issues[0].evidence["missing_signals"]
+
+
+# ---------------------------------------------------------------------------
+# Unavailable components are excluded from straggler cause attribution
+# ---------------------------------------------------------------------------
+
+
+def _straggler_issue(
+    per_rank_timing: dict[int, dict[str, float]],
+):
+    context = build_step_time_context(
+        metrics=(_step_metric(),),
+        thresholds=SUMMARY_STEP_TIME_POLICY.thresholds,
+        per_rank_timing=per_rank_timing,
+    )
+    return RankStragglerRule().evaluate(context)
+
+
+def test_h2d_unmeasured_on_victim_cannot_name_h2d_straggler() -> None:
+    sparse_victim = {
+        0: {
+            "input_wait": 5.0,
+            "h2d": 45.0,
+            "forward": 20.0,
+            "backward": 10.0,
+            "step_time": 100.0,
+        },
+        1: {
+            "input_wait": 5.0,
+            "forward": 20.0,
+            "backward": 50.0,
+            "step_time": 100.0,
+        },
+    }
+    issue = _straggler_issue(sparse_victim)
+
+    assert issue is not None
+    assert issue.kind == "STRAGGLER"
+    assert "h2d" not in issue.evidence["component_excesses_ms"]
+
+    measured_victim = {
+        0: dict(sparse_victim[0]),
+        1: dict(sparse_victim[1], h2d=0.0),
+    }
+    control = _straggler_issue(measured_victim)
+
+    assert control is not None
+    assert control.kind == "H2D_STRAGGLER"
+
+
+# ---------------------------------------------------------------------------
+# Partial rank coverage: available findings still fire on measured ranks
+# ---------------------------------------------------------------------------
+
+
+def test_input_bound_fires_from_partially_covered_ranks() -> None:
+    heavy_input = dict(_BALANCED_RANK, input_wait=20.0)
+    result = _diagnose(
+        {
+            0: _step_events(**heavy_input),
+            1: _step_events(
+                omit=("input_wait",),
+                **{
+                    key: value
+                    for key, value in _BALANCED_RANK.items()
+                    if key != "input_wait"
+                },
+            ),
+        }
+    )
+
+    assert result.primary.kind == "INPUT_BOUND"
+
+
+# ---------------------------------------------------------------------------
+# Complete-data behavior is unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_complete_balanced_window_stays_balanced() -> None:
+    result = _diagnose({0: _step_events(**_BALANCED_RANK)})
+
+    assert result.primary.kind == "BALANCED"
+
+
+# ---------------------------------------------------------------------------
+# INCOMPLETE_DATA is a first-class status everywhere
+# ---------------------------------------------------------------------------
+
+
+def test_incomplete_data_serializes_and_formats() -> None:
+    result = _diagnose(
+        {
+            0: _step_events(
+                omit=("forward",),
+                input_wait=2.0,
+                backward=60.0,
+                optimizer_step=10.0,
+                step_time=90.0,
+            )
+        }
+    )
+
+    diagnosis_json, issues_json = diagnostic_result_to_json(result)
+    assert diagnosis_json["kind"] == "INCOMPLETE_DATA"
+    assert diagnosis_json["status"] == "INCOMPLETE DATA"
+    assert diagnosis_json["evidence"]["missing_signals"] == ["forward"]
+    assert issues_json[0] == diagnosis_json
+
+    rendered = format_cli_diagnosis(result.primary)
+    assert "INCOMPLETE DATA" in rendered
+    assert "forward" in rendered
+
+
+def test_incomplete_data_compare_rank_matches_no_data_tier() -> None:
+    assert step_time_status_rank("INCOMPLETE DATA") == 0
+    assert step_time_status_rank("INCOMPLETE DATA") < step_time_status_rank(
+        "BALANCED"
+    )
+
+
+def test_incomplete_data_routes_to_insufficient_primary() -> None:
+    result = _diagnose(
+        {
+            0: _step_events(
+                omit=("forward",),
+                input_wait=2.0,
+                backward=60.0,
+                optimizer_step=10.0,
+                step_time=90.0,
+            )
+        }
+    )
+    diagnosis_json, issues_json = diagnostic_result_to_json(result)
+    step_time_summary = {
+        "diagnosis": diagnosis_json,
+        "issues": issues_json,
+        "global": {"window": {"steps_analyzed": 30}},
+    }
+
+    primary = build_primary_diagnosis(
+        system_summary={
+            "diagnosis": {"kind": "LOW_GPU_UTILIZATION"},
+            "global": {"average": {"gpu_util_percent": 10.0}},
+        },
+        process_summary={},
+        step_time_summary=step_time_summary,
+        step_memory_summary={},
+    )
+
+    # Incomplete timing must become the insufficient-data primary, never
+    # the low-GPU-utilization fallback reserved for BALANCED windows.
+    assert primary["kind"] == "INSUFFICIENT_STEP_TIME_DATA"
+    assert primary["evidence"]["step_time_status"] == "INCOMPLETE DATA"
+    assert "missing phase signals" in primary["summary"]

--- a/tests/diagnostics/test_step_time_missing_signals.py
+++ b/tests/diagnostics/test_step_time_missing_signals.py
@@ -19,7 +19,10 @@ from typing import Iterable
 import pytest
 
 from traceml_ai.diagnostics.common import DiagnosticResult
-from traceml_ai.diagnostics.step_time.api import StepDiagnosis
+from traceml_ai.diagnostics.step_time.api import (
+    StepDiagnosis,
+    build_step_diagnosis_result,
+)
 from traceml_ai.diagnostics.step_time.context import build_step_time_context
 from traceml_ai.diagnostics.step_time.formatters import format_cli_diagnosis
 from traceml_ai.diagnostics.step_time.policy import SUMMARY_STEP_TIME_POLICY
@@ -29,7 +32,10 @@ from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeMetric,
     StepCombinedTimeSummary,
 )
-from traceml_ai.reporting.compare.policy import step_time_status_rank
+from traceml_ai.reporting.compare.policy import (
+    _STEP_TIME_STATUS_RANK,
+    step_time_status_rank,
+)
 from traceml_ai.reporting.primary_diagnosis import build_primary_diagnosis
 from traceml_ai.reporting.summaries.issue_summary import (
     diagnostic_result_to_json,
@@ -361,11 +367,14 @@ def test_missing_forward_blocks_fsdp_straggler() -> None:
 
 def _straggler_issue(
     per_rank_timing: dict[int, dict[str, float]],
+    *,
+    training_strategy: str = "ddp",
 ):
     context = build_step_time_context(
         metrics=(_step_metric(),),
         thresholds=SUMMARY_STEP_TIME_POLICY.thresholds,
         per_rank_timing=per_rank_timing,
+        training_strategy=training_strategy,
     )
     return RankStragglerRule().evaluate(context)
 
@@ -462,11 +471,17 @@ def test_incomplete_data_serializes_and_formats() -> None:
     assert issues_json[0] == diagnosis_json
 
     rendered = format_cli_diagnosis(result.primary)
-    assert "INCOMPLETE DATA" in rendered
+    # The neutral grey styling is the point of the formatter hunk, not
+    # incidental markup: the status must render like NO DATA / WARMUP.
+    assert "[bold bright_black]INCOMPLETE DATA[/bold bright_black]" in rendered
     assert "forward" in rendered
 
 
 def test_incomplete_data_compare_rank_matches_no_data_tier() -> None:
+    # Membership matters: step_time_status_rank defaults unknown statuses
+    # to 0, so asserting the rank alone could not detect a missing
+    # registration.
+    assert "INCOMPLETE DATA" in _STEP_TIME_STATUS_RANK
     assert step_time_status_rank("INCOMPLETE DATA") == 0
     assert step_time_status_rank("INCOMPLETE DATA") < step_time_status_rank(
         "BALANCED"
@@ -507,3 +522,130 @@ def test_incomplete_data_routes_to_insufficient_primary() -> None:
     assert primary["kind"] == "INSUFFICIENT_STEP_TIME_DATA"
     assert primary["evidence"]["step_time_status"] == "INCOMPLETE DATA"
     assert "missing phase signals" in primary["summary"]
+
+
+# ---------------------------------------------------------------------------
+# H2D is occurrence-driven: absence is never a missing signal
+# ---------------------------------------------------------------------------
+
+
+def test_gpu_run_without_h2d_events_stays_balanced() -> None:
+    # A fully instrumented gpu-clock run with zero host-to-device copies
+    # (device-resident data) emits no h2d events at all. That is not
+    # missing instrumentation and must not flip a healthy verdict.
+    result = _diagnose(
+        {
+            0: _step_events(
+                gpu=True,
+                omit=("h2d",),
+                **{k: v for k, v in _BALANCED_RANK.items() if k != "h2d"},
+            )
+        }
+    )
+
+    assert result.primary.kind == "BALANCED"
+
+
+def test_gpu_window_without_h2d_still_derives_residual() -> None:
+    window = build_step_time_window_from_events(
+        {
+            0: _step_events(
+                gpu=True,
+                omit=("h2d",),
+                **{k: v for k, v in _BALANCED_RANK.items() if k != "h2d"},
+            )
+        },
+        max_rows=30,
+    )
+
+    assert window.clock == "gpu"
+    assert "residual_proxy" in window.per_rank_timing[0]
+    assert "h2d" not in window.per_rank_timing[0]
+
+
+def test_gpu_missing_forward_reports_incomplete_data() -> None:
+    result = _diagnose(
+        {
+            0: _step_events(
+                gpu=True,
+                omit=("forward",),
+                input_wait=2.0,
+                h2d=1.0,
+                backward=60.0,
+                optimizer_step=10.0,
+                step_time=90.0,
+            )
+        }
+    )
+
+    assert result.primary.kind == "INCOMPLETE_DATA"
+    assert result.issues[0].evidence["missing_signals"] == ["forward"]
+
+
+# ---------------------------------------------------------------------------
+# Metrics-only callers: availability is unknowable, never "missing"
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_only_diagnosis_stays_balanced() -> None:
+    window = build_step_time_window_from_events(
+        {0: _step_events(**_BALANCED_RANK)}, max_rows=30
+    )
+
+    result = build_step_diagnosis_result(window.metrics)
+
+    assert result.primary.kind == "BALANCED"
+
+
+# ---------------------------------------------------------------------------
+# Per-metric statistics come from exactly the measuring ranks
+# ---------------------------------------------------------------------------
+
+
+def test_partial_metric_stats_use_measuring_ranks() -> None:
+    window = build_step_time_window_from_events(
+        {
+            0: _step_events(
+                omit=("h2d",),
+                **{k: v for k, v in _BALANCED_RANK.items() if k != "h2d"},
+            ),
+            1: _step_events(**dict(_BALANCED_RANK, h2d=9.0)),
+        },
+        max_rows=30,
+    )
+
+    h2d_metric = next(m for m in window.metrics if m.metric == "h2d")
+    # Rank 0 never measured h2d: it cannot appear in the statistics.
+    assert h2d_metric.summary.worst_rank == 1
+    assert h2d_metric.summary.worst_total == pytest.approx(9.0)
+    assert h2d_metric.summary.median_total == pytest.approx(9.0)
+    assert h2d_metric.summary.skew_pct == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Straggler evidence keeps measured components in its maps
+# ---------------------------------------------------------------------------
+
+
+def test_fsdp_straggler_evidence_keeps_zero_compute_entry() -> None:
+    rows = {
+        0: {
+            "input_wait": 5.0,
+            "forward": 20.0,
+            "backward": 10.0,
+            "step_time": 100.0,
+        },
+        1: {
+            "input_wait": 5.0,
+            "forward": 20.0,
+            "backward": 50.0,
+            "step_time": 100.0,
+        },
+    }
+    issue = _straggler_issue(rows, training_strategy="fsdp")
+
+    assert issue is not None
+    # FSDP never attributes compute, but the measured phases keep their
+    # zero entry so the evidence shape matches complete-data output.
+    assert issue.evidence["component_excesses_ms"]["compute"] == 0.0
+    assert issue.evidence["component_coverage"]["compute"] == 0.0

--- a/tests/display/test_model_combined_section.py
+++ b/tests/display/test_model_combined_section.py
@@ -103,3 +103,15 @@ def test_step_time_dashboard_hero_uses_diagnosis_metrics() -> None:
     assert panel["kpis"]["median"].content.startswith("100")
     assert panel["kpis"]["worst"].content.startswith("100")
     assert not panel["kpis"]["median"].content.startswith("20")
+
+
+def test_diagnostics_rail_incomplete_data_is_neutral() -> None:
+    from traceml_ai.aggregator.display_drivers.nicegui_sections import (
+        model_diagnostics_section as mds,
+    )
+
+    assert (
+        mds._row_sev({"severity": "info", "kind": "INCOMPLETE_DATA"})
+        == "neutral"
+    )
+    assert mds._row_sev({"severity": "info", "kind": "BALANCED"}) == "healthy"

--- a/tests/renderers/test_step_time_compute.py
+++ b/tests/renderers/test_step_time_compute.py
@@ -97,3 +97,28 @@ def test_step_time_compute_uses_selected_gpu_diagnosis_clock(
     per_rank = result.per_rank_timing[0]
     assert per_rank["input_wait"] == 5.0
     assert per_rank["step_time"] == 30.0
+
+
+def test_worst_rank_requires_measured_total_step() -> None:
+    from traceml_ai.renderers.step_time.compute import _worst_rank_from_window
+
+    # Ranks without a measured total step (input wait never measured)
+    # cannot win the status-line worst-rank pick with a fake zero.
+    assert (
+        _worst_rank_from_window(
+            {
+                0: {"step_time": 100.0},
+                1: {"step_time": 400.0},
+            }
+        )
+        is None
+    )
+    assert (
+        _worst_rank_from_window(
+            {
+                0: {"step_time": 100.0, "total_step": 105.0},
+                1: {"step_time": 400.0},
+            }
+        )
+        == 0
+    )

--- a/tests/reporting/html/test_banner.py
+++ b/tests/reporting/html/test_banner.py
@@ -268,3 +268,15 @@ def test_render_banner_falls_back_to_status_when_summary_missing(
 
 def test_render_html_report_includes_the_banner(make_payload) -> None:
     assert '<div class="banner' in render_html_report(make_payload())
+
+
+def test_severity_tier_incomplete_data_is_neutral() -> None:
+    from traceml_ai.reporting.html.banner import severity_tier
+
+    # INCOMPLETE DATA is a coverage state, not a finding: it must render
+    # with the neutral tier like its NO_DATA / WARMUP siblings.
+    assert (
+        severity_tier({"severity": "info", "kind": "INCOMPLETE_DATA"})
+        == "neutral"
+    )
+    assert severity_tier({"severity": "info", "kind": "BALANCED"}) == "good"

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -173,10 +173,14 @@ def _alternating_residual_step_metrics(steps: int = 64) -> dict[int, dict]:
         compute_ms, step_time_ms = (
             (50.0, 100.0) if step % 2 == 0 else (100.0, 50.0)
         )
+        # backward/optimizer are measured zeros: the residual derivation
+        # requires every compute phase to be measured, not assumed.
         out[step] = {
             "_traceml_internal:dataloader_next": _event_stats(cpu_ms=0.0),
             "_traceml_internal:h2d_time": _event_stats(cpu_ms=0.0),
             "_traceml_internal:forward_time": _event_stats(cpu_ms=compute_ms),
+            "_traceml_internal:backward_time": _event_stats(cpu_ms=0.0),
+            "_traceml_internal:optimizer_step": _event_stats(cpu_ms=0.0),
             "_traceml_internal:step_time": _event_stats(cpu_ms=step_time_ms),
         }
     return out


### PR DESCRIPTION
Closes #257. First of a three-PR stack (#257 -> #258 -> #259) targeting `version_0.3.6`; the stack should land together (rebase-merge or merge-commit, not squash).

## Problem

The canonical Step Time window converts missing timing events to `0.0`, so diagnosis cannot tell a measured zero from an unmeasured signal. Unmeasured compute leaks into `residual_proxy` (false RESIDUAL-HEAVY), missing input wait deflates iteration time, and a window with dark signals reports a confident BALANCED. Parent bug: #188.

## What changed

- Window builder: a metric measured in at least one aligned step of a rank's window is available; absent steps of an available metric count as zero work (gradient accumulation keeps working). A metric never measured stays an absent key, never `0.0`. Derived metrics gate on availability: `compute` needs all three phases, `total_step` needs input wait + step envelope, `residual_proxy` needs the envelope + all compute phases.
- H2D is occurrence-driven: a fully instrumented run with no host-to-device copies emits no h2d events, so absence means "no observed transfers" and contributes zero to the residual. It is never reported as a missing signal. This deviates from the issue text (which lists H2D as required for residual); taking it literally would kill RESIDUAL-HEAVY on every CPU run and flip healthy device-resident GPU runs to INCOMPLETE_DATA. Flagging for your call.
- Rules abstain when their required signals are unavailable; they still fire from ranks that measured their signals, so one dark rank does not silence a measured finding.
- New `INCOMPLETE_DATA` kind (status `INCOMPLETE DATA`, severity info): replaces BALANCED only when no rule fired and at least one abstained on missing signals. Evidence carries `missing_signals` and per-signal `signal_coverage` (`measured/observed` ranks). Metrics-only callers of `build_step_diagnosis` (no per-rank rows) keep returning BALANCED: availability is unknowable there.
- Rank stragglers: eligibility now also requires a measured input wait; cause attribution only considers components measured on both culprit and victim (measured zeros stay in the evidence maps).
- Registered everywhere a status is enumerated: CLI style, dashboard rail neutral kinds, HTML banner neutral kinds, compare rank map (tier 0, drift guard enforces), primary diagnosis routing (INSUFFICIENT_STEP_TIME_DATA with dedicated wording).
- Docs: DIAGNOSIS.md and the rank straggler policy updated in-step. CI now runs the step-time diagnosis suites.
- Demo pair: `src/dev/demo/mlp_incomplete_signals.py` (direct `model.forward()` call, so forward timing never records) fires INCOMPLETE DATA naming `forward`; the healthy baseline stays quiet.

## Notes for reviewers

- Runs with known-dark integration streams (for example the HuggingFace step-time-only stream) stop reporting BALANCED and start reporting INCOMPLETE DATA. That is the honest verdict, but it is visible.
- At this commit the dashboard hero still hard-gates on all seven metrics and will not render for windows without an h2d metric; #259 in this stack replaces that gate. Land the stack together.
- The pre-existing `test_registry.py` failures (4) and the HuggingFace conformance failure are unchanged by this stack and reproduce identically on the base commit.

## Verification

- `pytest tests/diagnostics tests/reporting tests/renderers tests/display --deselect tests/diagnostics/test_registry.py`: 367 passed.
- 23 acceptance tests in `tests/diagnostics/test_step_time_missing_signals.py`, each missing-signal scenario paired with a measured-zero or complete-data control twin; the behavioral tests fail on the base commit.
- Complete-data equivalence probed base-vs-head with hex-exact floats over 26 scenarios through the real entry points; the only intended deltas are the ones described here.
- Demo pair run through the real launcher on CPU: incomplete run reports `INCOMPLETE DATA` with `missing_signals: ["forward"]`, control reports `BALANCED`.
