### PR TITLE
Show incomplete Step Time coverage in the live CLI and dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,6 @@ jobs:
             tests/telemetry/test_distributed.py \
             tests/telemetry/test_msgpack.py \
             tests/telemetry/test_sender_sequence.py \
-            tests/renderers \
-            tests/display \
             -q
 
   test-integration:
@@ -89,7 +87,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[torch]"
+          pip install -e ".[torch,dashboard]"
           pip install pytest
       - name: Run integration tests
         run: |
@@ -99,6 +97,8 @@ jobs:
             tests/reporting/compare \
             tests/reporting/html \
             tests/reporting/summary \
+            tests/renderers \
+            tests/display \
             -q
 
   test-latest-deps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
             tests/telemetry/test_distributed.py \
             tests/telemetry/test_msgpack.py \
             tests/telemetry/test_sender_sequence.py \
+            tests/renderers \
+            tests/display \
             -q
 
   test-integration:

--- a/docs/developer_guide/architecture.md
+++ b/docs/developer_guide/architecture.md
@@ -102,6 +102,7 @@ Architectural risks and known structural debt. Day-to-day bugs live in the issue
 | H2D | Host-to-device copy (CPU to GPU), timed by patching `Tensor.to`. |
 | Phase | A timed part of a step: input wait, H2D, forward, backward, or optimizer. |
 | Step / trace_step | A training iteration; `with trace_step(model)` marks the boundary that phase timing is computed against. |
+| Step Time availability | `StepTimeWindow` carries the expected rank universe and sparse per-rank metrics. Measured-rank populations and multi-metric eligibility are derived from those facts; consumers do not maintain a second coverage model. |
 | Residual (residual_proxy) | Residual step time, `max(0, step - h2d - forward - backward - optimizer)`. |
 | INPUT_BOUND / COMPUTE_BOUND | Input wait is material, or compute reaches 90% of typical selected-clock iteration time. |
 | INPUT_STRAGGLER / COMPUTE_STRAGGLER / H2D_STRAGGLER / STRAGGLER | Visible rank skew exists; the label names the culprit's material input, DDP-forward, or H2D excess, or `STRAGGLER` when the skew is sync-bound or unattributed. |

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -104,7 +104,10 @@ live step-time table rather than shown as `0.0 ms`, and the diagnosis block
 shows `INCOMPLETE DATA` with the missing signal names when no reliable
 conclusion is possible. The step-time dashboard card behaves the same way:
 unmeasured phases leave the ribbon, the window label adds `partial signals`,
-and an underivable residual shows `n/a`.
+and an underivable residual shows `n/a`. H2D is the exception on both
+surfaces: its events only occur when host-to-device copies happen, so an
+absent H2D means no observed transfers and never counts as partial
+coverage.
 
 ### Local UI
 

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -99,6 +99,13 @@ When launched with `--mode=cli`, the terminal shows live:
 Live CLI mode is intended for single-node runs, including single-node
 multi-GPU.
 
+Phases that were never measured in the current window are omitted from the
+live step-time table rather than shown as `0.0 ms`, and the diagnosis block
+shows `INCOMPLETE DATA` with the missing signal names when no reliable
+conclusion is possible. The step-time dashboard card behaves the same way:
+unmeasured phases leave the ribbon, the window label adds `partial signals`,
+and an underivable residual shows `n/a`.
+
 ### Local UI
 
 The local UI shows the same ideas in a more compact review format:

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -102,12 +102,15 @@ multi-GPU.
 Phases that were never measured in the current window are omitted from the
 live step-time table rather than shown as `0.0 ms`, and the diagnosis block
 shows `INCOMPLETE DATA` with the missing signal names when no reliable
-conclusion is possible. The step-time dashboard card behaves the same way:
-unmeasured phases leave the ribbon, the window label adds `partial signals`,
-and an underivable residual shows `n/a`. H2D is the exception on both
-surfaces: its events only occur when host-to-device copies happen, so an
-absent H2D means no observed transfers and never counts as partial
-coverage.
+conclusion is possible. The local UI's step-time hero card behaves the same
+way: an unmeasured phase renders as a hatched sliver on the ribbon, never as
+an empty (zero-width) segment, so a dark stream can never be mistaken for a
+confirmed-fast one; the window label adds `partial: <names>`, and an
+underivable residual shows `n/a`. If a run stops reporting entirely, both
+surfaces show the last window has expired instead of freezing on a dead
+run's numbers. H2D is the exception throughout: its events only occur when
+host-to-device copies happen, so an absent H2D means no observed transfers
+and never counts as partial coverage.
 
 ### Local UI
 

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -103,14 +103,20 @@ Phases that were never measured in the current window are omitted from the
 live step-time table rather than shown as `0.0 ms`, and the diagnosis block
 shows `INCOMPLETE DATA` with the missing signal names when no reliable
 conclusion is possible. The local UI's step-time hero card behaves the same
