### PR TITLE
test(#276): pin the HF/Accelerate H2D coverage window with a real GA=1/GA=2 Trainer

### DIFF
--- a/src/dev/repro/hf_accelerate_h2d_window.py
+++ b/src/dev/repro/hf_accelerate_h2d_window.py
@@ -1,0 +1,190 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reproduce the Hugging Face + Accelerate H2D coverage-window gap (#276).
+
+Reported on the HF forum: with the Trainer + Accelerate path and gradient
+accumulation, a real CPU->CUDA transfer happens while TraceML reports
+``H2D: 0.0 ms`` (pre-#274) or ``H2D: n/a`` (with #274).
+
+Mechanism, measured rather than assumed (see
+``tests/integrations/test_hf_h2d_window.py``, which pins it on CPU): the
+transfer is performed by Accelerate's PREPARED DATALOADER, which places the
+batch on the device inside ``__next__``. The fetch happens between steps,
+after the previous ``on_step_end`` and before the next ``on_step_begin``,
+so it falls outside the ``trace_step`` bracket that arms the H2D timer.
+Under gradient accumulation, GA microbatches are fetched per optimizer step,
+so GA transfers land outside the window. Note this is NOT
+``Trainer._prepare_inputs``: on current transformers that call runs inside
+the window and is a no-op once Accelerate has already moved the batch.
+
+This script measures the CPU->CUDA transfer with independent CUDA events and
+compares it to what TraceML captured, plus a positive control that moves a
+tensor INSIDE ``trace_step`` to show the timer works when the transfer lands
+in the window.
+
+Needs a CUDA device. On CPU it prints why it cannot run and exits 0.
+
+Run:
+    python -m dev.repro.hf_accelerate_h2d_window
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def _independent_h2d_ms(num_bytes_mb: int = 64) -> float:
+    """Time one CPU->CUDA copy with CUDA events, independent of TraceML."""
+    import torch
+
+    host = torch.empty(num_bytes_mb * 1024 * 1024 // 4, dtype=torch.float32)
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    torch.cuda.synchronize()
+    start.record()
+    host.to("cuda", non_blocking=False)
+    end.record()
+    torch.cuda.synchronize()
+    return float(start.elapsed_time(end))
+
+
+def _positive_control_ms(num_bytes_mb: int = 64) -> float | None:
+    """Move a tensor INSIDE trace_step; TraceML should capture this one."""
+    import torch
+
+    from traceml_ai.sdk.instrumentation import trace_step
+    from traceml_ai.utils.timing import get_step_time_queue
+
+    model = torch.nn.Linear(4, 4).cuda()
+    host = torch.empty(num_bytes_mb * 1024 * 1024 // 4, dtype=torch.float32)
+    with trace_step(model):
+        host.to("cuda", non_blocking=False)
+        torch.cuda.synchronize()
+
+    captured = None
+    queue = get_step_time_queue()
+    while not queue.empty():
+        batch = queue.get_nowait()
+        for evt in getattr(batch, "events", []):
+            if evt.name == "_traceml_internal:h2d_time":
+                captured = float(getattr(evt, "gpu_ms", 0.0) or 0.0)
+    return captured
+
+
+def _traceml_reported_h2d(grad_accum: int = 2) -> float | None:
+    """Run a tiny HF Trainer + Accelerate GA loop; read the reported H2D."""
+    import tempfile
+
+    import torch
+    from transformers import (
+        BertConfig,
+        BertForSequenceClassification,
+        Trainer,
+        TrainingArguments,
+    )
+
+    from traceml_ai.integrations.huggingface import TraceMLTrainerCallback
+    from traceml_ai.utils.timing import get_step_time_queue
+
+    class _DS(torch.utils.data.Dataset):
+        def __len__(self):
+            return 40
+
+        def __getitem__(self, i):
+            return {
+                "input_ids": torch.arange(16) % 128,
+                "attention_mask": torch.ones(16, dtype=torch.long),
+                "labels": torch.tensor(i % 4),
+            }
+
+    model = BertForSequenceClassification(
+        BertConfig(
+            vocab_size=128,
+            hidden_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_labels=4,
+        )
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        args = TrainingArguments(
+            output_dir=tmp,
+            max_steps=3,
+            per_device_train_batch_size=4,
+            gradient_accumulation_steps=grad_accum,
+            report_to=[],
+            logging_strategy="no",
+        )
+        trainer = Trainer(
+            model=model,
+            args=args,
+            train_dataset=_DS(),
+            callbacks=[TraceMLTrainerCallback()],
+        )
+        trainer.train()
+
+    reported = None
+    queue = get_step_time_queue()
+    while not queue.empty():
+        batch = queue.get_nowait()
+        vals = [
+            float(getattr(evt, "gpu_ms", 0.0) or 0.0)
+            for evt in getattr(batch, "events", [])
+            if evt.name == "_traceml_internal:h2d_time"
+        ]
+        if vals:
+            reported = sum(vals)
+        elif reported is None:
+            reported = 0.0  # no h2d event captured in the bracket
+    return reported
+
+
+def main() -> int:
+    try:
+        import torch
+    except ImportError:
+        print("torch is not installed; cannot run this reproduction.")
+        return 0
+
+    if not torch.cuda.is_available():
+        print(
+            "No CUDA device. This reproduction needs a GPU to move tensors "
+            "host->device. Run it on Colab or an AWS GPU box."
+        )
+        return 0
+
+    from traceml_ai.sdk.initial import init
+
+    init()
+
+    independent = _independent_h2d_ms()
+    control = _positive_control_ms()
+    reported = _traceml_reported_h2d(grad_accum=2)
+
+    print("=" * 60)
+    print("HF + Accelerate H2D coverage-window reproduction (#276)")
+    print("=" * 60)
+    print(f"independent cuda-event H2D (real transfer): {independent:.3f} ms")
+    print(f"positive control (transfer inside window):  {control} ms")
+    print(f"TraceML reported H2D (GA=2, pre-step move):  {reported} ms")
+    print("-" * 60)
+    if control and control > 0.0 and (reported in (0.0, None)):
+        print(
+            "REPRODUCED: the timer captures an in-window transfer but not "
+            "the Accelerate pre-step transfer, so H2D reads as "
+            f"{reported} despite a real {independent:.3f} ms copy."
+        )
+    else:
+        print(
+            "Did not reproduce with these settings; the Trainer/Accelerate "
+            "version may move batches inside the step window."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integrations/test_hf_h2d_window.py
+++ b/tests/integrations/test_hf_h2d_window.py
@@ -1,0 +1,261 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""H2D coverage window for the Hugging Face Trainer callback (issue #276).
+
+Reported from a Colab reproduction on the Hugging Face forum: under
+``Trainer`` + Accelerate, independent CUDA-event timing showed a real
+CPU->CUDA transfer while TraceML reported ``H2D: 0.0 ms``.
+
+The mechanism is a COVERAGE-WINDOW gap, not a broken timer. Accelerate's
+prepared dataloader performs device placement while the batch is FETCHED,
+and the fetch happens between steps: after ``on_step_end`` of the previous
+step and before ``on_step_begin`` of the next. The H2D auto-timer is armed
+only inside the ``trace_step`` bracket that ``on_step_begin`` opens, so the
+transfer is never observed. Under gradient accumulation the effect scales:
+GA microbatches are fetched per optimizer step, so GA transfers land
+outside the window.
+
+These tests pin the ordering with a REAL ``Trainer`` and a REAL prepared
+dataloader rather than a hand-called callback, because the defect is in the
+interaction between the two. Ordering is device-independent, so they run on
+CPU; the end-to-end CUDA reproduction that compares TraceML's reported value
+against independent CUDA-event timing lives in
+``src/dev/repro/hf_accelerate_h2d_window.py`` and needs a GPU.
+
+What this file does NOT do is widen the window. Timing Accelerate's device
+placement as its own pre-step phase is deliberately left as follow-up work
+on #276, so the optimizer-step definition does not change silently. The
+guarantee asserted here is the honest one: the transfer is outside the
+window, therefore H2D is reported as unavailable rather than as a measured
+zero, and no H2D-based verdict may rest on evidence that was never captured.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
+pytest.importorskip("accelerate")
+
+from torch.utils.data import Dataset  # noqa: E402
+from transformers import Trainer, TrainingArguments  # noqa: E402
+
+from traceml_ai.diagnostics.step_time.policy import (  # noqa: E402
+    SUMMARY_STEP_TIME_POLICY,
+)
+from traceml_ai.instrumentation.patches.h2d_auto_timer_patch import (  # noqa: E402,E501
+    _enabled,
+)
+from traceml_ai.integrations import huggingface as hf  # noqa: E402
+from traceml_ai.sdk.instrumentation import trace_step  # noqa: E402
+from traceml_ai.utils.step_time_window import (  # noqa: E402
+    build_step_time_window_from_events,
+    diagnose_step_time_window,
+    public_step_time_metric_values,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal real training setup
+# ---------------------------------------------------------------------------
+
+
+class _Batches(Dataset):
+    def __len__(self) -> int:
+        return 32
+
+    def __getitem__(self, index):
+        return {"x": torch.randn(4), "labels": torch.randn(1)}
+
+
+class _Tiny(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(4, 1)
+
+    def forward(self, x=None, labels=None):
+        out = self.linear(x)
+        loss = torch.nn.functional.mse_loss(out, labels)
+        return {"loss": loss, "logits": out}
+
+
+class _FetchSpy:
+    """Wrap the prepared dataloader and record the timer state per fetch.
+
+    Accelerate does its device placement inside ``__next__``, so the timer
+    state AT FETCH is exactly the question: armed means the transfer would
+    be captured, unarmed means it is invisible to TraceML.
+    """
+
+    def __init__(self, inner, log):
+        self._inner = inner
+        self._log = log
+
+    def __iter__(self):
+        iterator = iter(self._inner)
+        while True:
+            self._log.append(("fetch", _enabled()))
+            try:
+                yield next(iterator)
+            except StopIteration:
+                return
+
+    def __len__(self):
+        return len(self._inner)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def _run_trainer(gradient_accumulation_steps: int, max_steps: int = 2):
+    """Run a real Trainer and return the ordered (event, armed) log."""
+    log: list[tuple[str, bool]] = []
+    callback = hf.TraceMLTrainerCallback()
+
+    begin, end = callback.on_step_begin, callback.on_step_end
+
+    def _begin(*args, **kwargs):
+        result = begin(*args, **kwargs)
+        log.append(("window_open", _enabled()))
+        return result
+
+    def _end(*args, **kwargs):
+        log.append(("window_close", _enabled()))
+        return end(*args, **kwargs)
+
+    callback.on_step_begin = _begin
+    callback.on_step_end = _end
+
+    trainer = Trainer(
+        model=_Tiny(),
+        args=TrainingArguments(
+            output_dir="/tmp/traceml-hf-h2d-window",
+            per_device_train_batch_size=4,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            max_steps=max_steps,
+            logging_strategy="no",
+            save_strategy="no",
+            report_to=[],
+            use_cpu=True,
+        ),
+        train_dataset=_Batches(),
+        callbacks=[callback],
+    )
+
+    real_loader = trainer.get_train_dataloader
+    trainer.get_train_dataloader = lambda: _FetchSpy(real_loader(), log)
+    trainer.train()
+    return log
+
+
+# ---------------------------------------------------------------------------
+# The regression: batch fetch lands outside the step window (GA=1 and GA=2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ga", [1, 2])
+def test_accelerate_batch_fetch_is_outside_the_step_window(ga: int) -> None:
+    log = _run_trainer(gradient_accumulation_steps=ga)
+
+    fetch_states = [armed for event, armed in log if event == "fetch"]
+    assert fetch_states, "no batch fetch observed"
+    # The defect, stated positively: not one fetch is covered by the window.
+    assert not any(fetch_states)
+
+    # ... while the window itself really does arm the timer, so this is a
+    # coverage gap and not a dead timer.
+    window_states = [armed for event, armed in log if event == "window_open"]
+    assert window_states and all(window_states)
+
+    # Under accumulation the exposure scales with GA: every microbatch for
+    # the next optimizer step is fetched before that step's window opens.
+    events = [event for event, _ in log]
+    first_open = events.index("window_open")
+    assert events[:first_open].count("fetch") == ga
+
+
+def test_in_window_transfer_is_covered_positive_control() -> None:
+    # Control for the assertion above: the same timer, armed the same way,
+    # DOES cover work performed inside the bracket. Without this a reader
+    # cannot tell a coverage gap from an instrumentation that never works.
+    assert _enabled() is False
+    with trace_step(_Tiny()):
+        assert _enabled() is True
+    assert _enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Consequence: an uncaptured transfer must read as unavailable, never 0.0
+# ---------------------------------------------------------------------------
+
+_EVENTS = {
+    "input_wait": "_traceml_internal:dataloader_next",
+    "h2d": "_traceml_internal:h2d_time",
+    "forward": "_traceml_internal:forward_time",
+    "backward": "_traceml_internal:backward_time",
+    "optimizer_step": "_traceml_internal:optimizer_step",
+    "step_time": "_traceml_internal:step_time",
+}
+
+_RUN_MS = {
+    "input_wait": 3.0,
+    "h2d": 2.0,
+    "forward": 20.0,
+    "backward": 30.0,
+    "optimizer_step": 10.0,
+    "step_time": 66.0,
+}
+
+
+def _stat(value: float) -> dict:
+    return {
+        "cuda:0": {
+            "duration_ms": value,
+            "cpu_ms": value,
+            "gpu_ms": value,
+            "n_calls": 1,
+        }
+    }
+
+
+def _gpu_window(*, omit=(), h2d_value=None, steps: int = 30):
+    values = dict(_RUN_MS)
+    if h2d_value is not None:
+        values["h2d"] = h2d_value
+    per_rank = {0: {}}
+    for step in range(steps):
+        per_rank[0][step] = {
+            _EVENTS[key]: _stat(values[key])
+            for key in _EVENTS
+            if key not in set(omit)
+        }
+    return build_step_time_window_from_events(per_rank, max_rows=steps)
+
+
+def test_uncaptured_h2d_reports_unavailable_not_measured_zero() -> None:
+    # The GA case on CUDA: the transfer happened, outside the window, so no
+    # h2d event exists. Reporting 0.0 here would assert a measurement that
+    # was never taken, which is what the issue reported.
+    absent = _gpu_window(omit=("h2d",))
+    assert absent.clock == "gpu"
+    assert (
+        public_step_time_metric_values(absent.per_rank_timing[0])["h2d_ms"]
+        is None
+    )
+
+    # Twin: an in-window transfer that really measured 0.0 stays 0.0.
+    measured = _gpu_window(h2d_value=0.0)
+    assert (
+        public_step_time_metric_values(measured.per_rank_timing[0])["h2d_ms"]
+        == 0.0
+    )
+
+
+def test_uncaptured_h2d_cannot_produce_an_h2d_verdict() -> None:
+    absent = _gpu_window(omit=("h2d",))
+    result = diagnose_step_time_window(absent, policy=SUMMARY_STEP_TIME_POLICY)
+    assert result.primary.kind != "H2D_BOUND"


### PR DESCRIPTION
Addresses the regression-test follow-up on #276. Tests only, no behavior change.

## Mechanism, measured

The reported symptom is `H2D: 0.0 ms` while an independent CUDA-event timer sees a real transfer. Tracing it with a real `Trainer` confirms the ordering described in the issue and localizes the exact call site:

The transfer is performed by **Accelerate's prepared dataloader**, which places the batch on the device inside `__next__`. That fetch happens between steps, after the previous `on_step_end` and before the next `on_step_begin`, so it falls outside the `trace_step` bracket that arms the H2D timer. Under gradient accumulation the exposure scales: GA microbatches are fetched per optimizer step, so GA transfers land outside the window.

One dead end worth recording so nobody re-chases it: the call site is **not** `Trainer._prepare_inputs`. On current transformers that runs inside the window, and it is a no-op by then because Accelerate has already moved the batch, so a fix aimed there would change nothing.

Measured ordering, GA=2, two optimizer steps:

```
fetch          timer NOT armed   <- Accelerate places microbatch 1 here
fetch          timer NOT armed   <- ... and microbatch 2
window_open    timer ARMED
window_close   timer ARMED
```

## What this PR adds

`tests/integrations/test_hf_h2d_window.py` (5 tests), driving a real `Trainer` with a real prepared dataloader rather than hand-called callbacks, since the defect lives in the interaction between the two:

- the batch fetch is outside the window, parametrized over GA=1 and GA=2, asserting the count of uncovered fetches equals GA;
- an in-window positive control, so a reader can tell a coverage gap from a timer that never works;
- an uncaptured H2D reports unavailable, with a measured-zero twin that must stay `0.0`;
- no H2D-based verdict may rest on evidence that was never captured.

`src/dev/repro/hf_accelerate_h2d_window.py` is the GPU reproduction: it compares TraceML's reported value against independent CUDA-event timing, the same comparison the reporter made.

## What is already covered, and what is deliberately left

The metric-semantics half of the issue landed with #274 and #277. Verified against the current base rather than assumed: an absent H2D projects to `null` while a measured zero stays `0.0`, and a window with no H2D evidence diagnoses `BALANCED` rather than an H2D verdict.

Not done here, and deliberately: timing Accelerate's device placement as its own pre-step phase. That is the remaining follow-up on the issue, and it changes what an optimizer step means, which should be an explicit decision rather than a side effect of a test PR.

One observation that may reshape that follow-up. The dataloader-fetch timer is armed process-wide, not scoped to the step window, so the fetch itself **is** timed. The transfer's cost is therefore not lost, it is attributed to input wait. What is missing is the breakdown, so the open question is narrower than "recover lost time": it is whether to split input wait into fetch versus transfer. This comes from reading the patch, not from a separate measurement.

## Verification

- New tests: 5 passed. Full suite 667 passed, with the same 20 pre-existing failures as base `upstream/version_0.3.6`. Zero regressions.
- Load-bearing: run against the pre-#274 commit, `test_uncaptured_h2d_reports_unavailable_not_measured_zero` fails with `assert 0.0 is None`, which is the reported symptom itself.
- Real hardware, AWS `g4dn.xlarge` (Tesla T4), real `Trainer` + Accelerate at GA=2 through the launcher: `final_summary.json` reports `h2d_ms: null` at schema 1.7, and the summary card shows `H2D  n/a`. An independent CUDA-event copy on the same box measured 47.680 ms, confirming the timer works and the window is the gap.
- Ordering reproduced on two transformers versions (5.9.0 local, 5.14.1 on the box), so it is not a single-version artifact.

GATE: conformance suite not run in this PR; the change is test-only and adds no stream
TWINS: measured-zero vs unavailable asserted at the public projection
TRANSITIONS: n/a, no stateful surface in this change
RANKS: per-rank asymmetry tested? n/a, single-process HF Trainer path
DOUBLES: none used; the test drives the real Trainer and the real prepared dataloader
TRIPWIRE: made the assertion fail on purpose? yes, against pre-#274 (`assert 0.0 is None`)
ENV: CI's integration job installs `.[torch]`, so these skip there until the `hf` extra is added. Enabling it surfaces HuggingFace conformance failures that already fail on base, so that is a separate change rather than a quiet addition here. Verified locally and on the GPU box, where the extra is installed.

