### PR TITLE
ci: reconcile the workflow with main so the forward merge cannot drop coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
       - '*.md'
       - '.gitignore'
   workflow_dispatch:
+  schedule:
+    # Weekly early warning that the newest published dependencies still work.
+    - cron: '0 6 * * 1'
 
 concurrency:
   group: ci-${{ github.head_ref || github.run_id }}
@@ -57,7 +60,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install pytest
+          # tomli backports tomllib to 3.10 for the packaging guard.
+          pip install pytest 'tomli; python_version < "3.11"'
       - name: Run core tests
         run: |
           pytest \
@@ -95,9 +99,62 @@ jobs:
             tests/reporting/summary \
             -q
 
-  smoke-test-install:
-    name: Clean-install Smoke Test
+  test-latest-deps:
+    name: Latest Dependencies (early warning)
+    # Not a pull-request gate. A brand new release of a dependency must not
+    # block contributors, but we want to hear about it before users do.
+    #
+    # Deliberately runs without setup-python's pip cache. The cache once
+    # held a locally source-built numpy-1.26.4-cp313-cp313-linux_x86_64
+    # wheel, which kept the `numpy<2` cap green on Python 3.13 in CI long
+    # after it had become uninstallable for anyone starting from a clean
+    # environment (issue #263). A resolution check must resolve for real.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    # This job resolves and builds dependency versions that did not exist
+    # when the commit was written, so it executes third-party build code by
+    # design. Give it read-only scope and keep the checkout token out of the
+    # git config that build code could read.
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install with the newest resolvable dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-cache-dir --upgrade --upgrade-strategy eager \
+            -e ".[torch]"
+          # tomli backports tomllib to 3.10 for the packaging guard.
+          pip install pytest 'tomli; python_version < "3.11"'
+      - name: Report the resolved environment
+        run: pip list
+      - name: Run core tests
+        run: |
+          pytest \
+            tests/core \
+            tests/diagnostics/test_bands.py \
+            tests/diagnostics/test_common.py \
+            tests/telemetry/test_distributed.py \
+            tests/telemetry/test_msgpack.py \
+            tests/telemetry/test_sender_sequence.py \
+            -q
+
+  smoke-test-install:
+    name: Clean-install Smoke Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -110,13 +167,26 @@ jobs:
           python -m pip install --upgrade pip build
           python -m build --wheel
       - name: Install the built wheel into a clean environment
+        shell: bash
         run: |
-          python -m venv /tmp/smoke-env
-          /tmp/smoke-env/bin/pip install --upgrade pip
-          /tmp/smoke-env/bin/pip install dist/*.whl
+          set -euo pipefail
+          python -m venv smoke-env
+          # venv writes console scripts to Scripts/ on Windows, bin/ elsewhere.
+          bindir=smoke-env/Scripts
+          [ -d "$bindir" ] || bindir=smoke-env/bin
+          echo "SMOKE_BIN=$bindir" >> "$GITHUB_ENV"
+          "$bindir/python" -m pip install --upgrade pip
+          "$bindir/python" -m pip install dist/*.whl
       - name: Assert documented CLI surface is installed
+        shell: bash
         run: |
-          /tmp/smoke-env/bin/traceml --help | grep -q 'view' || \
+          set -euo pipefail
+          # Redirect instead of piping into grep: grep -q closes the pipe on
+          # first match, which makes the launcher exit non-zero and would hide
+          # its real status. set -e then catches a launcher that cannot start.
+          "$SMOKE_BIN/traceml" --help > root-help.txt
+          "$SMOKE_BIN/traceml" run --help > run-help.txt
+          grep -q 'view' root-help.txt || \
             (echo "::error::traceml --help is missing the documented 'view' subcommand" && exit 1)
-          /tmp/smoke-env/bin/traceml run --help | grep -q 'html-report' || \
+          grep -q 'html-report' run-help.txt || \
             (echo "::error::traceml run --help is missing the documented '--html-report' flag" && exit 1)


### PR DESCRIPTION
Closes #288.

## What changed

`.github/workflows/ci.yml` on this branch becomes the union of what `main` and `version_0.3.6` each had. Nothing is dropped from either side.

Taken from `main`:

- the `test-latest-deps` job, its `schedule:` cron, the `permissions: contents: read` / `persist-credentials: false` scoping, and the `--no-cache-dir` install
- the `windows-latest` leg of the clean-install smoke test, with the portable `bindir` resolution and the redirect-instead-of-pipe assertions
- the `tomli` install line that keeps the packaging guard active on Python 3.10

Kept from this branch:

- `branches: [main, 'version_*']` on both triggers, so CI keeps running on release branches
- `tests/diagnostics/test_step_time.py` and `tests/diagnostics/test_step_time_missing_signals.py` in `test-core`
- `tests/reporting/summary` in `test-integration`

## Why

The two files had diverged in both directions, 93 differing lines. A forward merge would conflict, and resolving it by taking either side would silently delete whatever the other side added. `windows-latest` appeared once on `main` and not at all here, so taking this branch's version would have removed the Windows leg without anything reporting the loss. That is the same shape as the `numpy<2` cap, which survived seven months because CI could not object to it.

The guard added in #266 does not help here. It checks runtime dependency bounds in `pyproject.toml` and has no view of workflow files.

## Effect on the next forward merge

After this lands, this branch's `ci.yml` is a strict superset of `main`'s. The merge instruction becomes "take this branch's version of `ci.yml`" rather than a 93-line hand-merge, which is checkable rather than a judgement call.

## Verification

Confirmed every feature from both sides survives, by grep against the merged file:

```
✓ broader triggers (version_*)          ✓ test-latest-deps job
✓ tests/diagnostics/test_step_time.py   ✓ schedule cron
✓ test_step_time_missing_signals.py     ✓ tomli for the 3.10 guard
✓ tests/reporting/summary               ✓ windows-latest smoke leg
                                        ✓ persist-credentials: false
```

The file parses, and the job list is `lint`, `test-core`, `test-integration`, `test-latest-deps`, `smoke-test-install`. Triggers resolve to `push: [main, version_*]` and `pull_request: [main, version_*]`.

The remaining lines that differ from the old version on this branch are deliberate replacements rather than removals: `/tmp/smoke-env` gives way to the portable path, and `Clean-install Smoke Test` becomes the matrix-suffixed name.

## Note

The check name gains an OS suffix here as it already did on `main`, so it reads `Clean-install Smoke Test (ubuntu-latest)` / `(windows-latest)`. On `main` that name was not a required status check. Worth a look before merging if this branch is protected differently.
