### PR TITLE
Release prep for 0.3.5.1: accept X.Y.Z.W versions, roll CHANGELOG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,38 @@ jobs:
           git tag -a "v$VERSION" -m "Release v$VERSION"
           git push origin "v$VERSION"
 
+      - name: Warn when runtime dependencies changed since the last release
+        # The conda-forge autotick bot only bumps version and sha256 in its
+        # feedstock PR; dependency changes must be applied there by hand.
+        # This step makes that need visible in the run summary at the exact
+        # moment a release is cut, instead of relying on someone remembering.
+        run: |
+          PREV_TAG=$(git tag --list 'v*' --sort=-v:refname | grep -vx "v$VERSION" | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found; skipping dependency-change check."
+            exit 0
+          fi
+          extract_deps() {
+            git show "$1:pyproject.toml" | sed -n '/^dependencies = \[/,/^\]/p'
+          }
+          if ! diff <(extract_deps "$PREV_TAG") <(extract_deps HEAD) > /tmp/dep_diff.txt; then
+            {
+              echo "## Runtime dependencies changed since $PREV_TAG"
+              echo ""
+              echo "The conda-forge autotick bot only bumps version and sha256."
+              echo "It will NOT apply these dependency changes. Edit the recipe"
+              echo "by hand in the bot's bump PR on the traceml-ai feedstock"
+              echo "before it merges. See CONTRIBUTING.md, Releasing (maintainers)."
+              echo ""
+              echo '```diff'
+              cat /tmp/dep_diff.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Runtime dependencies changed since $PREV_TAG. The conda-forge bump PR needs a manual recipe edit; see the run summary."
+          else
+            echo "No runtime dependency changes since $PREV_TAG."
+          fi
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Validate version format
         run: |
-          echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' || {
-            echo "::error::Version must be X.Y.Z, e.g. 0.3.5 (no leading v, no suffix)"
+          echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$' || {
+            echo "::error::Version must be X.Y.Z or X.Y.Z.W, e.g. 0.3.5 or 0.3.5.1 (no leading v, no suffix)"
             exit 1
           }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,22 @@ which carry the full historical notes for versions predating this file.
 
 ## [Unreleased]
 
+- NumPy 2 is supported: the `numpy<2` cap is removed, so installing
+  TraceML no longer downgrades NumPy in a modern environment and
+  resolvers no longer fall back to old TraceML releases.
+- The aggregator starts on Windows: `SO_REUSEPORT` is applied only on
+  platforms that have it.
+- `plotly` is no longer a dependency; nothing imported it, and its
+  absence no longer blocks dashboard mode.
+- `nicegui` carries a version floor covering the dashboard's API use,
+  so resolvers can no longer select a version that breaks at runtime.
+- Runtime dependencies are guarded against undocumented upper bounds,
+  and a scheduled CI leg resolves the newest published dependencies.
+- CONTRIBUTING documents the dependency policy behind these changes.
 - Cutting a release now also creates the GitHub Release entry, so a
   published version is never missing its release notes.
+- The release workflow accepts four-component patch versions
+  (for example 0.3.5.1).
 
 ## [0.3.5] - 2026-07-26
 


### PR DESCRIPTION
Prep for cutting 0.3.5.1 (#267): the patch release that carries the NumPy fix and the install-friction work to PyPI.

## Changes

- `release.yml`: the version validation accepted only `X.Y.Z`, so the "Cut a release" button would reject `0.3.5.1`. The regex now also accepts a four-component `X.Y.Z.W`, with the error text updated to match. Everything else in the workflow is untouched; the version still flows through the quoted `$VERSION` env var.
- `CHANGELOG.md`: the Unreleased section now lists everything queued for this release: the NumPy 2 uncap, the Windows aggregator fix, the plotly removal, the nicegui floor, the dependency guards, the dependency policy, the GitHub-Release step, and this version-format change.

## Merge order

Two Unreleased bullets describe #278 (plotly) and #279 (nicegui floor). Merge those first so the changelog states facts; if either is rejected, drop its bullet here.

## After merging

Actions -> "Cut a release" -> `0.3.5.1`. The run tags, builds, publishes to PyPI via Trusted Publishing, and creates the GitHub Release entry.
