### PR TITLE
Reach grandchildren when tearing down a process group on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,25 @@ jobs:
             tests/telemetry/test_sender_sequence.py \
             -q
 
+  test-windows-teardown:
+    name: Windows Process Teardown
+    # The process-group teardown path is platform-specific and cannot be
+    # exercised on Linux, where the POSIX branch always wins. This is the
+    # only leg that proves a grandchild is actually reaped on Windows.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest
+      - name: Run process teardown tests
+        run: pytest tests/runtime/test_process_group_teardown.py -q
+
   test-integration:
     name: Integration Smoke Tests
     runs-on: ubuntu-latest

--- a/src/traceml_ai/launcher/process.py
+++ b/src/traceml_ai/launcher/process.py
@@ -21,6 +21,10 @@ from typing import Any, BinaryIO, Callable, Iterable, Optional
 
 from traceml_ai.launcher.manifest import update_run_manifest
 
+_IS_WINDOWS = sys.platform == "win32"
+# Absent on POSIX, where start_new_session is used instead.
+_CREATE_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+
 DEFAULT_TCP_READY_TIMEOUT_SEC = 15.0
 DEFAULT_SHUTDOWN_TIMEOUT_SEC = 5.0
 DEFAULT_STDERR_TAIL_BYTES = 64 * 1024
@@ -163,6 +167,44 @@ def start_stderr_tail_capture(
     )
 
 
