### PR TITLE
Remove plotly from runtime dependencies; nothing imports it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,14 +48,12 @@ dependencies = [
     "msgspec",
     "pyyaml>=6.0",
     "nicegui",
-    "plotly",
 ]
 
 [project.optional-dependencies]
 
 dashboard = [
     "nicegui",
-    "plotly",
 ]
 
 torch = [

--- a/src/traceml_ai/aggregator/trace_aggregator.py
+++ b/src/traceml_ai/aggregator/trace_aggregator.py
@@ -31,9 +31,9 @@ from traceml_ai.transport.tcp_transport import TCPConfig, TCPServer
 from traceml_ai.utils.atomic_io import write_json_atomic
 
 DASHBOARD_DEPENDENCY_INSTALL_HINT = (
-    "Dashboard mode requires nicegui and plotly. They are included in the "
-    "default TraceML install; if they are missing, run "
-    "`pip install -U traceml-ai` or `pip install nicegui plotly`."
+    "Dashboard mode requires nicegui. It is included in the "
+    "default TraceML install; if it is missing, run "
+    "`pip install -U traceml-ai` or `pip install nicegui`."
 )
 _SQLITE_FINALIZE_BUDGET_FRACTION = 0.25
 _SQLITE_FINALIZE_BUDGET_MIN_SEC = 5.0
@@ -69,7 +69,7 @@ def _resolve_display_driver(mode: str) -> Type[BaseDisplayDriver]:
                 NiceGUIDisplayDriver,
             )
         except ModuleNotFoundError as exc:
-            if exc.name in {"nicegui", "plotly"}:
+            if exc.name == "nicegui":
                 raise RuntimeError(
                     f"[TraceML] {DASHBOARD_DEPENDENCY_INSTALL_HINT}"
                 ) from exc

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -48,9 +48,9 @@ from traceml_ai.runtime.settings import DEFAULT_FINALIZE_TIMEOUT_SEC
 from traceml_ai.utils.msgpack_codec import Decoder as MsgpackDecoder
 
 DASHBOARD_DEPENDENCY_INSTALL_HINT = (
-    "Dashboard mode requires nicegui and plotly. They are included in the "
-    "default TraceML install; if they are missing, run "
-    "`pip install -U traceml-ai` or `pip install nicegui plotly`."
+    "Dashboard mode requires nicegui. It is included in the "
+    "default TraceML install; if it is missing, run "
+    "`pip install -U traceml-ai` or `pip install nicegui`."
 )
 
 SINGLE_NODE_DEFAULT_MODE = "dashboard"
@@ -79,7 +79,7 @@ def _require_dashboard_dependencies(mode: str) -> None:
 
     missing = [
         package
-        for package in ("nicegui", "plotly")
+        for package in ("nicegui",)
         if importlib.util.find_spec(package) is None
     ]
     if missing:
@@ -707,7 +707,7 @@ def run_serve(args: argparse.Namespace) -> None:
     if getattr(args, "mode", None) == "dashboard":
         missing = [
             package
-            for package in ("nicegui", "plotly")
+            for package in ("nicegui",)
             if importlib.util.find_spec(package) is None
         ]
         if missing:

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -139,9 +139,7 @@ def test_serve_dashboard_missing_deps_reports_hint_not_nameerror(
         importlib_util,
         "find_spec",
         lambda name, *a, **k: (
-            None
-            if name in ("nicegui", "plotly")
-            else real_find_spec(name, *a, **k)
+            None if name == "nicegui" else real_find_spec(name, *a, **k)
         ),
     )
     from traceml_ai.launcher.commands import run_serve
@@ -151,8 +149,28 @@ def test_serve_dashboard_missing_deps_reports_hint_not_nameerror(
         run_serve(args)
 
     message = str(excinfo.value)
-    assert "nicegui" in message and "plotly" in message
+    assert "nicegui" in message
     assert "Missing:" in message
+
+
+def test_dashboard_dep_check_passes_without_plotly(monkeypatch) -> None:
+    # Acceptance for the plotly removal: plotly is not imported anywhere,
+    # so its absence must not block dashboard mode (previously the guard
+    # tuples refused to start the dashboard over a package nothing used).
+    import importlib.util as importlib_util
+
+    real_find_spec = importlib_util.find_spec
+    monkeypatch.setattr(
+        importlib_util,
+        "find_spec",
+        lambda name, *a, **k: (
+            None if name == "plotly" else real_find_spec(name, *a, **k)
+        ),
+    )
+    from traceml_ai.launcher.commands import _require_dashboard_dependencies
+
+    # Must not raise: nicegui present, plotly absent.
+    _require_dashboard_dependencies("dashboard")
 
 
 def test_serve_configures_logging_without_preset_env(


### PR DESCRIPTION
Closes #269. Part of #268.

`plotly` was a declared runtime dependency that nothing imports. Every occurrence in the tree was an availability-guard tuple or an error-message string, and the guard actively refused to start the dashboard for users missing a package nothing would have used.

## Changes

- Drop `plotly` from `dependencies` and from the `dashboard` extra.
- Guard tuples in `launcher/commands.py` (two sites) and the `ModuleNotFoundError` check in `aggregator/trace_aggregator.py` now check `nicegui` only.
- Both install-hint strings updated to match.
- New test: the dashboard dependency check passes with `plotly` absent (the issue's acceptance criterion).

## Verification

- `grep -rn plotly src/ pyproject.toml` returns zero references (only the new test mentions it, to assert its absence is harmless).
- `tests/runtime/test_launcher.py`: 37 passed, 1 failed. The failure (`test_serve_configures_logging_without_preset_env`) fails identically on a clean `main` checkout in the same environment, so it is pre-existing and untouched by this diff; flagging separately rather than folding a fix into this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard functionality now requires only NiceGUI; Plotly is no longer required.
* **Bug Fixes**
  * Improved dashboard dependency detection and installation guidance.
  * Missing Plotly no longer prevents dashboard startup when NiceGUI is available.
* **Tests**
  * Added coverage confirming dashboards start successfully without Plotly.
  * Updated missing-dependency checks and messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->