### PR TITLE
CONTRIBUTING: add the dependency policy from #268

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,40 +164,35 @@ To keep the project focused, we are currently **not** accepting:
 
 ## Dependency Policy
 
-`pyproject.toml` is user-facing API. A wrong constraint does not break our
-CI; it breaks a stranger's environment, silently. A `numpy<2` cap shipped
-this way once: CI stayed green while `pip install traceml-ai` downgraded
-NumPy 2 in place, and resolvers that refuse to downgrade backsolved users
-to a months-old release instead (#263). These rules exist so that class of
-defect cannot ship again.
+Dependency constraints affect downstream package resolution and can create
+installation issues that are not visible in the project's regular CI. Please
+follow these rules when adding or updating dependencies.
 
-1. **No upper bounds without a recorded reason.** A cap on a runtime
-   dependency is only allowed for a concrete, current incompatibility,
-   recorded in `ALLOWED_UPPER_BOUNDS` in
-   `tests/core/test_packaging_constraints.py`. The test fails on any
-   undocumented cap. "Might break someday" is not a reason: users can pin
-   around a missing cap, but cannot relax one we ship.
-2. **Lower bounds follow the APIs we call.** When code depends on a
-   specific API of a dependency, the dependency carries a floor naming the
-   first version that has it (e.g. `nicegui>=1.4.23` for `ui.context`),
-   with a comment in `pyproject.toml` recording why. Without a floor, a
-   resolver working around an unrelated conflict can select a version that
-   imports fine and breaks at runtime.
-3. **If the core import path does not import it, it is an extra.** Runtime
-   dependencies are for code every user runs. Anything only some modes or
-   integrations need belongs in an optional extra. The dashboard stack is
-   the known exception today; whether it migrates to an extra is tracked
-   in #268.
-4. **CI hears ecosystem drift before users do.** A scheduled CI leg
-   resolves the newest published versions of all dependencies and runs the
-   core suite, so a new NumPy or NiceGUI that breaks us is our alarm
-   rather than a user's bug report.
+1. **Document runtime upper bounds.** Add an upper bound only for a verified,
+   current incompatibility. Record the dependency and rationale in
+   `ALLOWED_UPPER_BOUNDS` in `tests/core/test_packaging_constraints.py`; the
+   test rejects undocumented upper bounds. A possible future incompatibility
+   alone is not sufficient reason to add a cap.
 
-Background reading:
+2. **Set lower bounds from required APIs.** If TraceML uses an API introduced
+   in a particular dependency version, set that version as the minimum and
+   add a short comment in `pyproject.toml` explaining the requirement. This
+   prevents dependency resolution from selecting a version that imports
+   successfully but lacks an API used at runtime.
+
+3. **Use extras for optional functionality.** Dependencies not required by the
+   core import path belong in an optional extra. The current dashboard
+   dependency arrangement is a documented exception; its possible migration
+   to an extra is tracked in #268.
+
+4. **Test against current dependency releases.** Scheduled CI resolves the
+   newest published dependency versions and runs the core suite so ecosystem
+   compatibility issues are detected early.
+
+For background, see #263 and
 [Should You Use Upper Bound Version Constraints?](https://iscinumpy.dev/post/bound-version-constraints/)
-(Henry Schreiner) on why caps are harmful in Python's flat dependency
-model, and [SPEC 0](https://scientific-python.org/specs/spec-0000/) for
-the support windows the scientific Python ecosystem expects.
+by Henry Schreiner, along with
+[Scientific Python SPEC 0](https://scientific-python.org/specs/spec-0000/).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,45 @@ To keep the project focused, we are currently **not** accepting:
 
 ---
 
+## Dependency Policy
+
+`pyproject.toml` is user-facing API. A wrong constraint does not break our
+CI; it breaks a stranger's environment, silently. A `numpy<2` cap shipped
+this way once: CI stayed green while `pip install traceml-ai` downgraded
+NumPy 2 in place, and resolvers that refuse to downgrade backsolved users
+to a months-old release instead (#263). These rules exist so that class of
+defect cannot ship again.
+
+1. **No upper bounds without a recorded reason.** A cap on a runtime
+   dependency is only allowed for a concrete, current incompatibility,
+   recorded in `ALLOWED_UPPER_BOUNDS` in
+   `tests/core/test_packaging_constraints.py`. The test fails on any
+   undocumented cap. "Might break someday" is not a reason: users can pin
+   around a missing cap, but cannot relax one we ship.
+2. **Lower bounds follow the APIs we call.** When code depends on a
+   specific API of a dependency, the dependency carries a floor naming the
+   first version that has it (e.g. `nicegui>=1.4.23` for `ui.context`),
+   with a comment in `pyproject.toml` recording why. Without a floor, a
+   resolver working around an unrelated conflict can select a version that
+   imports fine and breaks at runtime.
+3. **If the core import path does not import it, it is an extra.** Runtime
+   dependencies are for code every user runs. Anything only some modes or
+   integrations need belongs in an optional extra. The dashboard stack is
+   the known exception today; whether it migrates to an extra is tracked
+   in #268.
+4. **CI hears ecosystem drift before users do.** A scheduled CI leg
+   resolves the newest published versions of all dependencies and runs the
+   core suite, so a new NumPy or NiceGUI that breaks us is our alarm
+   rather than a user's bug report.
+
+Background reading:
+[Should You Use Upper Bound Version Constraints?](https://iscinumpy.dev/post/bound-version-constraints/)
+(Henry Schreiner) on why caps are harmful in Python's flat dependency
+model, and [SPEC 0](https://scientific-python.org/specs/spec-0000/) for
+the support windows the scientific Python ecosystem expects.
+
+---
+
 ## Releasing (maintainers)
 
 There is no version to edit anywhere in the repo. The package version comes


### PR DESCRIPTION
Part of #268 (does not close it; the release, the yank, and the dashboard-extra decision remain).

Adds a Dependency Policy section to CONTRIBUTING.md, between "What We Are Not Looking For (Yet)" and "Releasing (maintainers)". It records the four rules from the RFC as contributor-facing policy:

1. No upper bounds without a recorded reason (enforced by the #266 guard test's allowlist).
2. Lower bounds follow the APIs we call, with the reason commented in `pyproject.toml` (the #270 pattern).
3. Not imported by the core import path means extra, not runtime dependency. The dashboard stack is called out honestly as the known open case, deferred to #268.
4. A scheduled newest-deps CI leg exists so ecosystem drift is our alarm, not a user's bug report.

Opens with the #263 story in two sentences as the motivation, and closes with two references (Henry Schreiner's upper-bound essay and SPEC 0), both link-checked before inclusion.

Docs-only change; no code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new dependency policy section to the contributor guide, detailing how to set version constraints and document runtime upper bounds.
  * Clarified guidance for deriving lower bounds from required APIs and for organizing non-core dependencies as optional extras.
  * Documented CI checks to detect ecosystem drift by testing against the newest published versions, along with references for best practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->