### PR TITLE
ci: run the clean-install smoke test on Windows too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,8 +146,12 @@ jobs:
             -q
 
   smoke-test-install:
-    name: Clean-install Smoke Test
-    runs-on: ubuntu-latest
+    name: Clean-install Smoke Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -160,13 +164,26 @@ jobs:
           python -m pip install --upgrade pip build
           python -m build --wheel
       - name: Install the built wheel into a clean environment
+        shell: bash
         run: |
-          python -m venv /tmp/smoke-env
-          /tmp/smoke-env/bin/pip install --upgrade pip
-          /tmp/smoke-env/bin/pip install dist/*.whl
+          set -euo pipefail
+          python -m venv smoke-env
+          # venv writes console scripts to Scripts/ on Windows, bin/ elsewhere.
+          bindir=smoke-env/Scripts
+          [ -d "$bindir" ] || bindir=smoke-env/bin
+          echo "SMOKE_BIN=$bindir" >> "$GITHUB_ENV"
+          "$bindir/python" -m pip install --upgrade pip
+          "$bindir/python" -m pip install dist/*.whl
       - name: Assert documented CLI surface is installed
+        shell: bash
         run: |
-          /tmp/smoke-env/bin/traceml --help | grep -q 'view' || \
+          set -euo pipefail
+          # Redirect instead of piping into grep: grep -q closes the pipe on
+          # first match, which makes the launcher exit non-zero and would hide
+          # its real status. set -e then catches a launcher that cannot start.
+          "$SMOKE_BIN/traceml" --help > root-help.txt
+          "$SMOKE_BIN/traceml" run --help > run-help.txt
+          grep -q 'view' root-help.txt || \
             (echo "::error::traceml --help is missing the documented 'view' subcommand" && exit 1)
-          /tmp/smoke-env/bin/traceml run --help | grep -q 'html-report' || \
+          grep -q 'html-report' run-help.txt || \
             (echo "::error::traceml run --help is missing the documented '--html-report' flag" && exit 1)


### PR DESCRIPTION
## Summary

`smoke-test-install` is the only job that runs the real `traceml` console script, and it has only ever run on `ubuntu-latest`. This matrixes it over `ubuntu-latest` and `windows-latest` and makes the two shell steps portable.

Motivated by the follow-up suggested in #281 ("a Windows leg in CI that runs at least `traceml --help`"). The docs list a Linux/macOS/Windows launcher under portability, but both Windows breaks so far (#264, #281) were found from outside the project rather than by CI.

**To be clear up front: this is not a fix for #281.** I root-caused that separately and posted the evidence on the issue — it is a conda recipe packaging bug, not a TraceML bug. `traceml --help` works correctly from a normal pip/wheel install on Windows. This PR is the CI-gap half of that issue, not the fix.

## Changes

- `smoke-test-install` runs on `ubuntu-latest` and `windows-latest`, `fail-fast: false`.
- The venv script directory is resolved (`Scripts/` on Windows, `bin/` elsewhere) instead of hard-coded, and the `/tmp` prefix is dropped. Both steps use `shell: bash`, which is present on the Windows runners.
- The assertions now check the launcher's **exit status**, not just its output. Previously the help output was piped into `grep -q`, so the pipeline reported grep's status; a launcher that died without printing could only be caught indirectly. Output now goes to a file under `set -euo pipefail`.
  - The redirect is deliberate rather than adding `pipefail` to the existing pipe: `grep -q` closes the pipe on first match, which gives the writer a broken pipe and a non-zero exit, so `pipefail` alone would have produced spurious failures.

## Verification

Windows 11, Python 3.11, run locally:

- Built the wheel and ran both new step scripts verbatim under git-bash. `SMOKE_BIN` resolved to `smoke-env/Scripts`, install succeeded, both assertions passed, step exit 0.
- Confirmed the guard is not vacuous: I broke the installed launcher the same way #281 breaks it (made its embedded interpreter path unresolvable) and re-ran the assertion step. It failed with exit 1, matching the reported symptom exactly — exit 1, 0 bytes on stdout, 0 bytes on stderr. On `main`'s current pipe-into-grep version this is only caught as "missing subcommand"; with the redirect it is caught as what it is, a launcher that cannot start.
- Also ran the `test-core` subset on Windows out of interest: 55 passed. So a Windows leg for core tests looks viable too if you want one — I left it out to keep this PR to a single job.

## Note for maintainers

The check name changes from `Clean-install Smoke Test` to `Clean-install Smoke Test (ubuntu-latest)` / `(windows-latest)`. If that name is configured as a required status check on `main`, the branch protection rule needs updating alongside this.

Based on `main` because `version_0.3.6` does not carry this job yet. Happy to retarget or port if you prefer it on the integration branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded clean-install verification to run on both Ubuntu and Windows.
  * Improved command-line checks with clearer error reporting.
  * Strengthened test environment setup and error handling for more reliable installation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
