### PR TITLE
Fix 22 test failures on a clean full-suite run

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,31 @@ install first.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+
+
+@pytest.fixture(autouse=True)
+def _contain_traceml_disabled_env():
+    """Keep TRACEML_DISABLED from leaking out of the test that set it.
+
+    `init()` writes this variable straight to os.environ on its fail-open path
+    (`sdk/initial.py::_noop_config`), so one unreachable-aggregator call would
+    otherwise turn every later test, and every subprocess they spawn, into a
+    disabled no-op run.
+    """
+    original = os.environ.get("TRACEML_DISABLED")
+    yield
+    if original is None:
+        os.environ.pop("TRACEML_DISABLED", None)
+    else:
+        os.environ["TRACEML_DISABLED"] = original

--- a/tests/diagnostics/test_registry.py
+++ b/tests/diagnostics/test_registry.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+from traceml_ai.diagnostics import model_diagnostics
 from traceml_ai.diagnostics.model_diagnostics import (
     DEFAULT_MODEL_DIAGNOSTIC_REGISTRY,
     ModelDiagnosisItem,

--- a/tests/integrations/test_deepspeed.py
+++ b/tests/integrations/test_deepspeed.py
@@ -3,6 +3,7 @@ import torch
 import torch.nn as nn
 
 import traceml_ai as traceml
+from traceml_ai.runtime.arming import _set_tracing_armed, is_tracing_armed
 
 try:
     import deepspeed  # noqa: F401
@@ -114,6 +115,18 @@ def _install_auto_instrumentation() -> None:
     patch_h2d()
     patch_dataloader()
     ensure_optimizer_timing_installed()
+
+
+@pytest.fixture(autouse=True)
+def _armed_tracing():
+    # The patches are gated on the process-wide flag that init() raises once
+    # its patches install cleanly. This file installs the patches directly, so
+    # arm the flag here and restore it, keeping the file runnable on its own
+    # rather than depending on some earlier test having called init().
+    previous = is_tracing_armed()
+    _set_tracing_armed(True)
+    yield
+    _set_tracing_armed(previous)
 
 
 def test_deepspeed_recipe_brackets_step():

--- a/tests/integrations/test_hf_trainer.py
+++ b/tests/integrations/test_hf_trainer.py
@@ -215,7 +215,7 @@ def test_hf_trainer_callback_integration():
 
 
 @pytest.mark.skipif(not HAS_TRANSFORMERS, reason="transformers not installed")
-def test_hf_trainer_callback_grad_accum_folds_microbatches():
+def test_hf_trainer_callback_grad_accum_folds_microbatches(monkeypatch):
     """
     With gradient_accumulation_steps=2 and max_steps=3, the callback should
     advance the TraceML step counter exactly 3 times (one TraceML step per
@@ -224,6 +224,17 @@ def test_hf_trainer_callback_grad_accum_folds_microbatches():
     accumulated micro-batches within a single trace_step bracket.
     """
     _reset_traceml_state()
+
+    # This test verifies callback step semantics, not runtime startup. Stub
+    # the bootstrap so init() installs its patches without reaching an
+    # aggregator. Otherwise the connect times out, init() fails open to a
+    # disabled no-op, and TRACEML_DISABLED=1 leaks to every later test.
+    import traceml_ai.sdk.initial as initialization
+
+    monkeypatch.setattr(
+        initialization, "_start_runtime_for_init", lambda **kwargs: None
+    )
+
     # Auto-timers trace_step arms are no-ops until init() installs the patches.
     init()
     max_steps = 3

--- a/tests/test_h2d_timing.py
+++ b/tests/test_h2d_timing.py
@@ -39,6 +39,10 @@ if str(SRC) not in sys.path:
 import traceml_ai.instrumentation.patches.h2d_auto_timer_patch as h2d_patch  # noqa: E402
 import traceml_ai.utils.timing as timing_module  # noqa: E402
 from traceml_ai.instrumentation.h2d import is_cuda_target  # noqa: E402
+from traceml_ai.runtime.arming import (  # noqa: E402
+    _set_tracing_armed,
+    is_tracing_armed,
+)
 from traceml_ai.sdk.wrappers import wrap_h2d  # noqa: E402
 
 _H2D_TLS = h2d_patch._H2D_TLS
@@ -88,6 +92,18 @@ def _recorded_h2d_events(buf: deque) -> list:
 
 def _fake_tensor_to(tensor, *args, **kwargs):
     return tensor
+
+
+@pytest.fixture(autouse=True)
+def _armed_tracing():
+    # The patched .to() checks the process-wide flag that init() raises once
+    # its patches install cleanly. These tests call the patch directly, so arm
+    # the flag here and restore it. Without this the patch passes straight
+    # through and the negative assertions below would hold vacuously.
+    previous = is_tracing_armed()
+    _set_tracing_armed(True)
+    yield
+    _set_tracing_armed(previous)
 
 
 # Auto-patch: CUDA target detection


### PR DESCRIPTION
## What changed

Test-only changes that make `pytest` pass on a clean checkout. No `src/` changes, so the product under test is byte-identical and no assertion was weakened.

- `tests/integrations/test_hf_trainer.py` : stub `_start_runtime_for_init` in the grad-accum test, mirroring what `test_hf_init_enables_dataloader_and_h2d_patches` already does
- `tests/diagnostics/test_registry.py` : import the `model_diagnostics` module, which four tests monkeypatch but never bound
- `tests/integrations/test_deepspeed.py`, `tests/test_h2d_timing.py` arm tracing explicitly instead of inheriting it from whatever ran earlier
- `tests/conftest.py` : autouse fixture containing `TRACEML_DISABLED` so no test can leak it to the rest of the session

## Why

`pytest -v` on a clean clone of `main` failed 22 tests (658 passed, 1 skipped). Three root causes:

**1. A leaked env var, 14 failures.** `test_hf_trainer.py` called the real `init()` with no aggregator running. It blocked 10s, raised, and hit the fail-open ladder at `sdk/initial.py:597-620`, which calls `_noop_config()` and that writes `os.environ["TRACEML_DISABLED"] = "1"` process-wide (`initial.py:54`). Everything downstream followed from that one line:

- `init()` short-circuits at `initial.py:553` on the env var, so `test_hf_init_enables_dataloader_and_h2d_patches` saw `disabled=True` *despite* stubbing the runtim the env check runs before the stub is reached
- `trace_step` became a no-op, so HF step counters read 0 and every `_traceml_disabled()` gate in `lightning.py` short-circuited
- `validate_launch_args` early-returned via `_disable_traceml_requested(args, os.environ)`, giving 6 "DID NOT RAISE SystemExit" failures in `test_launcher.py` plus one in `reporting/html/test_cli.py`
- `test_final_summary_smoke.py`'s subprocess inherited the env and printed `TraceML is disabled via --disable-traceml. Running natively.` a flag that test never passes

`tests/sdk/test_init_runtime.py:30` already documents this hazard in a fixture docstring; the guard just never went global.

**2. Tracing never armed, 4 failures.** deepspeed ×2 and h2d ×2 install patches directly, but every patch wrapper checks `is_tracing_armed()`, which only a *successful* `init()` sets (`initial.py:204`). These tests passed only when an earlier test happened to leave the flag on.

**3. Missing import, 4 failures.** `NameError: name 'model_diagnostics' is not defined`.



## How I tested

```bash
pip install -e '.[torch,dev,lightning,hf,deepspeed]'
pytest -v          # before: 22 failed, 658 passed, 1 skipped
                   # after:  green
```

- [x] Tests added or updated
- [x] Existing tests run
- [ ] Manual smoke test
- [ ] Not run; reason:

## Runtime impact

- [x] No training-path impact
- [ ] May affect tracing, runtime, telemetry, or distributed behavior
- [ ] Not sure

Notes: zero changes under `src/`. Only test setup and one missing import.

## Docs

- [ ] Updated
- [x] Not needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test isolation by preventing tracing-related environment settings and runtime state from leaking between tests.
  - Stabilized integration tests for DeepSpeed, Hugging Face Trainer, and device-transfer timing.
  - Added required diagnostic test imports and controlled initialization behavior for more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->