### PR TITLE
Add nicegui>=1.4.23 floor; ui.context is absent on older releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,14 +47,17 @@ dependencies = [
     "numpy>=1.26",
     "msgspec",
     "pyyaml>=6.0",
-    "nicegui",
+    # Floor: the dashboard display driver calls ui.context, added in
+    # nicegui 1.4.23. Older nicegui imports fine and then raises
+    # AttributeError at runtime.
+    "nicegui>=1.4.23",
     "plotly",
 ]
 
 [project.optional-dependencies]
 
 dashboard = [
-    "nicegui",
+    "nicegui>=1.4.23",
     "plotly",
 ]
 

--- a/tests/core/test_packaging_constraints.py
+++ b/tests/core/test_packaging_constraints.py
@@ -174,3 +174,27 @@ def test_numpy_is_not_capped_below_version_2() -> None:
             f"numpy is capped below 2 by {requirement!r}. This downgrades "
             "NumPy in place for every user on a modern scientific stack."
         )
+
+
+def test_nicegui_floor_covers_ui_context() -> None:
+    """Regression guard for issue #270.
+
+    The display driver calls ui.context, which nicegui added in 1.4.23.
+    Without a floor, an unrelated constraint elsewhere in the user's
+    environment (an old fastapi pin, for example) walks nicegui back to
+    a version that imports fine and raises AttributeError at runtime.
+    """
+    for requirement in _runtime_dependencies():
+        if _requirement_name(requirement) != "nicegui":
+            continue
+
+        specifier = _version_specifier(requirement).replace(" ", "")
+
+        assert ">=1.4.23" in specifier or ">1.4.22" in specifier, (
+            f"nicegui is declared as {requirement!r} without a floor "
+            "covering ui.context (added in 1.4.23). Resolvers may select "
+            "an older nicegui that breaks the dashboard at runtime."
+        )
+        return
+
+    pytest.fail("nicegui not found among runtime dependencies")


### PR DESCRIPTION
Closes #270. Part of #268.

`nicegui` was declared with no version floor while the display driver calls `ui.context` at three sites. Because nicegui has a large dependency surface, an unrelated pin elsewhere in a user environment (an old fastapi, for example) walks nicegui back to a release where `ui.context` does not exist, and the dashboard raises `AttributeError` at runtime instead of failing at resolve time.

## Changes

- `nicegui>=1.4.23` in `dependencies` and the `dashboard` extra, with a comment recording why the floor exists.
- Regression test in `test_packaging_constraints.py` mirroring the numpy guard: fails if the floor is ever dropped.

## How the floor was chosen

Verified by execution, not changelog. All 15 nicegui APIs the display drivers touch (`ui.element`, `ui.label`, `ui.row`, `ui.html`, `ui.echart`, `ui.timer`, `ui.context`, `ui.run`, `ui.page`, `ui.link`, `ui.column`, `ui.add_head_html`, `app.on_startup`, `app.on_disconnect`, `app.add_static_files`) were checked for presence against installed copies of nicegui 1.4.7, 1.4.22, 1.4.23, and 2.0.0:

```
nicegui 1.4.7:  MISSING: ['ui.context']
nicegui 1.4.22: MISSING: ['ui.context']
nicegui 1.4.23: ALL 15 APIs PRESENT
nicegui 2.0.0:  ALL 15 APIs PRESENT
```

1.4.23 is exactly the minimum for the API surface in use.

## Verification

- `tests/core/test_packaging_constraints.py`: 13 passed (includes the new guard).

## Note

Trivial planned conflict with #278 on adjacent `pyproject.toml` lines (plotly removal). Merge in either order and take both changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned the minimum required NiceGUI version for runtime usage (including the dashboard option) to ensure the needed UI context behavior is present and avoid compatibility-related runtime errors.

* **Tests**
  * Added a regression test that verifies the package dependency specifier continues to enforce the expected NiceGUI “floor” version covering UI context support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->