### PR TITLE
Represent missing Step Time metrics as null in final summaries (schema 1.7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
             tests/runtime/test_telemetry_publisher.py \
             tests/reporting/compare \
             tests/reporting/html \
+            tests/reporting/summary \
             -q
 
   smoke-test-install:

--- a/docs/developer_guide/architecture.md
+++ b/docs/developer_guide/architecture.md
@@ -108,6 +108,6 @@ Architectural risks and known structural debt. Day-to-day bugs live in the issue
 | RESIDUAL_HEAVY | A large window-wide share of step time is unattributed residual time. |
 | HIGH_PRESSURE / IMBALANCE | GPU memory is near capacity, or uneven across ranks. |
 | CREEP_EARLY / CREEP_CONFIRMED | Direction-confirmed GPU-memory growth across the run, early or confirmed. |
-| final_summary | The end-of-run `final_summary.{json,txt}`; the JSON carries `schema_version` (currently 1.6). |
+| final_summary | The end-of-run `final_summary.{json,txt}`; the JSON carries `schema_version` (currently 1.7). |
 | Wire envelope | The per-batch message, `{meta, body: {tables}}`, sent as a msgpack frame behind a 4-byte length prefix. |
 | NoOpRuntime | The inert runtime the system falls back to if instrumentation boot fails (fail-open). |

--- a/docs/user_guide/compare.md
+++ b/docs/user_guide/compare.md
@@ -193,6 +193,9 @@ That means:
 This helps keep compare useful across incremental TraceML releases.
 For Step Time input timing, schema 1.6 compares selected-clock `input_wait_ms`
 when present and falls back to legacy `dataloader_ms` for older summaries.
+Since schema 1.7, a Step Time metric can be `null` when its timing signal was
+never measured in the analyzed window; compare treats a null side as
+unavailable (no delta) instead of reading it as zero.
 
 ---
 

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -137,6 +137,30 @@ It is based on:
 - residual / overhead
 - culprit/victim visible rank skew in distributed runs
 
+A signal that was never measured in the analyzed window is reported as
+missing (`null` in `final_summary.json`, `n/a` in text), never as a fake
+`0.0`. A phase measured at zero milliseconds stays `0.0`.
+
+### `INCOMPLETE DATA`
+
+Meaning:
+
+- timing samples exist, but one or more phase signals were never measured,
+  and no reliable conclusion is possible from the signals that remain
+
+This usually means:
+
+- an integration or manual-mode setup did not instrument every phase (for
+  example calling `model.forward(...)` directly, an unwrapped DataLoader,
+  or a custom optimizer without `wrap_optimizer`)
+
+What to do next:
+
+- check the missing signal names listed in the diagnosis evidence
+- use auto mode or the matching `wrap_*` helpers to restore coverage
+
+---
+
 ### `BALANCED`
 
 Meaning:

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -88,8 +88,12 @@ Selection policy:
   and System reports `LOW_GPU_UTILIZATION` or `MODERATE_GPU_UTILIZATION`.
 - `NO_CLEAR_PERFORMANCE_BOTTLENECK` appears when Step Time is `BALANCED` and
   GPU utilization is not low/moderate.
-- `INSUFFICIENT_STEP_TIME_DATA` appears when Step Time is `NO_DATA` or
-  `WARMUP`.
+- `INSUFFICIENT_STEP_TIME_DATA` appears when Step Time is `NO_DATA`,
+  `WARMUP`, or `INCOMPLETE_DATA`. For `INCOMPLETE_DATA` its summary and
+  action name the missing-phase problem, its evidence carries
+  `step_time_status: "INCOMPLETE DATA"`, and the Step Time section's
+  diagnosis evidence lists `missing_signals` plus per-signal
+  `signal_coverage`.
 - Step Time may emit warning-only bottleneck diagnoses before its confident
   threshold; critical Step Time diagnoses require the confident window size.
   Live and summary use the same global-rank Step Time SQLite window loader;

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -1,8 +1,15 @@
 # Final Summary JSON
 
-TraceML writes one end-of-run JSON file. The current schema version is `1.6`.
+TraceML writes one end-of-run JSON file. The current schema version is `1.7`.
 Each section has the same outer shape so the output is easy to store, diff, and
 consume from tooling.
+
+Schema `1.7` made every public Step Time metric nullable. `null` means the
+underlying timing signal was never measured in the analyzed window (missing
+instrumentation), while a measured zero stays `0.0`. Null metrics are
+excluded from `global.average`, `global.median`, and `global.worst` and from
+rank median/worst selection; a rank with only some metrics measured (for
+example an H2D-only rank) keeps its row with `null` for the others.
 
 Sections:
 
@@ -16,7 +23,7 @@ Sections:
 
 ```json
 {
-  "schema_version": 1.6,
+  "schema_version": 1.7,
   "generated_at": "...",
   "duration_s": null,
   "meta": {
@@ -260,6 +267,9 @@ Fallback evidence types are:
 - Row-level diagnosis is intentionally omitted for now.
 - `global.average`, `global.median`, `global.worst`, and
   `groups.rows[*].metrics` must use exactly `metadata.section_metric_names`.
+  Keys are always present; a Step Time metric whose signal was never
+  measured carries `null` (`{"value": null, "idx": null}` for rank points)
+  and never a fabricated `0.0`.
 - `global.index_by` must match `groups.by`.
 - `idx` points to a key in `groups.rows`.
 - `metadata.global_ranks_seen` is all observed ranks.

--- a/src/traceml_ai/reporting/compare/core.py
+++ b/src/traceml_ai/reporting/compare/core.py
@@ -62,7 +62,8 @@ def _schema_warnings(
         (
             "Summary schema versions differ: A uses "
             f"{lhs_version}, B uses {rhs_version}. Step Time fields changed "
-            "in schema 1.6, so Step Time deltas may not be directly "
+            "in schema 1.6 and became nullable in schema 1.7, so Step "
+            "Time deltas may not be directly "
             "comparable."
         )
     ]

--- a/src/traceml_ai/reporting/compare/sections/base.py
+++ b/src/traceml_ai/reporting/compare/sections/base.py
@@ -66,6 +66,20 @@ def global_average(section: Any, metric_name: str) -> Any:
     return nested_get(section, "global", "average", metric_name)
 
 
+def global_average_has_key(section: Any, metric_name: str) -> bool:
+    """Return whether `global.average` carries `metric_name` as a key.
+
+    A schema>=1.6 payload always carries every public metric name, so a
+    present-but-null value means the signal was genuinely never measured
+    this window. A pre-1.6 payload never had the key at all. `.get()`
+    based reads (``global_average`` above) collapse both to ``None``;
+    this distinguishes them for callers that fall back on absence, not
+    on a null value.
+    """
+    average = nested_get(section, "global", "average")
+    return isinstance(average, dict) and metric_name in average
+
+
 def global_point_value(section: Any, kind: str, metric_name: str) -> Any:
     """Read the numeric value from `global.median/worst.<metric>`."""
     point = nested_get(section, "global", kind, metric_name)

--- a/src/traceml_ai/reporting/compare/sections/step_time.py
+++ b/src/traceml_ai/reporting/compare/sections/step_time.py
@@ -14,6 +14,7 @@ from traceml_ai.reporting.compare.model import CompareSection
 from traceml_ai.reporting.compare.sections.base import (
     as_float,
     global_average,
+    global_average_has_key,
     numeric_metric,
     section_available,
     section_diagnosis,
@@ -113,11 +114,20 @@ class StepTimeComparer:
         return global_average(section, key)
 
     def _input_value(self, section: Any) -> Any:
-        """Return selected-clock input wait, falling back for pre-1.6 data."""
+        """Return selected-clock input wait.
+
+        Falls back to ``dataloader_ms`` only when ``input_wait_ms`` is
+        absent entirely (a pre-1.6 payload that never had the key). A
+        schema>=1.6 payload always carries the key; a present-but-null
+        value there means the signal was genuinely never measured this
+        window and must not be silently replaced by a different metric.
+        """
         value = self._value(section, "input_wait_ms")
-        return (
-            self._value(section, "dataloader_ms") if value is None else value
-        )
+        if value is not None:
+            return value
+        if global_average_has_key(section, "input_wait_ms"):
+            return None
+        return self._value(section, "dataloader_ms")
 
     def _dominant_phase(self, section: Any) -> Any:
         phases = {

--- a/src/traceml_ai/reporting/final.py
+++ b/src/traceml_ai/reporting/final.py
@@ -41,6 +41,11 @@ from traceml_ai.sdk.protocol import (
 )
 from traceml_ai.utils.atomic_io import write_json_atomic, write_text_atomic
 
+# Version of the final_summary.json contract. 1.7 made every public
+# Step Time metric nullable: null means the signal was never measured in
+# the analyzed window, while a measured zero stays 0.0.
+SCHEMA_VERSION = 1.7
+
 SUMMARY_WIDTH = 78
 SUMMARY_INNER_TEXT_WIDTH = SUMMARY_WIDTH - 4
 
@@ -831,7 +836,7 @@ class FinalReportGenerator:
         )
 
         return {
-            "schema_version": 1.6,
+            "schema_version": SCHEMA_VERSION,
             "generated_at": utc_now_iso(),
             "duration_s": _summary_duration_s(
                 step_time_summary,

--- a/src/traceml_ai/reporting/html/svg.py
+++ b/src/traceml_ai/reporting/html/svg.py
@@ -31,8 +31,16 @@ def phase_bar(step_time_section: Dict[str, Any]) -> str:
     total = 0.0
     for metric, label, color in _PHASES:
         value = avg.get(metric)
-        if value is None and metric == "input_wait_ms":
-            # Back-compat: schema < 1.6 reports carry dataloader_ms only.
+        if (
+            value is None
+            and metric == "input_wait_ms"
+            and "input_wait_ms" not in avg
+        ):
+            # Back-compat: a pre-1.6 report never carried this key at
+            # all. A schema>=1.6 report always carries the key, so a
+            # present-but-null value here means genuinely unmeasured,
+            # not "borrow dataloader_ms" -- fall through to the isinstance
+            # check below and drop this phase from the chart.
             value = avg.get("dataloader_ms")
         if isinstance(value, (int, float)) and value > 0:
             present.append((label, color, float(value)))

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -307,12 +307,7 @@ def build_step_time_payload(
         # example H2D-only) is excluded from those picks but is still the
         # run's only rank.
         only_rank = global_ranks_used[0]
-        only_summary = rank_summary.get(only_rank)
-        steps_analyzed = (
-            only_summary.steps_analyzed
-            if only_summary is not None
-            else step_time_window.coverage.steps_used
-        )
+        steps_analyzed = rank_summary[only_rank].steps_analyzed
         lines.extend(
             [
                 f"- Diagnosis: {diagnosis_status}",

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -29,8 +29,8 @@ from traceml_ai.reporting.sections.step_time.model import (
     build_global_rollup,
     build_overview,
     closest_rank_to_median,
-    compute_residual_avg_ms,
     finite_float,
+    finite_float_or_none,
     summary_metric_values,
 )
 from traceml_ai.reporting.summaries.issue_summary import (
@@ -125,38 +125,25 @@ def _build_card_stats(
     if not per_global_rank_summary:
         return None
 
+    def _measured(field: str) -> Dict[int, float]:
+        # Ranks whose signal was never measured stay out of the card
+        # statistics; a measured zero stays in.
+        out: Dict[int, float] = {}
+        for rank, summary in per_global_rank_summary.items():
+            value = finite_float_or_none(getattr(summary, field))
+            if value is not None:
+                out[int(rank)] = value
+        return out
+
     return StepTimeCardStats(
         global_rank_count=len(per_global_rank_summary),
         total_step=_metric_pair_from_rank_values(
-            {
-                int(rank): finite_float(summary.avg_total_step_ms)
-                for rank, summary in per_global_rank_summary.items()
-            }
+            _measured("avg_total_step_ms")
         ),
-        compute=_metric_pair_from_rank_values(
-            {
-                int(rank): finite_float(summary.avg_compute_ms)
-                for rank, summary in per_global_rank_summary.items()
-            }
-        ),
-        residual=_metric_pair_from_rank_values(
-            {
-                int(rank): compute_residual_avg_ms(summary)
-                for rank, summary in per_global_rank_summary.items()
-            }
-        ),
-        input=_metric_pair_from_rank_values(
-            {
-                int(rank): finite_float(summary.avg_input_wait_ms)
-                for rank, summary in per_global_rank_summary.items()
-            }
-        ),
-        h2d=_metric_pair_from_rank_values(
-            {
-                int(rank): finite_float(summary.avg_h2d_ms)
-                for rank, summary in per_global_rank_summary.items()
-            }
-        ),
+        compute=_metric_pair_from_rank_values(_measured("avg_compute_ms")),
+        residual=_metric_pair_from_rank_values(_measured("avg_residual_ms")),
+        input=_metric_pair_from_rank_values(_measured("avg_input_wait_ms")),
+        h2d=_metric_pair_from_rank_values(_measured("avg_h2d_ms")),
     )
 
 

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -261,17 +261,6 @@ def build_step_time_payload(
 
     median_global_rank = overview["median_global_rank"]
     worst_global_rank = overview["worst_global_rank"]
-    median_summary = (
-        rank_summary.get(median_global_rank)
-        if median_global_rank is not None
-        else None
-    )
-    worst_summary = (
-        rank_summary.get(worst_global_rank)
-        if worst_global_rank is not None
-        else None
-    )
-    primary_summary = median_summary or worst_summary
 
     summary_diag = diagnosis_result.primary
     issues = diagnosis_result.issues
@@ -312,13 +301,23 @@ def build_step_time_payload(
                 f"- Why: {diagnosis_why}",
             ]
         )
-    elif len(global_ranks_used) == 1 and primary_summary is not None:
+    elif len(global_ranks_used) == 1:
+        # The single-rank wording must not depend on the rank winning a
+        # median/worst pick: a rank whose total step is unmeasured (for
+        # example H2D-only) is excluded from those picks but is still the
+        # run's only rank.
         only_rank = global_ranks_used[0]
+        only_summary = rank_summary.get(only_rank)
+        steps_analyzed = (
+            only_summary.steps_analyzed
+            if only_summary is not None
+            else step_time_window.coverage.steps_used
+        )
         lines.extend(
             [
                 f"- Diagnosis: {diagnosis_status}",
                 (
-                    f"- Scope: last {primary_summary.steps_analyzed} "
+                    f"- Scope: last {steps_analyzed} "
                     f"aligned steps on global rank r{only_rank}"
                 ),
             ]

--- a/src/traceml_ai/reporting/sections/step_time/model.py
+++ b/src/traceml_ai/reporting/sections/step_time/model.py
@@ -40,6 +40,22 @@ def finite_float(x: Any) -> float:
     return v if np.isfinite(v) else 0.0
 
 
+def finite_float_or_none(x: Any) -> Optional[float]:
+    """Convert to float, preserving missing values.
+
+    ``None`` (a signal never measured in the window) stays ``None`` so it
+    can be reported as unavailable instead of a fake zero; unusable
+    non-finite values also become ``None``.
+    """
+    if x is None:
+        return None
+    try:
+        v = float(x)
+    except (TypeError, ValueError):
+        return None
+    return v if np.isfinite(v) else None
+
+
 def closest_rank_to_median(rank_to_value: Dict[int, float]) -> Optional[int]:
     """
     Return the rank whose value is closest to the median of all values.
@@ -73,20 +89,24 @@ def closest_rank_to_median(rank_to_value: Dict[int, float]) -> Optional[int]:
 
 @dataclass
 class RankStepSummary:
-    """Per-rank Step Time summary with compatibility and diagnosis fields."""
+    """Per-rank Step Time summary with compatibility and diagnosis fields.
+
+    A ``None`` metric means the underlying signal was never measured in
+    the analyzed window; a measured zero stays ``0.0``.
+    """
 
     steps_analyzed: int
-    avg_dataloader_ms: float
-    avg_input_wait_ms: float
-    avg_step_time_ms: float
-    avg_h2d_ms: float
-    avg_forward_ms: float
-    avg_backward_ms: float
-    avg_optimizer_ms: float
-    avg_traced_step_ms: float
-    avg_compute_ms: float
-    avg_residual_ms: float
-    avg_total_step_ms: float
+    avg_dataloader_ms: Optional[float]
+    avg_input_wait_ms: Optional[float]
+    avg_step_time_ms: Optional[float]
+    avg_h2d_ms: Optional[float]
+    avg_forward_ms: Optional[float]
+    avg_backward_ms: Optional[float]
+    avg_optimizer_ms: Optional[float]
+    avg_traced_step_ms: Optional[float]
+    avg_compute_ms: Optional[float]
+    avg_residual_ms: Optional[float]
+    avg_total_step_ms: Optional[float]
 
 
 @dataclass(frozen=True)
@@ -110,17 +130,17 @@ def rank_summary_from_timing(
     public = public_step_time_metric_values(timing)
     return RankStepSummary(
         steps_analyzed=max(0, int(steps_analyzed)),
-        avg_dataloader_ms=finite_float(public["dataloader_ms"]),
-        avg_input_wait_ms=finite_float(public["input_wait_ms"]),
-        avg_step_time_ms=finite_float(public["step_time_ms"]),
-        avg_h2d_ms=finite_float(public["h2d_ms"]),
-        avg_forward_ms=finite_float(public["forward_ms"]),
-        avg_backward_ms=finite_float(public["backward_ms"]),
-        avg_optimizer_ms=finite_float(public["optimizer_ms"]),
-        avg_traced_step_ms=finite_float(timing.get("step_time")),
-        avg_compute_ms=finite_float(public["compute_ms"]),
-        avg_residual_ms=finite_float(public["residual_ms"]),
-        avg_total_step_ms=finite_float(public["total_step_ms"]),
+        avg_dataloader_ms=finite_float_or_none(public["dataloader_ms"]),
+        avg_input_wait_ms=finite_float_or_none(public["input_wait_ms"]),
+        avg_step_time_ms=finite_float_or_none(public["step_time_ms"]),
+        avg_h2d_ms=finite_float_or_none(public["h2d_ms"]),
+        avg_forward_ms=finite_float_or_none(public["forward_ms"]),
+        avg_backward_ms=finite_float_or_none(public["backward_ms"]),
+        avg_optimizer_ms=finite_float_or_none(public["optimizer_ms"]),
+        avg_traced_step_ms=finite_float_or_none(timing.get("step_time")),
+        avg_compute_ms=finite_float_or_none(public["compute_ms"]),
+        avg_residual_ms=finite_float_or_none(public["residual_ms"]),
+        avg_total_step_ms=finite_float_or_none(public["total_step_ms"]),
     )
 
 
@@ -137,78 +157,62 @@ def rank_summaries_from_window(
     }
 
 
-def compute_residual_avg_ms(s: RankStepSummary) -> float:
+def compute_residual_avg_ms(s: RankStepSummary) -> Optional[float]:
     """
     Return canonical average residual for one rank summary.
 
     residual_ms is averaged from per-step clamped residuals:
     max(0, step_time_ms - h2d_ms - compute_ms). This intentionally differs
-    from clamping the already-averaged phase totals.
+    from clamping the already-averaged phase totals. ``None`` means a
+    component phase was never measured, so the residual is underivable.
     """
-    return finite_float(s.avg_residual_ms)
+    return finite_float_or_none(s.avg_residual_ms)
+
+
+_METRIC_FIELDS: Dict[str, str] = {
+    "total_step_ms": "avg_total_step_ms",
+    "dataloader_ms": "avg_dataloader_ms",
+    "input_wait_ms": "avg_input_wait_ms",
+    "step_time_ms": "avg_step_time_ms",
+    "h2d_ms": "avg_h2d_ms",
+    "compute_ms": "avg_compute_ms",
+    "residual_ms": "avg_residual_ms",
+    "forward_ms": "avg_forward_ms",
+    "backward_ms": "avg_backward_ms",
+    "optimizer_ms": "avg_optimizer_ms",
+}
 
 
 def _rank_metric_values(
     per_global_rank_summary: Dict[int, RankStepSummary],
 ) -> Dict[str, Dict[int, float]]:
-    """Return global-rank values for each Step Time metric."""
-    return {
-        "total_step_ms": {
-            int(rank): finite_float(summary.avg_total_step_ms)
-            for rank, summary in per_global_rank_summary.items()
-        },
-        "dataloader_ms": {
-            int(rank): finite_float(summary.avg_dataloader_ms)
-            for rank, summary in per_global_rank_summary.items()
-        },
-        "input_wait_ms": {
-            int(rank): finite_float(summary.avg_input_wait_ms)
-            for rank, summary in per_global_rank_summary.items()
-        },
-        "step_time_ms": {
-            int(rank): finite_float(summary.avg_step_time_ms)
-            for rank, summary in per_global_rank_summary.items()
-        },
-        "h2d_ms": {
-            int(rank): finite_float(summary.avg_h2d_ms)
-            for rank, summary in per_global_rank_summary.items()
-        },
-        "compute_ms": {
-            int(rank): finite_float(summary.avg_compute_ms)
-            for rank, summary in per_global_rank_summary.items()
-        },
-        "residual_ms": {
-            int(rank): compute_residual_avg_ms(summary)
-            for rank, summary in per_global_rank_summary.items()
-        },
-        "forward_ms": {
-            int(rank): finite_float(summary.avg_forward_ms)
-            for rank, summary in per_global_rank_summary.items()
-        },
-        "backward_ms": {
-            int(rank): finite_float(summary.avg_backward_ms)
-            for rank, summary in per_global_rank_summary.items()
-        },
-        "optimizer_ms": {
-            int(rank): finite_float(summary.avg_optimizer_ms)
-            for rank, summary in per_global_rank_summary.items()
-        },
-    }
+    """Return global-rank values for each Step Time metric.
+
+    Ranks whose metric is ``None`` (never measured) are excluded, so
+    missing values cannot enter averages, medians, or worst-rank picks.
+    """
+    out: Dict[str, Dict[int, float]] = {}
+    for metric, field in _METRIC_FIELDS.items():
+        values: Dict[int, float] = {}
+        for rank, summary in per_global_rank_summary.items():
+            value = finite_float_or_none(getattr(summary, field))
+            if value is not None:
+                values[int(rank)] = value
+        out[metric] = values
+    return out
 
 
-def summary_metric_values(summary: RankStepSummary) -> Dict[str, float]:
-    """Return public row metrics for one global-rank step-time summary."""
+def summary_metric_values(
+    summary: RankStepSummary,
+) -> Dict[str, Optional[float]]:
+    """Return public row metrics for one global-rank step-time summary.
+
+    Every metric key is always present; a signal never measured for this
+    rank is ``None`` (rendered as ``n/a``), a measured zero stays ``0.0``.
+    """
     return {
-        "total_step_ms": finite_float(summary.avg_total_step_ms),
-        "dataloader_ms": finite_float(summary.avg_dataloader_ms),
-        "input_wait_ms": finite_float(summary.avg_input_wait_ms),
-        "step_time_ms": finite_float(summary.avg_step_time_ms),
-        "h2d_ms": finite_float(summary.avg_h2d_ms),
-        "compute_ms": finite_float(summary.avg_compute_ms),
-        "residual_ms": compute_residual_avg_ms(summary),
-        "forward_ms": finite_float(summary.avg_forward_ms),
-        "backward_ms": finite_float(summary.avg_backward_ms),
-        "optimizer_ms": finite_float(summary.avg_optimizer_ms),
+        metric: finite_float_or_none(getattr(summary, field))
+        for metric, field in _METRIC_FIELDS.items()
     }
 
 
@@ -314,14 +318,25 @@ def build_overview(
             "step_time_skew_percent": None,
         }
 
+    # Ranks whose total step is unavailable (e.g. an H2D-only rank) keep
+    # their row but cannot compete for median or worst selection.
     avg_total_by_rank = {
-        rank: s.avg_total_step_ms
+        rank: value
         for rank, s in per_global_rank_summary.items()
+        if (value := finite_float_or_none(s.avg_total_step_ms)) is not None
     }
-    worst_global_rank = max(avg_total_by_rank, key=avg_total_by_rank.get)
+    worst_global_rank = (
+        max(avg_total_by_rank, key=avg_total_by_rank.get)
+        if avg_total_by_rank
+        else None
+    )
     median_global_rank = closest_rank_to_median(avg_total_by_rank)
 
-    worst_avg_step_ms = avg_total_by_rank.get(worst_global_rank)
+    worst_avg_step_ms = (
+        avg_total_by_rank.get(worst_global_rank)
+        if worst_global_rank is not None
+        else None
+    )
     median_avg_step_ms = (
         avg_total_by_rank.get(median_global_rank)
         if median_global_rank is not None

--- a/src/traceml_ai/reporting/sections/step_time/model.py
+++ b/src/traceml_ai/reporting/sections/step_time/model.py
@@ -157,18 +157,6 @@ def rank_summaries_from_window(
     }
 
 
-def compute_residual_avg_ms(s: RankStepSummary) -> Optional[float]:
-    """
-    Return canonical average residual for one rank summary.
-
-    residual_ms is averaged from per-step clamped residuals:
-    max(0, step_time_ms - h2d_ms - compute_ms). This intentionally differs
-    from clamping the already-averaged phase totals. ``None`` means a
-    component phase was never measured, so the residual is underivable.
-    """
-    return finite_float_or_none(s.avg_residual_ms)
-
-
 _METRIC_FIELDS: Dict[str, str] = {
     "total_step_ms": "avg_total_step_ms",
     "dataloader_ms": "avg_dataloader_ms",
@@ -378,8 +366,8 @@ __all__ = [
     "build_global_rollup",
     "build_overview",
     "closest_rank_to_median",
-    "compute_residual_avg_ms",
     "finite_float",
+    "finite_float_or_none",
     "rank_summaries_from_window",
     "rank_summary_from_timing",
     "summary_metric_values",

--- a/tests/reporting/compare/test_compare.py
+++ b/tests/reporting/compare/test_compare.py
@@ -503,8 +503,9 @@ def test_compare_warns_when_summary_schema_versions_differ() -> None:
     assert compare_payload["warnings"] == [
         (
             "Summary schema versions differ: A uses 1.5, B uses 1.6. "
-            "Step Time fields changed in schema 1.6, so Step Time deltas "
-            "may not be directly comparable."
+            "Step Time fields changed in schema 1.6 and became nullable "
+            "in schema 1.7, so Step Time deltas may not be directly "
+            "comparable."
         )
     ]
     assert "Notes" in text

--- a/tests/reporting/compare/test_compare.py
+++ b/tests/reporting/compare/test_compare.py
@@ -546,6 +546,40 @@ def test_compare_step_time_input_prefers_selected_input_wait() -> None:
     assert step_time["metrics"]["dominant_phase"]["rhs"] == "forward"
 
 
+def test_compare_step_time_null_input_wait_is_not_borrowed_from_dataloader() -> (
+    None
+):
+    # Schema >= 1.6 always carries the input_wait_ms key; a present-but-
+    # null value means the signal was genuinely never measured this
+    # window (e.g. GPU clock dropped it on some step), not "old payload
+    # without the key" -- the fallback must not silently substitute
+    # dataloader_ms for it.
+    section = _step_time_section(total_step_ms=120.0)
+    section["global"]["average"]["input_wait_ms"] = None
+
+    payload = _payload_with_sections(step_time=section)
+    step_time = _build_compare(payload, payload)["sections"]["step_time"]
+
+    assert step_time["metrics"]["input_ms"]["lhs"] is None
+    assert step_time["metrics"]["input_ms"]["rhs"] is None
+
+
+def test_compare_step_time_absent_input_wait_still_falls_back_pre_1_6() -> (
+    None
+):
+    # True pre-1.6 shape: the key never existed at all. This case must
+    # keep falling back to dataloader_ms.
+    section = _step_time_section(total_step_ms=120.0)
+    assert "input_wait_ms" not in section["global"]["average"]
+
+    payload = _payload_with_sections(step_time=section)
+    step_time = _build_compare(payload, payload)["sections"]["step_time"]
+
+    assert step_time["metrics"]["input_ms"]["lhs"] == (
+        section["global"]["average"]["dataloader_ms"]
+    )
+
+
 def test_compare_includes_top_level_primary_diagnosis_change() -> None:
     lhs = _set_primary(
         _payload_with_sections(

--- a/tests/reporting/html/test_svg.py
+++ b/tests/reporting/html/test_svg.py
@@ -47,6 +47,27 @@ def test_phase_bar_falls_back_to_dataloader_ms_for_pre_1_6(
     assert out.count("<rect") == 2  # input (via dataloader_ms) + forward
 
 
+def test_phase_bar_null_input_wait_is_not_borrowed_from_dataloader(
+    make_section,
+) -> None:
+    # Schema >= 1.6 always carries the input_wait_ms key; a present-but-
+    # null value means genuinely unmeasured, not "old payload without
+    # the key" -- the chart must drop the phase, not borrow
+    # dataloader_ms's number under the "input wait" label.
+    section = make_section(
+        metric_names=["total_step_ms", "input_wait_ms", "forward_ms"],
+        average={
+            "input_wait_ms": None,
+            "dataloader_ms": 60.0,
+            "forward_ms": 40.0,
+            "total_step_ms": 100.0,
+        },
+    )
+    out = phase_bar(section)
+    assert "input wait" not in out
+    assert out.count("<rect") == 1  # forward only
+
+
 def test_phase_bar_empty_when_no_timing(make_section) -> None:
     section = make_section(
         metric_names=["total_step_ms"], average={"total_step_ms": 0.0}

--- a/tests/reporting/summary/test_final.py
+++ b/tests/reporting/summary/test_final.py
@@ -116,7 +116,7 @@ def test_final_report_generator_preserves_summary_schema_and_order():
         ),
     )
 
-    assert payload["schema_version"] == 1.6
+    assert payload["schema_version"] == 1.7
     assert payload["duration_s"] == 10.0
     assert list(payload.keys()) == [
         "schema_version",
@@ -244,6 +244,57 @@ def test_final_text_uses_single_process_average_layout():
     assert "node=n" not in text
     assert payload["step_time"]["card"] == "STEP TIME ORIGINAL CARD"
     assert payload["system"]["card"] == "SYSTEM ORIGINAL CARD"
+
+
+def test_final_text_renders_missing_step_metrics_as_na():
+    step_diag = _diagnosis(
+        "INCOMPLETE_DATA",
+        "INCOMPLETE DATA",
+        summary="Missing timing signals prevent a reliable diagnosis: h2d.",
+        action="Instrument the missing phases.",
+    )
+    step_time = _payload(
+        metadata={"global_ranks_used": 1},
+        diagnosis=step_diag,
+        global_summary={
+            "window": {"steps_analyzed": 60, "diagnosis_clock": "cpu"},
+            "average": {
+                "total_step_ms": 139.1,
+                "dataloader_ms": 120.0,
+                "input_wait_ms": 130.8,
+                "step_time_ms": 139.1,
+                "compute_ms": None,
+                "residual_ms": None,
+                "h2d_ms": None,
+            },
+        },
+        card="STEP TIME ORIGINAL CARD",
+    )
+
+    payload = build_summary_payload(
+        "fake.db",
+        generator=_generator(
+            _PayloadSection("system", _status_payload("NORMAL")),
+            _PayloadSection("process", _status_payload("NORMAL")),
+            _PayloadSection("step_time", step_time),
+            _PayloadSection("step_memory", _status_payload("BALANCED")),
+        ),
+    )
+
+    text = payload["text"]
+    lines = text.splitlines()
+
+    def _evidence_row(label: str) -> str:
+        for line in lines:
+            if label in line:
+                return line
+        raise AssertionError(f"no evidence row for {label}")
+
+    # A never-measured metric renders n/a; measured metrics keep values.
+    assert "n/a" in _evidence_row("H2D")
+    assert "n/a" in _evidence_row("Compute")
+    assert "n/a" in _evidence_row("Residual")
+    assert "130.8ms" in _evidence_row("Input Wait")
 
 
 def test_final_text_uses_selected_step_time_for_phase_shares():

--- a/tests/reporting/summary/test_fixtures.py
+++ b/tests/reporting/summary/test_fixtures.py
@@ -30,7 +30,6 @@ from traceml_ai.reporting.sections.step_memory import StepMemorySummarySection
 from traceml_ai.reporting.sections.step_time import StepTimeSummarySection
 from traceml_ai.reporting.sections.system import SystemSummarySection
 
-
 SECTION_KEYS = {
     "metadata",
     "diagnosis",
@@ -866,7 +865,7 @@ def test_final_summary_fixture_schema_contains_all_sections(
 
     payload = build_summary_payload(str(db_path))
 
-    assert payload["schema_version"] == 1.6
+    assert payload["schema_version"] == 1.7
     assert set(payload) == {
         "schema_version",
         "generated_at",

--- a/tests/reporting/summary/test_step_time_nullable.py
+++ b/tests/reporting/summary/test_step_time_nullable.py
@@ -57,7 +57,8 @@ def _create_db(path: str, per_rank_events: dict) -> None:
     """Create a step_time db; per_rank_events maps rank -> metric ms map."""
     conn = sqlite3.connect(path)
     try:
-        conn.execute("""
+        conn.execute(
+            """
             CREATE TABLE step_time_samples (
                 id                 INTEGER PRIMARY KEY AUTOINCREMENT,
                 recv_ts_ns         INTEGER NOT NULL,
@@ -73,13 +74,16 @@ def _create_db(path: str, per_rank_events: dict) -> None:
                 step               INTEGER,
                 events_json        TEXT NOT NULL
             );
-            """)
-        conn.execute("""
+            """
+        )
+        conn.execute(
+            """
             CREATE TABLE runtime_environment (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 training_strategy TEXT
             );
-            """)
+            """
+        )
         conn.execute(
             "INSERT INTO runtime_environment(training_strategy) VALUES (?);",
             ("ddp",),
@@ -223,3 +227,60 @@ def test_compare_treats_null_metric_as_unavailable(tmp_path) -> None:
     assert metrics["compute_ms"]["pct_change"] is None
     # Null on both sides is equally quiet.
     assert metrics["residual_ms"]["delta"] is None
+
+
+def test_single_rank_scope_wording_survives_null_total(tmp_path) -> None:
+    db = tmp_path / "telemetry"
+    _create_db(str(db), {0: {"h2d": 3.0}})
+    summary = generate_step_time_summary_card(str(db), print_to_stdout=False)
+
+    # A single-rank run keeps single-rank wording even when its total
+    # step is unmeasured and it cannot win a median/worst pick.
+    assert "aligned steps on global rank r0" in summary["card"]
+    assert "across 1 global ranks" not in summary["card"]
+
+
+def test_all_ranks_without_total_step_null_the_rank_picks(tmp_path) -> None:
+    db = tmp_path / "telemetry"
+    _create_db(str(db), {0: {"h2d": 2.0}, 1: {"h2d": 6.0}})
+    summary = generate_step_time_summary_card(str(db), print_to_stdout=False)
+
+    assert summary["global"]["worst"]["total_step_ms"] == {
+        "value": None,
+        "idx": None,
+    }
+    assert summary["global"]["average"]["total_step_ms"] is None
+    assert summary["global"]["average"]["h2d_ms"] == 4.0
+    assert summary["global"]["worst"]["h2d_ms"]["idx"] == "1"
+    assert "total n/a" in summary["card"]
+
+
+def test_partial_compute_triplet_nulls_only_derived_metrics(
+    tmp_path,
+) -> None:
+    db = tmp_path / "telemetry"
+    values = {k: v for k, v in _FULL_RANK_MS.items() if k != "optimizer_step"}
+    _create_db(str(db), {0: values})
+    summary = generate_step_time_summary_card(str(db), print_to_stdout=False)
+
+    metrics = summary["groups"]["rows"]["0"]["metrics"]
+    # Measured phases keep their values; only the metrics that need the
+    # unmeasured optimizer become null.
+    assert metrics["forward_ms"] == 5.0
+    assert metrics["backward_ms"] == 10.0
+    assert metrics["optimizer_ms"] is None
+    assert metrics["compute_ms"] is None
+    assert metrics["residual_ms"] is None
+    assert metrics["total_step_ms"] == 31.0
+
+
+def test_finite_float_or_none_preserves_missing_and_zero() -> None:
+    from traceml_ai.reporting.sections.step_time.model import (
+        finite_float_or_none,
+    )
+
+    assert finite_float_or_none(None) is None
+    assert finite_float_or_none(0.0) == 0.0
+    assert finite_float_or_none(float("nan")) is None
+    assert finite_float_or_none(float("inf")) is None
+    assert finite_float_or_none("bogus") is None

--- a/tests/reporting/summary/test_step_time_nullable.py
+++ b/tests/reporting/summary/test_step_time_nullable.py
@@ -1,0 +1,225 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Nullable public Step Time metrics in final summaries (issue #258).
+
+Missing signals surface as JSON ``null`` / text ``n/a`` and stay out of
+rollups and rank selection; measured zeros stay ``0.0``.
+"""
+
+import json
+import sqlite3
+
+from traceml_ai.reporting.compare.core import build_compare_payload
+from traceml_ai.reporting.summaries.step_time import (
+    generate_step_time_summary_card,
+)
+
+_EVENT_NAMES = {
+    "input_wait": "_traceml_internal:dataloader_next",
+    "h2d": "_traceml_internal:h2d_time",
+    "forward": "_traceml_internal:forward_time",
+    "backward": "_traceml_internal:backward_time",
+    "optimizer_step": "_traceml_internal:optimizer_step",
+    "step_time": "_traceml_internal:step_time",
+}
+
+_FULL_RANK_MS = {
+    "input_wait": 1.0,
+    "forward": 5.0,
+    "backward": 10.0,
+    "optimizer_step": 4.0,
+    "step_time": 30.0,
+}
+
+
+def _events_json(values_ms: dict) -> str:
+    return json.dumps(
+        {
+            _EVENT_NAMES[key]: {
+                "cpu": {
+                    "is_gpu": False,
+                    "duration_ms": value,
+                    "cpu_ms": value,
+                    "gpu_ms": None,
+                    "n_calls": 1,
+                }
+            }
+            for key, value in values_ms.items()
+        }
+    )
+
+
+def _create_db(path: str, per_rank_events: dict) -> None:
+    """Create a step_time db; per_rank_events maps rank -> metric ms map."""
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("""
+            CREATE TABLE step_time_samples (
+                id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+                recv_ts_ns         INTEGER NOT NULL,
+                rank               INTEGER,
+                global_rank        INTEGER,
+                local_rank         INTEGER,
+                world_size         INTEGER,
+                local_world_size   INTEGER,
+                node_rank          INTEGER,
+                hostname           TEXT,
+                sample_ts_s        REAL,
+                seq                INTEGER,
+                step               INTEGER,
+                events_json        TEXT NOT NULL
+            );
+            """)
+        conn.execute("""
+            CREATE TABLE runtime_environment (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                training_strategy TEXT
+            );
+            """)
+        conn.execute(
+            "INSERT INTO runtime_environment(training_strategy) VALUES (?);",
+            ("ddp",),
+        )
+        world_size = len(per_rank_events)
+        rows = []
+        row_id = 0
+        for rank, values_ms in per_rank_events.items():
+            for step in (1, 2):
+                row_id += 1
+                rows.append(
+                    (
+                        row_id,
+                        rank,
+                        rank,
+                        rank,
+                        world_size,
+                        world_size,
+                        0,
+                        f"worker-{rank}",
+                        float(step),
+                        step,
+                        step,
+                        _events_json(values_ms),
+                    )
+                )
+        conn.executemany(
+            """
+            INSERT INTO step_time_samples(
+                recv_ts_ns, rank, global_rank, local_rank, world_size,
+                local_world_size, node_rank, hostname, sample_ts_s,
+                seq, step, events_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """,
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_missing_h2d_is_null_and_measured_zero_stays_zero(tmp_path) -> None:
+    missing_db = tmp_path / "missing"
+    _create_db(str(missing_db), {0: dict(_FULL_RANK_MS)})
+    missing = generate_step_time_summary_card(
+        str(missing_db), print_to_stdout=False
+    )
+
+    zero_db = tmp_path / "zero"
+    _create_db(str(zero_db), {0: dict(_FULL_RANK_MS, h2d=0.0)})
+    zero = generate_step_time_summary_card(str(zero_db), print_to_stdout=False)
+
+    assert missing["global"]["average"]["h2d_ms"] is None
+    assert missing["global"]["median"]["h2d_ms"] == {
+        "value": None,
+        "idx": None,
+    }
+    assert missing["global"]["worst"]["h2d_ms"] == {
+        "value": None,
+        "idx": None,
+    }
+    assert missing["groups"]["rows"]["0"]["metrics"]["h2d_ms"] is None
+    # Measured metrics on the same row stay plain floats.
+    assert missing["groups"]["rows"]["0"]["metrics"]["step_time_ms"] == 30.0
+    assert "H2D n/a" in missing["card"]
+
+    assert zero["global"]["average"]["h2d_ms"] == 0.0
+    assert zero["groups"]["rows"]["0"]["metrics"]["h2d_ms"] == 0.0
+    assert "H2D 0.0ms" in zero["card"]
+
+
+def test_h2d_only_rank_keeps_row_and_stays_out_of_rank_selection(
+    tmp_path,
+) -> None:
+    db = tmp_path / "telemetry"
+    _create_db(
+        str(db),
+        {
+            0: dict(_FULL_RANK_MS, h2d=2.0),
+            1: {"h2d": 6.0},
+        },
+    )
+    summary = generate_step_time_summary_card(str(db), print_to_stdout=False)
+
+    rows = summary["groups"]["rows"]
+    assert set(rows) == {"0", "1"}
+    # The H2D-only rank keeps its H2D observation and nulls elsewhere.
+    assert rows["1"]["metrics"]["h2d_ms"] == 6.0
+    assert rows["1"]["metrics"]["step_time_ms"] is None
+    assert rows["1"]["metrics"]["total_step_ms"] is None
+
+    # Null metrics stay out of averages and rank picks: the H2D average
+    # spans both ranks, total-step rollups only the measured rank.
+    assert summary["global"]["average"]["h2d_ms"] == 4.0
+    assert summary["global"]["average"]["total_step_ms"] == 31.0
+    assert summary["global"]["worst"]["total_step_ms"]["idx"] == "0"
+    assert summary["global"]["worst"]["h2d_ms"]["idx"] == "1"
+
+
+def test_compare_treats_null_metric_as_unavailable(tmp_path) -> None:
+    def _summary_payload(compute_ms):
+        return {
+            "schema_version": 1.7,
+            "duration_s": 10.0,
+            "system": {},
+            "process": {},
+            "step_memory": {},
+            "step_time": {
+                "diagnosis": {
+                    "kind": "INCOMPLETE_DATA",
+                    "status": "INCOMPLETE DATA",
+                },
+                "global": {
+                    "average": {
+                        "total_step_ms": 31.0,
+                        "input_wait_ms": 1.0,
+                        "h2d_ms": None,
+                        "compute_ms": compute_ms,
+                        "residual_ms": None,
+                        "forward_ms": 5.0,
+                        "backward_ms": 10.0,
+                        "optimizer_ms": compute_ms,
+                    }
+                },
+            },
+        }
+
+    payload = build_compare_payload(
+        lhs_payload=_summary_payload(19.0),
+        rhs_payload=_summary_payload(None),
+        lhs_path=tmp_path / "a" / "final_summary.json",
+        rhs_path=tmp_path / "b" / "final_summary.json",
+    )
+
+    metrics = payload["sections"]["step_time"]["metrics"]
+    # A null side yields no delta: unavailable, never "went to zero".
+    assert metrics["compute_ms"]["lhs"] == 19.0
+    assert metrics["compute_ms"]["rhs"] is None
+    assert metrics["compute_ms"]["delta"] is None
+    assert metrics["compute_ms"]["pct_change"] is None
+    # Null on both sides is equally quiet.
+    assert metrics["residual_ms"]["delta"] is None


### PR DESCRIPTION
Closes #258. Depends on #257 (second PR of the stack targeting `version_0.3.6`).

## Problem

Final-summary rank rows and rollups convert unavailable Step Time phases to `0.0`, so missing instrumentation looks like measured work: averages dilute, median and worst-rank picks can land on ranks that never measured the metric, and an H2D-only rank distorts every total-step statistic.

## What changed

- Every public Step Time metric is now nullable: `null` in JSON means the signal was never measured in the analyzed window; a measured zero stays `0.0`. All ten metric keys are always present, so the section schema validator and existing consumers keep exact key parity.
- Rollups (`global.average`, `global.median`, `global.worst`) and median/worst-rank selection exclude null values. A rank with only some metrics measured keeps its row with `null` for the others; an H2D-only rank keeps its H2D observation and stays out of total-step picks. The single-rank card wording no longer depends on the rank winning a median/worst pick.
- The residual fallback that re-derived `residual_ms` from partial sums is gone: a residual the window could not derive stays `null` instead of silently absorbing an unmeasured phase.
- Text renders missing metrics as `n/a`; HTML renders an em dash; compare treats a null side as unavailable (no delta), never as a drop to zero.
- `compare` and the HTML phase bar no longer conflate "genuinely null" (schema>=1.6, signal never measured) with "key absent" (pre-1.6 payload): both now check key presence, not just value, before falling back to `dataloader_ms` for the input-wait figure. The old value-only check meant a schema-1.7 payload with a real, unmeasured input wait could silently render a different metric's number under the "Input" label.
- Schema version 1.6 -> 1.7 via a named `SCHEMA_VERSION` constant; SCHEMA.md, the compare version warning, the architecture glossary, and the user guides updated. CI now runs the summary reporting suites.

## Notes for reviewers

- Visible change: CPU-only runs now report `h2d_ms: null` (previously a fabricated `0.0`). H2D events only occur when transfers happen, so null is the truthful value there.
- A downstream consumer of `final_summary.json` needs a small companion change for 1.7 (new status registration plus one null guard); prepared separately.

## Verification

- `pytest tests/diagnostics tests/reporting tests/renderers tests/display --deselect tests/diagnostics/test_registry.py`: 410 passed.
- New acceptance tests drive real SQLite fixtures end to end: missing-vs-zero h2d, H2D-only rank row retention and rollup exclusion, all-ranks-without-total rank picks, partial compute triplet nullability, compare null handling, text `n/a` rendering, single-rank card wording with a null total. The db-driven tests fail on the #257 base.
- Complete-data payloads are byte-identical to the base through the summary entry point over five scenario databases.
- Real hardware: ran a healthy 4-GPU DDP baseline, a single-rank incomplete-signals scenario, and a new 4-GPU DDP scenario with genuinely asymmetric H2D coverage (one rank's data pre-placed on-device, so its H2D timer never arms) through the actual launcher on a `g4dn.12xlarge`. The device-resident rank reports `h2d_ms: null` and is correctly excluded from H2D rank selection; the diagnosis stays a confident verdict rather than falling back to INCOMPLETE_DATA on the strength of the other measured signals.