-way: an unmeasured phase renders as a hatched sliver on the ribbon, never as
-an empty (zero-width) segment, so a dark stream can never be mistaken for a
-confirmed-fast one; the window label adds `partial: <names>`, and an
-underivable residual shows `n/a`. If a run stops reporting entirely, both
-surfaces show the last window has expired instead of freezing on a dead
-run's numbers. H2D is the exception throughout: its events only occur when
-host-to-device copies happen, so an absent H2D means no observed transfers
-and never counts as partial coverage.
+way. The ribbon is one real representative rank from the common eligible
+cohort, named in the window label; it never combines phases from unrelated
+ranks. An unmeasured phase renders as a hatched sliver rather than a measured
+zero, while unavailable shares and cross-rank gaps render as `n/a`. If no rank
+has a coherent composition, the ribbon clears and independently valid KPIs
+continue updating. H2D is the exception throughout: its events only occur
+when host-to-device copies happen, so an absent H2D means no observed
+transfers and never counts as partial coverage.
+
+The live reader bridges short empty or failed reads using its last good
+window, then expires that bridge. Persisted SQLite rows remain a valid saved
+snapshot; an unchanged step number is not treated as proof that the producer
+stopped. Detecting producer liveness requires a separate heartbeat or source
+timestamp.
 
 ### Local UI
 

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
@@ -26,6 +26,11 @@ from traceml_ai.renderers.step_time.schema import (
 
 from . import theme
 
+# Fixed ribbon width for a non-h2d phase that was never measured this
+# window -- large enough to read as a deliberate marker, not a rounding
+# artifact of a real proportional segment.
+_UNMEASURED_SLIVER_PCT = 6.0
+
 
 def build_model_combined_section() -> Dict[str, Any]:
     seg_divs: List[Any] = []
@@ -109,10 +114,30 @@ def _index(
     return {m.metric: m for m in metrics}
 
 
+_EXPIRED_SIG = "__expired__"
+
+
+def _mark_expired(panel: Dict[str, Any]) -> None:
+    """Had data before, none now: the run stopped reporting and the
+    computer's stale window expired. Clear the card instead of freezing
+    on the last complete view (the CLI sibling does the same)."""
+    if panel.get("_last_sig") == _EXPIRED_SIG:
+        return
+    panel["_last_sig"] = _EXPIRED_SIG
+    for seg, sl in zip(panel["seg_divs"], panel["seg_labs"]):
+        seg.style("width:0%;")
+        sl.text = ""
+    for kpi in panel["kpis"].values():
+        kpi.content = theme.kval("—")
+    panel["win"].text = "window expired"
+
+
 def update_model_combined_section(
     panel: Dict[str, Any], payload: Optional[StepCombinedTimeResult]
 ) -> None:
     if not payload or not getattr(payload, "diagnosis_metrics", None):
+        if payload is not None and getattr(payload, "had_ok", False):
+            _mark_expired(panel)
         return
     m = _index(payload.diagnosis_metrics)
     if "step_time" not in m:
@@ -130,7 +155,8 @@ def update_model_combined_section(
     }
     measured = {k: v for k, v in vals.items() if v is not None}
     st = m["step_time"].summary
-    partial = any(value is None for key, value in vals.items() if key != "h2d")
+    missing = [key for key, value in vals.items() if value is None]
+    partial = any(key != "h2d" for key in missing)
     # Denominator: at least the median iteration envelope (input wait +
     # step envelope), so unmeasured time shows as empty ribbon space
     # instead of stretching the measured phases to fill 100%.
@@ -139,6 +165,17 @@ def update_model_combined_section(
         input_wait_value if input_wait_value is not None else 0.0
     )
     tot = max(sum(measured.values()), envelope) or 1.0
+
+    # A measured-zero segment and a genuinely unmeasured one must never
+    # render identically -- an absent input_wait would otherwise let the
+    # OTHER phases sum to exactly step_time (residual is a remainder), so
+    # the ribbon fills to 100% and a dark dataloader stream reads as a
+    # confirmed-fast one. Non-h2d unmeasured phases get a fixed hatched
+    # sliver instead of a proportional width; measured phases give up
+    # that width so the row still totals 100%.
+    unmeasured_non_h2d = [key for key in missing if key != "h2d"]
+    reserved_pct = _UNMEASURED_SLIVER_PCT * len(unmeasured_non_h2d)
+    measured_scale = max(0.0, (100.0 - reserved_pct) / 100.0)
 
     sig = tuple(
         round(vals[k], 3) if vals[k] is not None else None
@@ -157,7 +194,19 @@ def update_model_combined_section(
         theme.PHASES, panel["seg_divs"], panel["seg_labs"]
     ):
         value = vals[key]
-        pct = (value / tot * 100.0) if value is not None else 0.0
+        if key in unmeasured_non_h2d:
+            seg.style(
+                f"width:{_UNMEASURED_SLIVER_PCT:.1f}%; "
+                "background:repeating-linear-gradient(45deg, "
+                "var(--muted) 0 3px, transparent 3px 6px);"
+            )
+            sl.text = f"{lab}?"
+            continue
+        pct = (
+            (value / tot * 100.0 * measured_scale)
+            if value is not None
+            else 0.0
+        )
         seg.style(f"width:{pct:.3f}%")
         sl.text = lab if pct >= 7.0 else ""
 
@@ -184,7 +233,10 @@ def update_model_combined_section(
     )
     steps_text = f"{int(st.steps_used or 0)} aligned steps"
     if partial:
-        steps_text += " · partial signals"
+        missing_labels = ",".join(
+            lab for lab, key, _c in theme.PHASES if key in unmeasured_non_h2d
+        )
+        steps_text += f" · partial: {missing_labels}"
     panel["win"].text = steps_text
 
 

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
@@ -26,8 +26,6 @@ from traceml_ai.renderers.step_time.schema import (
 
 from . import theme
 
-_REQUIRED = {k for _, k, _ in theme.PHASES} | {"step_time"}
-
 
 def build_model_combined_section() -> Dict[str, Any]:
     seg_divs: List[Any] = []
@@ -117,16 +115,26 @@ def update_model_combined_section(
     if not payload or not getattr(payload, "diagnosis_metrics", None):
         return
     m = _index(payload.diagnosis_metrics)
-    if not _REQUIRED.issubset(m):
+    if "step_time" not in m:
         return
 
-    vals = {
-        k: float(m[k].summary.median_total or 0.0) for _, k, _ in theme.PHASES
+    # A metric absent from the payload was never measured this window: it
+    # renders as an empty segment instead of freezing the whole card on
+    # the last complete view. Measured zeros stay zero-width but count as
+    # measured.
+    vals: Dict[str, Optional[float]] = {
+        k: (float(m[k].summary.median_total or 0.0) if k in m else None)
+        for _, k, _ in theme.PHASES
     }
-    tot = sum(vals.values()) or 1.0
+    measured = {k: v for k, v in vals.items() if v is not None}
+    tot = sum(measured.values()) or 1.0
     st = m["step_time"].summary
+    partial = len(measured) < len(vals)
 
-    sig = tuple(round(vals[k], 3) for _, k, _ in theme.PHASES) + (
+    sig = tuple(
+        round(vals[k], 3) if vals[k] is not None else None
+        for _, k, _ in theme.PHASES
+    ) + (
         round(float(st.median_total or 0), 3),
         round(float(st.worst_total or 0), 3),
         int(st.steps_used or 0),
@@ -139,7 +147,8 @@ def update_model_combined_section(
     for (lab, key, _c), seg, sl in zip(
         theme.PHASES, panel["seg_divs"], panel["seg_labs"]
     ):
-        pct = vals[key] / tot * 100.0
+        value = vals[key]
+        pct = (value / tot * 100.0) if value is not None else 0.0
         seg.style(f"width:{pct:.3f}%")
         sl.text = lab if pct >= 7.0 else ""
 
@@ -154,12 +163,20 @@ def update_model_combined_section(
     )
     k["worst"].content = theme.kval(f"{float(st.worst_total or 0):.0f}", "ms")
     k["gap"].content = theme.kval(f"{float(st.skew_pct or 0):.0f}", "%")
-    residual_share = vals["residual_proxy"] / tot * 100.0 if tot > 0 else 0.0
-    k["residual"].content = theme.kval(f"{residual_share:.0f}", "%")
+    residual_value = vals.get("residual_proxy")
+    if residual_value is not None and tot > 0:
+        k["residual"].content = theme.kval(
+            f"{residual_value / tot * 100.0:.0f}", "%"
+        )
+    else:
+        k["residual"].content = theme.kval("n/a")
     k["rank"].content = theme.kval(
         f"r{int(st.worst_rank)}" if st.worst_rank is not None else "—"
     )
-    panel["win"].text = f"{int(st.steps_used or 0)} aligned steps"
+    steps_text = f"{int(st.steps_used or 0)} aligned steps"
+    if partial:
+        steps_text += " · partial signals"
+    panel["win"].text = steps_text
 
 
 def update_step_verdict(panel: Dict[str, Any], diag_payload: Any) -> None:

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
@@ -195,12 +195,18 @@ def update_model_combined_section(
     ):
         value = vals[key]
         if key in unmeasured_non_h2d:
+            # Unmeasured non-h2d phase: a hatched sliver marks "unknown, not
+            # zero" (a dark stream must never read as confirmed-fast). No
+            # on-sliver text -- it would overlap the hatch illegibly at this
+            # width, and the window meta already names the missing phases
+            # ("partial: FWD,RESIDUAL") with the legend mapping position to
+            # phase.
             seg.style(
                 f"width:{_UNMEASURED_SLIVER_PCT:.1f}%; "
                 "background:repeating-linear-gradient(45deg, "
-                "var(--muted) 0 3px, transparent 3px 6px);"
+                "var(--muted) 0 2px, transparent 2px 5px);"
             )
-            sl.text = f"{lab}?"
+            sl.text = ""
             continue
         pct = (
             (value / tot * 100.0 * measured_scale)

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
@@ -23,13 +23,19 @@ from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeMetric,
     StepCombinedTimeResult,
 )
+from traceml_ai.utils.step_time_window import OCCURRENCE_METRICS
 
 from . import theme
 
-# Fixed ribbon width for a non-h2d phase that was never measured this
-# window -- large enough to read as a deliberate marker, not a rounding
-# artifact of a real proportional segment.
+# Fixed ribbon width for a phase that was never measured this window --
+# large enough to read as a deliberate marker, not a rounding artifact of
+# a real proportional segment.
 _UNMEASURED_SLIVER_PCT = 6.0
+
+# Derived remainder, never carried per-rank: its availability comes from
+# the aggregate window (the engine emits it only when derivable), so the
+# per-rank coverage check below does not apply to it.
+_DERIVED_METRICS = frozenset(("residual_proxy",))
 
 
 def build_model_combined_section() -> Dict[str, Any]:
@@ -114,22 +120,49 @@ def _index(
     return {m.metric: m for m in metrics}
 
 
+def _partially_covered(
+    per_rank_timing: Dict[int, Dict[str, float]],
+    keys: List[str],
+) -> List[str]:
+    """Return phases measured on some observed ranks but not all.
+
+    Mirrors the diagnosis engine's rule (a signal counts as measured only
+    when every observed rank measured it). Occurrence-driven metrics are
+    exempt, derived remainders are never carried per-rank, and with no
+    per-rank rows availability is unknowable, so nothing is reported.
+    """
+    if len(per_rank_timing) < 2:
+        return []
+    thin: List[str] = []
+    for key in keys:
+        if key in OCCURRENCE_METRICS or key in _DERIVED_METRICS:
+            continue
+        seen = sum(1 for vals in per_rank_timing.values() if key in vals)
+        if 0 < seen < len(per_rank_timing):
+            thin.append(key)
+    return thin
+
+
 _EXPIRED_SIG = "__expired__"
+_NO_ENVELOPE_SIG = "__no_envelope__"
 
 
-def _mark_expired(panel: Dict[str, Any]) -> None:
-    """Had data before, none now: the run stopped reporting and the
-    computer's stale window expired. Clear the card instead of freezing
-    on the last complete view (the CLI sibling does the same)."""
-    if panel.get("_last_sig") == _EXPIRED_SIG:
+def _clear_view(panel: Dict[str, Any], sig: str, label: str) -> None:
+    """Blank the ribbon and KPIs, then state why.
+
+    Any path that cannot draw a trustworthy ribbon must clear it rather
+    than return early: a stale complete view left on screen is read as
+    current, which is the failure this issue exists to remove.
+    """
+    if panel.get("_last_sig") == sig:
         return
-    panel["_last_sig"] = _EXPIRED_SIG
+    panel["_last_sig"] = sig
     for seg, sl in zip(panel["seg_divs"], panel["seg_labs"]):
-        seg.style("width:0%;")
+        seg.style("width:0%; background:transparent;")
         sl.text = ""
     for kpi in panel["kpis"].values():
         kpi.content = theme.kval("—")
-    panel["win"].text = "window expired"
+    panel["win"].text = label
 
 
 def update_model_combined_section(
@@ -137,10 +170,17 @@ def update_model_combined_section(
 ) -> None:
     if not payload or not getattr(payload, "diagnosis_metrics", None):
         if payload is not None and getattr(payload, "had_ok", False):
-            _mark_expired(panel)
+            # Had data before, none now: the run stopped reporting and the
+            # computer's stale window expired (the CLI sibling does the
+            # same).
+            _clear_view(panel, _EXPIRED_SIG, "window expired")
         return
     m = _index(payload.diagnosis_metrics)
     if "step_time" not in m:
+        # No step envelope means no denominator, so every phase share
+        # would be invented. Clear rather than leave the previous ribbon
+        # and KPIs standing as if they described this window.
+        _clear_view(panel, _NO_ENVELOPE_SIG, "step envelope unavailable")
         return
 
     # A metric absent from the payload was never measured this window: it
@@ -156,7 +196,17 @@ def update_model_combined_section(
     measured = {k: v for k, v in vals.items() if v is not None}
     st = m["step_time"].summary
     missing = [key for key, value in vals.items() if value is None]
-    partial = any(key != "h2d" for key in missing)
+    # Aggregate presence is not coverage: a metric measured on rank 0 and
+    # absent on rank 1 still appears in the aggregate window, while the
+    # canonical diagnosis reports INCOMPLETE DATA for it. Re-derive
+    # coverage per rank so this card cannot claim complete data the
+    # engine is calling incomplete.
+    thin = _partially_covered(
+        getattr(payload, "per_rank_timing", None) or {},
+        [key for _, key, _ in theme.PHASES],
+    )
+    unmeasured = [key for key in missing if key not in OCCURRENCE_METRICS]
+    partial = bool(unmeasured or thin)
     # Denominator: at least the median iteration envelope (input wait +
     # step envelope), so unmeasured time shows as empty ribbon space
     # instead of stretching the measured phases to fill 100%.
@@ -173,18 +223,21 @@ def update_model_combined_section(
     # confirmed-fast one. Non-h2d unmeasured phases get a fixed hatched
     # sliver instead of a proportional width; measured phases give up
     # that width so the row still totals 100%.
-    unmeasured_non_h2d = [key for key in missing if key != "h2d"]
-    reserved_pct = _UNMEASURED_SLIVER_PCT * len(unmeasured_non_h2d)
+    reserved_pct = _UNMEASURED_SLIVER_PCT * len(unmeasured)
     measured_scale = max(0.0, (100.0 - reserved_pct) / 100.0)
 
-    sig = tuple(
-        round(vals[k], 3) if vals[k] is not None else None
-        for _, k, _ in theme.PHASES
-    ) + (
-        round(float(st.median_total or 0), 3),
-        round(float(st.worst_total or 0), 3),
-        int(st.steps_used or 0),
-        int(st.worst_rank if st.worst_rank is not None else -1),
+    sig = (
+        tuple(
+            round(vals[k], 3) if vals[k] is not None else None
+            for _, k, _ in theme.PHASES
+        )
+        + tuple(sorted(thin))
+        + (
+            round(float(st.median_total or 0), 3),
+            round(float(st.worst_total or 0), 3),
+            int(st.steps_used or 0),
+            int(st.worst_rank if st.worst_rank is not None else -1),
+        )
     )
     if panel.get("_last_sig") == sig:
         return
@@ -194,15 +247,14 @@ def update_model_combined_section(
         theme.PHASES, panel["seg_divs"], panel["seg_labs"]
     ):
         value = vals[key]
-        if key in unmeasured_non_h2d:
-            # Unmeasured non-h2d phase: a hatched sliver in the PHASE'S OWN
-            # color marks "unknown, not zero" (a dark stream must never read
-            # as confirmed-fast). The color still identifies the phase (blue
-            # = forward, gold = residual, matching the legend); the diagonal
+        if key in unmeasured:
+            # Unmeasured phase: a hatched sliver in the PHASE'S OWN color
+            # marks "unknown, not zero" (a dark stream must never read as
+            # confirmed-fast). The color still identifies the phase (blue =
+            # forward, gold = residual, matching the legend); the diagonal
             # hatch overlay is what says "unmeasured". No on-sliver text --
             # it would overlap the hatch illegibly at this width, and the
-            # window meta already names the missing phases ("partial:
-            # FWD,RESIDUAL").
+            # window meta already names the missing phases.
             seg.style(
                 f"width:{_UNMEASURED_SLIVER_PCT:.1f}%; "
                 "background:repeating-linear-gradient(45deg, "
@@ -215,7 +267,10 @@ def update_model_combined_section(
             if value is not None
             else 0.0
         )
-        seg.style(f"width:{pct:.3f}%")
+        # Always restate the background. Style updates MERGE, so a phase
+        # that was hatched while unmeasured would keep the hatch forever
+        # once it recovers if this path only set the width.
+        seg.style(f"width:{pct:.3f}%; background:{col};")
         sl.text = lab if pct >= 7.0 else ""
 
     # The verdict is intentionally NOT set here. It is owned by the diagnosis
@@ -241,10 +296,11 @@ def update_model_combined_section(
     )
     steps_text = f"{int(st.steps_used or 0)} aligned steps"
     if partial:
-        missing_labels = ",".join(
-            lab for lab, key, _c in theme.PHASES if key in unmeasured_non_h2d
+        incomplete = set(unmeasured) | set(thin)
+        labels = ",".join(
+            lab for lab, key, _c in theme.PHASES if key in incomplete
         )
-        steps_text += f" · partial: {missing_labels}"
+        steps_text += f" · partial: {labels}"
     panel["win"].text = steps_text
 
 

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
@@ -73,7 +73,7 @@ def build_model_combined_section() -> Dict[str, Any]:
                     ui.element("div").classes("legdot").style(
                         f"background:{col};"
                     )
-                    ui.label(lab)
+                    ui.label(theme.PHASE_LEGEND_LABELS.get(_key, lab))
 
         with (
             ui.row()
@@ -190,21 +190,23 @@ def update_model_combined_section(
         return
     panel["_last_sig"] = sig
 
-    for (lab, key, _c), seg, sl in zip(
+    for (lab, key, col), seg, sl in zip(
         theme.PHASES, panel["seg_divs"], panel["seg_labs"]
     ):
         value = vals[key]
         if key in unmeasured_non_h2d:
-            # Unmeasured non-h2d phase: a hatched sliver marks "unknown, not
-            # zero" (a dark stream must never read as confirmed-fast). No
-            # on-sliver text -- it would overlap the hatch illegibly at this
-            # width, and the window meta already names the missing phases
-            # ("partial: FWD,RESIDUAL") with the legend mapping position to
-            # phase.
+            # Unmeasured non-h2d phase: a hatched sliver in the PHASE'S OWN
+            # color marks "unknown, not zero" (a dark stream must never read
+            # as confirmed-fast). The color still identifies the phase (blue
+            # = forward, gold = residual, matching the legend); the diagonal
+            # hatch overlay is what says "unmeasured". No on-sliver text --
+            # it would overlap the hatch illegibly at this width, and the
+            # window meta already names the missing phases ("partial:
+            # FWD,RESIDUAL").
             seg.style(
                 f"width:{_UNMEASURED_SLIVER_PCT:.1f}%; "
                 "background:repeating-linear-gradient(45deg, "
-                "var(--muted) 0 2px, transparent 2px 5px);"
+                f"{col} 0 2px, transparent 2px 5px);"
             )
             sl.text = ""
             continue

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
@@ -23,7 +23,6 @@ from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeMetric,
     StepCombinedTimeResult,
 )
-from traceml_ai.utils.step_time_window import OCCURRENCE_METRICS
 
 from . import theme
 
@@ -36,6 +35,11 @@ _UNMEASURED_SLIVER_PCT = 6.0
 # the aggregate window (the engine emits it only when derivable), so the
 # per-rank coverage check below does not apply to it.
 _DERIVED_METRICS = frozenset(("residual_proxy",))
+
+# step_time is the envelope, not a ribbon phase, so it has no entry in
+# theme.PHASES. It still needs a name when it is the incomplete signal.
+# Matches the CLI table's abbreviation.
+_STEP_TIME_LABEL = "STEP"
 
 
 def build_model_combined_section() -> Dict[str, Any]:
@@ -124,18 +128,25 @@ def _partially_covered(
     per_rank_timing: Dict[int, Dict[str, float]],
     keys: List[str],
 ) -> List[str]:
-    """Return phases measured on some observed ranks but not all.
+    """Return signals measured on some observed ranks but not all.
 
     Mirrors the diagnosis engine's rule (a signal counts as measured only
-    when every observed rank measured it). Occurrence-driven metrics are
-    exempt, derived remainders are never carried per-rank, and with no
-    per-rank rows availability is unknowable, so nothing is reported.
+    when every observed rank measured it). Only h2d is exempt, matching
+    ``_missing_signal_report``: occurrence-driven means an absent event is
+    no observed transfer, and that is true per rank too. Derived
+    remainders are never carried per-rank, and with fewer than two ranks
+    there is nothing to compare, so nothing is reported.
+
+    ``step_time`` is checked alongside the ribbon phases even though it is
+    not one: it is the envelope every share is computed against, so a rank
+    missing it makes the window incomplete in exactly the way the engine
+    reports.
     """
     if len(per_rank_timing) < 2:
         return []
     thin: List[str] = []
     for key in keys:
-        if key in OCCURRENCE_METRICS or key in _DERIVED_METRICS:
+        if key == "h2d" or key in _DERIVED_METRICS:
             continue
         seen = sum(1 for vals in per_rank_timing.values() if key in vals)
         if 0 < seen < len(per_rank_timing):
@@ -203,9 +214,14 @@ def update_model_combined_section(
     # engine is calling incomplete.
     thin = _partially_covered(
         getattr(payload, "per_rank_timing", None) or {},
-        [key for _, key, _ in theme.PHASES],
+        [key for _, key, _ in theme.PHASES] + ["step_time"],
     )
-    unmeasured = [key for key in missing if key not in OCCURRENCE_METRICS]
+    # Only h2d is exempt. Occurrence-driven governs INTERMITTENT presence
+    # (seen at least once, gaps zero-filled); a phase never seen at all is
+    # unavailable even when it is occurrence-driven, which is what
+    # `_rank_metric_availability` does by only considering metrics it
+    # actually observed.
+    unmeasured = [key for key in missing if key != "h2d"]
     partial = bool(unmeasured or thin)
     # Denominator: at least the median iteration envelope (input wait +
     # step envelope), so unmeasured time shows as empty ribbon space
@@ -284,8 +300,15 @@ def update_model_combined_section(
     )
     k["worst"].content = theme.kval(f"{float(st.worst_total or 0):.0f}", "ms")
     k["gap"].content = theme.kval(f"{float(st.skew_pct or 0):.0f}", "%")
+    # A share needs BOTH a numerator and a trustworthy denominator.
+    # residual_proxy derives from step_time and the compute phases, so it
+    # survives an unmeasured input_wait -- but the envelope does not: it
+    # substitutes zero for the missing wait and is then short by an
+    # unknown amount. Reporting a share against it would state a confident
+    # percentage of a total we do not know.
+    denominator_is_whole = vals.get("input_wait") is not None
     residual_value = vals.get("residual_proxy")
-    if residual_value is not None and tot > 0:
+    if residual_value is not None and tot > 0 and denominator_is_whole:
         k["residual"].content = theme.kval(
             f"{residual_value / tot * 100.0:.0f}", "%"
         )
@@ -297,10 +320,14 @@ def update_model_combined_section(
     steps_text = f"{int(st.steps_used or 0)} aligned steps"
     if partial:
         incomplete = set(unmeasured) | set(thin)
-        labels = ",".join(
-            lab for lab, key, _c in theme.PHASES if key in incomplete
-        )
-        steps_text += f" · partial: {labels}"
+        names = [lab for lab, key, _c in theme.PHASES if key in incomplete]
+        # step_time has no ribbon segment, so it is not in PHASES, but it
+        # can still be the thing that is incomplete. Name it with the same
+        # abbreviation the CLI table uses rather than dropping it and
+        # printing a bare "partial:".
+        if "step_time" in incomplete:
+            names.append(_STEP_TIME_LABEL)
+        steps_text += f" · partial: {','.join(names)}"
     panel["win"].text = steps_text
 
 

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
@@ -4,8 +4,9 @@ Signature element: a phase RIBBON (selected-clock average phase proportions)
 plus a VERDICT, then a compact step-KPI strip. The ribbon recomposes as the
 bottleneck shifts.
 
-The ribbon and KPI strip are driven by StepCombinedTimeResult diagnosis
-metrics (``update_model_combined_section``). The VERDICT is NOT computed here:
+The ribbon and KPI strip are driven by the canonical StepTimeWindow carried by
+StepCombinedTimeResult (``update_model_combined_section``). The VERDICT is NOT
+computed here:
 it is taken verbatim from the diagnosis engine's step-time ``status`` via
 ``update_step_verdict`` (fed the model-diagnostics payload), so it is identical
 to the Diagnostics rail, the CLI, and final_summary, and tracks any future
@@ -15,6 +16,7 @@ own classification — interpretation belongs to the engine.
 
 from __future__ import annotations
 
+import statistics
 from typing import Any, Dict, List, Optional
 
 from nicegui import ui
@@ -23,6 +25,10 @@ from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeMetric,
     StepCombinedTimeResult,
 )
+from traceml_ai.utils.step_time_window import (
+    StepTimeWindow,
+    median_iteration_component_share,
+)
 
 from . import theme
 
@@ -30,11 +36,6 @@ from . import theme
 # large enough to read as a deliberate marker, not a rounding artifact of
 # a real proportional segment.
 _UNMEASURED_SLIVER_PCT = 6.0
-
-# Derived remainder, never carried per-rank: its availability comes from
-# the aggregate window (the engine emits it only when derivable), so the
-# per-rank coverage check below does not apply to it.
-_DERIVED_METRICS = frozenset(("residual_proxy",))
 
 # step_time is the envelope, not a ribbon phase, so it has no entry in
 # theme.PHASES. It still needs a name when it is the incomplete signal.
@@ -124,38 +125,33 @@ def _index(
     return {m.metric: m for m in metrics}
 
 
-def _partially_covered(
-    per_rank_timing: Dict[int, Dict[str, float]],
-    keys: List[str],
-) -> List[str]:
-    """Return signals measured on some observed ranks but not all.
+def _representative_rank(window: StepTimeWindow) -> Optional[int]:
+    """Choose a real median-iteration rank with a coherent phase row."""
+    present_phases = [
+        key
+        for _label, key, _color in theme.PHASES
+        if key != "h2d" and window.ranks_for(key)
+    ]
+    eligible = window.eligible_ranks(("step_time", *present_phases))
+    if not eligible:
+        return None
 
-    Mirrors the diagnosis engine's rule (a signal counts as measured only
-    when every observed rank measured it). Only h2d is exempt, matching
-    ``_missing_signal_report``: occurrence-driven means an absent event is
-    no observed transfer, and that is true per rank too. Derived
-    remainders are never carried per-rank, and with fewer than two ranks
-    there is nothing to compare, so nothing is reported.
-
-    ``step_time`` is checked alongside the ribbon phases even though it is
-    not one: it is the envelope every share is computed against, so a rank
-    missing it makes the window incomplete in exactly the way the engine
-    reports.
-    """
-    if len(per_rank_timing) < 2:
-        return []
-    thin: List[str] = []
-    for key in keys:
-        if key == "h2d" or key in _DERIVED_METRICS:
-            continue
-        seen = sum(1 for vals in per_rank_timing.values() if key in vals)
-        if 0 < seen < len(per_rank_timing):
-            thin.append(key)
-    return thin
+    anchors = {
+        rank: float(
+            window.per_rank_timing[rank].get(
+                "total_step",
+                window.per_rank_timing[rank]["step_time"],
+            )
+        )
+        for rank in eligible
+    }
+    middle = float(statistics.median(anchors.values()))
+    return min(eligible, key=lambda rank: (abs(anchors[rank] - middle), rank))
 
 
 _EXPIRED_SIG = "__expired__"
 _NO_ENVELOPE_SIG = "__no_envelope__"
+_NO_COHORT_SIG = "__no_cohort__"
 
 
 def _clear_view(panel: Dict[str, Any], sig: str, label: str) -> None:
@@ -176,58 +172,93 @@ def _clear_view(panel: Dict[str, Any], sig: str, label: str) -> None:
     panel["win"].text = label
 
 
+def _clear_ribbon(panel: Dict[str, Any], sig: str, label: str) -> None:
+    """Clear an untrustworthy composition while retaining valid KPIs."""
+    if panel.get("_last_sig") == sig:
+        return
+    panel["_last_sig"] = sig
+    for seg, sl in zip(panel["seg_divs"], panel["seg_labs"]):
+        seg.style("width:0%; background:transparent;")
+        sl.text = ""
+    panel["win"].text = label
+
+
+def _update_kpis(
+    panel: Dict[str, Any],
+    window: StepTimeWindow,
+    step_metric: StepCombinedTimeMetric,
+) -> None:
+    """Update independently valid Step Time KPI values."""
+    st = step_metric.summary
+    kpis = panel["kpis"]
+    kpis["median"].content = theme.kval(f"{st.median_total:.0f}", "ms")
+    kpis["worst"].content = theme.kval(f"{st.worst_total:.0f}", "ms")
+    kpis["gap"].content = (
+        theme.kval("n/a")
+        if st.skew_pct is None
+        else theme.kval(f"{st.skew_pct * 100.0:.0f}", "%")
+    )
+    residual_share = median_iteration_component_share(
+        window.per_rank_timing,
+        "residual_proxy",
+    )
+    kpis["residual"].content = (
+        theme.kval("n/a")
+        if residual_share is None
+        else theme.kval(f"{residual_share * 100.0:.0f}", "%")
+    )
+    kpis["rank"].content = theme.kval(
+        f"r{int(st.worst_rank)}" if st.worst_rank is not None else "—"
+    )
+
+
 def update_model_combined_section(
     panel: Dict[str, Any], payload: Optional[StepCombinedTimeResult]
 ) -> None:
-    if not payload or not getattr(payload, "diagnosis_metrics", None):
+    window = payload.window if payload is not None else None
+    if window is None or not window.metrics:
         if payload is not None and getattr(payload, "had_ok", False):
-            # Had data before, none now: the run stopped reporting and the
-            # computer's stale window expired (the CLI sibling does the
-            # same).
             _clear_view(panel, _EXPIRED_SIG, "window expired")
         return
-    m = _index(payload.diagnosis_metrics)
+    m = _index(window.metrics)
     if "step_time" not in m:
-        # No step envelope means no denominator, so every phase share
-        # would be invented. Clear rather than leave the previous ribbon
-        # and KPIs standing as if they described this window.
         _clear_view(panel, _NO_ENVELOPE_SIG, "step envelope unavailable")
         return
 
-    # A metric absent from the payload was never measured this window: it
-    # renders as an empty segment instead of freezing the whole card on
-    # the last complete view. Measured zeros stay zero-width but count as
-    # measured. H2D events are occurrence-driven (no transfers, no
-    # events), so an absent H2D counts as measured-zero, not as partial
-    # coverage.
-    vals: Dict[str, Optional[float]] = {
-        k: (float(m[k].summary.median_total or 0.0) if k in m else None)
-        for _, k, _ in theme.PHASES
-    }
-    measured = {k: v for k, v in vals.items() if v is not None}
-    st = m["step_time"].summary
-    missing = [key for key, value in vals.items() if value is None]
-    # Aggregate presence is not coverage: a metric measured on rank 0 and
-    # absent on rank 1 still appears in the aggregate window, while the
-    # canonical diagnosis reports INCOMPLETE DATA for it. Re-derive
-    # coverage per rank so this card cannot claim complete data the
-    # engine is calling incomplete.
-    thin = _partially_covered(
-        getattr(payload, "per_rank_timing", None) or {},
-        [key for _, key, _ in theme.PHASES] + ["step_time"],
-    )
-    # Only h2d is exempt. Occurrence-driven governs INTERMITTENT presence
-    # (seen at least once, gaps zero-filled); a phase never seen at all is
-    # unavailable even when it is occurrence-driven, which is what
-    # `_rank_metric_availability` does by only considering metrics it
-    # actually observed.
-    unmeasured = [key for key in missing if key != "h2d"]
-    partial = bool(unmeasured or thin)
-    # Denominator: at least the median iteration envelope (input wait +
-    # step envelope), so unmeasured time shows as empty ribbon space
-    # instead of stretching the measured phases to fill 100%.
+    step_metric = m["step_time"]
+    st = step_metric.summary
+    _update_kpis(panel, window, step_metric)
+    representative = _representative_rank(window)
+    if representative is None:
+        _clear_ribbon(
+            panel,
+            _NO_COHORT_SIG,
+            f"{int(st.steps_used)} aligned steps · no coherent phase cohort",
+        )
+        return
+
+    rank_values = window.per_rank_timing[representative]
+    vals: Dict[str, Optional[float]] = {}
+    for _label, key, _color in theme.PHASES:
+        if key == "h2d":
+            vals[key] = float(rank_values.get(key, 0.0))
+        else:
+            value = rank_values.get(key)
+            vals[key] = float(value) if value is not None else None
+
+    measured = {key: value for key, value in vals.items() if value is not None}
+    unmeasured = [
+        key for key, value in vals.items() if value is None and key != "h2d"
+    ]
+    universe_size = len(window.rank_universe)
+    partial_metrics = [
+        key
+        for key in [phase[1] for phase in theme.PHASES] + ["step_time"]
+        if key != "h2d" and 0 < len(window.ranks_for(key)) < universe_size
+    ]
+
     input_wait_value = vals.get("input_wait")
-    envelope = float(st.median_total or 0.0) + (
+    envelope = float(rank_values["step_time"]) + (
         input_wait_value if input_wait_value is not None else 0.0
     )
     tot = max(sum(measured.values()), envelope) or 1.0
@@ -247,11 +278,12 @@ def update_model_combined_section(
             round(vals[k], 3) if vals[k] is not None else None
             for _, k, _ in theme.PHASES
         )
-        + tuple(sorted(thin))
+        + tuple(sorted(partial_metrics))
         + (
-            round(float(st.median_total or 0), 3),
-            round(float(st.worst_total or 0), 3),
-            int(st.steps_used or 0),
+            representative,
+            round(float(st.median_total), 3),
+            round(float(st.worst_total), 3),
+            int(st.steps_used),
             int(st.worst_rank if st.worst_rank is not None else -1),
         )
     )
@@ -293,33 +325,10 @@ def update_model_combined_section(
     # engine and set via update_step_verdict (fed the model-diagnostics
     # payload), so the card never asserts a classification of its own.
 
-    k = panel["kpis"]
-    # Step Time metrics are already selected-clock per-step averages.
-    k["median"].content = theme.kval(
-        f"{float(st.median_total or 0):.0f}", "ms"
-    )
-    k["worst"].content = theme.kval(f"{float(st.worst_total or 0):.0f}", "ms")
-    k["gap"].content = theme.kval(f"{float(st.skew_pct or 0):.0f}", "%")
-    # A share needs BOTH a numerator and a trustworthy denominator.
-    # residual_proxy derives from step_time and the compute phases, so it
-    # survives an unmeasured input_wait -- but the envelope does not: it
-    # substitutes zero for the missing wait and is then short by an
-    # unknown amount. Reporting a share against it would state a confident
-    # percentage of a total we do not know.
-    denominator_is_whole = vals.get("input_wait") is not None
-    residual_value = vals.get("residual_proxy")
-    if residual_value is not None and tot > 0 and denominator_is_whole:
-        k["residual"].content = theme.kval(
-            f"{residual_value / tot * 100.0:.0f}", "%"
-        )
-    else:
-        k["residual"].content = theme.kval("n/a")
-    k["rank"].content = theme.kval(
-        f"r{int(st.worst_rank)}" if st.worst_rank is not None else "—"
-    )
-    steps_text = f"{int(st.steps_used or 0)} aligned steps"
-    if partial:
-        incomplete = set(unmeasured) | set(thin)
+    steps_text = f"{int(st.steps_used)} aligned steps"
+    steps_text += f" · representative r{representative}"
+    if unmeasured or partial_metrics:
+        incomplete = set(unmeasured) | set(partial_metrics)
         names = [lab for lab, key, _c in theme.PHASES if key in incomplete]
         # step_time has no ribbon segment, so it is not in PHASES, but it
         # can still be the thing that is incomplete. Name it with the same

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
@@ -121,15 +121,24 @@ def update_model_combined_section(
     # A metric absent from the payload was never measured this window: it
     # renders as an empty segment instead of freezing the whole card on
     # the last complete view. Measured zeros stay zero-width but count as
-    # measured.
+    # measured. H2D events are occurrence-driven (no transfers, no
+    # events), so an absent H2D counts as measured-zero, not as partial
+    # coverage.
     vals: Dict[str, Optional[float]] = {
         k: (float(m[k].summary.median_total or 0.0) if k in m else None)
         for _, k, _ in theme.PHASES
     }
     measured = {k: v for k, v in vals.items() if v is not None}
-    tot = sum(measured.values()) or 1.0
     st = m["step_time"].summary
-    partial = len(measured) < len(vals)
+    partial = any(value is None for key, value in vals.items() if key != "h2d")
+    # Denominator: at least the median iteration envelope (input wait +
+    # step envelope), so unmeasured time shows as empty ribbon space
+    # instead of stretching the measured phases to fill 100%.
+    input_wait_value = vals.get("input_wait")
+    envelope = float(st.median_total or 0.0) + (
+        input_wait_value if input_wait_value is not None else 0.0
+    )
+    tot = max(sum(measured.values()), envelope) or 1.0
 
     sig = tuple(
         round(vals[k], 3) if vals[k] is not None else None

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
@@ -44,6 +44,18 @@ PHASES: List[Tuple[str, str, str]] = [
     ("OPT", "optimizer_step", "#2e7d32"),
     ("RESIDUAL", "residual_proxy", "#f9a825"),
 ]
+
+# Readable names for the legend. The ribbon keeps the compact abbreviations
+# above so an inline segment label never overflows a narrow slice; the
+# legend spells them out (esp. "IW", which is not self-evident).
+PHASE_LEGEND_LABELS: Dict[str, str] = {
+    "input_wait": "Input wait",
+    "h2d": "H2D",
+    "forward": "Forward",
+    "backward": "Backward",
+    "optimizer_step": "Optimizer",
+    "residual_proxy": "Residual",
+}
 SEV = {
     "crit": "#c62828",
     "warn": "#ef6c00",

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -103,7 +103,15 @@ zero to derived metrics, and is never reported as a missing signal. Derived
 metrics exist only when their inputs are available: `compute` needs forward,
 backward, and optimizer; `total_step` needs input wait plus the step
 envelope; `residual_proxy` needs the step envelope plus every compute
-phase. The public final-summary projection preserves absence rather than
+phase.
+
+The canonical `StepTimeWindow` carries the expected rank universe and sparse
+per-rank metrics. A metric's measured-rank population and any multi-metric
+eligible cohort are derived directly from those facts. Diagnosis, reporting,
+and presentation layers must not reconstruct a separate availability policy
+from aggregate values.
+
+The public final-summary projection preserves absence rather than
 re-deriving declined values. Each rule abstains when
 its required signals are unavailable: input needs input wait + step time;
 H2D needs GPU-clock H2D + input wait + step time; compute and residual need

--- a/src/traceml_ai/diagnostics/model_diagnostics.py
+++ b/src/traceml_ai/diagnostics/model_diagnostics.py
@@ -14,6 +14,7 @@ from traceml_ai.diagnostics.step_memory import (
     build_step_memory_diagnosis,
 )
 from traceml_ai.diagnostics.step_time import build_step_diagnosis
+from traceml_ai.diagnostics.step_time.policy import LIVE_STEP_TIME_POLICY
 from traceml_ai.diagnostics.trends import (
     DEFAULT_TREND_CONFIG,
     compute_trend_pct,
@@ -21,6 +22,11 @@ from traceml_ai.diagnostics.trends import (
 from traceml_ai.loggers.error_log import get_error_logger
 from traceml_ai.renderers.step_memory.schema import StepMemoryCombinedMetric
 from traceml_ai.renderers.step_time.schema import StepCombinedTimeMetric
+from traceml_ai.utils.step_time_window import (
+    StepTimeWindow,
+    diagnose_step_time_window,
+    median_iteration_component_share,
+)
 
 Severity = str  # "info" | "warn" | "crit"
 
@@ -83,9 +89,9 @@ def _log_model_diagnostic_error(message: str, exc: Exception) -> None:
     """
     Log domain failures without breaking dashboard/runtime rendering.
 
-    Model diagnostics are advisory and run on the aggregator/UI side. A broken
-    domain should produce a fallback item and be visible in TraceML's error log,
-    but it must not blank the dashboard or interrupt the user's training job.
+    Model diagnostics are advisory and run on the aggregator/UI side. A
+    broken domain should produce a fallback item and be visible in TraceML's
+    error log, but it must not blank the dashboard or interrupt training.
     """
     try:
         get_error_logger("ModelDiagnostics").exception("[TraceML] %s", message)
@@ -95,11 +101,7 @@ def _log_model_diagnostic_error(message: str, exc: Exception) -> None:
 
 def build_model_diagnostics_payload(
     *,
-    step_time_diagnosis_metrics: Optional[
-        Sequence[StepCombinedTimeMetric]
-    ] = None,
-    step_time_per_rank_timing: Optional[Dict[int, Dict[str, float]]] = None,
-    step_time_diagnosis_clock: str = "cpu",
+    step_time_window: Optional[StepTimeWindow] = None,
     step_time_training_strategy: str = "ddp",
     step_memory_metrics: Sequence[StepMemoryCombinedMetric],
     step_memory_status_message: Optional[str] = None,
@@ -115,9 +117,7 @@ def build_model_diagnostics_payload(
     """
     items: List[ModelDiagnosisItem] = []
     context = ModelDiagnosticContext(
-        step_time_diagnosis_metrics=tuple(step_time_diagnosis_metrics or ()),
-        step_time_per_rank_timing=dict(step_time_per_rank_timing or {}),
-        step_time_diagnosis_clock=str(step_time_diagnosis_clock or "cpu"),
+        step_time_window=step_time_window,
         step_time_training_strategy=str(step_time_training_strategy or "ddp"),
         step_memory_metrics=step_memory_metrics,
         step_memory_status_message=step_memory_status_message,
@@ -155,11 +155,15 @@ def _build_step_time_item(
     context: ModelDiagnosticContext,
 ) -> ModelDiagnosisItem:
     """Build the registered step-time model diagnostic item."""
-    step_time_diag = build_step_diagnosis(
-        context.step_time_diagnosis_metrics,
-        per_rank_timing=context.step_time_per_rank_timing,
-        diagnosis_clock=context.step_time_diagnosis_clock,
-        training_strategy=context.step_time_training_strategy,
+    window = context.step_time_window
+    step_time_diag = (
+        diagnose_step_time_window(
+            window,
+            policy=LIVE_STEP_TIME_POLICY,
+            training_strategy=context.step_time_training_strategy,
+        ).primary
+        if window is not None
+        else build_step_diagnosis([])
     )
     return ModelDiagnosisItem(
         source="step_time",
@@ -176,9 +180,7 @@ def _build_step_time_item(
         ),
         steps_used=getattr(step_time_diag, "steps_used", None),
         worst_rank=getattr(step_time_diag, "worst_rank", None),
-        evidence=_build_step_time_evidence(
-            context.step_time_diagnosis_metrics
-        ),
+        evidence=_build_step_time_evidence(window),
     )
 
 
@@ -198,7 +200,8 @@ def _build_step_memory_item(
             severity="info",
             status="NO GPU",
             reason=(
-                "No GPU found. Step memory uses torch-based GPU memory telemetry."
+                "No GPU found. Step memory uses torch-based GPU memory "
+                "telemetry."
             ),
             action="",
         )
@@ -266,14 +269,15 @@ DEFAULT_MODEL_DIAGNOSTIC_REGISTRY = DiagnosticDomainRegistry(
 
 
 def _build_step_time_evidence(
-    metrics: Sequence[StepCombinedTimeMetric],
+    window: Optional[StepTimeWindow],
 ) -> Dict[str, str]:
     """
     Build compact evidence fields for the step-time diagnosis card.
     """
-    by_key = {metric.metric: metric for metric in metrics}
+    if window is None:
+        return {}
+    by_key = {metric.metric: metric for metric in window.metrics}
     step = by_key.get("step_time")
-    residual = by_key.get("residual_proxy")
 
     if step is None:
         return {}
@@ -292,21 +296,23 @@ def _build_step_time_evidence(
         pass
 
     try:
-        evidence["gap"] = f"{float(step.summary.skew_pct or 0.0) * 100.0:.1f}%"
+        skew = step.summary.skew_pct
+        evidence["gap"] = (
+            "n/a" if skew is None else f"{float(skew) * 100.0:.1f}%"
+        )
     except Exception:
         pass
 
     try:
-        median_total = float(step.summary.median_total or 0.0)
-        residual_total = (
-            float(residual.summary.median_total or 0.0)
-            if residual is not None
-            else 0.0
+        residual_share = median_iteration_component_share(
+            window.per_rank_timing,
+            "residual_proxy",
         )
-        if median_total > 0.0:
-            evidence["residual"] = (
-                f"{(residual_total / median_total) * 100.0:.1f}%"
-            )
+        evidence["residual"] = (
+            "n/a"
+            if residual_share is None
+            else f"{residual_share * 100.0:.1f}%"
+        )
     except Exception:
         pass
 

--- a/src/traceml_ai/diagnostics/registry.py
+++ b/src/traceml_ai/diagnostics/registry.py
@@ -9,12 +9,12 @@ diagnostics orchestration loop.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional, Sequence
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Sequence
 
 from traceml_ai.core.registry import Registry
 from traceml_ai.renderers.step_memory.schema import StepMemoryCombinedMetric
-from traceml_ai.renderers.step_time.schema import StepCombinedTimeMetric
+from traceml_ai.utils.step_time_window import StepTimeWindow
 
 
 @dataclass(frozen=True)
@@ -28,13 +28,7 @@ class ModelDiagnosticContext:
     """
 
     step_memory_metrics: Sequence[StepMemoryCombinedMetric]
-    step_time_diagnosis_metrics: Sequence[StepCombinedTimeMetric] = field(
-        default_factory=tuple
-    )
-    step_time_per_rank_timing: Dict[int, Dict[str, float]] = field(
-        default_factory=dict
-    )
-    step_time_diagnosis_clock: str = "cpu"
+    step_time_window: Optional[StepTimeWindow] = None
     step_time_training_strategy: str = "ddp"
     step_memory_status_message: Optional[str] = None
     gpu_total_bytes: Optional[float] = None

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Sequence, cast
 
 from traceml_ai.renderers.step_time.schema import StepCombinedTimeMetric
+from traceml_ai.utils.step_time_window import median_iteration_component_share
 
 if TYPE_CHECKING:
     from .context import StepTimeAnalysisContext
@@ -33,7 +34,6 @@ from .context import (
     metric_worst_rank,
     metric_worst_total,
     non_negative_finite,
-    share,
 )
 from .policy import DEFAULT_THRESHOLDS, DiagnosisThresholds
 from .rules import run_step_time_rules
@@ -262,12 +262,12 @@ def _top_rank_entries(
 
 def _rank_summary_values(
     rank_values: Dict[int, float],
-) -> tuple[float, float, Optional[int], float]:
+) -> tuple[float, float, Optional[int], Optional[float]]:
     """
     Return median, worst value, worst rank, and skew for rank values.
     """
     if not rank_values:
-        return 0.0, 0.0, None, 0.0
+        return 0.0, 0.0, None, None
     clean = {
         int(rank): non_negative_finite(value)
         for rank, value in rank_values.items()
@@ -280,8 +280,20 @@ def _rank_summary_values(
         median = float((ordered[mid - 1] + ordered[mid]) / 2.0)
     worst_rank = max(clean, key=lambda rank: (clean[rank], -int(rank)))
     worst = clean[worst_rank]
-    skew = ((worst - median) / median) if median > 0.0 else 0.0
-    return median, worst, int(worst_rank), max(0.0, skew)
+    if len(clean) < 2:
+        skew = None
+    elif median > 0.0:
+        skew = (worst - median) / median
+    elif worst <= 0.0:
+        skew = 0.0
+    else:
+        skew = None
+    return (
+        median,
+        worst,
+        int(worst_rank),
+        max(0.0, skew) if skew is not None else None,
+    )
 
 
 def _metric_attribution_entry(
@@ -289,7 +301,7 @@ def _metric_attribution_entry(
     metric: Optional[StepCombinedTimeMetric],
     metric_key: str,
     rank_values: Dict[int, float],
-    step_total: float,
+    component_share: Optional[float],
     single_rank: bool,
     phase: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -303,9 +315,7 @@ def _metric_attribution_entry(
         "worst_total_ms": metric_worst_total(metric),
         "worst_rank": metric_worst_rank(metric),
         "skew_pct": metric_skew(metric, single_rank=single_rank),
-        "share_pct": share(
-            metric_total(metric, single_rank=single_rank), step_total
-        ),
+        "share_pct": component_share,
         "top_ranks": _top_rank_entries(rank_values),
     }
 
@@ -317,8 +327,8 @@ def _apply_trend_note(
     residual_metric: Optional[StepCombinedTimeMetric],
     input_wait_metric: Optional[StepCombinedTimeMetric],
     single_rank: bool,
-    residual_share: float,
-    input_bound_share: float,
+    residual_share: Optional[float],
+    input_bound_share: Optional[float],
     thresholds: DiagnosisThresholds,
 ) -> StepDiagnosis:
     """
@@ -360,13 +370,14 @@ def _missing_signal_report(
     """Return missing-signal names plus per-signal rank coverage.
 
     A signal is reported when an abstaining rule required it and it was
-    not measured on every observed rank. H2D is never reported missing:
+    not measured on every expected rank. A rank with no aligned timing row
+    is missing every required signal. H2D is never reported missing:
     its events are occurrence-driven (a fully instrumented run with no
     host-to-device copies emits none), so absence means no observed
     transfers, not missing instrumentation. Without per-rank rows,
     availability is unknowable, so nothing is reported missing either.
     """
-    ranks = max(0, int(context.ranks_observed))
+    ranks = max(0, int(context.rank_population_size))
     if ranks == 0:
         return [], {}
     counts = context.signal_rank_counts or {}
@@ -374,6 +385,9 @@ def _missing_signal_report(
 
     def _require(signals: Sequence[str]) -> None:
         needed.update(signals)
+
+    if context.ranks_with_rows < ranks:
+        _require(_MISSING_SIGNAL_ORDER)
 
     if context.input_bound_share is None:
         _require(("input_wait", "step_time"))
@@ -420,6 +434,7 @@ def build_step_diagnosis_result(
     thresholds: DiagnosisThresholds = DEFAULT_THRESHOLDS,
     *,
     per_rank_timing: Optional[Dict[int, Dict[str, float]]] = None,
+    expected_ranks: Optional[Sequence[int]] = None,
     diagnosis_clock: str = "cpu",
     training_strategy: str = "ddp",
 ) -> DiagnosticResult[StepDiagnosis]:
@@ -484,6 +499,7 @@ def build_step_diagnosis_result(
         metrics=metrics,
         thresholds=thresholds,
         per_rank_timing=per_rank_timing,
+        expected_ranks=expected_ranks,
         diagnosis_clock=diagnosis_clock,
         training_strategy=training_strategy,
     )
@@ -609,8 +625,8 @@ def build_step_diagnosis_result(
         residual_metric=context.residual_metric,
         input_wait_metric=context.input_wait_metric,
         single_rank=context.single_rank,
-        residual_share=context.residual_share or 0.0,
-        input_bound_share=context.input_bound_share or 0.0,
+        residual_share=context.residual_share,
+        input_bound_share=context.input_bound_share,
         thresholds=thresholds,
     )
 
@@ -644,13 +660,26 @@ def build_step_diagnosis_result(
         compute_worst_rank,
         compute_skew,
     ) = _rank_summary_values(compute_rank_values)
+    timing = per_rank_timing or {}
+    attribution_shares = {
+        key: median_iteration_component_share(timing, key)
+        for key in (
+            "input_wait",
+            "h2d",
+            "forward",
+            "backward",
+            "optimizer_step",
+            "residual_proxy",
+            "step_time",
+        )
+    }
 
     metric_attribution = {
         "input_wait": _metric_attribution_entry(
             metric=context.input_wait_metric,
             metric_key="input_wait",
             rank_values=context.rank_values.get("input_wait", {}),
-            step_total=context.step_total,
+            component_share=attribution_shares["input_wait"],
             single_rank=context.single_rank,
             phase="input",
         ),
@@ -658,7 +687,7 @@ def build_step_diagnosis_result(
             metric=context.h2d_metric,
             metric_key="h2d",
             rank_values=context.rank_values.get("h2d", {}),
-            step_total=context.step_total,
+            component_share=attribution_shares["h2d"],
             single_rank=context.single_rank,
             phase="h2d",
         ),
@@ -666,7 +695,7 @@ def build_step_diagnosis_result(
             metric=context.forward_metric,
             metric_key="forward",
             rank_values=context.rank_values.get("forward", {}),
-            step_total=context.step_total,
+            component_share=attribution_shares["forward"],
             single_rank=context.single_rank,
             phase="forward",
         ),
@@ -674,7 +703,7 @@ def build_step_diagnosis_result(
             metric=context.backward_metric,
             metric_key="backward",
             rank_values=context.rank_values.get("backward", {}),
-            step_total=context.step_total,
+            component_share=attribution_shares["backward"],
             single_rank=context.single_rank,
             phase="backward",
         ),
@@ -682,7 +711,7 @@ def build_step_diagnosis_result(
             metric=context.optimizer_metric,
             metric_key="optimizer_step",
             rank_values=context.rank_values.get("optimizer_step", {}),
-            step_total=context.step_total,
+            component_share=attribution_shares["optimizer_step"],
             single_rank=context.single_rank,
             phase="optimizer",
         ),
@@ -690,7 +719,7 @@ def build_step_diagnosis_result(
             metric=context.residual_metric,
             metric_key="residual_proxy",
             rank_values=context.rank_values.get("residual_proxy", {}),
-            step_total=context.step_total,
+            component_share=attribution_shares["residual_proxy"],
             single_rank=context.single_rank,
             phase="residual",
         ),
@@ -698,7 +727,7 @@ def build_step_diagnosis_result(
             metric=context.step_metric,
             metric_key="step_time",
             rank_values=context.rank_values.get("step_time", {}),
-            step_total=context.step_total,
+            component_share=attribution_shares["step_time"],
             single_rank=context.single_rank,
             phase="step",
         ),
@@ -709,7 +738,7 @@ def build_step_diagnosis_result(
             "worst_total_ms": compute_worst_ms,
             "worst_rank": compute_worst_rank,
             "skew_pct": compute_skew,
-            "share_pct": share(compute_median_ms, context.step_total),
+            "share_pct": context.compute_share,
             "top_ranks": _top_rank_entries(compute_rank_values),
         },
     }
@@ -726,6 +755,7 @@ def build_step_diagnosis(
     thresholds: DiagnosisThresholds = DEFAULT_THRESHOLDS,
     *,
     per_rank_timing: Optional[Dict[int, Dict[str, float]]] = None,
+    expected_ranks: Optional[Sequence[int]] = None,
     diagnosis_clock: str = "cpu",
     training_strategy: str = "ddp",
 ) -> StepDiagnosis:
@@ -739,12 +769,14 @@ def build_step_diagnosis(
         metrics,
         thresholds=thresholds,
         per_rank_timing=per_rank_timing,
+        expected_ranks=expected_ranks,
         diagnosis_clock=diagnosis_clock,
         training_strategy=training_strategy,
     ).primary
     if not isinstance(primary, StepDiagnosis):
         raise TypeError(
-            "build_step_diagnosis_result() must return StepDiagnosis as primary"
+            "build_step_diagnosis_result() must return StepDiagnosis "
+            "as primary"
         )
     return primary
 

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -13,10 +13,13 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Dict, Mapping, Optional, Sequence, Tuple
 
 from traceml_ai.renderers.step_time.schema import StepCombinedTimeMetric
-from traceml_ai.utils.step_time_window import worst_rank_by_total_step
+from traceml_ai.utils.step_time_window import (
+    median_iteration_component_share,
+    worst_rank_by_total_step,
+)
 from traceml_ai.utils.training_strategy import normalize_training_strategy
 
 if TYPE_CHECKING:
@@ -32,7 +35,7 @@ class ComputeSignal:
 
     label: str
     share: float
-    skew: float
+    skew: Optional[float]
     median_ms: float
     worst_ms: float
     excess_ms: float
@@ -118,8 +121,8 @@ class StepTimeAnalysisContext:
     input_bound_share: Optional[float]
     h2d_share: Optional[float]
 
-    input_bound_skew: float
-    compute_skew: float
+    input_bound_skew: Optional[float]
+    compute_skew: Optional[float]
     input_bound_worst_rank: Optional[int]
     diagnosis_clock: str
     input_wait_total: float
@@ -131,7 +134,8 @@ class StepTimeAnalysisContext:
     rank_values: Dict[str, Dict[int, float]]
     rank_straggler: Optional[_RankStragglerEvidence]
 
-    ranks_observed: int = 0
+    rank_population_size: int = 0
+    ranks_with_rows: int = 0
     signal_rank_counts: Dict[str, int] = field(default_factory=dict)
     straggler_eligible_ranks: int = 0
 
@@ -230,12 +234,14 @@ def metric_skew(
     metric: Optional[StepCombinedTimeMetric],
     *,
     single_rank: bool,
-) -> float:
+) -> Optional[float]:
     """
-    Return cross-rank skew for multi-rank runs, else 0.
+    Return cross-rank skew, or ``None`` without two measured ranks.
     """
     if metric is None or single_rank:
-        return 0.0
+        return None
+    if metric.summary.skew_pct is None:
+        return None
     return non_negative_finite(metric.summary.skew_pct)
 
 
@@ -492,11 +498,65 @@ def largest_compute_phase(
     optimizer: Optional[StepCombinedTimeMetric],
     step_total: float,
     single_rank: bool,
+    per_rank_timing: Optional[Mapping[int, Mapping[str, float]]] = None,
 ) -> Optional[ComputeSignal]:
     """
-    Pick the compute component with the largest typical share.
+    Pick the largest compute component from one coherent rank cohort.
+
+    When per-rank timing is available, every compared phase uses the same
+    ranks carrying all compute components plus the iteration envelope. The
+    aggregate-metric fallback exists only for legacy callers without rank rows.
     """
     candidates: list[ComputeSignal] = []
+
+    if per_rank_timing is not None:
+        required = {
+            "input_wait",
+            "step_time",
+            "forward",
+            "backward",
+            "optimizer_step",
+        }
+        cohort = {
+            int(rank): values
+            for rank, values in per_rank_timing.items()
+            if required.issubset(values)
+        }
+        if not cohort:
+            return None
+        iteration_total = _median(
+            tuple(
+                non_negative_finite(values["input_wait"])
+                + non_negative_finite(values["step_time"])
+                for values in cohort.values()
+            )
+        )
+        for label, key in (
+            ("Forward", "forward"),
+            ("Backward", "backward"),
+            ("Optimizer", "optimizer_step"),
+        ):
+            phase_values = {
+                rank: non_negative_finite(values[key])
+                for rank, values in cohort.items()
+            }
+            median, worst, worst_rank, excess = _rank_stats(phase_values)
+            if median <= 0.0:
+                continue
+            candidates.append(
+                ComputeSignal(
+                    label=label,
+                    share=share(median, iteration_total),
+                    skew=(excess / median if len(phase_values) >= 2 else None),
+                    median_ms=median,
+                    worst_ms=worst,
+                    excess_ms=excess,
+                    worst_rank=worst_rank,
+                )
+            )
+        if not candidates:
+            return None
+        return max(candidates, key=lambda item: item.median_ms)
 
     for label, metric in (
         ("Forward", forward),
@@ -569,41 +629,12 @@ def compute_rank_values_from_components(
     return out
 
 
-def _median_iteration_component_share(
-    per_rank_timing: Dict[int, Dict[str, float]],
-    component: str,
-) -> Optional[float]:
-    """Return the median selected-clock iteration share for one component.
-
-    Returns ``None`` when no rank measured the component together with
-    its iteration anchors; a measured-zero share stays ``0.0`` so rules
-    can distinguish "signal absent" from "signal present and small".
-    """
-    shares = []
-    for values in per_rank_timing.values():
-        if not {
-            "input_wait",
-            "step_time",
-            component,
-        }.issubset(values):
-            continue
-        iteration = non_negative_finite(
-            values["input_wait"]
-        ) + non_negative_finite(values["step_time"])
-        if iteration > 0.0:
-            shares.append(
-                share(non_negative_finite(values[component]), iteration)
-            )
-    if not shares:
-        return None
-    return _median(shares)
-
-
 def build_step_time_context(
     *,
     metrics: Sequence[StepCombinedTimeMetric],
     thresholds: "DiagnosisThresholds",
     per_rank_timing: Optional[Dict[int, Dict[str, float]]] = None,
+    expected_ranks: Optional[Sequence[int]] = None,
     diagnosis_clock: str = "cpu",
     training_strategy: str = "ddp",
 ) -> StepTimeAnalysisContext:
@@ -646,6 +677,7 @@ def build_step_time_context(
         optimizer=optimizer_metric,
         step_total=step_total,
         single_rank=single_rank,
+        per_rank_timing=per_rank_timing,
     )
 
     rank_values = {
@@ -712,11 +744,12 @@ def build_step_time_context(
         input_step_worst if single_rank else input_step_median
     )
     iteration_time_total = input_wait_total + input_bound_step_total
-    input_bound_skew = (
-        0.0
-        if single_rank or input_wait_median <= 0.0
-        else input_slack / input_wait_median
-    )
+    input_bound_skew = None
+    if len(input_wait_rank_values) >= 2:
+        if input_wait_median > 0.0:
+            input_bound_skew = input_slack / input_wait_median
+        elif input_wait_worst <= 0.0:
+            input_bound_skew = 0.0
     rank_straggler, straggler_eligible_ranks = _build_rank_straggler_evidence(
         per_rank_timing=local_per_rank_timing,
         score_threshold=thresholds.straggler_score_warn,
@@ -740,9 +773,12 @@ def build_step_time_context(
     }
     compute_rank_values = compute_rank_values_from_components(rank_values)
     _compute_median, _, _, _compute_slack = _rank_stats(compute_rank_values)
-    compute_skew_value = (
-        (_compute_slack / _compute_median) if _compute_median > 0.0 else 0.0
-    )
+    compute_skew_value = None
+    if len(compute_rank_values) >= 2:
+        if _compute_median > 0.0:
+            compute_skew_value = _compute_slack / _compute_median
+        elif max(compute_rank_values.values(), default=0.0) <= 0.0:
+            compute_skew_value = 0.0
 
     return StepTimeAnalysisContext(
         thresholds=thresholds,
@@ -760,19 +796,19 @@ def build_step_time_context(
         step_total=step_total,
         residual_total=residual_total,
         compute_total=compute_total_value,
-        residual_share=_median_iteration_component_share(
+        residual_share=median_iteration_component_share(
             local_per_rank_timing,
             "residual_proxy",
         ),
-        compute_share=_median_iteration_component_share(
+        compute_share=median_iteration_component_share(
             local_per_rank_timing,
             "compute",
         ),
-        input_bound_share=_median_iteration_component_share(
+        input_bound_share=median_iteration_component_share(
             local_per_rank_timing,
             "input_wait",
         ),
-        h2d_share=_median_iteration_component_share(
+        h2d_share=median_iteration_component_share(
             local_per_rank_timing,
             "h2d",
         ),
@@ -788,7 +824,12 @@ def build_step_time_context(
         largest_compute=largest_compute,
         rank_values=rank_values,
         rank_straggler=rank_straggler,
-        ranks_observed=len(local_per_rank_timing),
+        rank_population_size=(
+            len({int(rank) for rank in expected_ranks})
+            if expected_ranks is not None
+            else len(local_per_rank_timing)
+        ),
+        ranks_with_rows=len(local_per_rank_timing),
         signal_rank_counts=signal_rank_counts,
         straggler_eligible_ranks=straggler_eligible_ranks,
     )

--- a/src/traceml_ai/diagnostics/step_time/trend.py
+++ b/src/traceml_ai/diagnostics/step_time/trend.py
@@ -72,8 +72,8 @@ def build_step_trend_note(
     step_metric: Optional[StepCombinedTimeMetric],
     residual_metric: Optional[StepCombinedTimeMetric],
     input_wait_metric: Optional[StepCombinedTimeMetric],
-    residual_share: float,
-    input_bound_share: float,
+    residual_share: Optional[float],
+    input_bound_share: Optional[float],
     residual_warn_threshold: float,
     input_warn_threshold: float,
     cfg: StepTrendHeuristicConfig = DEFAULT_STEP_TREND_HEURISTICS,
@@ -99,15 +99,21 @@ def build_step_trend_note(
         residual_state = _trend_state(residual_tr, cfg=cfg)
         input_wait_state = _trend_state(input_wait_tr, cfg=cfg)
 
+        if diagnosis_kind in {"INPUT_BOUND", "INPUT_STRAGGLER"}:
+            if input_bound_share is None:
+                return None
+        if diagnosis_kind == "RESIDUAL_HEAVY" and residual_share is None:
+            return None
+
         if (
             diagnosis_kind in {"INPUT_BOUND", "INPUT_STRAGGLER"}
             and input_wait_state
         ):
-            return (
-                "Trend: input wait is "
-                f"{input_wait_state} "
-                f"({format_trend_pct(input_wait_tr, deadband_pct=cfg.deadband_pct)})."
+            formatted = format_trend_pct(
+                input_wait_tr,
+                deadband_pct=cfg.deadband_pct,
             )
+            return "Trend: input wait is " f"{input_wait_state} ({formatted})."
 
         if (
             diagnosis_kind
@@ -119,22 +125,28 @@ def build_step_trend_note(
             }
             and step_state
         ):
-            return (
-                "Trend: step time is "
-                f"{step_state} ({format_trend_pct(step_tr, deadband_pct=cfg.deadband_pct)})."
+            formatted = format_trend_pct(
+                step_tr,
+                deadband_pct=cfg.deadband_pct,
             )
+            return f"Trend: step time is {step_state} ({formatted})."
 
         if diagnosis_kind == "RESIDUAL_HEAVY" and residual_state:
+            formatted = format_trend_pct(
+                residual_tr,
+                deadband_pct=cfg.deadband_pct,
+            )
             return (
-                "Trend: residual time is "
-                f"{residual_state} ({format_trend_pct(residual_tr, deadband_pct=cfg.deadband_pct)})."
+                "Trend: residual time is " f"{residual_state} ({formatted})."
             )
 
-        near_residual_warn = residual_share >= (
+        near_residual_warn = residual_share is not None and residual_share >= (
             residual_warn_threshold * cfg.near_warn_fraction
         )
-        near_input_warn = input_bound_share >= (
-            input_warn_threshold * cfg.near_warn_fraction
+        near_input_warn = (
+            input_bound_share is not None
+            and input_bound_share
+            >= input_warn_threshold * cfg.near_warn_fraction
         )
 
         if (
@@ -142,10 +154,11 @@ def build_step_trend_note(
             and step_state == "worsening"
             and (near_residual_warn or near_input_warn)
         ):
-            return (
-                "Trend: step time is rising "
-                f"({format_trend_pct(step_tr, deadband_pct=cfg.deadband_pct)})."
+            formatted = format_trend_pct(
+                step_tr,
+                deadband_pct=cfg.deadband_pct,
             )
+            return f"Trend: step time is rising ({formatted})."
 
         return None
     except Exception:

--- a/src/traceml_ai/renderers/model_diagnostics/renderer.py
+++ b/src/traceml_ai/renderers/model_diagnostics/renderer.py
@@ -64,9 +64,7 @@ class ModelDiagnosticsRenderer(BaseRenderer):
             step_memory = self._step_memory.compute_dashboard()
 
             payload: ModelDiagnosticsPayload = build_model_diagnostics_payload(
-                step_time_diagnosis_metrics=step_time.diagnosis_metrics,
-                step_time_per_rank_timing=step_time.per_rank_timing,
-                step_time_diagnosis_clock=step_time.diagnosis_clock,
+                step_time_window=step_time.window,
                 step_time_training_strategy=step_time.training_strategy,
                 step_memory_metrics=step_memory.metrics,
                 step_memory_status_message=step_memory.status_message,

--- a/src/traceml_ai/renderers/step_time/compute.py
+++ b/src/traceml_ai/renderers/step_time/compute.py
@@ -1,5 +1,6 @@
 import sqlite3
 import time
+from dataclasses import replace
 from typing import Dict, Optional, Sequence
 
 from traceml_ai.loggers.error_log import get_error_logger
@@ -77,7 +78,7 @@ class StepCombinedComputer:
 
         self._last_ok = result
         self._last_ok_ts = time.time()
-        return result
+        return replace(result, had_ok=True)
 
     # ------------------------------------------------------------------
     # Core compute
@@ -148,6 +149,7 @@ class StepCombinedComputer:
 
     def _stale_or_empty(self, msg: str) -> StepCombinedTimeResult:
         now = time.time()
+        had_ok = self._last_ok is not None
         if self._last_ok is not None:
             if (
                 self._stale_ttl_s is None
@@ -159,12 +161,14 @@ class StepCombinedComputer:
                     diagnosis_clock=self._last_ok.diagnosis_clock,
                     training_strategy=self._last_ok.training_strategy,
                     diagnosis_metrics=self._last_ok.diagnosis_metrics,
+                    had_ok=True,
                 )
         return StepCombinedTimeResult(
             status_message="No fresh step-combined data",
             per_rank_timing={},
             diagnosis_clock="cpu",
             diagnosis_metrics=[],
+            had_ok=had_ok,
         )
 
 

--- a/src/traceml_ai/renderers/step_time/compute.py
+++ b/src/traceml_ai/renderers/step_time/compute.py
@@ -15,8 +15,8 @@ class StepCombinedComputer:
     Compute selected-clock Step Time diagnosis payloads from SQLite.
 
     Live delegates global-rank SQLite loading to the shared Step Time window
-    loader, then adds CLI/dashboard-specific stale handling and status text.
-    The output remains rank-shaped for existing UI and diagnosis consumers.
+    loader, then adds CLI/dashboard-specific empty-read bridging and status
+    text. Consumers receive that canonical window without copied metrics.
     """
 
     def __init__(
@@ -42,13 +42,6 @@ class StepCombinedComputer:
         self._stale_ttl_s = (
             float(stale_ttl_s) if stale_ttl_s is not None else None
         )
-        # Source-freshness cursor. SQLite rows outlive the process that
-        # wrote them, so a successful recompute proves only that rows
-        # exist, never that the run is alive. Liveness is an ADVANCING
-        # cursor; without this, a dead run recomputes the same window
-        # forever and the stale path never fires.
-        self._last_cursor: Optional[int] = None
-        self._last_advance_ts = time.time()
 
     # ------------------------------------------------------------------
     # Public API
@@ -64,9 +57,9 @@ class StepCombinedComputer:
     def had_ok(self) -> bool:
         """Whether any compute ever produced diagnosis metrics.
 
-        Lets renderers distinguish "no data yet" (calm waiting state)
-        from "had data, now expired" (the run died) when a compute
-        returns empty metrics.
+        Lets renderers distinguish "no data yet" from an expired last-good
+        bridge after repeated empty computes. It does not claim process
+        liveness.
         """
         return self._last_ok is not None
 
@@ -80,30 +73,10 @@ class StepCombinedComputer:
                 f"STALE (exception: {type(exc).__name__})"
             )
 
-        if not result.diagnosis_metrics:
+        if result.window is None or not result.window.metrics:
             return self._stale_or_empty("STALE (no metrics this tick)")
 
         now = time.time()
-        cursor = _window_cursor(result)
-        if cursor is not None and cursor == self._last_cursor:
-            # Rows are present but the window has not advanced: the
-            # producer may have stopped. Recomputing the same rows is not
-            # liveness, so age the view against the last real advance.
-            if (
-                self._stale_ttl_s is not None
-                and (now - self._last_advance_ts) > self._stale_ttl_s
-            ):
-                return StepCombinedTimeResult(
-                    status_message="No fresh step-combined data",
-                    per_rank_timing={},
-                    diagnosis_clock="cpu",
-                    diagnosis_metrics=[],
-                    had_ok=True,
-                )
-        elif cursor is not None:
-            self._last_cursor = cursor
-            self._last_advance_ts = now
-
         self._last_ok = result
         self._last_ok_ts = now
         return replace(result, had_ok=True)
@@ -150,10 +123,8 @@ class StepCombinedComputer:
 
         return StepCombinedTimeResult(
             status_message=status,
-            per_rank_timing=window.per_rank_timing,
-            diagnosis_clock=window.clock,
+            window=window,
             training_strategy=loaded.training_strategy,
-            diagnosis_metrics=window.metrics,
         )
 
     # ------------------------------------------------------------------
@@ -176,6 +147,7 @@ class StepCombinedComputer:
     # ------------------------------------------------------------------
 
     def _stale_or_empty(self, msg: str) -> StepCombinedTimeResult:
+        """Bridge transient empty reads without inferring producer liveness."""
         now = time.time()
         had_ok = self._last_ok is not None
         if self._last_ok is not None:
@@ -185,34 +157,14 @@ class StepCombinedComputer:
             ):
                 return StepCombinedTimeResult(
                     status_message=msg,
-                    per_rank_timing=self._last_ok.per_rank_timing,
-                    diagnosis_clock=self._last_ok.diagnosis_clock,
+                    window=self._last_ok.window,
                     training_strategy=self._last_ok.training_strategy,
-                    diagnosis_metrics=self._last_ok.diagnosis_metrics,
                     had_ok=True,
                 )
         return StepCombinedTimeResult(
             status_message="No fresh step-combined data",
-            per_rank_timing={},
-            diagnosis_clock="cpu",
-            diagnosis_metrics=[],
             had_ok=had_ok,
         )
-
-
-def _window_cursor(result: StepCombinedTimeResult) -> Optional[int]:
-    """Highest completed step in this window, or None if unknowable.
-
-    Monotonic marker of how far the producer has actually got. Used to
-    tell "the run is alive" from "the rows it already wrote are still on
-    disk", which a successful recompute alone cannot distinguish.
-    """
-    steps = [
-        int(metric.coverage.completed_step)
-        for metric in result.diagnosis_metrics
-        if metric.coverage is not None
-    ]
-    return max(steps) if steps else None
 
 
 def _worst_rank_from_window(

--- a/src/traceml_ai/renderers/step_time/compute.py
+++ b/src/traceml_ai/renderers/step_time/compute.py
@@ -52,6 +52,16 @@ class StepCombinedComputer:
     def compute_dashboard(self) -> StepCombinedTimeResult:
         return self._compute()
 
+    @property
+    def had_ok(self) -> bool:
+        """Whether any compute ever produced diagnosis metrics.
+
+        Lets renderers distinguish "no data yet" (calm waiting state)
+        from "had data, now expired" (the run died) when a compute
+        returns empty metrics.
+        """
+        return self._last_ok is not None
+
     def _compute(self) -> StepCombinedTimeResult:
         try:
             with self._connect() as conn:

--- a/src/traceml_ai/renderers/step_time/compute.py
+++ b/src/traceml_ai/renderers/step_time/compute.py
@@ -42,6 +42,13 @@ class StepCombinedComputer:
         self._stale_ttl_s = (
             float(stale_ttl_s) if stale_ttl_s is not None else None
         )
+        # Source-freshness cursor. SQLite rows outlive the process that
+        # wrote them, so a successful recompute proves only that rows
+        # exist, never that the run is alive. Liveness is an ADVANCING
+        # cursor; without this, a dead run recomputes the same window
+        # forever and the stale path never fires.
+        self._last_cursor: Optional[int] = None
+        self._last_advance_ts = time.time()
 
     # ------------------------------------------------------------------
     # Public API
@@ -76,8 +83,29 @@ class StepCombinedComputer:
         if not result.diagnosis_metrics:
             return self._stale_or_empty("STALE (no metrics this tick)")
 
+        now = time.time()
+        cursor = _window_cursor(result)
+        if cursor is not None and cursor == self._last_cursor:
+            # Rows are present but the window has not advanced: the
+            # producer may have stopped. Recomputing the same rows is not
+            # liveness, so age the view against the last real advance.
+            if (
+                self._stale_ttl_s is not None
+                and (now - self._last_advance_ts) > self._stale_ttl_s
+            ):
+                return StepCombinedTimeResult(
+                    status_message="No fresh step-combined data",
+                    per_rank_timing={},
+                    diagnosis_clock="cpu",
+                    diagnosis_metrics=[],
+                    had_ok=True,
+                )
+        elif cursor is not None:
+            self._last_cursor = cursor
+            self._last_advance_ts = now
+
         self._last_ok = result
-        self._last_ok_ts = time.time()
+        self._last_ok_ts = now
         return replace(result, had_ok=True)
 
     # ------------------------------------------------------------------
@@ -170,6 +198,21 @@ class StepCombinedComputer:
             diagnosis_metrics=[],
             had_ok=had_ok,
         )
+
+
+def _window_cursor(result: StepCombinedTimeResult) -> Optional[int]:
+    """Highest completed step in this window, or None if unknowable.
+
+    Monotonic marker of how far the producer has actually got. Used to
+    tell "the run is alive" from "the rows it already wrote are still on
+    disk", which a successful recompute alone cannot distinguish.
+    """
+    steps = [
+        int(metric.coverage.completed_step)
+        for metric in result.diagnosis_metrics
+        if metric.coverage is not None
+    ]
+    return max(steps) if steps else None
 
 
 def _worst_rank_from_window(

--- a/src/traceml_ai/renderers/step_time/renderer.py
+++ b/src/traceml_ai/renderers/step_time/renderer.py
@@ -11,7 +11,6 @@ Behavior:
 
 import math
 import shutil
-from typing import Optional
 
 from rich.console import Group
 from rich.panel import Panel
@@ -67,7 +66,7 @@ class StepCombinedRenderer(BaseRenderer):
         )
         self._computer = StepCombinedComputer(db_path=db_path)
 
-    def _payload(self) -> Optional[StepCombinedTimeResult]:
+    def _payload(self) -> StepCombinedTimeResult:
         """
         CLI compute is summary-only (cheap).
 
@@ -80,7 +79,9 @@ class StepCombinedRenderer(BaseRenderer):
     def get_panel_renderable(self) -> Panel:
         payload = self._payload()
 
-        if payload is None:
+        if not payload.diagnosis_metrics and not self._computer.had_ok:
+            # Never had data: normal warm-up, keep the calm waiting state
+            # instead of alarming with a NO DATA diagnosis.
             return Panel(
                 "Waiting for first fully completed step across all ranks…",
                 title="Model Step Summary",
@@ -97,11 +98,13 @@ class StepCombinedRenderer(BaseRenderer):
         metrics = _table_metrics(payload.diagnosis_metrics)
 
         if not metrics:
+            # Had data before, none now: the run stopped reporting and
+            # the computer's stale window expired.
             return Panel(
                 Group(
                     diag_text,
                     "",
-                    "Waiting for selected step-time diagnosis metrics…",
+                    "No fresh step timing; the last window expired.",
                 ),
                 title="Model Step Summary",
                 border_style="cyan",

--- a/src/traceml_ai/renderers/step_time/renderer.py
+++ b/src/traceml_ai/renderers/step_time/renderer.py
@@ -29,6 +29,10 @@ from traceml_ai.diagnostics.trends import (
 )
 from traceml_ai.renderers.base_renderer import BaseRenderer
 from traceml_ai.renderers.utils import fmt_time_run
+from traceml_ai.utils.step_time_window import (
+    diagnose_step_time_window,
+    median_iteration_component_share,
+)
 
 from .compute import StepCombinedComputer
 from .schema import StepCombinedTimeMetric, StepCombinedTimeResult
@@ -70,16 +74,18 @@ class StepCombinedRenderer(BaseRenderer):
         """
         CLI compute is summary-only (cheap).
 
-        The computer already bridges transient gaps from its own last-ok
-        window; once that expires the empty result is rendered as-is so a
-        dead run can never keep showing its last complete table.
+        The computer bridges transient empty reads from its own last-ok
+        window. Persisted rows are not treated as proof of producer liveness.
         """
         return self._computer.compute_cli()
 
     def get_panel_renderable(self) -> Panel:
         payload = self._payload()
 
-        if not payload.diagnosis_metrics and not self._computer.had_ok:
+        window = payload.window
+        if (
+            window is None or not window.metrics
+        ) and not self._computer.had_ok:
             # Never had data: normal warm-up, keep the calm waiting state
             # instead of alarming with a NO DATA diagnosis.
             return Panel(
@@ -87,19 +93,21 @@ class StepCombinedRenderer(BaseRenderer):
                 title="Model Step Summary",
             )
 
-        diag = build_step_diagnosis(
-            payload.diagnosis_metrics,
-            thresholds=LIVE_STEP_TIME_POLICY.thresholds,
-            per_rank_timing=payload.per_rank_timing,
-            diagnosis_clock=payload.diagnosis_clock,
-            training_strategy=payload.training_strategy,
+        diag = (
+            diagnose_step_time_window(
+                window,
+                policy=LIVE_STEP_TIME_POLICY,
+                training_strategy=payload.training_strategy,
+            ).primary
+            if window is not None
+            else build_step_diagnosis([])
         )
         diag_text = format_cli_diagnosis(diag)
-        metrics = _table_metrics(payload.diagnosis_metrics)
+        metrics = _table_metrics(window.metrics if window is not None else [])
 
         if not metrics:
-            # Had data before, none now: the run stopped reporting and
-            # the computer's stale window expired.
+            # Had data before, none now: the last-good empty-read bridge
+            # expired.
             return Panel(
                 Group(
                     diag_text,
@@ -177,7 +185,7 @@ class StepCombinedRenderer(BaseRenderer):
             )
             table.add_row(
                 "Skew (%)",
-                *[f"+{m.summary.skew_pct * 100:.1f}%" for m in metrics],
+                *[_format_skew(m.summary.skew_pct) for m in metrics],
             )
 
         table.add_row("")
@@ -191,27 +199,20 @@ class StepCombinedRenderer(BaseRenderer):
             table.add_row("")
 
         # Optional residual share line (still meaningful in both modes)
-        if (
-            step_metric
-            and residual_metric
-            and step_metric.summary.worst_total > 0
-        ):
-            denom = (
-                step_metric.summary.median_total
-                if not single_rank
-                else step_metric.summary.worst_total
+        if step_metric and residual_metric and window is not None:
+            residual_share = median_iteration_component_share(
+                window.per_rank_timing,
+                "residual_proxy",
             )
-            residual_share = (
-                residual_metric.summary.median_total / denom
-                if denom > 0
-                else 0.0
-            )
-
             table.add_row(
                 "Residual Share (%)",
                 *[
                     (
-                        f"[red]{residual_share * 100:.1f}%[/red]"
+                        (
+                            f"[red]{residual_share * 100:.1f}%[/red]"
+                            if residual_share is not None
+                            else "n/a"
+                        )
                         if m.metric == "residual_proxy"
                         else ""
                     )
@@ -224,7 +225,8 @@ class StepCombinedRenderer(BaseRenderer):
 
         footer = (
             "\n\n[dim]"
-            f"Clock={payload.diagnosis_clock.upper()} | "
+            "Clock="
+            f"{(window.clock if window is not None else 'cpu').upper()} | "
             "IW=input wait | H2D=host-to-device | FWD=forward | "
             "BWD=backward | OPT=optimizer | STEP=traced step | "
             "RESIDUAL=STEP−H2D−FWD−BWD−OPT"
@@ -258,6 +260,11 @@ def _table_metrics(
         metric for metric in metrics if metric.metric not in TABLE_METRIC_ORDER
     ]
     return ordered + extras
+
+
+def _format_skew(value: float | None) -> str:
+    """Format a skew ratio without turning unavailable into zero."""
+    return "n/a" if value is None else f"+{value * 100:.1f}%"
 
 
 def _metric_trend_label(metric, single_rank: bool) -> str:

--- a/src/traceml_ai/renderers/step_time/renderer.py
+++ b/src/traceml_ai/renderers/step_time/renderer.py
@@ -66,17 +66,16 @@ class StepCombinedRenderer(BaseRenderer):
             layout_section_name=MODEL_COMBINED_LAYOUT,
         )
         self._computer = StepCombinedComputer(db_path=db_path)
-        self._cached: Optional[StepCombinedTimeResult] = None
 
     def _payload(self) -> Optional[StepCombinedTimeResult]:
         """
         CLI compute is summary-only (cheap).
-        Cache to avoid flicker on transient incompleteness.
+
+        The computer already bridges transient gaps from its own last-ok
+        window; once that expires the empty result is rendered as-is so a
+        dead run can never keep showing its last complete table.
         """
-        payload = self._computer.compute_cli()
-        if payload and payload.diagnosis_metrics:
-            self._cached = payload
-        return self._cached
+        return self._computer.compute_cli()
 
     def get_panel_renderable(self) -> Panel:
         payload = self._payload()

--- a/src/traceml_ai/renderers/step_time/schema.py
+++ b/src/traceml_ai/renderers/step_time/schema.py
@@ -1,5 +1,10 @@
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from traceml_ai.utils.step_time_window import StepTimeWindow
 
 
 @dataclass(frozen=True)
@@ -17,8 +22,8 @@ class StepCombinedTimeSummary:
     median_total: float
     worst_total: float
     worst_rank: Optional[int]
-    skew_ratio: float
-    skew_pct: float
+    skew_ratio: Optional[float]
+    skew_pct: Optional[float]
 
 
 @dataclass(frozen=True)
@@ -42,14 +47,9 @@ class StepCombinedTimeMetric:
 
 @dataclass(frozen=True)
 class StepCombinedTimeResult:
+    """Live Step Time state wrapping one canonical analyzed window."""
+
     status_message: str = "OK"
-    per_rank_timing: Dict[int, Dict[str, float]] = field(default_factory=dict)
-    diagnosis_clock: str = "cpu"
+    window: Optional[StepTimeWindow] = None
     training_strategy: str = "ddp"
-    diagnosis_metrics: List[StepCombinedTimeMetric] = field(
-        default_factory=list
-    )
-    # Whether the producing computer ever had diagnosis metrics before
-    # this tick. Lets a consumer distinguish "no data yet" from "had
-    # data, now expired" without a side-channel to the computer.
     had_ok: bool = False

--- a/src/traceml_ai/renderers/step_time/schema.py
+++ b/src/traceml_ai/renderers/step_time/schema.py
@@ -49,3 +49,7 @@ class StepCombinedTimeResult:
     diagnosis_metrics: List[StepCombinedTimeMetric] = field(
         default_factory=list
     )
+    # Whether the producing computer ever had diagnosis metrics before
+    # this tick. Lets a consumer distinguish "no data yet" from "had
+    # data, now expired" without a side-channel to the computer.
+    had_ok: bool = False

--- a/src/traceml_ai/utils/step_time_window.py
+++ b/src/traceml_ai/utils/step_time_window.py
@@ -212,14 +212,7 @@ _COMPUTE_KEYS: tuple[str, ...] = ("forward", "backward", "optimizer_step")
 # gradient accumulation and H2D when a step performs no transfers. Every
 # other selected metric must occur on every bracketed step, so partial
 # presence there means lost instrumentation, not measured zeros.
-# Occurrence-driven metrics: an absent event means "no such work
-# happened", not "instrumentation missing", so absence never counts as a
-# coverage gap. Public because live surfaces must classify absence the
-# same way the diagnosis engine does; a second private copy in a renderer
-# is how the CLI and dashboard drift apart from the canonical verdict.
-OCCURRENCE_METRICS: frozenset[str] = frozenset(("optimizer_step", "h2d"))
-
-_OCCURRENCE_METRICS = OCCURRENCE_METRICS
+_OCCURRENCE_METRICS: frozenset[str] = frozenset(("optimizer_step", "h2d"))
 
 
 def _rank_metric_availability(
@@ -672,7 +665,6 @@ __all__ = [
     "DiagnosisClock",
     "EVENT_ALIASES",
     "INPUT_WAIT_KEY",
-    "OCCURRENCE_METRICS",
     "SELECTED_METRICS",
     "STEP_TIME_EVENT_NAME",
     "STEP_TIME_CPU_KEY",

--- a/src/traceml_ai/utils/step_time_window.py
+++ b/src/traceml_ai/utils/step_time_window.py
@@ -82,6 +82,7 @@ class StepTimeWindow:
 
     clock: DiagnosisClock = "cpu"
     steps: list[int] = field(default_factory=list)
+    expected_ranks: tuple[int, ...] = ()
     coverage: StepCombinedTimeCoverage = field(
         default_factory=lambda: StepCombinedTimeCoverage(
             expected_steps=0,
@@ -97,6 +98,38 @@ class StepTimeWindow:
     )
     per_rank_timing: Dict[int, Dict[str, float]] = field(default_factory=dict)
     metrics: list[StepCombinedTimeMetric] = field(default_factory=list)
+
+    @property
+    def rank_universe(self) -> tuple[int, ...]:
+        """Return expected ranks, or observed ranks for direct fixtures."""
+        if self.expected_ranks:
+            return self.expected_ranks
+        return tuple(sorted(int(rank) for rank in self.per_rank_timing))
+
+    def ranks_for(self, metric: str) -> tuple[int, ...]:
+        """Return expected ranks carrying one canonical sparse metric."""
+        key = str(metric)
+        return tuple(
+            rank
+            for rank in self.rank_universe
+            if key in self.per_rank_timing.get(rank, {})
+        )
+
+    def eligible_ranks(self, metrics: Sequence[str]) -> tuple[int, ...]:
+        """Return ranks carrying every requested metric in this window."""
+        keys = tuple(str(metric) for metric in metrics)
+        if not keys:
+            return self.rank_universe
+        return tuple(
+            rank
+            for rank in self.rank_universe
+            if all(key in self.per_rank_timing.get(rank, {}) for key in keys)
+        )
+
+    def is_complete(self, metric: str) -> bool:
+        """Return whether every expected rank measured one metric."""
+        ranks = self.rank_universe
+        return bool(ranks) and self.ranks_for(metric) == ranks
 
     def to_json(self) -> Dict[str, Any]:
         """Return the aligned step-window block used by final_summary."""
@@ -213,6 +246,50 @@ _COMPUTE_KEYS: tuple[str, ...] = ("forward", "backward", "optimizer_step")
 # other selected metric must occur on every bracketed step, so partial
 # presence there means lost instrumentation, not measured zeros.
 _OCCURRENCE_METRICS: frozenset[str] = frozenset(("optimizer_step", "h2d"))
+
+
+def median_iteration_component_share(
+    per_rank_timing: Mapping[int, Mapping[str, float]],
+    component: str,
+) -> Optional[float]:
+    """Return one component's median share of complete rank iterations.
+
+    Only ranks carrying the component, input wait, and the step envelope are
+    eligible. ``compute`` is derived only when all three compute phases exist.
+    No eligible rank returns ``None``; an eligible measured zero returns
+    ``0.0``.
+    """
+    shares: list[float] = []
+    for values in per_rank_timing.values():
+        if INPUT_WAIT_KEY not in values or "step_time" not in values:
+            continue
+        if component == "compute":
+            if not all(key in values for key in _COMPUTE_KEYS):
+                continue
+            components = [
+                _safe_non_negative_float(values[key]) for key in _COMPUTE_KEYS
+            ]
+            if any(value is None for value in components):
+                continue
+            numerator = sum(float(value) for value in components)
+        else:
+            if component not in values:
+                continue
+            numerator = _safe_non_negative_float(values[component])
+            if numerator is None:
+                continue
+
+        input_wait = _safe_non_negative_float(values[INPUT_WAIT_KEY])
+        step_time = _safe_non_negative_float(values["step_time"])
+        if input_wait is None or step_time is None:
+            continue
+        iteration = input_wait + step_time
+        if iteration > 0.0:
+            shares.append(float(numerator) / iteration)
+
+    if not shares:
+        return None
+    return float(np.median(np.asarray(shares, dtype=np.float64)))
 
 
 def _rank_metric_availability(
@@ -395,9 +472,9 @@ def _metric_values(
     for rank, values in per_rank_timing.items():
         if metric_key not in values:
             continue
-        out[int(rank)] = (
-            _safe_non_negative_float(values.get(metric_key)) or 0.0
-        )
+        value = _safe_non_negative_float(values.get(metric_key))
+        if value is not None:
+            out[int(rank)] = value
     return out
 
 
@@ -450,16 +527,21 @@ def build_step_time_metrics(
         worst_total = float(arr[worst_idx])
         worst_rank = int(metric_ranks[worst_idx])
 
-        if coverage.ranks_present <= 1 or len(metric_ranks) <= 1:
+        if len(metric_ranks) <= 1:
             median_total = worst_total
-            skew_ratio = 0.0
-            skew_pct = 0.0
+            skew_ratio = None
+            skew_pct = None
         elif median_total > 0.0:
             skew_ratio = worst_total / median_total
             skew_pct = (worst_total - median_total) / median_total
-        else:
+        elif worst_total <= 0.0:
             skew_ratio = 0.0
             skew_pct = 0.0
+        else:
+            # Relative skew is undefined when the median is zero but at
+            # least one rank is non-zero. Reporting 0% would claim equality.
+            skew_ratio = None
+            skew_pct = None
 
         series = None
         step_ids = [int(step) for step in (series_steps or ())]
@@ -507,8 +589,12 @@ def build_step_time_metrics(
                     median_total=float(median_total),
                     worst_total=float(worst_total),
                     worst_rank=int(worst_rank),
-                    skew_ratio=float(skew_ratio),
-                    skew_pct=float(skew_pct),
+                    skew_ratio=(
+                        float(skew_ratio) if skew_ratio is not None else None
+                    ),
+                    skew_pct=(
+                        float(skew_pct) if skew_pct is not None else None
+                    ),
                 ),
                 coverage=coverage,
             )
@@ -525,9 +611,11 @@ def build_step_time_window_from_events(
     completed_step: Optional[int] = None,
 ) -> StepTimeWindow:
     """Build one selected-clock window directly from raw event payloads."""
-    expected = [
-        int(rank) for rank in (expected_ranks or per_rank_steps.keys())
-    ]
+    expected = tuple(
+        sorted(
+            {int(rank) for rank in (expected_ranks or per_rank_steps.keys())}
+        )
+    )
     observed_steps = {
         int(rank): {int(step): events for step, events in step_map.items()}
         for rank, step_map in per_rank_steps.items()
@@ -548,12 +636,13 @@ def build_step_time_window_from_events(
     steps = common_suffix_steps(observed_steps, max_rows)
     if not observed_steps or not steps:
         return StepTimeWindow(
+            expected_ranks=expected,
             coverage=_empty_coverage(
                 max_rows=max_rows,
                 completed_step=latest_step,
                 world_size=len(expected),
                 ranks_present=len(observed_steps),
-            )
+            ),
         )
 
     clock = _select_clock_from_events(observed_steps, steps)
@@ -581,6 +670,7 @@ def build_step_time_window_from_events(
     return StepTimeWindow(
         clock=clock,
         steps=[int(step) for step in steps],
+        expected_ranks=expected,
         coverage=coverage,
         per_rank_step_timing=per_rank_step_timing,
         per_rank_timing=per_rank_timing,
@@ -605,6 +695,7 @@ def diagnose_step_time_window(
         window.metrics,
         thresholds=policy.thresholds,
         per_rank_timing=window.per_rank_timing,
+        expected_ranks=window.rank_universe,
         diagnosis_clock=window.clock,
         training_strategy=training_strategy,
     )
@@ -672,6 +763,7 @@ __all__ = [
     "build_step_time_metrics",
     "build_step_time_window_from_events",
     "diagnose_step_time_window",
+    "median_iteration_component_share",
     "public_step_time_metric_values",
     "worst_rank_by_total_step",
 ]

--- a/src/traceml_ai/utils/step_time_window.py
+++ b/src/traceml_ai/utils/step_time_window.py
@@ -212,7 +212,14 @@ _COMPUTE_KEYS: tuple[str, ...] = ("forward", "backward", "optimizer_step")
 # gradient accumulation and H2D when a step performs no transfers. Every
 # other selected metric must occur on every bracketed step, so partial
 # presence there means lost instrumentation, not measured zeros.
-_OCCURRENCE_METRICS: frozenset[str] = frozenset(("optimizer_step", "h2d"))
+# Occurrence-driven metrics: an absent event means "no such work
+# happened", not "instrumentation missing", so absence never counts as a
+# coverage gap. Public because live surfaces must classify absence the
+# same way the diagnosis engine does; a second private copy in a renderer
+# is how the CLI and dashboard drift apart from the canonical verdict.
+OCCURRENCE_METRICS: frozenset[str] = frozenset(("optimizer_step", "h2d"))
+
+_OCCURRENCE_METRICS = OCCURRENCE_METRICS
 
 
 def _rank_metric_availability(
@@ -665,6 +672,7 @@ __all__ = [
     "DiagnosisClock",
     "EVENT_ALIASES",
     "INPUT_WAIT_KEY",
+    "OCCURRENCE_METRICS",
     "SELECTED_METRICS",
     "STEP_TIME_EVENT_NAME",
     "STEP_TIME_CPU_KEY",

--- a/tests/diagnostics/test_registry.py
+++ b/tests/diagnostics/test_registry.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+from traceml_ai.diagnostics import model_diagnostics
 from traceml_ai.diagnostics.model_diagnostics import (
     DEFAULT_MODEL_DIAGNOSTIC_REGISTRY,
     ModelDiagnosisItem,
@@ -22,6 +23,7 @@ from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeMetric,
     StepCombinedTimeSummary,
 )
+from traceml_ai.utils.step_time_window import StepTimeWindow
 
 
 def _step_memory_metric() -> StepMemoryCombinedMetric:
@@ -89,7 +91,7 @@ def test_model_diagnostics_payload_uses_registered_domains():
     def build_custom_item(
         context: ModelDiagnosticContext,
     ) -> ModelDiagnosisItem:
-        assert context.step_time_per_rank_timing == {}
+        assert context.step_time_window is None
         assert context.step_memory_metrics == ()
         return ModelDiagnosisItem(
             source="custom_domain",
@@ -124,40 +126,47 @@ def test_model_diagnostics_payload_uses_registered_domains():
     assert payload.items[0].status == "BALANCED"
 
 
-def test_model_step_time_diagnostics_receive_per_rank_timing(monkeypatch):
+def test_model_step_time_diagnostics_receive_canonical_window(monkeypatch):
     per_rank_timing = {
         0: {"input_wait": 1.0, "total_step": 10.0},
         1: {"input_wait": 2.0, "total_step": 11.0},
     }
     captured = {}
 
-    def fake_diagnosis(metrics, *, per_rank_timing=None, **kwargs):
-        captured["metrics"] = metrics
-        captured["per_rank_timing"] = per_rank_timing
+    window = StepTimeWindow(
+        expected_ranks=(0, 1),
+        per_rank_timing=per_rank_timing,
+        metrics=[_step_time_metric("step_time", 10.0)],
+    )
+
+    def fake_diagnosis(received_window, **kwargs):
+        captured["window"] = received_window
         return SimpleNamespace(
-            kind="BALANCED",
-            severity="info",
-            status="BALANCED",
-            reason="No timing issue.",
-            action="Keep monitoring.",
-            note=None,
-            confidence=0.75,
-            steps_used=3,
-            worst_rank=1,
+            primary=SimpleNamespace(
+                kind="BALANCED",
+                severity="info",
+                status="BALANCED",
+                reason="No timing issue.",
+                action="Keep monitoring.",
+                note=None,
+                confidence=0.75,
+                steps_used=3,
+                worst_rank=1,
+            )
         )
 
     monkeypatch.setattr(
         model_diagnostics,
-        "build_step_diagnosis",
+        "diagnose_step_time_window",
         fake_diagnosis,
     )
 
     payload = build_model_diagnostics_payload(
-        step_time_per_rank_timing=per_rank_timing,
+        step_time_window=window,
         step_memory_metrics=(),
     )
 
-    assert captured["per_rank_timing"] == per_rank_timing
+    assert captured["window"] is window
     assert payload.items[0].source == "step_time"
     assert payload.items[0].status == "BALANCED"
 
@@ -170,37 +179,49 @@ def test_model_step_time_diagnostics_use_selected_metrics(monkeypatch):
     )
     captured = {}
 
-    def fake_diagnosis(metrics, **kwargs):
-        captured["metrics"] = metrics
-        captured["diagnosis_clock"] = kwargs.get("diagnosis_clock")
+    window = StepTimeWindow(
+        clock="gpu",
+        expected_ranks=(0,),
+        per_rank_timing={
+            0: {
+                "input_wait": 40.0,
+                "step_time": 100.0,
+                "residual_proxy": 0.0,
+            }
+        },
+        metrics=list(diagnosis_metrics),
+    )
+
+    def fake_diagnosis(received_window, **kwargs):
+        captured["window"] = received_window
         captured["training_strategy"] = kwargs.get("training_strategy")
         return SimpleNamespace(
-            kind="INPUT_BOUND",
-            severity="warn",
-            status="INPUT-BOUND",
-            reason="Input wait is high.",
-            action="Increase workers.",
-            note=None,
-            confidence=0.75,
-            steps_used=1,
-            worst_rank=0,
+            primary=SimpleNamespace(
+                kind="INPUT_BOUND",
+                severity="warn",
+                status="INPUT-BOUND",
+                reason="Input wait is high.",
+                action="Increase workers.",
+                note=None,
+                confidence=0.75,
+                steps_used=1,
+                worst_rank=0,
+            )
         )
 
     monkeypatch.setattr(
         model_diagnostics,
-        "build_step_diagnosis",
+        "diagnose_step_time_window",
         fake_diagnosis,
     )
 
     payload = build_model_diagnostics_payload(
-        step_time_diagnosis_metrics=diagnosis_metrics,
-        step_time_diagnosis_clock="gpu",
+        step_time_window=window,
         step_time_training_strategy="fsdp",
         step_memory_metrics=(),
     )
 
-    assert captured["metrics"] == diagnosis_metrics
-    assert captured["diagnosis_clock"] == "gpu"
+    assert captured["window"] is window
     assert captured["training_strategy"] == "fsdp"
     assert payload.items[0].status == "INPUT-BOUND"
     assert payload.items[0].evidence["dominant"] == "input wait"
@@ -232,11 +253,10 @@ def test_model_step_time_diagnostics_do_not_fallback_to_public_metrics(
     )
 
     payload = build_model_diagnostics_payload(
-        step_time_diagnosis_metrics=(),
         step_memory_metrics=(),
     )
 
-    assert captured["metrics"] == ()
+    assert captured["metrics"] == []
     assert payload.items[0].evidence == {}
 
 

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Literal
 
 import pytest
@@ -28,6 +29,7 @@ from traceml_ai.diagnostics.step_time.rules import (
     RankStragglerRule,
     ResidualHeavyRule,
 )
+from traceml_ai.diagnostics.step_time.trend import build_step_trend_note
 from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeCoverage,
     StepCombinedTimeMetric,
@@ -1598,3 +1600,70 @@ def test_summary_input_bound_trend_uses_selected_input_wait_series() -> None:
     assert result.primary.note is not None
     assert result.primary.note.startswith("Trend: input wait is ")
     assert "dataloader" not in result.primary.note
+
+
+@pytest.mark.parametrize(
+    ("kind", "residual_share", "input_share"),
+    [
+        ("RESIDUAL_HEAVY", None, 0.0),
+        ("INPUT_BOUND", 0.0, None),
+    ],
+)
+def test_trend_abstains_when_required_share_is_unavailable(
+    kind: str,
+    residual_share: float | None,
+    input_share: float | None,
+) -> None:
+    metric = _time_metric("trend", median=10.0, worst=10.0, steps=120)
+    rising = [1.0] * 60 + [10.0] * 60
+    metric = replace(
+        metric,
+        series=StepCombinedTimeSeries(
+            steps=list(range(120)),
+            median=rising,
+            worst=rising,
+            sum=rising,
+        ),
+    )
+
+    note = build_step_trend_note(
+        diagnosis_kind=kind,
+        steps_used=120,
+        single_rank=False,
+        step_metric=metric,
+        residual_metric=metric,
+        input_wait_metric=metric,
+        residual_share=residual_share,
+        input_bound_share=input_share,
+        residual_warn_threshold=0.1,
+        input_warn_threshold=0.1,
+    )
+
+    assert note is None
+
+
+def test_largest_compute_phase_uses_one_eligible_rank_cohort() -> None:
+    context = _time_context(
+        _time_metric("input_wait", median=0.0, worst=0.0),
+        _time_metric("forward", median=55.0, worst=100.0),
+        _time_metric("backward", median=20.0, worst=20.0),
+        _time_metric("optimizer_step", median=10.0, worst=10.0),
+        _time_metric("step_time", median=100.0, worst=100.0),
+        per_rank_timing={
+            0: {
+                "input_wait": 0.0,
+                "forward": 10.0,
+                "backward": 20.0,
+                "optimizer_step": 10.0,
+                "step_time": 100.0,
+            },
+            1: {
+                "input_wait": 0.0,
+                "forward": 100.0,
+                "step_time": 100.0,
+            },
+        },
+    )
+
+    assert context.largest_compute is not None
+    assert context.largest_compute.label == "Backward"

--- a/tests/diagnostics/test_step_time_invariants.py
+++ b/tests/diagnostics/test_step_time_invariants.py
@@ -31,6 +31,7 @@ from traceml_ai.utils.step_time_window import (
     _OCCURRENCE_METRICS,
     SELECTED_METRICS,
     build_step_time_window_from_events,
+    median_iteration_component_share,
     public_step_time_metric_values,
 )
 
@@ -116,6 +117,138 @@ def assert_metric_worst_is_self_consistent(window) -> None:
 # ---------------------------------------------------------------------------
 # F1: availability is metric-specific
 # ---------------------------------------------------------------------------
+
+
+def test_window_carries_canonical_metric_rank_availability() -> None:
+    presence_by_rank = {
+        0: _all_steps(),
+        1: _all_steps(),
+    }
+    del presence_by_rank[1]["forward"]
+    del presence_by_rank[0]["input_wait"]
+    del presence_by_rank[1]["input_wait"]
+
+    per_rank = {0: {}, 1: {}}
+    for rank, presence in presence_by_rank.items():
+        for step in range(_WINDOW):
+            events = {}
+            for metric, present_steps in presence.items():
+                if step in present_steps:
+                    value = (
+                        0.0
+                        if rank == 0 and metric == "backward"
+                        else _BASE_MS[metric]
+                    )
+                    events[_EVENT_NAMES[metric]] = _stat(value)
+            per_rank[rank][step] = events
+
+    window = build_step_time_window_from_events(
+        per_rank,
+        max_rows=_WINDOW,
+        expected_ranks=(0, 1),
+    )
+    assert window.rank_universe == (0, 1)
+    assert window.ranks_for("input_wait") == ()
+    assert window.ranks_for("forward") == (0,)
+    assert window.ranks_for("backward") == (0, 1)
+    assert window.per_rank_timing[0]["backward"] == pytest.approx(0.0)
+    assert window.is_complete("input_wait") is False
+    assert window.is_complete("forward") is False
+    assert window.is_complete("backward") is True
+    assert window.eligible_ranks(("forward", "backward")) == (0,)
+
+
+def test_empty_window_keeps_expected_rank_universe() -> None:
+    window = build_step_time_window_from_events(
+        {},
+        max_rows=_WINDOW,
+        expected_ranks=(0, 1),
+    )
+    assert window.rank_universe == (0, 1)
+    assert all(window.ranks_for(metric) == () for metric in SELECTED_METRICS)
+
+
+def test_skew_requires_two_measured_ranks_but_zero_remains_measured() -> None:
+    single = _window_from_presence(_all_steps())
+    single_step = next(m for m in single.metrics if m.metric == "step_time")
+    assert single_step.summary.skew_pct is None
+    assert single_step.summary.skew_ratio is None
+
+    presence_by_rank = {0: _all_steps(), 1: _all_steps()}
+    per_rank = {0: {}, 1: {}}
+    for rank, presence in presence_by_rank.items():
+        for step in range(_WINDOW):
+            events = {
+                _EVENT_NAMES[metric]: _stat(
+                    0.0 if metric == "backward" else _BASE_MS[metric]
+                )
+                for metric, present_steps in presence.items()
+                if step in present_steps
+            }
+            per_rank[rank][step] = events
+
+    window = build_step_time_window_from_events(
+        per_rank,
+        max_rows=_WINDOW,
+        expected_ranks=(0, 1),
+    )
+    backward = next(m for m in window.metrics if m.metric == "backward")
+    assert backward.summary.skew_pct == pytest.approx(0.0)
+
+
+def test_skew_is_unavailable_when_zero_median_hides_a_nonzero_rank() -> None:
+    per_rank = {rank: {} for rank in range(3)}
+    for rank in per_rank:
+        for step in range(_WINDOW):
+            per_rank[rank][step] = {
+                _EVENT_NAMES[metric]: _stat(
+                    10.0
+                    if metric == "backward" and rank == 2
+                    else (0.0 if metric == "backward" else _BASE_MS[metric])
+                )
+                for metric in _EVENT_NAMES
+            }
+
+    window = build_step_time_window_from_events(
+        per_rank,
+        max_rows=_WINDOW,
+        expected_ranks=(0, 1, 2),
+    )
+    backward = next(m for m in window.metrics if m.metric == "backward")
+    assert backward.summary.median_total == pytest.approx(0.0)
+    assert backward.summary.worst_total == pytest.approx(10.0)
+    assert backward.summary.skew_pct is None
+    assert backward.summary.skew_ratio is None
+
+
+def test_iteration_share_preserves_unavailable_and_measured_zero() -> None:
+    rows = {
+        0: {
+            "input_wait": 100.0,
+            "step_time": 100.0,
+            "residual_proxy": 10.0,
+        }
+    }
+    assert median_iteration_component_share(
+        rows, "residual_proxy"
+    ) == pytest.approx(0.05)
+    rows[0]["residual_proxy"] = 0.0
+    assert median_iteration_component_share(
+        rows, "residual_proxy"
+    ) == pytest.approx(0.0)
+    del rows[0]["residual_proxy"]
+    assert median_iteration_component_share(rows, "residual_proxy") is None
+
+    invalid_compute = {
+        0: {
+            "input_wait": 10.0,
+            "step_time": 100.0,
+            "forward": None,
+            "backward": 20.0,
+            "optimizer_step": 10.0,
+        }
+    }
+    assert median_iteration_component_share(invalid_compute, "compute") is None
 
 
 @pytest.mark.parametrize("metric", _REQUIRED_METRICS)

--- a/tests/diagnostics/test_step_time_missing_signals.py
+++ b/tests/diagnostics/test_step_time_missing_signals.py
@@ -303,6 +303,22 @@ _BALANCED_RANK = dict(
 )
 
 
+def test_expected_rank_without_window_rows_is_incomplete() -> None:
+    window = build_step_time_window_from_events(
+        {0: _step_events(**_BALANCED_RANK)},
+        max_rows=30,
+        expected_ranks=(0, 1),
+    )
+
+    result = diagnose_step_time_window(
+        window,
+        policy=SUMMARY_STEP_TIME_POLICY,
+    )
+
+    assert result.primary.kind == "INCOMPLETE_DATA"
+    assert result.issues[0].evidence["signal_coverage"]["backward"] == "1/2"
+
+
 def test_missing_backward_blocks_ddp_straggler() -> None:
     result = _diagnose(
         {
@@ -619,7 +635,9 @@ def test_partial_metric_stats_use_measuring_ranks() -> None:
     assert h2d_metric.summary.worst_rank == 1
     assert h2d_metric.summary.worst_total == pytest.approx(9.0)
     assert h2d_metric.summary.median_total == pytest.approx(9.0)
-    assert h2d_metric.summary.skew_pct == pytest.approx(0.0)
+    # One eligible rank has no cross-rank population from which to compute
+    # skew; unavailable is distinct from a measured zero gap.
+    assert h2d_metric.summary.skew_pct is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/display/test_model_combined_section.py
+++ b/tests/display/test_model_combined_section.py
@@ -111,11 +111,15 @@ def test_step_time_dashboard_hero_renders_sparse_metrics() -> None:
     # 10 + step 100 = 110) minus the sliver's reserved width.
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
+    by_lab = dict(zip(keys, panel["seg_labs"]))
     assert by_key["h2d"].styles[-1] == "width:0.000%"
     assert (
         f"width:{_UNMEASURED_SLIVER_PCT:.1f}%"
         in by_key["residual_proxy"].styles[-1]
     )
+    # The sliver carries NO on-segment text -- it would overlap the hatch
+    # illegibly; the missing phases are named in the window meta instead.
+    assert by_lab["residual_proxy"].text == ""
     assert by_key["input_wait"].styles[-1] == "width:8.545%"
     # An underivable residual shows n/a, never a fake 0%.
     assert "n/a" in panel["kpis"]["residual"].content

--- a/tests/display/test_model_combined_section.py
+++ b/tests/display/test_model_combined_section.py
@@ -35,7 +35,11 @@ class _FakeHtml:
         self.content = ""
 
 
-def _metric(name: str, value: float) -> StepCombinedTimeMetric:
+def _metric(
+    name: str,
+    value: float,
+    worst: float | None = None,
+) -> StepCombinedTimeMetric:
     return StepCombinedTimeMetric(
         metric=name,
         clock="gpu",
@@ -44,7 +48,7 @@ def _metric(name: str, value: float) -> StepCombinedTimeMetric:
             window_size=5,
             steps_used=5,
             median_total=value,
-            worst_total=value,
+            worst_total=worst if worst is not None else value,
             worst_rank=0,
             skew_ratio=0.0,
             skew_pct=0.0,
@@ -99,13 +103,14 @@ def test_step_time_dashboard_hero_renders_sparse_metrics() -> None:
     # The panel updated (no freeze): window label reflects the sparse
     # window and flags the partial coverage.
     assert panel["win"].text == "5 aligned steps · partial signals"
-    # Missing phases render as empty segments; measured phases keep
-    # their proportional widths (input_wait 10 of 80 measured -> 12.5%).
+    # Missing phases render as empty segments; measured phases scale
+    # against the iteration envelope (input_wait 10 + step 100 = 110),
+    # so unmeasured time stays visible as empty ribbon space.
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
     assert by_key["h2d"].styles[-1] == "width:0.000%"
     assert by_key["residual_proxy"].styles[-1] == "width:0.000%"
-    assert by_key["input_wait"].styles[-1] == "width:12.500%"
+    assert by_key["input_wait"].styles[-1] == "width:9.091%"
     # An underivable residual shows n/a, never a fake 0%.
     assert "n/a" in panel["kpis"]["residual"].content
     assert panel["kpis"]["median"].content.startswith("100")
@@ -118,7 +123,7 @@ def test_step_time_dashboard_hero_measured_zero_is_not_partial() -> None:
         _metric("forward", 20.0),
         _metric("backward", 30.0),
         _metric("optimizer_step", 20.0),
-        _metric("residual_proxy", 20.0),
+        _metric("residual_proxy", 30.0),
         _metric("step_time", 100.0),
     ]
     payload = StepCombinedTimeResult(
@@ -134,17 +139,75 @@ def test_step_time_dashboard_hero_measured_zero_is_not_partial() -> None:
     assert "n/a" not in panel["kpis"]["residual"].content
 
 
+def test_step_time_dashboard_hero_absent_h2d_is_not_partial() -> None:
+    # H2D events are occurrence-driven: a run with no host-to-device
+    # copies emits none, which is complete coverage, not partial.
+    diagnosis_metrics = [
+        _metric("input_wait", 10.0),
+        _metric("forward", 20.0),
+        _metric("backward", 30.0),
+        _metric("optimizer_step", 20.0),
+        _metric("residual_proxy", 30.0),
+        _metric("step_time", 100.0),
+    ]
+    payload = StepCombinedTimeResult(
+        diagnosis_metrics=diagnosis_metrics,
+        diagnosis_clock="cpu",
+    )
+    panel = _panel()
+
+    update_model_combined_section(panel, payload)
+
+    assert panel["win"].text == "5 aligned steps"
+    keys = [key for _, key, _ in theme.PHASES]
+    by_key = dict(zip(keys, panel["seg_divs"]))
+    assert by_key["h2d"].styles[-1] == "width:0.000%"
+
+
+def test_step_time_dashboard_hero_step_time_only_extreme() -> None:
+    payload = StepCombinedTimeResult(
+        diagnosis_metrics=[_metric("step_time", 100.0)],
+        diagnosis_clock="cpu",
+    )
+    panel = _panel()
+
+    update_model_combined_section(panel, payload)
+
+    assert panel["win"].text == "5 aligned steps · partial signals"
+    assert all(seg.styles[-1] == "width:0.000%" for seg in panel["seg_divs"])
+    assert "n/a" in panel["kpis"]["residual"].content
+    assert panel["kpis"]["median"].content.startswith("100")
+
+
+def test_step_time_dashboard_hero_ignores_payload_without_step_time() -> None:
+    payload = StepCombinedTimeResult(
+        diagnosis_metrics=[
+            _metric("input_wait", 10.0),
+            _metric("forward", 20.0),
+        ],
+        diagnosis_clock="cpu",
+    )
+    panel = _panel()
+
+    update_model_combined_section(panel, payload)
+
+    # Without the step envelope there is nothing coherent to draw: the
+    # panel stays untouched instead of raising into the UI tick.
+    assert panel["win"].text == ""
+
+
 def test_step_time_dashboard_hero_uses_diagnosis_metrics() -> None:
     assert theme.PHASES[0][:2] == ("IW", "input_wait")
 
+    # Self-consistent window shape: phases sum to input_wait + step.
     diagnosis_metrics = [
         _metric("input_wait", 10.0),
         _metric("h2d", 10.0),
         _metric("forward", 20.0),
         _metric("backward", 30.0),
         _metric("optimizer_step", 20.0),
-        _metric("residual_proxy", 10.0),
-        _metric("step_time", 100.0),
+        _metric("residual_proxy", 20.0),
+        _metric("step_time", 100.0, worst=200.0),
     ]
     payload = StepCombinedTimeResult(
         diagnosis_metrics=diagnosis_metrics,
@@ -155,10 +218,11 @@ def test_step_time_dashboard_hero_uses_diagnosis_metrics() -> None:
     update_model_combined_section(panel, payload)
 
     assert panel["seg_labs"][0].text == "IW"
-    assert panel["seg_divs"][0].styles[-1] == "width:10.000%"
+    # input_wait 10 of the 110 ms iteration envelope.
+    assert panel["seg_divs"][0].styles[-1] == "width:9.091%"
     assert panel["win"].text == "5 aligned steps"
     assert panel["kpis"]["median"].content.startswith("100")
-    assert panel["kpis"]["worst"].content.startswith("100")
+    assert panel["kpis"]["worst"].content.startswith("200")
     assert not panel["kpis"]["median"].content.startswith("20")
 
 

--- a/tests/display/test_model_combined_section.py
+++ b/tests/display/test_model_combined_section.py
@@ -113,10 +113,13 @@ def test_step_time_dashboard_hero_renders_sparse_metrics() -> None:
     by_key = dict(zip(keys, panel["seg_divs"]))
     by_lab = dict(zip(keys, panel["seg_labs"]))
     assert by_key["h2d"].styles[-1] == "width:0.000%"
-    assert (
-        f"width:{_UNMEASURED_SLIVER_PCT:.1f}%"
-        in by_key["residual_proxy"].styles[-1]
-    )
+    residual_sliver = by_key["residual_proxy"].styles[-1]
+    assert f"width:{_UNMEASURED_SLIVER_PCT:.1f}%" in residual_sliver
+    # The hatch is drawn in the PHASE'S OWN color (residual = gold), so the
+    # sliver still identifies which phase, matching the legend dot.
+    residual_color = dict((k, c) for _, k, c in theme.PHASES)["residual_proxy"]
+    assert "repeating-linear-gradient" in residual_sliver
+    assert residual_color in residual_sliver
     # The sliver carries NO on-segment text -- it would overlap the hatch
     # illegibly; the missing phases are named in the window meta instead.
     assert by_lab["residual_proxy"].text == ""

--- a/tests/display/test_model_combined_section.py
+++ b/tests/display/test_model_combined_section.py
@@ -77,6 +77,63 @@ def _panel() -> dict:
     }
 
 
+def test_step_time_dashboard_hero_renders_sparse_metrics() -> None:
+    # h2d and residual_proxy were never measured: the hero must still
+    # update from the fresh sparse window instead of freezing on the last
+    # complete view (issue #259).
+    diagnosis_metrics = [
+        _metric("input_wait", 10.0),
+        _metric("forward", 20.0),
+        _metric("backward", 30.0),
+        _metric("optimizer_step", 20.0),
+        _metric("step_time", 100.0),
+    ]
+    payload = StepCombinedTimeResult(
+        diagnosis_metrics=diagnosis_metrics,
+        diagnosis_clock="cpu",
+    )
+    panel = _panel()
+
+    update_model_combined_section(panel, payload)
+
+    # The panel updated (no freeze): window label reflects the sparse
+    # window and flags the partial coverage.
+    assert panel["win"].text == "5 aligned steps · partial signals"
+    # Missing phases render as empty segments; measured phases keep
+    # their proportional widths (input_wait 10 of 80 measured -> 12.5%).
+    keys = [key for _, key, _ in theme.PHASES]
+    by_key = dict(zip(keys, panel["seg_divs"]))
+    assert by_key["h2d"].styles[-1] == "width:0.000%"
+    assert by_key["residual_proxy"].styles[-1] == "width:0.000%"
+    assert by_key["input_wait"].styles[-1] == "width:12.500%"
+    # An underivable residual shows n/a, never a fake 0%.
+    assert "n/a" in panel["kpis"]["residual"].content
+    assert panel["kpis"]["median"].content.startswith("100")
+
+
+def test_step_time_dashboard_hero_measured_zero_is_not_partial() -> None:
+    diagnosis_metrics = [
+        _metric("input_wait", 10.0),
+        _metric("h2d", 0.0),
+        _metric("forward", 20.0),
+        _metric("backward", 30.0),
+        _metric("optimizer_step", 20.0),
+        _metric("residual_proxy", 20.0),
+        _metric("step_time", 100.0),
+    ]
+    payload = StepCombinedTimeResult(
+        diagnosis_metrics=diagnosis_metrics,
+        diagnosis_clock="cpu",
+    )
+    panel = _panel()
+
+    update_model_combined_section(panel, payload)
+
+    # A measured-zero H2D is complete coverage, not partial signals.
+    assert panel["win"].text == "5 aligned steps"
+    assert "n/a" not in panel["kpis"]["residual"].content
+
+
 def test_step_time_dashboard_hero_uses_diagnosis_metrics() -> None:
     assert theme.PHASES[0][:2] == ("IW", "input_wait")
 

--- a/tests/display/test_model_combined_section.py
+++ b/tests/display/test_model_combined_section.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import json
+import sqlite3
+
 import pytest
+from rich.console import Console
 
 pytest.importorskip("nicegui")
 
@@ -9,11 +13,24 @@ from traceml_ai.aggregator.display_drivers.nicegui_sections.model_combined_secti
     _UNMEASURED_SLIVER_PCT,
     update_model_combined_section,
 )
+from traceml_ai.diagnostics.model_diagnostics import (
+    build_model_diagnostics_payload,
+)
+from traceml_ai.diagnostics.step_time import LIVE_STEP_TIME_POLICY
+from traceml_ai.renderers.step_time.compute import StepCombinedComputer
+from traceml_ai.renderers.step_time.renderer import StepCombinedRenderer
 from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeCoverage,
     StepCombinedTimeMetric,
     StepCombinedTimeResult,
     StepCombinedTimeSummary,
+)
+from traceml_ai.reporting.sections.step_time.loader import (
+    load_step_time_section_data,
+)
+from traceml_ai.utils.step_time_window import (
+    StepTimeWindow,
+    diagnose_step_time_window,
 )
 
 
@@ -93,6 +110,33 @@ def _metric(
     )
 
 
+def _payload(
+    metrics: list[StepCombinedTimeMetric],
+    *,
+    per_rank_timing: dict[int, dict[str, float]] | None = None,
+    clock: str = "cpu",
+    had_ok: bool = False,
+) -> StepCombinedTimeResult:
+    """Build a live result around one canonical Step Time window."""
+    if per_rank_timing is None:
+        row = {
+            metric.metric: float(metric.summary.median_total)
+            for metric in metrics
+        }
+        if "input_wait" in row and "step_time" in row:
+            row["total_step"] = row["input_wait"] + row["step_time"]
+        per_rank_timing = {0: row}
+    return StepCombinedTimeResult(
+        window=StepTimeWindow(
+            clock="gpu" if clock == "gpu" else "cpu",
+            expected_ranks=tuple(sorted(per_rank_timing)),
+            per_rank_timing=per_rank_timing,
+            metrics=metrics,
+        ),
+        had_ok=had_ok,
+    )
+
+
 def _panel() -> dict:
     return {
         "seg_divs": [_FakeSegment() for _ in theme.PHASES],
@@ -121,17 +165,17 @@ def test_step_time_dashboard_hero_renders_sparse_metrics() -> None:
         _metric("optimizer_step", 20.0),
         _metric("step_time", 100.0),
     ]
-    payload = StepCombinedTimeResult(
-        diagnosis_metrics=diagnosis_metrics,
-        diagnosis_clock="cpu",
-    )
+    payload = _payload(diagnosis_metrics)
     panel = _panel()
 
     update_model_combined_section(panel, payload)
 
     # The panel updated (no freeze): window label reflects the sparse
     # window and names the missing signal.
-    assert panel["win"].text == "5 aligned steps · partial: RESIDUAL"
+    assert (
+        panel["win"].text
+        == "5 aligned steps · representative r0 · partial: RESIDUAL"
+    )
     # H2D is occurrence-driven and absent, so it's plain measured-zero.
     # residual_proxy is genuinely unmeasured (non-h2d), so it gets the
     # hatched sliver, not an empty segment indistinguishable from zero.
@@ -167,16 +211,13 @@ def test_step_time_dashboard_hero_measured_zero_is_not_partial() -> None:
         _metric("residual_proxy", 30.0),
         _metric("step_time", 100.0),
     ]
-    payload = StepCombinedTimeResult(
-        diagnosis_metrics=diagnosis_metrics,
-        diagnosis_clock="cpu",
-    )
+    payload = _payload(diagnosis_metrics)
     panel = _panel()
 
     update_model_combined_section(panel, payload)
 
     # A measured-zero H2D is complete coverage, not partial signals.
-    assert panel["win"].text == "5 aligned steps"
+    assert panel["win"].text == "5 aligned steps · representative r0"
     assert "n/a" not in panel["kpis"]["residual"].content
 
 
@@ -191,25 +232,19 @@ def test_step_time_dashboard_hero_absent_h2d_is_not_partial() -> None:
         _metric("residual_proxy", 30.0),
         _metric("step_time", 100.0),
     ]
-    payload = StepCombinedTimeResult(
-        diagnosis_metrics=diagnosis_metrics,
-        diagnosis_clock="cpu",
-    )
+    payload = _payload(diagnosis_metrics)
     panel = _panel()
 
     update_model_combined_section(panel, payload)
 
-    assert panel["win"].text == "5 aligned steps"
+    assert panel["win"].text == "5 aligned steps · representative r0"
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
     assert by_key["h2d"].width == "0.000%"
 
 
 def test_step_time_dashboard_hero_step_time_only_extreme() -> None:
-    payload = StepCombinedTimeResult(
-        diagnosis_metrics=[_metric("step_time", 100.0)],
-        diagnosis_clock="cpu",
-    )
+    payload = _payload([_metric("step_time", 100.0)])
     panel = _panel()
 
     update_model_combined_section(panel, payload)
@@ -220,8 +255,8 @@ def test_step_time_dashboard_hero_step_time_only_extreme() -> None:
     # `_rank_metric_availability` does by only considering metrics it
     # actually observed. So a wholly absent optimizer_step IS partial.
     assert (
-        panel["win"].text
-        == "5 aligned steps · partial: IW,FWD,BWD,OPT,RESIDUAL"
+        panel["win"].text == "5 aligned steps · representative r0 · partial: "
+        "IW,FWD,BWD,OPT,RESIDUAL"
     )
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
@@ -246,16 +281,15 @@ def test_absent_optimizer_step_is_not_a_measured_zero() -> None:
     # absence, not an occurrence of zero: the canonical availability rule
     # drops a never-seen optimizer entirely, so the card must not render
     # it as a confident 0%.
-    payload = StepCombinedTimeResult(
-        diagnosis_metrics=[
+    payload = _payload(
+        [
             _metric("input_wait", 10.0),
             _metric("h2d", 10.0),
             _metric("forward", 20.0),
             _metric("backward", 30.0),
             _metric("residual_proxy", 20.0),
             _metric("step_time", 100.0),
-        ],
-        diagnosis_clock="cpu",
+        ]
     )
     panel = _panel()
     update_model_combined_section(panel, payload)
@@ -263,7 +297,10 @@ def test_absent_optimizer_step_is_not_a_measured_zero() -> None:
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
     assert by_key["optimizer_step"].hatched
-    assert panel["win"].text == "5 aligned steps · partial: OPT"
+    assert (
+        panel["win"].text
+        == "5 aligned steps · representative r0 · partial: OPT"
+    )
 
 
 def test_residual_share_is_na_when_input_wait_is_unavailable() -> None:
@@ -271,16 +308,15 @@ def test_residual_share_is_na_when_input_wait_is_unavailable() -> None:
     # survives an unmeasured input_wait -- but the DENOMINATOR does not.
     # The envelope substitutes zero for the missing wait, so any share
     # computed against it is a confident percentage of an unknown total.
-    payload = StepCombinedTimeResult(
-        diagnosis_metrics=[
+    payload = _payload(
+        [
             _metric("h2d", 10.0),
             _metric("forward", 20.0),
             _metric("backward", 30.0),
             _metric("optimizer_step", 20.0),
             _metric("residual_proxy", 10.0),
             _metric("step_time", 100.0),
-        ],
-        diagnosis_clock="cpu",
+        ]
     )
     panel = _panel()
     update_model_combined_section(panel, payload)
@@ -289,10 +325,9 @@ def test_residual_share_is_na_when_input_wait_is_unavailable() -> None:
 
     # Control twin: with input_wait measured the denominator is whole, so
     # the same residual reports a real share.
-    with_wait = StepCombinedTimeResult(
-        diagnosis_metrics=list(payload.diagnosis_metrics)
-        + [_metric("input_wait", 10.0)],
-        diagnosis_clock="cpu",
+    assert payload.window is not None
+    with_wait = _payload(
+        list(payload.window.metrics) + [_metric("input_wait", 10.0)]
     )
     control = _panel()
     update_model_combined_section(control, with_wait)
@@ -303,8 +338,8 @@ def test_partial_rank_coverage_includes_step_time() -> None:
     # step_time is not a ribbon phase, but it is the envelope every share
     # is computed against, so a rank missing it makes the window
     # incomplete exactly as the engine reports it.
-    payload = StepCombinedTimeResult(
-        diagnosis_metrics=[
+    payload = _payload(
+        [
             _metric("input_wait", 10.0),
             _metric("h2d", 10.0),
             _metric("forward", 20.0),
@@ -320,6 +355,7 @@ def test_partial_rank_coverage_includes_step_time() -> None:
                 "forward": 20.0,
                 "backward": 30.0,
                 "optimizer_step": 20.0,
+                "residual_proxy": 20.0,
                 "step_time": 100.0,
                 "total_step": 110.0,
             },
@@ -332,12 +368,14 @@ def test_partial_rank_coverage_includes_step_time() -> None:
                 "total_step": 110.0,
             },
         },
-        diagnosis_clock="cpu",
     )
     panel = _panel()
     update_model_combined_section(panel, payload)
 
-    assert panel["win"].text == "5 aligned steps · partial: STEP"
+    assert (
+        panel["win"].text
+        == "5 aligned steps · representative r0 · partial: RESIDUAL,STEP"
+    )
 
 
 def test_step_time_dashboard_hero_dark_input_wait_is_not_measured_zero() -> (
@@ -349,16 +387,15 @@ def test_step_time_dashboard_hero_dark_input_wait_is_not_measured_zero() -> (
     # even though input_wait itself is unmeasured -- the ribbon must not
     # let the OTHER phases silently fill to 100% and read as "confirmed
     # no wait", which is exactly the class of bug this test pins.
-    dark_input_wait = StepCombinedTimeResult(
-        diagnosis_metrics=[
+    dark_input_wait = _payload(
+        [
             _metric("h2d", 10.0),
             _metric("forward", 20.0),
             _metric("backward", 30.0),
             _metric("optimizer_step", 20.0),
             _metric("residual_proxy", 20.0),
             _metric("step_time", 100.0),
-        ],
-        diagnosis_clock="cpu",
+        ]
     )
     panel = _panel()
     update_model_combined_section(panel, dark_input_wait)
@@ -368,12 +405,15 @@ def test_step_time_dashboard_hero_dark_input_wait_is_not_measured_zero() -> (
     # Unmeasured, not a confirmed-zero: the hatched sliver, not 0%.
     assert by_key["input_wait"].width == f"{_UNMEASURED_SLIVER_PCT:.1f}%"
     assert by_key["input_wait"].hatched
-    assert panel["win"].text == "5 aligned steps · partial: IW"
+    assert (
+        panel["win"].text
+        == "5 aligned steps · representative r0 · partial: IW"
+    )
 
     # Control twin: input_wait genuinely measured as 0ms must render as
     # a real 0%-width segment, distinct from the unmeasured case above.
-    measured_zero_input_wait = StepCombinedTimeResult(
-        diagnosis_metrics=[
+    measured_zero_input_wait = _payload(
+        [
             _metric("input_wait", 0.0),
             _metric("h2d", 10.0),
             _metric("forward", 20.0),
@@ -381,22 +421,21 @@ def test_step_time_dashboard_hero_dark_input_wait_is_not_measured_zero() -> (
             _metric("optimizer_step", 20.0),
             _metric("residual_proxy", 20.0),
             _metric("step_time", 100.0),
-        ],
-        diagnosis_clock="cpu",
+        ]
     )
     control_panel = _panel()
     update_model_combined_section(control_panel, measured_zero_input_wait)
     control_by_key = dict(zip(keys, control_panel["seg_divs"]))
     assert control_by_key["input_wait"].width == "0.000%"
-    assert control_panel["win"].text == "5 aligned steps"
+    assert control_panel["win"].text == "5 aligned steps · representative r0"
 
 
 def test_step_time_dashboard_hero_dead_run_shows_expired() -> None:
     # The CLI sibling distinguishes "no data yet" from "had data, now
     # expired" via StepCombinedComputer.had_ok; the dashboard hero must
     # do the same instead of freezing on the last complete view forever.
-    good = StepCombinedTimeResult(
-        diagnosis_metrics=[
+    good = _payload(
+        [
             _metric("input_wait", 10.0),
             _metric("h2d", 10.0),
             _metric("forward", 20.0),
@@ -405,24 +444,23 @@ def test_step_time_dashboard_hero_dead_run_shows_expired() -> None:
             _metric("residual_proxy", 20.0),
             _metric("step_time", 100.0),
         ],
-        diagnosis_clock="cpu",
         had_ok=True,
     )
     panel = _panel()
     update_model_combined_section(panel, good)
-    assert panel["win"].text == "5 aligned steps"
+    assert panel["win"].text == "5 aligned steps · representative r0"
     assert panel["kpis"]["median"].content.startswith("100")
 
     # A never-had-data payload (cold start) must NOT clear the panel --
     # there is nothing to clear yet.
-    cold_start = StepCombinedTimeResult(diagnosis_metrics=[], had_ok=False)
+    cold_start = StepCombinedTimeResult(had_ok=False)
     cold_panel = _panel()
     update_model_combined_section(cold_panel, cold_start)
     assert cold_panel["win"].text == ""
 
     # TTL expired: the computer reports had_ok=True with empty metrics.
     # The dashboard must visibly clear rather than keep showing "good".
-    expired = StepCombinedTimeResult(diagnosis_metrics=[], had_ok=True)
+    expired = StepCombinedTimeResult(had_ok=True)
     update_model_combined_section(panel, expired)
 
     assert panel["win"].text == "window expired"
@@ -465,16 +503,15 @@ def test_step_time_dashboard_hero_recovered_phase_drops_the_hatch() -> None:
     # was hatched while unmeasured must have its solid background
     # restored on recovery; otherwise it stays visually "unmeasured"
     # forever while reporting a real width.
-    sparse = StepCombinedTimeResult(
-        diagnosis_metrics=[
+    sparse = _payload(
+        [
             _metric("input_wait", 10.0),
             _metric("h2d", 10.0),
             _metric("backward", 30.0),
             _metric("optimizer_step", 20.0),
             _metric("residual_proxy", 20.0),
             _metric("step_time", 100.0),
-        ],
-        diagnosis_clock="cpu",
+        ]
     )
     panel = _panel()
     update_model_combined_section(panel, sparse)
@@ -482,11 +519,14 @@ def test_step_time_dashboard_hero_recovered_phase_drops_the_hatch() -> None:
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
     assert by_key["forward"].hatched
-    assert panel["win"].text == "5 aligned steps · partial: FWD"
+    assert (
+        panel["win"].text
+        == "5 aligned steps · representative r0 · partial: FWD"
+    )
 
     # Forward starts reporting again.
-    complete = StepCombinedTimeResult(
-        diagnosis_metrics=[
+    complete = _payload(
+        [
             _metric("input_wait", 10.0),
             _metric("h2d", 10.0),
             _metric("forward", 20.0),
@@ -494,8 +534,7 @@ def test_step_time_dashboard_hero_recovered_phase_drops_the_hatch() -> None:
             _metric("optimizer_step", 20.0),
             _metric("residual_proxy", 20.0),
             _metric("step_time", 100.0),
-        ],
-        diagnosis_clock="cpu",
+        ]
     )
     update_model_combined_section(panel, complete)
 
@@ -503,7 +542,7 @@ def test_step_time_dashboard_hero_recovered_phase_drops_the_hatch() -> None:
     assert not by_key["forward"].hatched
     assert by_key["forward"].background == forward_color
     assert by_key["forward"].width != f"{_UNMEASURED_SLIVER_PCT:.1f}%"
-    assert panel["win"].text == "5 aligned steps"
+    assert panel["win"].text == "5 aligned steps · representative r0"
 
 
 def test_step_time_dashboard_hero_flags_partial_rank_coverage() -> None:
@@ -511,8 +550,8 @@ def test_step_time_dashboard_hero_flags_partial_rank_coverage() -> None:
     # and absent on rank 1, so the canonical diagnosis calls the window
     # INCOMPLETE; the card must not report it as fully covered just
     # because the aggregate metric exists.
-    payload = StepCombinedTimeResult(
-        diagnosis_metrics=[
+    payload = _payload(
+        [
             _metric("input_wait", 10.0),
             _metric("h2d", 10.0),
             _metric("forward", 20.0),
@@ -540,16 +579,19 @@ def test_step_time_dashboard_hero_flags_partial_rank_coverage() -> None:
                 "total_step": 110.0,
             },
         },
-        diagnosis_clock="cpu",
     )
     panel = _panel()
     update_model_combined_section(panel, payload)
 
-    assert panel["win"].text == "5 aligned steps · partial: BWD"
+    assert (
+        panel["win"].text
+        == "5 aligned steps · representative r0 · partial: BWD,RESIDUAL"
+    )
 
     # Control twin: every rank measured everything -> not partial.
-    symmetric = StepCombinedTimeResult(
-        diagnosis_metrics=payload.diagnosis_metrics,
+    assert payload.window is not None
+    symmetric = _payload(
+        payload.window.metrics,
         per_rank_timing={
             rank: {
                 "input_wait": 10.0,
@@ -557,16 +599,16 @@ def test_step_time_dashboard_hero_flags_partial_rank_coverage() -> None:
                 "forward": 20.0,
                 "backward": 30.0,
                 "optimizer_step": 20.0,
+                "residual_proxy": 20.0,
                 "step_time": 100.0,
                 "total_step": 110.0,
             }
             for rank in (0, 1)
         },
-        diagnosis_clock="cpu",
     )
     control = _panel()
     update_model_combined_section(control, symmetric)
-    assert control["win"].text == "5 aligned steps"
+    assert control["win"].text == "5 aligned steps · representative r0"
 
 
 def test_step_time_dashboard_hero_clears_when_step_envelope_missing() -> None:
@@ -574,8 +616,8 @@ def test_step_time_dashboard_hero_clears_when_step_envelope_missing() -> None:
     # with no step_time. Without the envelope there is no denominator, so
     # every share would be invented -- the card must clear rather than
     # leave the previous ribbon and KPIs standing as if they were current.
-    complete = StepCombinedTimeResult(
-        diagnosis_metrics=[
+    complete = _payload(
+        [
             _metric("input_wait", 10.0),
             _metric("h2d", 10.0),
             _metric("forward", 20.0),
@@ -583,20 +625,18 @@ def test_step_time_dashboard_hero_clears_when_step_envelope_missing() -> None:
             _metric("optimizer_step", 20.0),
             _metric("residual_proxy", 20.0),
             _metric("step_time", 100.0),
-        ],
-        diagnosis_clock="cpu",
+        ]
     )
     panel = _panel()
     update_model_combined_section(panel, complete)
-    assert panel["win"].text == "5 aligned steps"
+    assert panel["win"].text == "5 aligned steps · representative r0"
     assert panel["kpis"]["median"].content.startswith("100")
 
-    no_envelope = StepCombinedTimeResult(
-        diagnosis_metrics=[
+    no_envelope = _payload(
+        [
             _metric("input_wait", 10.0),
             _metric("forward", 20.0),
-        ],
-        diagnosis_clock="cpu",
+        ]
     )
     update_model_combined_section(panel, no_envelope)
 
@@ -620,10 +660,7 @@ def test_step_time_dashboard_hero_uses_diagnosis_metrics() -> None:
         _metric("residual_proxy", 20.0),
         _metric("step_time", 100.0, worst=200.0),
     ]
-    payload = StepCombinedTimeResult(
-        diagnosis_metrics=diagnosis_metrics,
-        diagnosis_clock="gpu",
-    )
+    payload = _payload(diagnosis_metrics, clock="gpu")
     panel = _panel()
 
     update_model_combined_section(panel, payload)
@@ -631,10 +668,200 @@ def test_step_time_dashboard_hero_uses_diagnosis_metrics() -> None:
     assert panel["seg_labs"][0].text == "IW"
     # input_wait 10 of the 110 ms iteration envelope.
     assert panel["seg_divs"][0].width == "9.091%"
-    assert panel["win"].text == "5 aligned steps"
+    assert panel["win"].text == "5 aligned steps · representative r0"
     assert panel["kpis"]["median"].content.startswith("100")
     assert panel["kpis"]["worst"].content.startswith("200")
     assert not panel["kpis"]["median"].content.startswith("20")
+
+
+def test_ribbon_selects_one_real_representative_rank() -> None:
+    metrics = [
+        _metric("input_wait", 50.0),
+        _metric("forward", 45.0),
+        _metric("backward", 15.0),
+        _metric("optimizer_step", 7.5),
+        _metric("residual_proxy", 32.5),
+        _metric("step_time", 100.0),
+    ]
+    payload = _payload(
+        metrics,
+        per_rank_timing={
+            0: {
+                "input_wait": 0.0,
+                "forward": 10.0,
+                "backward": 20.0,
+                "optimizer_step": 10.0,
+                "residual_proxy": 60.0,
+                "step_time": 100.0,
+                "total_step": 100.0,
+            },
+            1: {
+                "input_wait": 100.0,
+                "forward": 80.0,
+                "backward": 10.0,
+                "optimizer_step": 5.0,
+                "residual_proxy": 5.0,
+                "step_time": 100.0,
+                "total_step": 200.0,
+            },
+        },
+    )
+    panel = _panel()
+
+    update_model_combined_section(panel, payload)
+
+    keys = [key for _, key, _ in theme.PHASES]
+    segments = dict(zip(keys, panel["seg_divs"]))
+    assert "representative r0" in panel["win"].text
+    assert segments["forward"].width == "10.000%"
+    assert segments["residual_proxy"].width == "60.000%"
+
+
+def test_disjoint_rank_populations_clear_only_the_ribbon() -> None:
+    payload = _payload(
+        [
+            _metric("input_wait", 10.0),
+            _metric("forward", 40.0),
+            _metric("backward", 40.0),
+            _metric("optimizer_step", 10.0),
+            _metric("step_time", 100.0),
+        ],
+        per_rank_timing={
+            0: {
+                "input_wait": 10.0,
+                "forward": 40.0,
+                "step_time": 100.0,
+                "total_step": 110.0,
+            },
+            1: {
+                "backward": 40.0,
+                "optimizer_step": 10.0,
+                "step_time": 120.0,
+            },
+        },
+    )
+    panel = _panel()
+
+    update_model_combined_section(panel, payload)
+
+    assert "no coherent phase cohort" in panel["win"].text
+    assert all(segment.width == "0%" for segment in panel["seg_divs"])
+    assert panel["kpis"]["median"].content.startswith("100")
+    assert panel["kpis"]["gap"].content != theme.kval("—")
+
+
+def test_sqlite_window_has_one_share_across_live_and_summary_consumers(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "step-time-pipeline.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE step_time_samples (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                recv_ts_ns INTEGER NOT NULL,
+                rank INTEGER,
+                global_rank INTEGER,
+                local_rank INTEGER,
+                world_size INTEGER,
+                local_world_size INTEGER,
+                node_rank INTEGER,
+                hostname TEXT,
+                sample_ts_s REAL,
+                seq INTEGER,
+                step INTEGER,
+                events_json TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE runtime_environment (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                training_strategy TEXT
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO runtime_environment(training_strategy) "
+            "VALUES ('ddp');"
+        )
+        values = {
+            "_traceml_internal:dataloader_next": 100.0,
+            "_traceml_internal:forward_time": 30.0,
+            "_traceml_internal:backward_time": 30.0,
+            "_traceml_internal:optimizer_step": 30.0,
+            "_traceml_internal:step_time": 100.0,
+        }
+        events_json = json.dumps(
+            {
+                name: {
+                    "cpu": {
+                        "duration_ms": value,
+                        "cpu_ms": value,
+                        "gpu_ms": None,
+                        "n_calls": 1,
+                    }
+                }
+                for name, value in values.items()
+            }
+        )
+        conn.executemany(
+            """
+            INSERT INTO step_time_samples(
+                recv_ts_ns, rank, global_rank, local_rank, world_size,
+                local_world_size, node_rank, hostname, sample_ts_s,
+                seq, step, events_json
+            ) VALUES (?, 0, 0, 0, 1, 1, 0, 'worker-0', ?, ?, ?, ?);
+            """,
+            [
+                (step, float(step), step, step, events_json)
+                for step in range(1, 31)
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    result = StepCombinedComputer(str(db_path), window_size=30).compute_cli()
+    assert result.window is not None
+    assert result.window.per_rank_timing[0]["residual_proxy"] == pytest.approx(
+        10.0
+    )
+    diagnosis = diagnose_step_time_window(
+        result.window,
+        policy=LIVE_STEP_TIME_POLICY,
+    )
+    assert diagnosis.metric_attribution["residual_proxy"][
+        "share_pct"
+    ] == pytest.approx(0.05)
+
+    summary = load_step_time_section_data(str(db_path), max_rows=30)
+    assert summary.per_global_rank_summary[0].avg_residual_ms == pytest.approx(
+        10.0
+    )
+    assert summary.per_global_rank_summary[0].avg_h2d_ms is None
+
+    renderer = StepCombinedRenderer(str(db_path))
+    monkeypatch.setattr(renderer, "_payload", lambda: result)
+    console = Console(record=True, width=140, color_system=None)
+    console.print(renderer.get_panel_renderable())
+    assert "5.0%" in console.export_text()
+
+    diagnostics = build_model_diagnostics_payload(
+        step_time_window=result.window,
+        step_memory_metrics=(),
+    )
+    step_item = next(
+        item for item in diagnostics.items if item.source == "step_time"
+    )
+    assert step_item.evidence["residual"] == "5.0%"
+
+    panel = _panel()
+    update_model_combined_section(panel, result)
+    assert panel["kpis"]["residual"].content == theme.kval("5", "%")
 
 
 def test_diagnostics_rail_incomplete_data_is_neutral() -> None:

--- a/tests/display/test_model_combined_section.py
+++ b/tests/display/test_model_combined_section.py
@@ -6,6 +6,7 @@ pytest.importorskip("nicegui")
 
 from traceml_ai.aggregator.display_drivers.nicegui_sections import theme
 from traceml_ai.aggregator.display_drivers.nicegui_sections.model_combined_section import (
+    _UNMEASURED_SLIVER_PCT,
     update_model_combined_section,
 )
 from traceml_ai.renderers.step_time.schema import (
@@ -101,16 +102,21 @@ def test_step_time_dashboard_hero_renders_sparse_metrics() -> None:
     update_model_combined_section(panel, payload)
 
     # The panel updated (no freeze): window label reflects the sparse
-    # window and flags the partial coverage.
-    assert panel["win"].text == "5 aligned steps · partial signals"
-    # Missing phases render as empty segments; measured phases scale
-    # against the iteration envelope (input_wait 10 + step 100 = 110),
-    # so unmeasured time stays visible as empty ribbon space.
+    # window and names the missing signal.
+    assert panel["win"].text == "5 aligned steps · partial: RESIDUAL"
+    # H2D is occurrence-driven and absent, so it's plain measured-zero.
+    # residual_proxy is genuinely unmeasured (non-h2d), so it gets the
+    # hatched sliver, not an empty segment indistinguishable from zero.
+    # Measured phases scale against the iteration envelope (input_wait
+    # 10 + step 100 = 110) minus the sliver's reserved width.
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
     assert by_key["h2d"].styles[-1] == "width:0.000%"
-    assert by_key["residual_proxy"].styles[-1] == "width:0.000%"
-    assert by_key["input_wait"].styles[-1] == "width:9.091%"
+    assert (
+        f"width:{_UNMEASURED_SLIVER_PCT:.1f}%"
+        in by_key["residual_proxy"].styles[-1]
+    )
+    assert by_key["input_wait"].styles[-1] == "width:8.545%"
     # An underivable residual shows n/a, never a fake 0%.
     assert "n/a" in panel["kpis"]["residual"].content
     assert panel["kpis"]["median"].content.startswith("100")
@@ -173,10 +179,118 @@ def test_step_time_dashboard_hero_step_time_only_extreme() -> None:
 
     update_model_combined_section(panel, payload)
 
-    assert panel["win"].text == "5 aligned steps · partial signals"
-    assert all(seg.styles[-1] == "width:0.000%" for seg in panel["seg_divs"])
+    assert (
+        panel["win"].text
+        == "5 aligned steps · partial: IW,FWD,BWD,OPT,RESIDUAL"
+    )
+    keys = [key for _, key, _ in theme.PHASES]
+    by_key = dict(zip(keys, panel["seg_divs"]))
+    assert by_key["h2d"].styles[-1] == "width:0.000%"
+    for key in (
+        "input_wait",
+        "forward",
+        "backward",
+        "optimizer_step",
+        "residual_proxy",
+    ):
+        assert f"width:{_UNMEASURED_SLIVER_PCT:.1f}%" in by_key[key].styles[-1]
     assert "n/a" in panel["kpis"]["residual"].content
     assert panel["kpis"]["median"].content.startswith("100")
+
+
+def test_step_time_dashboard_hero_dark_input_wait_is_not_measured_zero() -> (
+    None
+):
+    # #88/#135 shape: the dataloader stream goes dark while everything
+    # else keeps reporting. residual_proxy is a remainder (step_time -
+    # h2d - forward - backward - optimizer_step) so it stays derivable
+    # even though input_wait itself is unmeasured -- the ribbon must not
+    # let the OTHER phases silently fill to 100% and read as "confirmed
+    # no wait", which is exactly the class of bug this test pins.
+    dark_input_wait = StepCombinedTimeResult(
+        diagnosis_metrics=[
+            _metric("h2d", 10.0),
+            _metric("forward", 20.0),
+            _metric("backward", 30.0),
+            _metric("optimizer_step", 20.0),
+            _metric("residual_proxy", 20.0),
+            _metric("step_time", 100.0),
+        ],
+        diagnosis_clock="cpu",
+    )
+    panel = _panel()
+    update_model_combined_section(panel, dark_input_wait)
+
+    keys = [key for _, key, _ in theme.PHASES]
+    by_key = dict(zip(keys, panel["seg_divs"]))
+    # Unmeasured, not a confirmed-zero: the hatched sliver, not 0%.
+    assert (
+        f"width:{_UNMEASURED_SLIVER_PCT:.1f}%"
+        in by_key["input_wait"].styles[-1]
+    )
+    assert panel["win"].text == "5 aligned steps · partial: IW"
+
+    # Control twin: input_wait genuinely measured as 0ms must render as
+    # a real 0%-width segment, distinct from the unmeasured case above.
+    measured_zero_input_wait = StepCombinedTimeResult(
+        diagnosis_metrics=[
+            _metric("input_wait", 0.0),
+            _metric("h2d", 10.0),
+            _metric("forward", 20.0),
+            _metric("backward", 30.0),
+            _metric("optimizer_step", 20.0),
+            _metric("residual_proxy", 20.0),
+            _metric("step_time", 100.0),
+        ],
+        diagnosis_clock="cpu",
+    )
+    control_panel = _panel()
+    update_model_combined_section(control_panel, measured_zero_input_wait)
+    control_by_key = dict(zip(keys, control_panel["seg_divs"]))
+    assert control_by_key["input_wait"].styles[-1] == "width:0.000%"
+    assert control_panel["win"].text == "5 aligned steps"
+
+
+def test_step_time_dashboard_hero_dead_run_shows_expired() -> None:
+    # The CLI sibling distinguishes "no data yet" from "had data, now
+    # expired" via StepCombinedComputer.had_ok; the dashboard hero must
+    # do the same instead of freezing on the last complete view forever.
+    good = StepCombinedTimeResult(
+        diagnosis_metrics=[
+            _metric("input_wait", 10.0),
+            _metric("h2d", 10.0),
+            _metric("forward", 20.0),
+            _metric("backward", 30.0),
+            _metric("optimizer_step", 20.0),
+            _metric("residual_proxy", 20.0),
+            _metric("step_time", 100.0),
+        ],
+        diagnosis_clock="cpu",
+        had_ok=True,
+    )
+    panel = _panel()
+    update_model_combined_section(panel, good)
+    assert panel["win"].text == "5 aligned steps"
+    assert panel["kpis"]["median"].content.startswith("100")
+
+    # A never-had-data payload (cold start) must NOT clear the panel --
+    # there is nothing to clear yet.
+    cold_start = StepCombinedTimeResult(diagnosis_metrics=[], had_ok=False)
+    cold_panel = _panel()
+    update_model_combined_section(cold_panel, cold_start)
+    assert cold_panel["win"].text == ""
+
+    # TTL expired: the computer reports had_ok=True with empty metrics.
+    # The dashboard must visibly clear rather than keep showing "good".
+    expired = StepCombinedTimeResult(diagnosis_metrics=[], had_ok=True)
+    update_model_combined_section(panel, expired)
+
+    assert panel["win"].text == "window expired"
+    assert all(seg.styles[-1] == "width:0%;" for seg in panel["seg_divs"])
+    assert all(sl.text == "" for sl in panel["seg_labs"])
+    assert all(
+        kpi.content == theme.kval("—") for kpi in panel["kpis"].values()
+    )
 
 
 def test_step_time_dashboard_hero_ignores_payload_without_step_time() -> None:

--- a/tests/display/test_model_combined_section.py
+++ b/tests/display/test_model_combined_section.py
@@ -214,22 +214,130 @@ def test_step_time_dashboard_hero_step_time_only_extreme() -> None:
 
     update_model_combined_section(panel, payload)
 
-    # h2d AND optimizer_step are occurrence-driven, so their absence is
-    # measured-zero, not a coverage gap -- matching the diagnosis engine's
-    # OCCURRENCE_METRICS. Only the required-every-step phases are partial.
+    # Only h2d is exempt. Occurrence-driven governs INTERMITTENT presence
+    # (seen once, gaps zero-filled); a phase never seen at all is
+    # unavailable even when occurrence-driven, which is what
+    # `_rank_metric_availability` does by only considering metrics it
+    # actually observed. So a wholly absent optimizer_step IS partial.
     assert (
-        panel["win"].text == "5 aligned steps · partial: IW,FWD,BWD,RESIDUAL"
+        panel["win"].text
+        == "5 aligned steps · partial: IW,FWD,BWD,OPT,RESIDUAL"
     )
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
-    for occurrence in ("h2d", "optimizer_step"):
-        assert by_key[occurrence].width == "0.000%"
-        assert not by_key[occurrence].hatched
-    for key in ("input_wait", "forward", "backward", "residual_proxy"):
+    assert by_key["h2d"].width == "0.000%"
+    assert not by_key["h2d"].hatched
+    for key in (
+        "input_wait",
+        "forward",
+        "backward",
+        "optimizer_step",
+        "residual_proxy",
+    ):
         assert by_key[key].width == f"{_UNMEASURED_SLIVER_PCT:.1f}%"
         assert by_key[key].hatched
     assert "n/a" in panel["kpis"]["residual"].content
     assert panel["kpis"]["median"].content.startswith("100")
+
+
+def test_absent_optimizer_step_is_not_a_measured_zero() -> None:
+    # Narrow guard for the predicate itself. optimizer_step is
+    # occurrence-driven, but "never observed in the whole window" is
+    # absence, not an occurrence of zero: the canonical availability rule
+    # drops a never-seen optimizer entirely, so the card must not render
+    # it as a confident 0%.
+    payload = StepCombinedTimeResult(
+        diagnosis_metrics=[
+            _metric("input_wait", 10.0),
+            _metric("h2d", 10.0),
+            _metric("forward", 20.0),
+            _metric("backward", 30.0),
+            _metric("residual_proxy", 20.0),
+            _metric("step_time", 100.0),
+        ],
+        diagnosis_clock="cpu",
+    )
+    panel = _panel()
+    update_model_combined_section(panel, payload)
+
+    keys = [key for _, key, _ in theme.PHASES]
+    by_key = dict(zip(keys, panel["seg_divs"]))
+    assert by_key["optimizer_step"].hatched
+    assert panel["win"].text == "5 aligned steps · partial: OPT"
+
+
+def test_residual_share_is_na_when_input_wait_is_unavailable() -> None:
+    # residual_proxy derives from step_time and the compute phases, so it
+    # survives an unmeasured input_wait -- but the DENOMINATOR does not.
+    # The envelope substitutes zero for the missing wait, so any share
+    # computed against it is a confident percentage of an unknown total.
+    payload = StepCombinedTimeResult(
+        diagnosis_metrics=[
+            _metric("h2d", 10.0),
+            _metric("forward", 20.0),
+            _metric("backward", 30.0),
+            _metric("optimizer_step", 20.0),
+            _metric("residual_proxy", 10.0),
+            _metric("step_time", 100.0),
+        ],
+        diagnosis_clock="cpu",
+    )
+    panel = _panel()
+    update_model_combined_section(panel, payload)
+
+    assert "n/a" in panel["kpis"]["residual"].content
+
+    # Control twin: with input_wait measured the denominator is whole, so
+    # the same residual reports a real share.
+    with_wait = StepCombinedTimeResult(
+        diagnosis_metrics=list(payload.diagnosis_metrics)
+        + [_metric("input_wait", 10.0)],
+        diagnosis_clock="cpu",
+    )
+    control = _panel()
+    update_model_combined_section(control, with_wait)
+    assert "n/a" not in control["kpis"]["residual"].content
+
+
+def test_partial_rank_coverage_includes_step_time() -> None:
+    # step_time is not a ribbon phase, but it is the envelope every share
+    # is computed against, so a rank missing it makes the window
+    # incomplete exactly as the engine reports it.
+    payload = StepCombinedTimeResult(
+        diagnosis_metrics=[
+            _metric("input_wait", 10.0),
+            _metric("h2d", 10.0),
+            _metric("forward", 20.0),
+            _metric("backward", 30.0),
+            _metric("optimizer_step", 20.0),
+            _metric("residual_proxy", 20.0),
+            _metric("step_time", 100.0),
+        ],
+        per_rank_timing={
+            0: {
+                "input_wait": 10.0,
+                "h2d": 10.0,
+                "forward": 20.0,
+                "backward": 30.0,
+                "optimizer_step": 20.0,
+                "step_time": 100.0,
+                "total_step": 110.0,
+            },
+            1: {
+                "input_wait": 10.0,
+                "h2d": 10.0,
+                "forward": 20.0,
+                "backward": 30.0,
+                "optimizer_step": 20.0,
+                "total_step": 110.0,
+            },
+        },
+        diagnosis_clock="cpu",
+    )
+    panel = _panel()
+    update_model_combined_section(panel, payload)
+
+    assert panel["win"].text == "5 aligned steps · partial: STEP"
 
 
 def test_step_time_dashboard_hero_dark_input_wait_is_not_measured_zero() -> (

--- a/tests/display/test_model_combined_section.py
+++ b/tests/display/test_model_combined_section.py
@@ -18,12 +18,40 @@ from traceml_ai.renderers.step_time.schema import (
 
 
 class _FakeSegment:
+    """Style double that MERGES like NiceGUI's ``Element.style()``.
+
+    An append-only list of style strings would let a stale declaration
+    (e.g. an unmeasured phase's hatch) survive a later width-only update
+    while every assertion still passed, because assertions read the last
+    call instead of the resulting style. Merging into a dict is what
+    makes that class of bug visible to a test at all. Pinned against the
+    real widget by ``test_fake_segment_matches_nicegui_style_merge``.
+    """
+
     def __init__(self) -> None:
         self.styles: list[str] = []
+        self.declarations: dict[str, str] = {}
 
     def style(self, value: str) -> "_FakeSegment":
         self.styles.append(value)
+        for part in value.split(";"):
+            if ":" not in part:
+                continue
+            name, _, val = part.partition(":")
+            self.declarations[name.strip()] = val.strip()
         return self
+
+    @property
+    def background(self) -> str:
+        return self.declarations.get("background", "")
+
+    @property
+    def width(self) -> str:
+        return self.declarations.get("width", "")
+
+    @property
+    def hatched(self) -> bool:
+        return "repeating-linear-gradient" in self.background
 
 
 class _FakeText:
@@ -112,18 +140,18 @@ def test_step_time_dashboard_hero_renders_sparse_metrics() -> None:
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
     by_lab = dict(zip(keys, panel["seg_labs"]))
-    assert by_key["h2d"].styles[-1] == "width:0.000%"
-    residual_sliver = by_key["residual_proxy"].styles[-1]
-    assert f"width:{_UNMEASURED_SLIVER_PCT:.1f}%" in residual_sliver
+    assert by_key["h2d"].width == "0.000%"
+    residual_seg = by_key["residual_proxy"]
+    assert residual_seg.width == f"{_UNMEASURED_SLIVER_PCT:.1f}%"
     # The hatch is drawn in the PHASE'S OWN color (residual = gold), so the
     # sliver still identifies which phase, matching the legend dot.
     residual_color = dict((k, c) for _, k, c in theme.PHASES)["residual_proxy"]
-    assert "repeating-linear-gradient" in residual_sliver
-    assert residual_color in residual_sliver
+    assert residual_seg.hatched
+    assert residual_color in residual_seg.background
     # The sliver carries NO on-segment text -- it would overlap the hatch
     # illegibly; the missing phases are named in the window meta instead.
     assert by_lab["residual_proxy"].text == ""
-    assert by_key["input_wait"].styles[-1] == "width:8.545%"
+    assert by_key["input_wait"].width == "8.545%"
     # An underivable residual shows n/a, never a fake 0%.
     assert "n/a" in panel["kpis"]["residual"].content
     assert panel["kpis"]["median"].content.startswith("100")
@@ -174,7 +202,7 @@ def test_step_time_dashboard_hero_absent_h2d_is_not_partial() -> None:
     assert panel["win"].text == "5 aligned steps"
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
-    assert by_key["h2d"].styles[-1] == "width:0.000%"
+    assert by_key["h2d"].width == "0.000%"
 
 
 def test_step_time_dashboard_hero_step_time_only_extreme() -> None:
@@ -186,21 +214,20 @@ def test_step_time_dashboard_hero_step_time_only_extreme() -> None:
 
     update_model_combined_section(panel, payload)
 
+    # h2d AND optimizer_step are occurrence-driven, so their absence is
+    # measured-zero, not a coverage gap -- matching the diagnosis engine's
+    # OCCURRENCE_METRICS. Only the required-every-step phases are partial.
     assert (
-        panel["win"].text
-        == "5 aligned steps · partial: IW,FWD,BWD,OPT,RESIDUAL"
+        panel["win"].text == "5 aligned steps · partial: IW,FWD,BWD,RESIDUAL"
     )
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
-    assert by_key["h2d"].styles[-1] == "width:0.000%"
-    for key in (
-        "input_wait",
-        "forward",
-        "backward",
-        "optimizer_step",
-        "residual_proxy",
-    ):
-        assert f"width:{_UNMEASURED_SLIVER_PCT:.1f}%" in by_key[key].styles[-1]
+    for occurrence in ("h2d", "optimizer_step"):
+        assert by_key[occurrence].width == "0.000%"
+        assert not by_key[occurrence].hatched
+    for key in ("input_wait", "forward", "backward", "residual_proxy"):
+        assert by_key[key].width == f"{_UNMEASURED_SLIVER_PCT:.1f}%"
+        assert by_key[key].hatched
     assert "n/a" in panel["kpis"]["residual"].content
     assert panel["kpis"]["median"].content.startswith("100")
 
@@ -231,10 +258,8 @@ def test_step_time_dashboard_hero_dark_input_wait_is_not_measured_zero() -> (
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
     # Unmeasured, not a confirmed-zero: the hatched sliver, not 0%.
-    assert (
-        f"width:{_UNMEASURED_SLIVER_PCT:.1f}%"
-        in by_key["input_wait"].styles[-1]
-    )
+    assert by_key["input_wait"].width == f"{_UNMEASURED_SLIVER_PCT:.1f}%"
+    assert by_key["input_wait"].hatched
     assert panel["win"].text == "5 aligned steps · partial: IW"
 
     # Control twin: input_wait genuinely measured as 0ms must render as
@@ -254,7 +279,7 @@ def test_step_time_dashboard_hero_dark_input_wait_is_not_measured_zero() -> (
     control_panel = _panel()
     update_model_combined_section(control_panel, measured_zero_input_wait)
     control_by_key = dict(zip(keys, control_panel["seg_divs"]))
-    assert control_by_key["input_wait"].styles[-1] == "width:0.000%"
+    assert control_by_key["input_wait"].width == "0.000%"
     assert control_panel["win"].text == "5 aligned steps"
 
 
@@ -293,28 +318,185 @@ def test_step_time_dashboard_hero_dead_run_shows_expired() -> None:
     update_model_combined_section(panel, expired)
 
     assert panel["win"].text == "window expired"
-    assert all(seg.styles[-1] == "width:0%;" for seg in panel["seg_divs"])
+    assert all(seg.width == "0%" for seg in panel["seg_divs"])
     assert all(sl.text == "" for sl in panel["seg_labs"])
     assert all(
         kpi.content == theme.kval("—") for kpi in panel["kpis"].values()
     )
 
 
-def test_step_time_dashboard_hero_ignores_payload_without_step_time() -> None:
+def test_fake_segment_matches_nicegui_style_merge() -> None:
+    """Pin the double against the real widget.
+
+    ``Element.style()`` MERGES declarations, so a background set while a
+    phase was unmeasured outlives a later width-only update. A double
+    that only appended style strings could never express that, which is
+    how the stale-hatch bug reached review: the test could not fail.
+    """
+    from nicegui import ui
+
+    real = ui.element("div")
+    fake = _FakeSegment()
+    for call in (
+        "background:#1976d2; width:0%;",
+        "width:6.0%; background:repeating-linear-gradient(45deg, "
+        "#1976d2 0 2px, transparent 2px 5px);",
+        "width:33.000%; background:#1976d2;",
+    ):
+        real.style(call)
+        fake.style(call)
+
+    assert dict(real._style) == fake.declarations
+    # And the property the production fix depends on: restating the
+    # background is what clears a previously-hatched segment.
+    assert not fake.hatched
+
+
+def test_step_time_dashboard_hero_recovered_phase_drops_the_hatch() -> None:
+    # Stateful sparse -> complete. NiceGUI merges styles, so a phase that
+    # was hatched while unmeasured must have its solid background
+    # restored on recovery; otherwise it stays visually "unmeasured"
+    # forever while reporting a real width.
+    sparse = StepCombinedTimeResult(
+        diagnosis_metrics=[
+            _metric("input_wait", 10.0),
+            _metric("h2d", 10.0),
+            _metric("backward", 30.0),
+            _metric("optimizer_step", 20.0),
+            _metric("residual_proxy", 20.0),
+            _metric("step_time", 100.0),
+        ],
+        diagnosis_clock="cpu",
+    )
+    panel = _panel()
+    update_model_combined_section(panel, sparse)
+
+    keys = [key for _, key, _ in theme.PHASES]
+    by_key = dict(zip(keys, panel["seg_divs"]))
+    assert by_key["forward"].hatched
+    assert panel["win"].text == "5 aligned steps · partial: FWD"
+
+    # Forward starts reporting again.
+    complete = StepCombinedTimeResult(
+        diagnosis_metrics=[
+            _metric("input_wait", 10.0),
+            _metric("h2d", 10.0),
+            _metric("forward", 20.0),
+            _metric("backward", 30.0),
+            _metric("optimizer_step", 20.0),
+            _metric("residual_proxy", 20.0),
+            _metric("step_time", 100.0),
+        ],
+        diagnosis_clock="cpu",
+    )
+    update_model_combined_section(panel, complete)
+
+    forward_color = dict((k, c) for _, k, c in theme.PHASES)["forward"]
+    assert not by_key["forward"].hatched
+    assert by_key["forward"].background == forward_color
+    assert by_key["forward"].width != f"{_UNMEASURED_SLIVER_PCT:.1f}%"
+    assert panel["win"].text == "5 aligned steps"
+
+
+def test_step_time_dashboard_hero_flags_partial_rank_coverage() -> None:
+    # Aggregate presence is not coverage. Backward is measured on rank 0
+    # and absent on rank 1, so the canonical diagnosis calls the window
+    # INCOMPLETE; the card must not report it as fully covered just
+    # because the aggregate metric exists.
     payload = StepCombinedTimeResult(
+        diagnosis_metrics=[
+            _metric("input_wait", 10.0),
+            _metric("h2d", 10.0),
+            _metric("forward", 20.0),
+            _metric("backward", 30.0),
+            _metric("optimizer_step", 20.0),
+            _metric("residual_proxy", 20.0),
+            _metric("step_time", 100.0),
+        ],
+        per_rank_timing={
+            0: {
+                "input_wait": 10.0,
+                "h2d": 10.0,
+                "forward": 20.0,
+                "backward": 30.0,
+                "optimizer_step": 20.0,
+                "step_time": 100.0,
+                "total_step": 110.0,
+            },
+            1: {
+                "input_wait": 10.0,
+                "h2d": 10.0,
+                "forward": 20.0,
+                "optimizer_step": 20.0,
+                "step_time": 100.0,
+                "total_step": 110.0,
+            },
+        },
+        diagnosis_clock="cpu",
+    )
+    panel = _panel()
+    update_model_combined_section(panel, payload)
+
+    assert panel["win"].text == "5 aligned steps · partial: BWD"
+
+    # Control twin: every rank measured everything -> not partial.
+    symmetric = StepCombinedTimeResult(
+        diagnosis_metrics=payload.diagnosis_metrics,
+        per_rank_timing={
+            rank: {
+                "input_wait": 10.0,
+                "h2d": 10.0,
+                "forward": 20.0,
+                "backward": 30.0,
+                "optimizer_step": 20.0,
+                "step_time": 100.0,
+                "total_step": 110.0,
+            }
+            for rank in (0, 1)
+        },
+        diagnosis_clock="cpu",
+    )
+    control = _panel()
+    update_model_combined_section(control, symmetric)
+    assert control["win"].text == "5 aligned steps"
+
+
+def test_step_time_dashboard_hero_clears_when_step_envelope_missing() -> None:
+    # Stateful: a COMPLETE window is drawn first, then a window arrives
+    # with no step_time. Without the envelope there is no denominator, so
+    # every share would be invented -- the card must clear rather than
+    # leave the previous ribbon and KPIs standing as if they were current.
+    complete = StepCombinedTimeResult(
+        diagnosis_metrics=[
+            _metric("input_wait", 10.0),
+            _metric("h2d", 10.0),
+            _metric("forward", 20.0),
+            _metric("backward", 30.0),
+            _metric("optimizer_step", 20.0),
+            _metric("residual_proxy", 20.0),
+            _metric("step_time", 100.0),
+        ],
+        diagnosis_clock="cpu",
+    )
+    panel = _panel()
+    update_model_combined_section(panel, complete)
+    assert panel["win"].text == "5 aligned steps"
+    assert panel["kpis"]["median"].content.startswith("100")
+
+    no_envelope = StepCombinedTimeResult(
         diagnosis_metrics=[
             _metric("input_wait", 10.0),
             _metric("forward", 20.0),
         ],
         diagnosis_clock="cpu",
     )
-    panel = _panel()
+    update_model_combined_section(panel, no_envelope)
 
-    update_model_combined_section(panel, payload)
-
-    # Without the step envelope there is nothing coherent to draw: the
-    # panel stays untouched instead of raising into the UI tick.
-    assert panel["win"].text == ""
+    assert panel["win"].text == "step envelope unavailable"
+    assert all(seg.width == "0%" for seg in panel["seg_divs"])
+    assert all(
+        kpi.content == theme.kval("—") for kpi in panel["kpis"].values()
+    )
 
 
 def test_step_time_dashboard_hero_uses_diagnosis_metrics() -> None:
@@ -340,7 +522,7 @@ def test_step_time_dashboard_hero_uses_diagnosis_metrics() -> None:
 
     assert panel["seg_labs"][0].text == "IW"
     # input_wait 10 of the 110 ms iteration envelope.
-    assert panel["seg_divs"][0].styles[-1] == "width:9.091%"
+    assert panel["seg_divs"][0].width == "9.091%"
     assert panel["win"].text == "5 aligned steps"
     assert panel["kpis"]["median"].content.startswith("100")
     assert panel["kpis"]["worst"].content.startswith("200")

--- a/tests/renderers/test_step_time_compute.py
+++ b/tests/renderers/test_step_time_compute.py
@@ -175,13 +175,18 @@ def test_computer_bridges_transients_then_expires(monkeypatch) -> None:
     results = iter([good, empty, empty])
     monkeypatch.setattr(computer, "_compute_impl", lambda conn: next(results))
 
-    assert computer.compute_cli().diagnosis_metrics == [metric]
+    first = computer.compute_cli()
+    assert first.diagnosis_metrics == [metric]
     assert computer.had_ok is True
+    # The payload itself carries had_ok too (dashboard subscribers only
+    # ever see the payload, never the computer instance directly).
+    assert first.had_ok is True
 
     # Within the TTL a transient gap re-serves the last good metrics.
     bridged = computer.compute_cli()
     assert bridged.diagnosis_metrics == [metric]
     assert bridged.status_message.startswith("STALE")
+    assert bridged.had_ok is True
 
     # Past the TTL the empty result comes through unbridged.
     monkeypatch.setattr(
@@ -193,3 +198,23 @@ def test_computer_bridges_transients_then_expires(monkeypatch) -> None:
     assert expired.diagnosis_metrics == []
     assert expired.status_message == "No fresh step-combined data"
     assert computer.had_ok is True
+    assert expired.had_ok is True
+
+
+def test_computer_had_ok_stays_false_on_cold_start(monkeypatch) -> None:
+    """A payload that never had good data reports had_ok=False on itself,
+    not just on the computer -- distinguishes cold start from a dead run
+    for any consumer that only sees the payload (issue #259)."""
+    from traceml_ai.renderers.step_time.schema import StepCombinedTimeResult
+
+    computer = StepCombinedComputer(db_path=":memory:", stale_ttl_s=30.0)
+    monkeypatch.setattr(
+        computer,
+        "_compute_impl",
+        lambda conn: StepCombinedTimeResult(status_message="no rows"),
+    )
+
+    result = computer.compute_cli()
+    assert result.diagnosis_metrics == []
+    assert result.had_ok is False
+    assert computer.had_ok is False

--- a/tests/renderers/test_step_time_compute.py
+++ b/tests/renderers/test_step_time_compute.py
@@ -122,3 +122,74 @@ def test_worst_rank_requires_measured_total_step() -> None:
         )
         == 0
     )
+
+
+def test_computer_bridges_transients_then_expires(monkeypatch) -> None:
+    """The last-ok window is the only flicker/dead-view bridge (issue #259).
+
+    A transient empty compute re-serves the last good metrics with a
+    STALE status; once the TTL passes, the empty result comes through
+    and had_ok records that data existed before.
+    """
+    from traceml_ai.renderers.step_time import compute as compute_module
+    from traceml_ai.renderers.step_time.schema import (
+        StepCombinedTimeCoverage,
+        StepCombinedTimeMetric,
+        StepCombinedTimeResult,
+        StepCombinedTimeSummary,
+    )
+
+    metric = StepCombinedTimeMetric(
+        metric="step_time",
+        clock="cpu",
+        series=None,
+        summary=StepCombinedTimeSummary(
+            window_size=1,
+            steps_used=1,
+            median_total=10.0,
+            worst_total=10.0,
+            worst_rank=0,
+            skew_ratio=0.0,
+            skew_pct=0.0,
+        ),
+        coverage=StepCombinedTimeCoverage(
+            expected_steps=1,
+            steps_used=1,
+            completed_step=1,
+            world_size=1,
+            ranks_present=1,
+            incomplete=False,
+        ),
+    )
+    good = StepCombinedTimeResult(
+        status_message="OK",
+        per_rank_timing={0: {"step_time": 10.0, "total_step": 10.0}},
+        diagnosis_clock="cpu",
+        diagnosis_metrics=[metric],
+    )
+    empty = StepCombinedTimeResult(status_message="no rows")
+
+    computer = StepCombinedComputer(db_path=":memory:", stale_ttl_s=30.0)
+    assert computer.had_ok is False
+
+    results = iter([good, empty, empty])
+    monkeypatch.setattr(computer, "_compute_impl", lambda conn: next(results))
+
+    assert computer.compute_cli().diagnosis_metrics == [metric]
+    assert computer.had_ok is True
+
+    # Within the TTL a transient gap re-serves the last good metrics.
+    bridged = computer.compute_cli()
+    assert bridged.diagnosis_metrics == [metric]
+    assert bridged.status_message.startswith("STALE")
+
+    # Past the TTL the empty result comes through unbridged.
+    monkeypatch.setattr(
+        compute_module.time,
+        "time",
+        lambda: computer._last_ok_ts + 31.0,
+    )
+    expired = computer.compute_cli()
+    assert expired.diagnosis_metrics == []
+    assert expired.status_message == "No fresh step-combined data"
+    assert computer.had_ok is True

--- a/tests/renderers/test_step_time_compute.py
+++ b/tests/renderers/test_step_time_compute.py
@@ -201,6 +201,87 @@ def test_computer_bridges_transients_then_expires(monkeypatch) -> None:
     assert expired.had_ok is True
 
 
+def test_dead_run_expires_even_though_sqlite_rows_persist(
+    monkeypatch,
+) -> None:
+    """The dead-run tripwire must actually trip.
+
+    SQLite rows outlive the process that wrote them, so a stopped run
+    keeps recomputing the SAME window successfully forever. Before source
+    -freshness tracking, that reset the stale timer on every tick and the
+    advertised expiry never fired in a real run, only in tests that
+    forced an empty compute.
+    """
+    from traceml_ai.renderers.step_time import compute as compute_module
+    from traceml_ai.renderers.step_time.schema import (
+        StepCombinedTimeCoverage,
+        StepCombinedTimeMetric,
+        StepCombinedTimeResult,
+        StepCombinedTimeSummary,
+    )
+
+    def _result(completed_step: int) -> StepCombinedTimeResult:
+        metric = StepCombinedTimeMetric(
+            metric="step_time",
+            clock="cpu",
+            series=None,
+            summary=StepCombinedTimeSummary(
+                window_size=1,
+                steps_used=1,
+                median_total=10.0,
+                worst_total=10.0,
+                worst_rank=0,
+                skew_ratio=0.0,
+                skew_pct=0.0,
+            ),
+            coverage=StepCombinedTimeCoverage(
+                expected_steps=1,
+                steps_used=1,
+                completed_step=completed_step,
+                world_size=1,
+                ranks_present=1,
+                incomplete=False,
+            ),
+        )
+        return StepCombinedTimeResult(
+            status_message="OK",
+            per_rank_timing={0: {"step_time": 10.0, "total_step": 10.0}},
+            diagnosis_clock="cpu",
+            diagnosis_metrics=[metric],
+        )
+
+    computer = StepCombinedComputer(db_path=":memory:", stale_ttl_s=30.0)
+
+    now = [1000.0]
+    monkeypatch.setattr(compute_module.time, "time", lambda: now[0])
+
+    # Live run: the window advances, so every tick stays fresh.
+    step = [1]
+    monkeypatch.setattr(
+        computer, "_compute_impl", lambda conn: _result(step[0])
+    )
+    assert computer.compute_cli().diagnosis_metrics != []
+    now[0] += 60.0
+    step[0] = 2
+    assert computer.compute_cli().diagnosis_metrics != []
+
+    # Producer stops. Rows remain, so _compute_impl keeps succeeding with
+    # the SAME completed_step. Within the TTL the view is still served.
+    now[0] += 10.0
+    assert computer.compute_cli().diagnosis_metrics != []
+
+    # Past the TTL with no advance, the view must expire.
+    now[0] += 31.0
+    expired = computer.compute_cli()
+    assert expired.diagnosis_metrics == []
+    assert expired.had_ok is True
+    assert expired.status_message == "No fresh step-combined data"
+
+    # And it recovers if the producer comes back.
+    step[0] = 3
+    assert computer.compute_cli().diagnosis_metrics != []
+
+
 def test_computer_had_ok_stays_false_on_cold_start(monkeypatch) -> None:
     """A payload that never had good data reports had_ok=False on itself,
     not just on the computer -- distinguishes cold start from a dead run

--- a/tests/renderers/test_step_time_compute.py
+++ b/tests/renderers/test_step_time_compute.py
@@ -2,6 +2,7 @@ import json
 import sqlite3
 
 from traceml_ai.renderers.step_time.compute import StepCombinedComputer
+from traceml_ai.utils.step_time_window import StepTimeWindow
 
 
 def test_step_time_compute_uses_selected_gpu_diagnosis_clock(
@@ -84,17 +85,18 @@ def test_step_time_compute_uses_selected_gpu_diagnosis_clock(
         window_size=2,
     ).compute_cli()
 
-    metrics = {metric.metric: metric for metric in result.diagnosis_metrics}
+    assert result.window is not None
+    metrics = {metric.metric: metric for metric in result.window.metrics}
     assert "dataloader_fetch" not in metrics
     assert metrics["input_wait"].summary.worst_total == 5.0
     assert metrics["step_time"].summary.worst_total == 30.0
     assert metrics["input_wait"].series is not None
     assert metrics["input_wait"].series.worst == [4.0, 6.0]
     assert metrics["input_wait"].series.sum == [4.0, 6.0]
-    assert result.diagnosis_clock == "gpu"
+    assert result.window.clock == "gpu"
     assert result.training_strategy == "ddp"
 
-    per_rank = result.per_rank_timing[0]
+    per_rank = result.window.per_rank_timing[0]
     assert per_rank["input_wait"] == 5.0
     assert per_rank["step_time"] == 30.0
 
@@ -163,9 +165,11 @@ def test_computer_bridges_transients_then_expires(monkeypatch) -> None:
     )
     good = StepCombinedTimeResult(
         status_message="OK",
-        per_rank_timing={0: {"step_time": 10.0, "total_step": 10.0}},
-        diagnosis_clock="cpu",
-        diagnosis_metrics=[metric],
+        window=StepTimeWindow(
+            expected_ranks=(0,),
+            per_rank_timing={0: {"step_time": 10.0, "total_step": 10.0}},
+            metrics=[metric],
+        ),
     )
     empty = StepCombinedTimeResult(status_message="no rows")
 
@@ -176,7 +180,7 @@ def test_computer_bridges_transients_then_expires(monkeypatch) -> None:
     monkeypatch.setattr(computer, "_compute_impl", lambda conn: next(results))
 
     first = computer.compute_cli()
-    assert first.diagnosis_metrics == [metric]
+    assert first.window is not None and first.window.metrics == [metric]
     assert computer.had_ok is True
     # The payload itself carries had_ok too (dashboard subscribers only
     # ever see the payload, never the computer instance directly).
@@ -184,7 +188,7 @@ def test_computer_bridges_transients_then_expires(monkeypatch) -> None:
 
     # Within the TTL a transient gap re-serves the last good metrics.
     bridged = computer.compute_cli()
-    assert bridged.diagnosis_metrics == [metric]
+    assert bridged.window is not None and bridged.window.metrics == [metric]
     assert bridged.status_message.startswith("STALE")
     assert bridged.had_ok is True
 
@@ -195,23 +199,16 @@ def test_computer_bridges_transients_then_expires(monkeypatch) -> None:
         lambda: computer._last_ok_ts + 31.0,
     )
     expired = computer.compute_cli()
-    assert expired.diagnosis_metrics == []
+    assert expired.window is None
     assert expired.status_message == "No fresh step-combined data"
     assert computer.had_ok is True
     assert expired.had_ok is True
 
 
-def test_dead_run_expires_even_though_sqlite_rows_persist(
+def test_non_advancing_nonempty_window_does_not_claim_source_expiry(
     monkeypatch,
 ) -> None:
-    """The dead-run tripwire must actually trip.
-
-    SQLite rows outlive the process that wrote them, so a stopped run
-    keeps recomputing the SAME window successfully forever. Before source
-    -freshness tracking, that reset the stale timer on every tick and the
-    advertised expiry never fired in a real run, only in tests that
-    forced an empty compute.
-    """
+    """Persisted rows cannot establish whether their producer is alive."""
     from traceml_ai.renderers.step_time import compute as compute_module
     from traceml_ai.renderers.step_time.schema import (
         StepCombinedTimeCoverage,
@@ -245,9 +242,11 @@ def test_dead_run_expires_even_though_sqlite_rows_persist(
         )
         return StepCombinedTimeResult(
             status_message="OK",
-            per_rank_timing={0: {"step_time": 10.0, "total_step": 10.0}},
-            diagnosis_clock="cpu",
-            diagnosis_metrics=[metric],
+            window=StepTimeWindow(
+                expected_ranks=(0,),
+                per_rank_timing={0: {"step_time": 10.0, "total_step": 10.0}},
+                metrics=[metric],
+            ),
         )
 
     computer = StepCombinedComputer(db_path=":memory:", stale_ttl_s=30.0)
@@ -260,31 +259,31 @@ def test_dead_run_expires_even_though_sqlite_rows_persist(
     monkeypatch.setattr(
         computer, "_compute_impl", lambda conn: _result(step[0])
     )
-    assert computer.compute_cli().diagnosis_metrics != []
+    assert computer.compute_cli().window is not None
     now[0] += 60.0
     step[0] = 2
-    assert computer.compute_cli().diagnosis_metrics != []
+    assert computer.compute_cli().window is not None
 
-    # Producer stops. Rows remain, so _compute_impl keeps succeeding with
-    # the SAME completed_step. Within the TTL the view is still served.
+    # The same persisted window remains a valid snapshot. Its unchanged
+    # completed-step cursor is not a process-liveness signal.
     now[0] += 10.0
-    assert computer.compute_cli().diagnosis_metrics != []
+    assert computer.compute_cli().window is not None
 
-    # Past the TTL with no advance, the view must expire.
+    # Even past the empty-read bridge TTL, a non-empty snapshot is retained.
     now[0] += 31.0
-    expired = computer.compute_cli()
-    assert expired.diagnosis_metrics == []
-    assert expired.had_ok is True
-    assert expired.status_message == "No fresh step-combined data"
+    persisted = computer.compute_cli()
+    assert persisted.window is not None
+    assert persisted.had_ok is True
+    assert persisted.status_message.startswith("OK")
 
     # And it recovers if the producer comes back.
     step[0] = 3
-    assert computer.compute_cli().diagnosis_metrics != []
+    assert computer.compute_cli().window is not None
 
 
 def test_computer_had_ok_stays_false_on_cold_start(monkeypatch) -> None:
     """A payload that never had good data reports had_ok=False on itself,
-    not just on the computer -- distinguishes cold start from a dead run
+    not just on the computer -- distinguishes cold start from an expired bridge
     for any consumer that only sees the payload (issue #259)."""
     from traceml_ai.renderers.step_time.schema import StepCombinedTimeResult
 
@@ -296,6 +295,6 @@ def test_computer_had_ok_stays_false_on_cold_start(monkeypatch) -> None:
     )
 
     result = computer.compute_cli()
-    assert result.diagnosis_metrics == []
+    assert result.window is None
     assert result.had_ok is False
     assert computer.had_ok is False

--- a/tests/renderers/test_step_time_renderer.py
+++ b/tests/renderers/test_step_time_renderer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from rich.console import Console
 
 from traceml_ai.diagnostics.step_time.api import StepDiagnosis
@@ -11,6 +13,7 @@ from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeResult,
     StepCombinedTimeSummary,
 )
+from traceml_ai.utils.step_time_window import StepTimeWindow
 
 
 def _metric(
@@ -56,30 +59,35 @@ def test_step_time_cli_diagnosis_uses_selected_metrics(monkeypatch) -> None:
         _metric("residual_proxy", 0.0),
     ]
     payload = StepCombinedTimeResult(
-        per_rank_timing={0: {"input_wait": 40.0, "step_time": 100.0}},
-        diagnosis_clock="gpu",
+        window=StepTimeWindow(
+            clock="gpu",
+            expected_ranks=(0,),
+            per_rank_timing={0: {"input_wait": 40.0, "step_time": 100.0}},
+            metrics=diagnosis_metrics,
+        ),
         training_strategy="fsdp",
-        diagnosis_metrics=diagnosis_metrics,
     )
     seen = {}
 
-    def fake_build_step_diagnosis(metrics, **kwargs):
-        seen["metrics"] = metrics
-        seen["diagnosis_clock"] = kwargs.get("diagnosis_clock")
+    def fake_diagnose(window, **kwargs):
+        seen["metrics"] = window.metrics
+        seen["diagnosis_clock"] = window.clock
         seen["training_strategy"] = kwargs.get("training_strategy")
-        return StepDiagnosis(
-            kind="INPUT_BOUND",
-            status="INPUT-BOUND",
-            severity="warn",
-            reason="Input wait is high.",
-            action="Increase workers.",
-            steps_used=1,
+        return SimpleNamespace(
+            primary=StepDiagnosis(
+                kind="INPUT_BOUND",
+                status="INPUT-BOUND",
+                severity="warn",
+                reason="Input wait is high.",
+                action="Increase workers.",
+                steps_used=1,
+            )
         )
 
     monkeypatch.setattr(
         renderer_module,
-        "build_step_diagnosis",
-        fake_build_step_diagnosis,
+        "diagnose_step_time_window",
+        fake_diagnose,
     )
 
     renderer = StepCombinedRenderer(db_path=":memory:")
@@ -108,25 +116,39 @@ def test_step_time_cli_renders_zero_timings_as_zero(monkeypatch) -> None:
         _metric("residual_proxy", 6.0),
     ]
     payload = StepCombinedTimeResult(
-        per_rank_timing={0: {"input_wait": 0.0, "step_time": 31.2}},
-        diagnosis_clock="cpu",
-        diagnosis_metrics=diagnosis_metrics,
+        window=StepTimeWindow(
+            expected_ranks=(0,),
+            per_rank_timing={
+                0: {
+                    "input_wait": 0.0,
+                    "h2d": 0.0,
+                    "forward": 4.5,
+                    "backward": 8.7,
+                    "optimizer_step": 12.0,
+                    "step_time": 31.2,
+                    "residual_proxy": 6.0,
+                }
+            },
+            metrics=diagnosis_metrics,
+        ),
     )
 
-    def fake_build_step_diagnosis(metrics, **kwargs):
-        return StepDiagnosis(
-            kind="RESIDUAL_HEAVY",
-            status="RESIDUAL-HEAVY",
-            severity="warn",
-            reason="Residual time is high.",
-            action="Inspect work outside traced phases.",
-            steps_used=1,
+    def fake_diagnose(window, **kwargs):
+        return SimpleNamespace(
+            primary=StepDiagnosis(
+                kind="RESIDUAL_HEAVY",
+                status="RESIDUAL-HEAVY",
+                severity="warn",
+                reason="Residual time is high.",
+                action="Inspect work outside traced phases.",
+                steps_used=1,
+            )
         )
 
     monkeypatch.setattr(
         renderer_module,
-        "build_step_diagnosis",
-        fake_build_step_diagnosis,
+        "diagnose_step_time_window",
+        fake_diagnose,
     )
 
     renderer = StepCombinedRenderer(db_path=":memory:")

--- a/tests/renderers/test_step_time_sparse_ui.py
+++ b/tests/renderers/test_step_time_sparse_ui.py
@@ -91,14 +91,13 @@ def test_cli_omits_missing_phase_and_shows_incomplete_data(
     assert "INCOMPLETE DATA" in text
     assert "forward" in text
 
-    # The unavailable phase columns are omitted entirely: the static
-    # legend line mentions FWD twice (its own entry and the residual
-    # formula) and RESIDUAL once, so any additional occurrence would be a
-    # rendered column. BWD keeps its column (2 legend + 1 header).
-    # Measured phases, including the measured-zero H2D, stay visible.
-    assert text.count("FWD") == 2
-    assert text.count("RESIDUAL") == 1
-    assert text.count("BWD") == 3
+    # The unavailable phase columns are omitted from the table header;
+    # measured phases, including the measured-zero H2D, stay visible.
+    header = next(line for line in text.splitlines() if "Metric" in line)
+    assert "FWD" not in header
+    assert "RESIDUAL" not in header
+    assert "BWD" in header
+    assert "H2D" in header
     assert "0.0 ms" in text
     assert "60.0 ms" in text
 
@@ -108,7 +107,12 @@ def test_cli_drops_dead_view_when_computer_window_expires(
 ) -> None:
     renderer = StepCombinedRenderer(db_path=":memory:")
 
-    monkeypatch.setattr(renderer._computer, "compute_cli", _sparse_payload)
+    live_payload = _sparse_payload()
+    monkeypatch.setattr(
+        renderer._computer, "compute_cli", lambda: live_payload
+    )
+    # Mirror the computer's own bookkeeping for a successful compute.
+    renderer._computer._last_ok = live_payload
     live_text = _render_text(renderer.get_panel_renderable())
     assert "60.0 ms" in live_text
 
@@ -125,3 +129,82 @@ def test_cli_drops_dead_view_when_computer_window_expires(
 
     assert "60.0 ms" not in stale_text
     assert "NO DATA" in stale_text
+    assert "the last window expired" in stale_text
+
+
+def test_cli_startup_shows_calm_waiting_panel() -> None:
+    renderer = StepCombinedRenderer(db_path=":memory:")
+
+    text = _render_text(renderer.get_panel_renderable())
+
+    # Never had data: normal warm-up must not alarm with NO DATA.
+    assert "Waiting for first fully completed step" in text
+    assert "NO DATA" not in text
+
+
+def test_cli_renders_multi_rank_sparse_table(monkeypatch) -> None:
+    def _multi_metric(name: str, value: float) -> StepCombinedTimeMetric:
+        metric = _metric(name, value)
+        summary = StepCombinedTimeSummary(
+            window_size=30,
+            steps_used=30,
+            median_total=value,
+            worst_total=value * 2,
+            worst_rank=1,
+            skew_ratio=2.0,
+            skew_pct=1.0,
+        )
+        coverage = StepCombinedTimeCoverage(
+            expected_steps=30,
+            steps_used=30,
+            completed_step=30,
+            world_size=2,
+            ranks_present=2,
+            incomplete=False,
+        )
+        return StepCombinedTimeMetric(
+            metric=metric.metric,
+            clock=metric.clock,
+            series=None,
+            summary=summary,
+            coverage=coverage,
+        )
+
+    payload = StepCombinedTimeResult(
+        per_rank_timing={
+            0: {
+                "input_wait": 2.0,
+                "backward": 60.0,
+                "optimizer_step": 10.0,
+                "step_time": 90.0,
+                "total_step": 92.0,
+            },
+            1: {
+                "input_wait": 2.0,
+                "backward": 120.0,
+                "optimizer_step": 10.0,
+                "step_time": 180.0,
+                "total_step": 182.0,
+            },
+        },
+        diagnosis_clock="cpu",
+        diagnosis_metrics=[
+            _multi_metric("input_wait", 2.0),
+            _multi_metric("backward", 60.0),
+            _multi_metric("optimizer_step", 10.0),
+            _multi_metric("step_time", 90.0),
+        ],
+    )
+    renderer = StepCombinedRenderer(db_path=":memory:")
+    monkeypatch.setattr(renderer, "_payload", lambda: payload)
+    text = _render_text(renderer.get_panel_renderable())
+
+    header = next(line for line in text.splitlines() if "Metric" in line)
+    assert "FWD" not in header
+    assert "BWD" in header
+    # Multi-rank rows render distinct median and worst averages.
+    assert "Median avg" in text
+    assert "Worst avg" in text
+    assert "60.0 ms" in text
+    assert "120.0 ms" in text
+    assert "Worst Rank" in text

--- a/tests/renderers/test_step_time_sparse_ui.py
+++ b/tests/renderers/test_step_time_sparse_ui.py
@@ -1,0 +1,127 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sparse Step Time coverage in the live CLI (issue #259).
+
+An unavailable phase is omitted (never rendered as a measured zero), the
+canonical INCOMPLETE_DATA diagnosis reaches the terminal, and a stale
+complete view is never re-served once the computer's own window expires.
+"""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+from traceml_ai.renderers.step_time.renderer import StepCombinedRenderer
+from traceml_ai.renderers.step_time.schema import (
+    StepCombinedTimeCoverage,
+    StepCombinedTimeMetric,
+    StepCombinedTimeResult,
+    StepCombinedTimeSummary,
+)
+
+
+def _metric(name: str, value: float) -> StepCombinedTimeMetric:
+    return StepCombinedTimeMetric(
+        metric=name,
+        clock="cpu",
+        series=None,
+        summary=StepCombinedTimeSummary(
+            window_size=30,
+            steps_used=30,
+            median_total=value,
+            worst_total=value,
+            worst_rank=0,
+            skew_ratio=0.0,
+            skew_pct=0.0,
+        ),
+        coverage=StepCombinedTimeCoverage(
+            expected_steps=30,
+            steps_used=30,
+            completed_step=30,
+            world_size=1,
+            ranks_present=1,
+            incomplete=False,
+        ),
+    )
+
+
+def _render_text(renderable) -> str:
+    console = Console(record=True, width=140, color_system=None)
+    console.print(renderable)
+    return console.export_text()
+
+
+def _sparse_payload() -> StepCombinedTimeResult:
+    # forward was never measured: no forward metric, no residual, and the
+    # per-rank timing carries no forward key.
+    return StepCombinedTimeResult(
+        per_rank_timing={
+            0: {
+                "input_wait": 2.0,
+                "h2d": 0.0,
+                "backward": 60.0,
+                "optimizer_step": 10.0,
+                "step_time": 90.0,
+                "total_step": 92.0,
+            }
+        },
+        diagnosis_clock="cpu",
+        diagnosis_metrics=[
+            _metric("input_wait", 2.0),
+            _metric("h2d", 0.0),
+            _metric("backward", 60.0),
+            _metric("optimizer_step", 10.0),
+            _metric("step_time", 90.0),
+        ],
+    )
+
+
+def test_cli_omits_missing_phase_and_shows_incomplete_data(
+    monkeypatch,
+) -> None:
+    renderer = StepCombinedRenderer(db_path=":memory:")
+    monkeypatch.setattr(renderer, "_payload", _sparse_payload)
+    text = _render_text(renderer.get_panel_renderable())
+
+    # The canonical diagnosis for the sparse window reaches the terminal.
+    assert "INCOMPLETE DATA" in text
+    assert "forward" in text
+
+    # The unavailable phase columns are omitted entirely: the static
+    # legend line mentions FWD twice (its own entry and the residual
+    # formula) and RESIDUAL once, so any additional occurrence would be a
+    # rendered column. BWD keeps its column (2 legend + 1 header).
+    # Measured phases, including the measured-zero H2D, stay visible.
+    assert text.count("FWD") == 2
+    assert text.count("RESIDUAL") == 1
+    assert text.count("BWD") == 3
+    assert "0.0 ms" in text
+    assert "60.0 ms" in text
+
+
+def test_cli_drops_dead_view_when_computer_window_expires(
+    monkeypatch,
+) -> None:
+    renderer = StepCombinedRenderer(db_path=":memory:")
+
+    monkeypatch.setattr(renderer._computer, "compute_cli", _sparse_payload)
+    live_text = _render_text(renderer.get_panel_renderable())
+    assert "60.0 ms" in live_text
+
+    # The computer only returns an empty result once its own stale window
+    # is exhausted; the renderer must not re-serve the old table.
+    expired = StepCombinedTimeResult(
+        status_message="No fresh step-combined data",
+        per_rank_timing={},
+        diagnosis_clock="cpu",
+        diagnosis_metrics=[],
+    )
+    monkeypatch.setattr(renderer._computer, "compute_cli", lambda: expired)
+    stale_text = _render_text(renderer.get_panel_renderable())
+
+    assert "60.0 ms" not in stale_text
+    assert "NO DATA" in stale_text

--- a/tests/renderers/test_step_time_sparse_ui.py
+++ b/tests/renderers/test_step_time_sparse_ui.py
@@ -22,6 +22,7 @@ from traceml_ai.renderers.step_time.schema import (
     StepCombinedTimeResult,
     StepCombinedTimeSummary,
 )
+from traceml_ai.utils.step_time_window import StepTimeWindow
 
 
 def _metric(name: str, value: float) -> StepCombinedTimeMetric:
@@ -58,25 +59,28 @@ def _render_text(renderable) -> str:
 def _sparse_payload() -> StepCombinedTimeResult:
     # forward was never measured: no forward metric, no residual, and the
     # per-rank timing carries no forward key.
+    per_rank_timing = {
+        0: {
+            "input_wait": 2.0,
+            "h2d": 0.0,
+            "backward": 60.0,
+            "optimizer_step": 10.0,
+            "step_time": 90.0,
+            "total_step": 92.0,
+        }
+    }
     return StepCombinedTimeResult(
-        per_rank_timing={
-            0: {
-                "input_wait": 2.0,
-                "h2d": 0.0,
-                "backward": 60.0,
-                "optimizer_step": 10.0,
-                "step_time": 90.0,
-                "total_step": 92.0,
-            }
-        },
-        diagnosis_clock="cpu",
-        diagnosis_metrics=[
-            _metric("input_wait", 2.0),
-            _metric("h2d", 0.0),
-            _metric("backward", 60.0),
-            _metric("optimizer_step", 10.0),
-            _metric("step_time", 90.0),
-        ],
+        window=StepTimeWindow(
+            expected_ranks=(0,),
+            per_rank_timing=per_rank_timing,
+            metrics=[
+                _metric("input_wait", 2.0),
+                _metric("h2d", 0.0),
+                _metric("backward", 60.0),
+                _metric("optimizer_step", 10.0),
+                _metric("step_time", 90.0),
+            ],
+        )
     )
 
 
@@ -120,9 +124,6 @@ def test_cli_drops_dead_view_when_computer_window_expires(
     # is exhausted; the renderer must not re-serve the old table.
     expired = StepCombinedTimeResult(
         status_message="No fresh step-combined data",
-        per_rank_timing={},
-        diagnosis_clock="cpu",
-        diagnosis_metrics=[],
     )
     monkeypatch.setattr(renderer._computer, "compute_cli", lambda: expired)
     stale_text = _render_text(renderer.get_panel_renderable())
@@ -170,30 +171,33 @@ def test_cli_renders_multi_rank_sparse_table(monkeypatch) -> None:
             coverage=coverage,
         )
 
-    payload = StepCombinedTimeResult(
-        per_rank_timing={
-            0: {
-                "input_wait": 2.0,
-                "backward": 60.0,
-                "optimizer_step": 10.0,
-                "step_time": 90.0,
-                "total_step": 92.0,
-            },
-            1: {
-                "input_wait": 2.0,
-                "backward": 120.0,
-                "optimizer_step": 10.0,
-                "step_time": 180.0,
-                "total_step": 182.0,
-            },
+    per_rank_timing = {
+        0: {
+            "input_wait": 2.0,
+            "backward": 60.0,
+            "optimizer_step": 10.0,
+            "step_time": 90.0,
+            "total_step": 92.0,
         },
-        diagnosis_clock="cpu",
-        diagnosis_metrics=[
-            _multi_metric("input_wait", 2.0),
-            _multi_metric("backward", 60.0),
-            _multi_metric("optimizer_step", 10.0),
-            _multi_metric("step_time", 90.0),
-        ],
+        1: {
+            "input_wait": 2.0,
+            "backward": 120.0,
+            "optimizer_step": 10.0,
+            "step_time": 180.0,
+            "total_step": 182.0,
+        },
+    }
+    payload = StepCombinedTimeResult(
+        window=StepTimeWindow(
+            expected_ranks=(0, 1),
+            per_rank_timing=per_rank_timing,
+            metrics=[
+                _multi_metric("input_wait", 2.0),
+                _multi_metric("backward", 60.0),
+                _multi_metric("optimizer_step", 10.0),
+                _multi_metric("step_time", 90.0),
+            ],
+        )
     )
     renderer = StepCombinedRenderer(db_path=":memory:")
     monkeypatch.setattr(renderer, "_payload", lambda: payload)


### PR DESCRIPTION
Closes #259. Last PR of the three-PR stack targeting `version_0.3.6`; #257 (#274) and #258 (#277) are already merged.

## Problem

The live Step Time UI assumes every phase metric exists. A sparse window could freeze the dashboard hero on its last complete view, the CLI kept a dead run's final table on screen indefinitely, and incomplete coverage was invisible.

## What changed

- CLI: the renderer-side cache with no expiry is gone; the computer's own 30-second last-ok window is the only bridge for transient gaps. Once it expires, the panel says the window expired instead of re-serving a dead table. Before any data arrives the calm waiting message is kept (warm-up is not an alarm). Unmeasured phases are omitted from the table instead of rendering `0.0 ms`; the diagnosis block shows `INCOMPLETE DATA` with the missing signal names.
- Dashboard hero: the all-metrics-present gate is replaced with sparse rendering. Measured phases draw against the median iteration envelope (input wait + step envelope), so unmeasured time shows as empty ribbon space instead of stretching measured phases to fill the bar; for self-consistent complete windows the widths are unchanged. H2D is occurrence-driven, so its absence never counts as partial coverage, matching the engine.
- Dashboard hero, dead-run signal: `StepCombinedComputer`'s `had_ok` (already used by the CLI) is now also carried on the `StepCombinedTimeResult` payload itself, since the dashboard subscriber only ever sees the payload, not the computer. Once a run stops reporting and the stale window expires, the card visibly clears (ribbon, KPIs, window label) instead of freezing on the last complete view.
- Dashboard hero, unmeasured vs measured-zero: a non-H2D phase that was never measured this window (most importantly `input_wait`, the dataloader-fetch signal, see #88/#135) now renders as a fixed hatched sliver, never a proportional width. Without this, an absent `input_wait` alone left the other phases summing to exactly `step_time` (since `residual_proxy` is a remainder), so the ribbon filled to 100% and a dark dataloader stream was visually indistinguishable from a confirmed-fast one. The window label also names the missing signal(s) (`partial: FWD,RESIDUAL`) instead of a generic `partial signals`.
- Dashboard hero, sliver styling: the hatched sliver is drawn in the phase's own color (blue for forward, gold for residual), so it still identifies which phase is missing while the diagonal hatch marks "unmeasured, not zero". It carries no on-segment text (it would overlap the hatch illegibly at that width; the window meta already names the missing phases).
- Dashboard hero, legend: the phase legend spells out the labels ("Input wait", "Forward", ...) instead of the terse "IW"/"FWD"; the ribbon segments keep the compact abbreviations so a narrow slice never overflows.
- Docs: the live CLI and dashboard behavior notes in the reading-output guide. CI now runs the renderer and display suites.

## Notes for reviewers

- Startup behavior changed deliberately: an expired run now shows an expiry message instead of the last table (CLI) or a cleared card (dashboard); a fresh run still shows the waiting message.
- The sibling step-memory and model-diagnostics renderers keep their own unbounded caches with no dead-run signal. That is out of scope for this stack; a candidate follow-up issue.
- Two of the fixes here (the dashboard dead-run signal and the unmeasured-`input_wait` rendering, both described above) address pre-existing behavior rather than anything the first #259 commit introduced. Both are called out directly by the issue text ("leave an old complete view visible").

## Verification

- `pytest tests/diagnostics tests/reporting tests/renderers tests/display --deselect tests/diagnostics/test_registry.py`: 423 passed.
- Full suite (`pytest tests/ --deselect tests/diagnostics/test_registry.py`, GPU/multiprocess excluded): 675 passed, 20 pre-existing failures reproduced identically on base `upstream/version_0.3.6` (unrelated integrations/launcher/H2D-patch tests). Zero regressions.
- The stale-TTL bridge (the property the cache removal leans on) is pinned with a computer-level test: bridged within the TTL with a STALE status, empty after expiry; `had_ok` is asserted on both the computer and the returned payload, including a cold-start (never-had-data) control.
- New tests cover the sparse hero (missing phases, measured-zero twin, absent-H2D twin, step-time-only extreme, payload without a step envelope), multi-rank sparse CLI rendering, calm startup, dead-view expiry (CLI and dashboard), and the dark-`input_wait`-vs-measured-zero-`input_wait` pair. The load-bearing ones fail with the source changes reverted.

## Validation on real hardware

Setup: AWS `g4dn.12xlarge`, 4x NVIDIA Tesla T4 (16 GB each), Amazon Linux 2023
DLAMI, PyTorch 2.11. Each scenario ran through the real `traceml run` launcher
(not a unit test) with a small MLP under DDP. The live views show a rolling
window of the last 100 aligned steps; each run stepped continuously for a few
minutes so the window is stable. Purpose-built scenario scripts force each
coverage case.

### Dashboard (`--mode=dashboard`)

**1. Partial coverage, forward signal dark (1 GPU).** The scenario calls
`model.forward()` directly, so `nn.Module.__call__` is never hit and forward
timing is never recorded. The hero ribbon renders the unmeasured phases
(Forward, Residual) as hatched slivers in their own colors rather than as
zero-width segments, the window label reads `partial: FWD,RESIDUAL`, the
Residual Share shows `n/a`, and the verdict is `INCOMPLETE DATA`. GPU
utilization, step memory, and GPU temperature are populated from the real
device.
<img width="1800" height="1250" alt="gpu_partial_1gpu" src="https://github.com/user-attachments/assets/3355fa79-df24-425f-85a2-cf2b2be4801b" />


**2. Complete coverage (4 GPU, control).** Every phase is measured. The ribbon
is fully solid with no partial marker and a real Residual Share, which confirms
the sparse-rendering path does not change the healthy case. The `STRAGGLER`
verdict is a cross-rank finding on this hardware ("r1 slower than r2 by
~16%"), not related to this change.
<img width="1800" height="1250" alt="gpu_healthy_4gpu" src="https://github.com/user-attachments/assets/cdf67af0-8e7b-46c9-a3cf-db88a8e2fd10" />


**3. No H2D anywhere (4 GPU).** Every rank's dataset is materialized on the
device, so no host-to-device copy ever happens and no H2D event is emitted.
H2D is occurrence-driven, so its absence is treated as a measured zero: the H2D
segment is a plain 0%-width solid segment (no hatch), there is no `partial`
marker, and the residual is still derivable. This is the frontend view of the
decision made in #257.
<img width="1800" height="1250" alt="gpu_no_h2d_4gpu" src="https://github.com/user-attachments/assets/5ad47ba6-c0af-4f1a-8a5d-77982805fd1d" />


### CLI (`--mode=cli`)

Rendered from the same runs' telemetry through the real CLI renderer.

**4. Partial coverage, forward dark.** The table omits the unmeasured Forward,
H2D, and Residual columns instead of printing `0.0 ms`, and the diagnosis block
reads `INCOMPLETE DATA` naming `forward`.
<img width="1638" height="530" alt="cli_partial" src="https://github.com/user-attachments/assets/43484411-b90b-469e-8e67-cb7859bb6252" />


**5. Complete coverage (control).** The full phase table with a real verdict
and Residual Share.
<img width="1638" height="530" alt="cli_healthy" src="https://github.com/user-attachments/assets/4f1caa4e-d27a-4509-ab5c-39030f810629" />


**6. Warm-up (never had data).** A calm waiting message, not an alarming
`NO DATA` verdict.
<img width="1638" height="172" alt="cli_startup" src="https://github.com/user-attachments/assets/753529dd-2fed-4a02-86e3-3b14153873e0" />
<img width="1638" height="302" alt="cli_expired" src="https://github.com/user-attachments/assets/7dc71fc0-7520-4d39-a429-5f46be8fb6cd" />


**7. Dead run (window expired).** Once a run stops reporting and the stale
window passes its TTL, the panel says the last window expired instead of
re-serving a stale complete table.