+def process_group_kwargs() -> dict[str, Any]:
+    """Popen keyword arguments that isolate the child in its own group.
+
+    ``start_new_session`` is a ``setsid()`` call and exists only on POSIX.
+    On Windows the equivalent is the CREATE_NEW_PROCESS_GROUP creation flag.
+    Without one of the two, teardown can only reach the direct child and any
+    grandchildren it spawned, such as torchrun or DataLoader workers, are
+    left running.
+    """
+    if _IS_WINDOWS:
+        return {"creationflags": _CREATE_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
+
+
+def _taskkill_tree(pid: int, *, force: bool) -> bool:
+    """Terminate a Windows process tree. Return True if taskkill ran.
+
+    Windows has no process-group signal, so the tree is walked by pid.
+    ``proc.terminate()`` alone would end only the direct child.
+    """
+    cmd = ["taskkill", "/T", "/PID", str(pid)]
+    if force:
+        cmd.insert(1, "/F")
+
+    try:
+        completed = subprocess.run(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=DEFAULT_SHUTDOWN_TIMEOUT_SEC,
+        )
+    except Exception:
+        return False
+
+    # 128 means the pid was already gone, which is a success for our purpose.
+    return completed.returncode in (0, 128)
+
+
 def terminate_process_group(
     proc: Optional[subprocess.Popen],
     timeout_sec: float = DEFAULT_SHUTDOWN_TIMEOUT_SEC,
@@ -171,13 +213,20 @@ def terminate_process_group(
     if proc is None or proc.poll() is not None:
         return
 
-    try:
-        os.killpg(proc.pid, signal.SIGTERM)
-    except Exception:
+    if _IS_WINDOWS:
+        if not _taskkill_tree(proc.pid, force=False):
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+    else:
         try:
-            proc.terminate()
+            os.killpg(proc.pid, signal.SIGTERM)
         except Exception:
-            pass
+            try:
+                proc.terminate()
+            except Exception:
+                pass
 
     try:
         proc.wait(timeout=timeout_sec)
@@ -185,13 +234,20 @@ def terminate_process_group(
     except Exception:
         pass
 
-    try:
-        os.killpg(proc.pid, signal.SIGKILL)
-    except Exception:
+    if _IS_WINDOWS:
+        if not _taskkill_tree(proc.pid, force=True):
+            try:
+                proc.kill()
+            except Exception:
+                pass
+    else:
         try:
-            proc.kill()
+            os.killpg(proc.pid, signal.SIGKILL)
         except Exception:
-            pass
+            try:
+                proc.kill()
+            except Exception:
+                pass
 
 
 def wait_for_tcp_listen(
@@ -275,7 +331,7 @@ def start_aggregator_process(
         cmd,
         env=env,
         cwd=cwd,
-        start_new_session=True,
+        **process_group_kwargs(),
     )
 
 
@@ -295,6 +351,6 @@ def start_training_process(
         train_cmd,
         env=env,
         cwd=cwd,
-        start_new_session=True,
+        **process_group_kwargs(),
         **popen_kwargs,
     )

--- a/tests/runtime/test_process_group_teardown.py
+++ b/tests/runtime/test_process_group_teardown.py
@@ -1,0 +1,162 @@
+"""Teardown must reach grandchildren, not only the direct child.
+
+A training launcher spawns workers of its own, so terminating just the
+child leaves those workers holding the GPU and open file handles. The
+end-to-end test below builds that exact shape, a child that spawns a
+grandchild, and asserts the grandchild is gone after teardown.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+from traceml_ai.launcher import process as process_mod
+
+# Child spawns a long-lived grandchild, prints its pid, then sleeps.
+_CHILD_SOURCE = """
+import subprocess, sys, time
+gc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"])
+print(gc.pid, flush=True)
+time.sleep(120)
+"""
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True while ``pid`` is still running."""
+    if sys.platform == "win32":
+        out = subprocess.run(
+            ["tasklist", "/FI", f"PID eq {pid}"],
+            capture_output=True,
+            text=True,
+        ).stdout
+        return str(pid) in out
+
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _wait_gone(pid: int, timeout_sec: float = 10.0) -> bool:
+    """Wait for ``pid`` to disappear, returning whether it did."""
+    deadline = time.time() + timeout_sec
+    while time.time() < deadline:
+        if not _pid_alive(pid):
+            return True
+        time.sleep(0.1)
+    return not _pid_alive(pid)
+
+
+def test_process_group_kwargs_matches_the_platform() -> None:
+    """POSIX gets a new session, Windows gets a new process group."""
+    kwargs = process_mod.process_group_kwargs()
+
+    if sys.platform == "win32":
+        assert kwargs == {
+            "creationflags": process_mod._CREATE_NEW_PROCESS_GROUP
+        }
+        assert kwargs["creationflags"] != 0
+    else:
+        assert kwargs == {"start_new_session": True}
+
+
+def test_windows_branch_kills_the_tree(monkeypatch) -> None:
+    """The Windows path must walk the tree instead of ending one process."""
+    monkeypatch.setattr(process_mod, "_IS_WINDOWS", True)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(process_mod.subprocess, "run", fake_run)
+
+    class StillRunning:
+        pid = 4321
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            raise subprocess.TimeoutExpired("cmd", timeout)
+
+        def terminate(self):
+            raise AssertionError("must not fall back while taskkill works")
+
+        def kill(self):
+            raise AssertionError("must not fall back while taskkill works")
+
+    process_mod.terminate_process_group(StillRunning(), timeout_sec=0.01)
+
+    assert len(calls) == 2, calls
+    graceful, forced = calls
+    assert graceful == ["taskkill", "/T", "/PID", "4321"]
+    assert forced == ["taskkill", "/F", "/T", "/PID", "4321"]
+
+
+def test_windows_branch_falls_back_when_taskkill_is_unavailable(
+    monkeypatch,
+) -> None:
+    """A missing taskkill must not leave the child running."""
+    monkeypatch.setattr(process_mod, "_IS_WINDOWS", True)
+    monkeypatch.setattr(
+        process_mod.subprocess,
+        "run",
+        lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    terminated: list[str] = []
+
+    class StillRunning:
+        pid = 99
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            raise subprocess.TimeoutExpired("cmd", timeout)
+
+        def terminate(self):
+            terminated.append("terminate")
+
+        def kill(self):
+            terminated.append("kill")
+
+    process_mod.terminate_process_group(StillRunning(), timeout_sec=0.01)
+
+    assert terminated == ["terminate", "kill"]
+
+
+def test_terminate_process_group_reaps_a_grandchild() -> None:
+    """End to end: the grandchild must not survive teardown."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _CHILD_SOURCE],
+        stdout=subprocess.PIPE,
+        text=True,
+        **process_mod.process_group_kwargs(),
+    )
+
+    try:
+        line = proc.stdout.readline().strip()
+        grandchild_pid = int(line)
+        assert _pid_alive(grandchild_pid), "grandchild never started"
+
+        process_mod.terminate_process_group(proc, timeout_sec=5.0)
+
+        assert _wait_gone(proc.pid), "child survived teardown"
+        assert _wait_gone(
+            grandchild_pid
+        ), f"grandchild {grandchild_pid} survived teardown"
+    finally:
+        for pid in (locals().get("grandchild_pid"), proc.pid):
+            if pid is None:
+                continue
+            try:
+                os.kill(pid, 9)
+            except Exception:
+                pass


### PR DESCRIPTION
Closes #287.

## What changed

On Windows, tearing down a run reached only the direct child. Grandchildren such as torchrun or DataLoader workers were left running, holding the GPU and open file handles, so a later run could fail to start for reasons that looked unrelated.

Two causes, both fixed here.

**The child was never in its own group.** Both launch sites passed `start_new_session=True`, which is a `setsid()` call and exists only on POSIX. On Windows it does nothing, and nothing passed the Windows equivalent. `process_group_kwargs()` now returns `start_new_session` on POSIX and `creationflags=CREATE_NEW_PROCESS_GROUP` on Windows, and both `start_aggregator_process` and `start_training_process` use it.

**Teardown assumed a POSIX process group.** `terminate_process_group` called `os.killpg`, which does not exist on Windows, so it raised `AttributeError` and fell through to `proc.terminate()`. That is a correct fallback for the child itself but ends only that one process. There is now a Windows branch that walks the tree with `taskkill /T`, escalating to `/F` on the same two-phase schedule the POSIX path already used. If `taskkill` cannot run at all, it still falls back to `terminate()` then `kill()`, so behaviour never gets worse than today.

The POSIX path is untouched.

## Verification

The interesting question for a change like this is whether the test can actually fail. It can. Reproducing the current Windows shape on POSIX, a child spawned with no process group and then ended with a plain `terminate()`:

```
grandchild pid: 1110 alive: True
after naive terminate() -> child alive: False | GRANDCHILD alive: True
```

The child dies, the grandchild survives. That is the bug, and it is exactly what `test_terminate_process_group_reaps_a_grandchild` asserts against: it spawns a child that spawns a grandchild, tears the group down, and requires both pids to be gone.

Test results:

- macOS (arm64, Python 3.12): 4 passed
- Linux (`python:3.12-slim`, aarch64): 4 passed
- Existing launcher and runtime suites, to confirm the POSIX path is unchanged: `tests/runtime` plus `tests/diagnostics/test_process.py`, 153 passed
- `ruff` clean on both changed files

**What I could not verify locally, and what this PR does about it.** I have no Windows machine, and Windows containers need a Windows host, so Docker on macOS cannot stand in. Rather than ship the Windows branch unexercised, this adds a `test-windows-teardown` job on `windows-latest` that runs the new test file. That leg is the thing that actually proves a grandchild is reaped on Windows, and it keeps proving it. The existing Windows smoke leg from #285 only runs `traceml --help`, so it would not have covered this.

Three of the four tests are platform-agnostic and pin the dispatch and the fallback. The end-to-end one runs on whatever platform it lands on and is the real check on the Windows leg.

## Evidence

GATE: conformance ran=false. EVIDENCE: n/a (this touches launcher process teardown, not a telemetry stream, so the StreamContract suite has nothing to assert here). What ran instead: `tests/runtime` plus `tests/diagnostics/test_process.py` = 153 passed, and the new file = 4 passed on macOS arm64 and on Linux aarch64.

TRANSITIONS: tested graceful->forced escalation (`taskkill /T` then `/F /T`, on the same two-phase schedule as the POSIX SIGTERM->SIGKILL path) and taskkill-available->taskkill-missing (falls back to `terminate()` then `kill()`, asserted in that order). Already-exited->no-op is covered by the existing `proc.poll()` guard.

RANKS: per-rank asymmetry tested? EVIDENCE: n/a (no per-rank telemetry in this path; teardown acts on one launched pid and its process tree, so there is no rank dimension to be asymmetric across).

TRIPWIRE: made the failure fire on purpose? yes. Reproduced the current Windows shape on POSIX, a child with no process group ended by a plain `terminate()`, and captured the grandchild surviving: `after naive terminate() -> child alive: False | GRANDCHILD alive: True`. The new end-to-end test asserts against exactly that state, so it is not vacuous.

## Note

`src/traceml_ai/launcher/process.py` has three pre-existing lines over the 79-character limit at what are now lines 121, 128 and 150, inside `StderrTailCapture.finish`. They are untouched here and predate this change.

## Runtime impact

- [x] May affect tracing, runtime, or distributed behaviour

Teardown only, and only on Windows. The POSIX path takes byte-for-byte the same branch as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved launcher process cleanup across Windows and POSIX systems.
  - Ensured terminating a launcher also cleans up its child and grandchild processes.
  - Added a fallback cleanup path when Windows process-tree termination is unavailable.

- **Tests**
  - Added cross-platform coverage for process-group setup and complete process-tree teardown.
  - Added automated Windows CI coverage for cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->