### PR TITLE
freeze current behavour before edit changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,9 @@ If in doubt, open an issue before implementing.
 
 For code extension points, see
 [`docs/developer_guide/extending.md`](docs/developer_guide/extending.md).
+For performance-sensitive Step Time changes, also read the
+[`Step Time pipeline contract`](docs/developer_guide/step-time-pipeline-contract.md)
+and run the feature-local `tests/step_time/` suite.
 
 ---
 

--- a/docs/developer_guide/architecture.md
+++ b/docs/developer_guide/architecture.md
@@ -43,6 +43,11 @@ paths. New implementation work should go under `src/traceml_ai/`.
 
 For the user-facing API surface (`trace_step`, `TraceMLTrainer`, `TraceMLCallback`, CLI usage), see the [Public API](../user_guide/public-api.md). The source tree above is the canonical reference for internals — start from the entry points and follow the imports.
 
+Contributors changing Step Time should begin with the
+[Step Time pipeline contract](step-time-pipeline-contract.md), which maps its
+canonical window, diagnosis, live surfaces, final-summary projection, and
+cross-surface fixtures without requiring a full source-tree traversal.
+
 ## Design principles
 
 - **Fail-open** — training must never crash because telemetry broke. Sampler/transport errors are logged, execution continues.

--- a/docs/developer_guide/contributing.md
+++ b/docs/developer_guide/contributing.md
@@ -72,6 +72,11 @@ pytest tests/
 
 New code must include tests unless the change is docs-only.
 
+Step Time contributors should run the feature-local contract suite in
+`tests/step_time/` and read the
+[Step Time pipeline contract](step-time-pipeline-contract.md) before changing
+window, diagnosis, dashboard, or final-summary behavior.
+
 ## Docs
 
 If a code change affects user-facing behavior, update the relevant doc in the same PR.

--- a/docs/developer_guide/extending.md
+++ b/docs/developer_guide/extending.md
@@ -20,6 +20,11 @@ Live UI and final summaries are separate paths. They can share diagnostics, but
 they should pass explicit policies such as `LIVE_STEP_TIME_POLICY` or
 `SUMMARY_STEP_TIME_POLICY` when thresholds differ.
 
+For Step Time specifically, start with the
+[Step Time pipeline contract](step-time-pipeline-contract.md). Its ownership
+map and six SQLite scenarios show which layer owns each calculation and how to
+verify CLI, dashboard, and final-summary behavior together.
+
 ## TraceML Lifecycle
 
 TraceML has two runtime pieces:
@@ -197,6 +202,7 @@ tests/sdk/
 tests/telemetry/
 tests/display/
 tests/integrations/
+tests/step_time/       cross-surface Step Time contracts
 ```
 
 Keep tests close to the behavior they protect. The most valuable tests are

--- a/docs/developer_guide/step-time-pipeline-baseline.md
+++ b/docs/developer_guide/step-time-pipeline-baseline.md
@@ -1,0 +1,90 @@
+# Step Time Pipeline Baseline
+
+This page records the pre-refactor Step Time cost and provider topology. The
+numbers are observational evidence, not CI pass/fail budgets. Re-run the
+benchmark on the same machine when comparing a later pipeline PR.
+
+## Recorded environment
+
+| Field | Value |
+|---|---|
+| Baseline commit | `ed130406a21a1214b985624f1b364cff0cbecd7d` |
+| Recorded | 2026-08-01 |
+| Python | 3.13.5 |
+| SQLite | 3.50.2 |
+| Platform | macOS, arm64 |
+| Rows | 400 per rank |
+| Live/final window | 100 aligned steps |
+| Live lookback | 4× window |
+| Warmups / repetitions | 2 / 7 |
+
+## What is counted
+
+Test-side `sqlite3.Connection.set_trace_callback` instrumentation counts only
+statements beginning with `SELECT` or `WITH`. Fixture creation, inserts,
+transactions, and pragmas are excluded.
+
+The current formulas are:
+
+| Path | SELECTs | Reason |
+|---|---:|---|
+| One live provider | `R + 2` | rank discovery, one bounded read per rank, and training-strategy context |
+| One dashboard refresh | `2R + 4` | two independent live providers perform the same read topology |
+| Final summary | `2R + 3` | canonical load, maximum step, and one identity read per rank |
+
+These formulas characterize current behavior. They are expected to change in
+later consolidation PRs and must not be treated as desirable long-term API
+contracts.
+
+## Recorded results
+
+| Ranks | Stage | SELECTs | Median (ms) | p95 (ms) |
+|---:|---|---:|---:|---:|
+| 1 | load + decode + analyze | 3 | 8.350 | 8.565 |
+| 1 | diagnose | 0 | 0.111 | 0.113 |
+| 1 | one live provider | 3 | 8.362 | 8.553 |
+| 1 | dashboard Step Time refresh | 6 | 16.591 | 16.862 |
+| 1 | final summary | 5 | 7.454 | 7.547 |
+| 8 | load + decode + analyze | 10 | 36.482 | 41.452 |
+| 8 | diagnose | 0 | 0.183 | 0.196 |
+| 8 | one live provider | 10 | 37.128 | 42.099 |
+| 8 | dashboard Step Time refresh | 20 | 73.372 | 79.595 |
+| 8 | final summary | 19 | 30.479 | 31.420 |
+| 32 | load + decode + analyze | 34 | 176.220 | 182.028 |
+| 32 | diagnose | 0 | 0.444 | 0.706 |
+| 32 | one live provider | 34 | 176.025 | 179.283 |
+| 32 | dashboard Step Time refresh | 68 | 371.727 | 422.793 |
+| 32 | final summary | 67 | 193.767 | 216.140 |
+
+SQLite loading, JSON decoding, alignment, and window analysis are fused in the
+current loader. The benchmark therefore reports that span honestly as one
+stage. Diagnosis is measured separately because it already accepts a canonical
+in-memory window.
+
+The dashboard row measures only its two Step Time reads, not unrelated System,
+Process, or Step Memory work. A production-path characterization test also
+proves that one real dashboard tick invokes two distinct Step Time computers.
+
+## Reproduce
+
+From the repository root:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 \
+python tests/benchmarks/bench_step_time_pipeline.py
+```
+
+Useful options:
+
+```bash
+python tests/benchmarks/bench_step_time_pipeline.py \
+  --ranks 1,8,32 \
+  --steps 400 \
+  --window-size 100 \
+  --warmups 2 \
+  --repetitions 7
+```
+
+When publishing a comparison, record the commit, Python and SQLite versions,
+platform, fixture shape, and full command. Compare query counts exactly;
+interpret wall time only against a run from a comparable environment.

--- a/docs/developer_guide/step-time-pipeline-contract.md
+++ b/docs/developer_guide/step-time-pipeline-contract.md
@@ -1,0 +1,150 @@
+# Step Time Pipeline Contract
+
+This page is the contributor map for Step Time. It describes the current
+behavior that CLI, dashboard, and final-summary changes must preserve. It does
+not prescribe the internal classes planned for later refactoring.
+
+For diagnosis thresholds and issue semantics, see
+[`diagnostics/DIAGNOSIS.md`](https://github.com/traceopt-ai/traceml/blob/main/src/traceml_ai/diagnostics/DIAGNOSIS.md).
+For the public final-summary shape, see
+[`reporting/SCHEMA.md`](https://github.com/traceopt-ai/traceml/blob/main/src/traceml_ai/reporting/SCHEMA.md).
+
+## Current flow
+
+```mermaid
+flowchart LR
+    DB[(step_time_samples)]
+    A["Live provider A<br/>StepCombinedRenderer"]
+    B["Live provider B<br/>ModelDiagnosticsRenderer"]
+    L["Shared live SQLite loader"]
+    W["Canonical live StepTimeWindow"]
+    D["Live Step Time diagnosis"]
+    CLI["Live CLI"]
+    HERO["Dashboard hero"]
+    RAIL["Dashboard diagnostics rail"]
+    S["Final-summary loader"]
+    SW["Canonical summary StepTimeWindow"]
+    SD["Summary Step Time diagnosis"]
+    OUT["JSON and text"]
+
+    DB --> A --> L --> W
+    DB -. "second independent read" .-> B
+    B --> L
+    W --> D
+    W --> CLI
+    W --> HERO
+    D --> CLI
+    D --> RAIL
+    RAIL --> HERO
+    DB --> S --> SW --> SD --> OUT
+```
+
+The diagram shows current technical debt deliberately: a dashboard refresh
+owns two independent Step Time computers. The hero receives timing data from
+one, while the diagnostics rail and hero verdict receive diagnosis from the
+other. PR1 measures this duplication; it does not change it.
+
+## Where each decision belongs
+
+| Concern | Source of truth | Change here when... |
+|---|---|---|
+| Event-to-metric names | `utils/step_time_window.py` | persisted event names or clock extraction change |
+| Common-step alignment and availability | `utils/step_time_window.py` | window, sparse-signal, or derived-metric semantics change |
+| SQLite rank loading and strategy context | `utils/step_time_sqlite.py` | persisted Step Time reads change |
+| Diagnosis thresholds and priority | `diagnostics/step_time/` | a rule, policy, attribution, or issue order changes |
+| Live CLI presentation | `renderers/step_time/renderer.py` | terminal labels or layout change |
+| Dashboard Step Time presentation | `aggregator/display_drivers/nicegui_sections/` | hero or diagnostics cards change |
+| Final-summary projection | `reporting/sections/step_time/` | public JSON or summary text changes |
+| Cross-surface contract scenarios | `tests/step_time/` | any item above changes intentionally |
+
+Start with the contract scenarios before following a surface-specific call
+path. They present the entire persisted-input-to-output behavior in one place.
+
+## Canonical window invariants
+
+| Contract | Meaning |
+|---|---|
+| Common window | Only the latest bounded set of completed step ids shared across the participating ranks is analyzed. |
+| Expected ranks | The window retains the persisted global-rank universe even when a rank lacks a metric. |
+| Selected clock | One clock, CPU or GPU, is selected for the entire window. Phase values are never mixed across clocks. |
+| Required metrics | Input wait, forward, backward, and step envelope must be measured on every aligned step for a rank. Partial presence makes that metric unavailable for the rank. |
+| Occurrence-driven metrics | H2D and optimizer may legitimately occur on only some steps. Once observed, absent steps contribute zero work. An entirely absent H2D means no observed transfers, not incomplete instrumentation. |
+| Missing versus zero | An unavailable metric is absent from the sparse rank row and projects to `null`. A measured `0.0` remains present and projects to `0.0`. |
+| Derived metrics | Compute needs forward, backward, and optimizer. Residual needs the step envelope and every compute phase; absent H2D contributes zero. Total step needs input wait and the step envelope. |
+| Rank cohorts | A diagnosis uses only ranks carrying all metrics required by that rule. Consumers must not reconstruct another availability policy. |
+| Metric statistics | Median, worst value, worst rank, and skew are computed from ranks that measured that metric. The worst value and rank must describe the same rank. |
+| Residual meaning | `max(0, step - h2d - forward - backward - optimizer)` is unattributed time, not proof of communication or NCCL overhead. |
+
+CPU compatibility fields in `final_summary.json` are intentionally different
+from selected-clock diagnosis values. `dataloader_ms` and `total_step_ms`
+remain CPU-clocked, while `input_wait_ms`, `step_time_ms`, and phase metrics use
+the selected diagnosis clock.
+
+## Surface responsibilities
+
+| Surface | Loads | Diagnoses | Presents |
+|---|---|---|---|
+| Live CLI | Recent aligned window with lookback | Live policy | Rich diagnosis and metric table |
+| Dashboard hero | Recent aligned window with lookback | Verdict comes from diagnostics payload | Phase ribbon and compact KPIs |
+| Dashboard diagnostics rail | A second recent aligned window today | Live policy | Structured finding and evidence |
+| Final summary | Larger bounded final window plus rank identity | Summary policy | Stable JSON projection and text card |
+
+Built-in live and summary policies currently use the same thresholds. Their
+window sizes and presentation responsibilities differ.
+
+## Contract scenarios
+
+[`tests/step_time/scenarios.py`](https://github.com/traceopt-ai/traceml/blob/main/tests/step_time/scenarios.py)
+defines six explicit SQLite scenarios:
+
+| Scenario | Contract protected |
+|---|---|
+| `complete_gpu` | complete multi-rank window, GPU selection, and separate CPU compatibility projection |
+| `sparse_missing_forward` | one rank lacks a required signal; compute and residual remain unavailable on that rank |
+| `measured_zero_forward` | an explicit zero remains measured and participates in compute, residual, and diagnosis |
+| `single_rank_cpu` | single-rank statistics and diagnosis without fabricated cross-rank skew |
+| `ddp_rank_straggler` | DDP visible-backward attribution and critical severity after a confident window |
+| `fsdp_rank_straggler` | FSDP strategy propagation, attribution behavior, and warning severity cap |
+
+The cross-surface goldens freeze:
+
+- selected clock, aligned steps, rank universe, and coverage;
+- sparse per-rank values and selected metric statistics;
+- diagnosis kind, status, severity, affected rank, and issue ordering;
+- CLI/dashboard/final-summary diagnosis parity;
+- final-summary window metadata and public `null` versus `0.0` projection.
+
+They intentionally do not snapshot timestamps, private cache state, complete
+Rich/NiceGUI markup, or dictionary ordering.
+
+## Changing Step Time safely
+
+Before submitting a Step Time change:
+
+1. Identify the ownership row above; avoid adding the same calculation to a
+   presenter.
+2. Add or update one explicit scenario only when a contract genuinely changes.
+3. Run the cross-surface tests and inspect CLI, dashboard, and summary effects
+   together.
+4. If SQL changes, update the observational query baseline deliberately.
+5. If public summary keys or meanings change, update `reporting/SCHEMA.md` and
+   consider schema-version compatibility.
+6. If diagnosis vocabulary or thresholds change, update
+   `diagnostics/DIAGNOSIS.md` and user-facing interpretation guidance.
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider tests/step_time -q
+```
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| Step envelope | Instrumented time inside one traced training step. |
+| Iteration | Selected input wait plus the selected step envelope. |
+| Common window | Aligned completed step suffix shared by participating ranks. |
+| Rank universe | Expected global ranks retained by the canonical window. |
+| Measured rank | A rank carrying a particular sparse metric. |
+| Eligible cohort | Ranks carrying every signal required by one calculation or rule. |
+| Provider | A stateful live computer that reads SQLite and owns last-good behavior. |
+| Projection | A surface-specific view derived from the canonical window or diagnosis. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,8 @@ nav:
       - Public API: user_guide/public-api.md
   - Developer Guide:
       - Architecture: developer_guide/architecture.md
+      - Step Time Pipeline Contract: developer_guide/step-time-pipeline-contract.md
+      - Step Time Pipeline Baseline: developer_guide/step-time-pipeline-baseline.md
       - Rank Straggler Policy: developer_guide/rank-straggler-policy.md
       - Extending TraceML: developer_guide/extending.md
       - Contributing: developer_guide/contributing.md

--- a/tests/benchmarks/bench_step_time_pipeline.py
+++ b/tests/benchmarks/bench_step_time_pipeline.py
@@ -1,0 +1,220 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reproducible observational benchmark for the Step Time pipeline.
+
+This is intentionally a standalone script rather than a CI performance gate.
+It reports current query counts and median/p95 wall time for the existing
+loader, diagnosis, live, dashboard, and final-summary paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import platform
+import sqlite3
+import statistics
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+for import_root in (ROOT, SRC):
+    if str(import_root) not in sys.path:
+        sys.path.insert(0, str(import_root))
+
+from tests.step_time.scenarios import (  # noqa: E402
+    BALANCED_PROFILE,
+    SQLiteSelectRecorder,
+    StepTimeScenario,
+    create_step_time_database,
+)
+from traceml_ai.diagnostics.step_time.policy import (  # noqa: E402
+    LIVE_STEP_TIME_POLICY,
+)
+from traceml_ai.renderers.step_time.compute import (  # noqa: E402
+    StepCombinedComputer,
+)
+from traceml_ai.reporting.sections.step_time import (  # noqa: E402
+    StepTimeSummarySection,
+)
+from traceml_ai.utils.step_time_sqlite import (  # noqa: E402
+    load_step_time_window_from_sqlite,
+)
+from traceml_ai.utils.step_time_window import (  # noqa: E402
+    diagnose_step_time_window,
+)
+
+
+@dataclass(frozen=True)
+class Measurement:
+    """One timing and query-count result printed by the benchmark."""
+
+    stage: str
+    median_ms: float
+    p95_ms: float
+    selects: int
+
+
+def _measure(
+    stage: str,
+    call: Callable[[], object],
+    *,
+    warmups: int,
+    repetitions: int,
+) -> Measurement:
+    for _ in range(warmups):
+        call()
+
+    samples: list[float] = []
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        call()
+        samples.append((time.perf_counter() - started) * 1000.0)
+
+    ordered = sorted(samples)
+    p95_index = max(0, math.ceil(len(ordered) * 0.95) - 1)
+    recorder = SQLiteSelectRecorder()
+    with patch.object(sqlite3, "connect", recorder.connect):
+        call()
+    return Measurement(
+        stage=stage,
+        median_ms=statistics.median(samples),
+        p95_ms=ordered[p95_index],
+        selects=recorder.count,
+    )
+
+
+def _benchmark_rank_count(
+    root: Path,
+    *,
+    rank_count: int,
+    stored_steps: int,
+    window_size: int,
+    warmups: int,
+    repetitions: int,
+) -> list[Measurement]:
+    scenario = StepTimeScenario(
+        name=f"benchmark_{rank_count}_ranks",
+        profiles={rank: dict(BALANCED_PROFILE) for rank in range(rank_count)},
+        steps=tuple(range(1, stored_steps + 1)),
+    )
+    db_path = root / f"step-time-{rank_count}-ranks.db"
+    create_step_time_database(db_path, scenario)
+
+    def load_window():
+        with sqlite3.connect(db_path) as conn:
+            return load_step_time_window_from_sqlite(
+                conn,
+                max_rows=window_size,
+                lookback_factor=4,
+            )
+
+    loaded = load_window()
+    live = StepCombinedComputer(str(db_path), window_size=window_size)
+    dashboard_hero = StepCombinedComputer(
+        str(db_path),
+        window_size=window_size,
+    )
+    dashboard_rail = StepCombinedComputer(
+        str(db_path),
+        window_size=window_size,
+    )
+    summary = StepTimeSummarySection(max_rows=window_size)
+
+    calls = (
+        ("load + decode + analyze", load_window),
+        (
+            "diagnose",
+            lambda: diagnose_step_time_window(
+                loaded.window,
+                policy=LIVE_STEP_TIME_POLICY,
+                training_strategy=loaded.training_strategy,
+            ),
+        ),
+        ("one live provider", live.compute_cli),
+        (
+            "dashboard Step Time refresh",
+            lambda: (
+                dashboard_hero.compute_dashboard(),
+                dashboard_rail.compute_dashboard(),
+            ),
+        ),
+        ("final summary", lambda: summary.build(str(db_path))),
+    )
+    return [
+        _measure(
+            stage,
+            call,
+            warmups=warmups,
+            repetitions=repetitions,
+        )
+        for stage, call in calls
+    ]
+
+
+def main() -> None:
+    """Run the benchmark and print a Markdown-ready baseline table."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--ranks",
+        default="1,8,32",
+        help="Comma-separated rank counts (default: 1,8,32)",
+    )
+    parser.add_argument("--steps", type=int, default=400)
+    parser.add_argument("--window-size", type=int, default=100)
+    parser.add_argument("--warmups", type=int, default=2)
+    parser.add_argument("--repetitions", type=int, default=7)
+    args = parser.parse_args()
+
+    rank_counts = tuple(
+        int(value.strip()) for value in args.ranks.split(",") if value.strip()
+    )
+    if not rank_counts or any(rank <= 0 for rank in rank_counts):
+        parser.error("--ranks must contain positive integers")
+    if min(args.steps, args.window_size, args.repetitions) <= 0:
+        parser.error("--steps, --window-size, and --repetitions must be > 0")
+    if args.warmups < 0:
+        parser.error("--warmups must be >= 0")
+
+    print(f"Python: {platform.python_version()}")
+    print(f"SQLite: {sqlite3.sqlite_version}")
+    print(f"Platform: {platform.system()} {platform.machine()}")
+    print(
+        f"Rows: {args.steps}/rank; window: {args.window_size}; "
+        f"warmups: {args.warmups}; repetitions: {args.repetitions}"
+    )
+    print()
+    print("| Ranks | Stage | SELECTs | Median (ms) | p95 (ms) |")
+    print("|---:|---|---:|---:|---:|")
+
+    with tempfile.TemporaryDirectory(prefix="traceml-step-time-bench-") as td:
+        root = Path(td)
+        for rank_count in rank_counts:
+            for result in _benchmark_rank_count(
+                root,
+                rank_count=rank_count,
+                stored_steps=args.steps,
+                window_size=args.window_size,
+                warmups=args.warmups,
+                repetitions=args.repetitions,
+            ):
+                print(
+                    f"| {rank_count} | {result.stage} | {result.selects} | "
+                    f"{result.median_ms:.3f} | {result.p95_ms:.3f} |"
+                )
+
+
+if __name__ == "__main__":
+    # Keep plain ``python tests/benchmarks/bench_step_time_pipeline.py``
+    # working from the repository root without requiring an editable install.
+    sys.exit(main())

--- a/tests/display/test_nicegui_driver.py
+++ b/tests/display/test_nicegui_driver.py
@@ -19,6 +19,21 @@ pytest.importorskip("nicegui")
 from traceml_ai.aggregator.display_drivers.nicegui import (  # noqa: E402
     NiceGUIDisplayDriver,
 )
+from traceml_ai.renderers.model_diagnostics.renderer import (  # noqa: E402
+    ModelDiagnosticsRenderer,
+)
+from traceml_ai.renderers.step_memory.schema import (  # noqa: E402
+    StepMemoryCombinedResult,
+)
+from traceml_ai.renderers.step_time.compute import (  # noqa: E402
+    StepCombinedComputer,
+)
+from traceml_ai.renderers.step_time.renderer import (  # noqa: E402
+    StepCombinedRenderer,
+)
+from traceml_ai.renderers.step_time.schema import (  # noqa: E402
+    StepCombinedTimeResult,
+)
 from traceml_ai.runtime.settings import TraceMLSettings  # noqa: E402
 
 
@@ -158,3 +173,50 @@ def test_dashboard_sections_build_without_error() -> None:
     build_process_section()
     build_step_memory_section()
     build_model_diagnostics_section()
+
+
+def test_dashboard_tick_currently_invokes_two_step_time_providers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Characterize the duplicate production providers before consolidation.
+
+    The Step Time hero and diagnostics rail currently own independent
+    computers. A later pipeline PR should change this test to one shared
+    provider; PR1 records the existing two-call behavior without changing it.
+    """
+    calls: list[StepCombinedComputer] = []
+
+    def record_compute(
+        computer: StepCombinedComputer,
+    ) -> StepCombinedTimeResult:
+        calls.append(computer)
+        return StepCombinedTimeResult()
+
+    monkeypatch.setattr(
+        StepCombinedComputer,
+        "compute_dashboard",
+        record_compute,
+    )
+    driver = _driver()
+    for renderer in driver._renderers:
+        if isinstance(renderer, ModelDiagnosticsRenderer):
+            monkeypatch.setattr(
+                renderer._step_memory,
+                "compute_dashboard",
+                lambda: StepMemoryCombinedResult(
+                    metrics=[],
+                    status_message="No GPU detected",
+                ),
+            )
+        elif not isinstance(renderer, StepCombinedRenderer):
+            monkeypatch.setattr(
+                renderer,
+                "get_dashboard_renderable",
+                lambda: {},
+            )
+
+    driver._ui_ready = True
+    driver.tick()
+
+    assert len(calls) == 2
+    assert calls[0] is not calls[1]

--- a/tests/step_time/__init__.py
+++ b/tests/step_time/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-surface Step Time contract tests and their local support data."""

--- a/tests/step_time/scenarios.py
+++ b/tests/step_time/scenarios.py
@@ -1,0 +1,311 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical SQLite scenarios for cross-surface Step Time tests.
+
+This module deliberately keeps scenario definition and persistence together.
+Contract tests should need only two operations: select a named scenario and
+write it to SQLite. Keeping that path shallow avoids repeating event encodings
+across the CLI, dashboard, and final-summary test suites.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+MetricProfile = Mapping[str, float]
+RankProfiles = Mapping[int, MetricProfile]
+
+EVENT_NAMES: Mapping[str, str] = {
+    "input_wait": "_traceml_internal:dataloader_next",
+    "h2d": "_traceml_internal:h2d_time",
+    "forward": "_traceml_internal:forward_time",
+    "backward": "_traceml_internal:backward_time",
+    "optimizer_step": "_traceml_internal:optimizer_step",
+    "step_time": "_traceml_internal:step_time",
+}
+
+BALANCED_PROFILE: Mapping[str, float] = {
+    "input_wait": 5.0,
+    "h2d": 5.0,
+    "forward": 30.0,
+    "backward": 45.0,
+    "optimizer_step": 10.0,
+    "step_time": 95.0,
+}
+
+
+@dataclass(frozen=True)
+class StepTimeScenario:
+    """One deterministic telemetry window shared by every output surface.
+
+    Parameters
+    ----------
+    name:
+        Stable pytest id and contributor-facing scenario name.
+    profiles:
+        Selected-clock metric values keyed by global rank. Omitting a metric
+        represents an unavailable signal; an explicit ``0.0`` is measured.
+    steps:
+        Completed step ids persisted for every rank.
+    clock:
+        Expected selected diagnosis clock. GPU scenarios also persist a CPU
+        compatibility clock at twice the selected value.
+    training_strategy:
+        Advisory strategy persisted in ``runtime_environment``.
+    """
+
+    name: str
+    profiles: RankProfiles
+    steps: tuple[int, ...]
+    clock: str = "cpu"
+    training_strategy: str = "ddp"
+
+
+class SQLiteSelectRecorder:
+    """Open traced SQLite connections and retain only read statements.
+
+    The recorder is test-side instrumentation. Patch ``sqlite3.connect`` with
+    :meth:`connect` only around the production call being measured; database
+    setup must happen before the patch so fixture writes are excluded.
+    """
+
+    def __init__(self) -> None:
+        self._connect = sqlite3.connect
+        self.statements: list[str] = []
+
+    def connect(self, *args: Any, **kwargs: Any) -> sqlite3.Connection:
+        """Return a connection whose SELECT/WITH statements are recorded."""
+        conn = self._connect(*args, **kwargs)
+        conn.set_trace_callback(self._record)
+        return conn
+
+    @property
+    def count(self) -> int:
+        """Return the number of recorded read statements."""
+        return len(self.statements)
+
+    def _record(self, statement: str) -> None:
+        normalized = statement.lstrip().upper()
+        if normalized.startswith(("SELECT", "WITH")):
+            self.statements.append(statement)
+
+
+def _profile(**overrides: float) -> dict[str, float]:
+    """Return a balanced profile with selected values replaced explicitly."""
+    return {**BALANCED_PROFILE, **overrides}
+
+
+def _without(profile: MetricProfile, metric: str) -> dict[str, float]:
+    """Copy a profile while making one metric unavailable."""
+    return {key: value for key, value in profile.items() if key != metric}
+
+
+SCENARIOS: tuple[StepTimeScenario, ...] = (
+    StepTimeScenario(
+        name="complete_gpu",
+        profiles={0: _profile(), 1: _profile()},
+        steps=(10, 11, 12, 13),
+        clock="gpu",
+    ),
+    StepTimeScenario(
+        name="sparse_missing_forward",
+        profiles={
+            0: _profile(),
+            1: _without(_profile(), "forward"),
+        },
+        steps=(20, 21, 22, 23),
+    ),
+    StepTimeScenario(
+        name="measured_zero_forward",
+        profiles={0: _profile(), 1: _profile(forward=0.0)},
+        steps=(30, 31, 32, 33),
+    ),
+    StepTimeScenario(
+        name="single_rank_cpu",
+        profiles={0: _profile()},
+        steps=(40, 41, 42, 43),
+    ),
+    StepTimeScenario(
+        name="ddp_rank_straggler",
+        profiles={
+            0: _profile(
+                input_wait=100.0,
+                h2d=0.0,
+                forward=20.0,
+                backward=20.0,
+                optimizer_step=0.0,
+                step_time=40.0,
+            ),
+            1: _profile(
+                input_wait=0.0,
+                h2d=0.0,
+                forward=20.0,
+                backward=120.0,
+                optimizer_step=0.0,
+                step_time=140.0,
+            ),
+        },
+        steps=tuple(range(50, 74)),
+        training_strategy="ddp",
+    ),
+    StepTimeScenario(
+        name="fsdp_rank_straggler",
+        profiles={
+            0: _profile(
+                input_wait=100.0,
+                h2d=0.0,
+                forward=20.0,
+                backward=20.0,
+                optimizer_step=0.0,
+                step_time=40.0,
+            ),
+            1: _profile(
+                input_wait=0.0,
+                h2d=0.0,
+                forward=80.0,
+                backward=80.0,
+                optimizer_step=0.0,
+                step_time=160.0,
+            ),
+        },
+        steps=tuple(range(80, 104)),
+        training_strategy="fsdp",
+    ),
+)
+
+SCENARIOS_BY_NAME: Mapping[str, StepTimeScenario] = {
+    scenario.name: scenario for scenario in SCENARIOS
+}
+
+
+def _event_payload(profile: MetricProfile, clock: str) -> dict:
+    """Encode one rank profile in the production ``events_json`` shape."""
+    events = {}
+    for metric, value in profile.items():
+        event_name = EVENT_NAMES[metric]
+        selected = float(value)
+        cpu_ms = selected * 2.0 if clock == "gpu" else selected
+        events[event_name] = {
+            "cuda:0" if clock == "gpu" else "cpu": {
+                "is_gpu": clock == "gpu",
+                "duration_ms": cpu_ms,
+                "cpu_ms": cpu_ms,
+                "gpu_ms": selected if clock == "gpu" else None,
+                "n_calls": 1,
+            }
+        }
+    return events
+
+
+def create_step_time_database(
+    path: str | Path,
+    scenario: StepTimeScenario,
+) -> None:
+    """Persist a scenario using the columns read by all Step Time surfaces.
+
+    Parameters
+    ----------
+    path:
+        SQLite database path to create.
+    scenario:
+        Canonical scenario whose rows and runtime strategy are persisted.
+    """
+    db_path = str(path)
+    world_size = len(scenario.profiles)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE step_time_samples (
+                id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+                recv_ts_ns         INTEGER NOT NULL,
+                rank               INTEGER,
+                global_rank        INTEGER,
+                local_rank         INTEGER,
+                world_size         INTEGER,
+                local_world_size   INTEGER,
+                node_rank          INTEGER,
+                hostname           TEXT,
+                sample_ts_s        REAL,
+                seq                INTEGER,
+                step               INTEGER,
+                events_json        TEXT NOT NULL
+            );
+
+            CREATE TABLE runtime_environment (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                training_strategy TEXT
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO runtime_environment(training_strategy) VALUES (?);",
+            (scenario.training_strategy,),
+        )
+
+        rows = []
+        sequence = 0
+        for global_rank, profile in sorted(scenario.profiles.items()):
+            payload = json.dumps(
+                _event_payload(profile, scenario.clock),
+                sort_keys=True,
+            )
+            for step in scenario.steps:
+                sequence += 1
+                rows.append(
+                    (
+                        sequence,
+                        global_rank,
+                        global_rank,
+                        global_rank,
+                        world_size,
+                        world_size,
+                        0,
+                        "worker-0",
+                        float(step),
+                        sequence,
+                        step,
+                        payload,
+                    )
+                )
+
+        conn.executemany(
+            """
+            INSERT INTO step_time_samples(
+                recv_ts_ns,
+                rank,
+                global_rank,
+                local_rank,
+                world_size,
+                local_world_size,
+                node_rank,
+                hostname,
+                sample_ts_s,
+                seq,
+                step,
+                events_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """,
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+__all__ = [
+    "BALANCED_PROFILE",
+    "SCENARIOS",
+    "SCENARIOS_BY_NAME",
+    "SQLiteSelectRecorder",
+    "StepTimeScenario",
+    "create_step_time_database",
+]

--- a/tests/step_time/test_contract_baseline.py
+++ b/tests/step_time/test_contract_baseline.py
@@ -1,0 +1,422 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-surface characterization tests for the Step Time pipeline.
+
+These tests freeze semantic contracts, not implementation layout. Every case
+starts from the same SQLite scenario and reaches the real CLI, dashboard, and
+final-summary adapters. Incidental Rich markup, timestamps, cache internals,
+and dictionary ordering intentionally remain outside the golden surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
+
+from tests.step_time.scenarios import (
+    SCENARIOS,
+    StepTimeScenario,
+    create_step_time_database,
+)
+from traceml_ai.diagnostics.step_time.policy import LIVE_STEP_TIME_POLICY
+from traceml_ai.renderers.model_diagnostics.renderer import (
+    ModelDiagnosticsRenderer,
+)
+from traceml_ai.renderers.step_memory.schema import StepMemoryCombinedResult
+from traceml_ai.renderers.step_time import renderer as cli_renderer_module
+from traceml_ai.renderers.step_time.compute import StepCombinedComputer
+from traceml_ai.renderers.step_time.renderer import StepCombinedRenderer
+from traceml_ai.reporting.sections.step_time import StepTimeSummarySection
+from traceml_ai.reporting.sections.step_time.model import (
+    STEP_TIME_METRIC_NAMES,
+)
+from traceml_ai.utils.step_time_window import diagnose_step_time_window
+
+_WINDOW_KEYS = {
+    "input_wait",
+    "h2d",
+    "forward",
+    "backward",
+    "optimizer_step",
+    "step_time",
+    "residual_proxy",
+    "total_step",
+}
+
+
+@dataclass(frozen=True)
+class DiagnosisGolden:
+    """Stable diagnosis fields shared by live and final surfaces."""
+
+    kind: str
+    status: str
+    severity: str
+    worst_rank: int | None
+    issues: tuple[str, ...]
+    score: float | None = None
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+
+
+# Raw selected metrics already live beside each scenario. Only derived values
+# need separate goldens; this avoids copying every fixture profile into the
+# assertion table and keeps missing keys visible.
+EXPECTED_DERIVED_TIMING: dict[str, dict[int, dict[str, float]]] = {
+    "complete_gpu": {
+        0: {"residual_proxy": 5.0, "total_step": 100.0},
+        1: {"residual_proxy": 5.0, "total_step": 100.0},
+    },
+    "sparse_missing_forward": {
+        0: {"residual_proxy": 5.0, "total_step": 100.0},
+        1: {"total_step": 100.0},
+    },
+    "measured_zero_forward": {
+        0: {"residual_proxy": 5.0, "total_step": 100.0},
+        1: {"residual_proxy": 35.0, "total_step": 100.0},
+    },
+    "single_rank_cpu": {
+        0: {"residual_proxy": 5.0, "total_step": 100.0},
+    },
+    "ddp_rank_straggler": {
+        0: {"residual_proxy": 0.0, "total_step": 140.0},
+        1: {"residual_proxy": 0.0, "total_step": 140.0},
+    },
+    "fsdp_rank_straggler": {
+        0: {"residual_proxy": 0.0, "total_step": 140.0},
+        1: {"residual_proxy": 0.0, "total_step": 160.0},
+    },
+}
+
+EXPECTED_DIAGNOSIS: dict[str, DiagnosisGolden] = {
+    "complete_gpu": DiagnosisGolden(
+        kind="BALANCED",
+        status="BALANCED",
+        severity="info",
+        worst_rank=0,
+        issues=("BALANCED",),
+    ),
+    "sparse_missing_forward": DiagnosisGolden(
+        kind="BALANCED",
+        status="BALANCED",
+        severity="info",
+        worst_rank=0,
+        issues=("BALANCED",),
+    ),
+    "measured_zero_forward": DiagnosisGolden(
+        kind="RESIDUAL_HEAVY",
+        status="RESIDUAL-HEAVY",
+        severity="warn",
+        worst_rank=0,
+        issues=("RESIDUAL_HEAVY",),
+        score=0.2,
+    ),
+    "single_rank_cpu": DiagnosisGolden(
+        kind="BALANCED",
+        status="BALANCED",
+        severity="info",
+        worst_rank=None,
+        issues=("BALANCED",),
+    ),
+    "ddp_rank_straggler": DiagnosisGolden(
+        kind="INPUT_STRAGGLER",
+        status="INPUT STRAGGLER",
+        severity="crit",
+        worst_rank=0,
+        issues=("INPUT_STRAGGLER", "INPUT_BOUND"),
+        score=5.0 / 7.0,
+        evidence={
+            "culprit_rank": 0,
+            "victim_rank": 1,
+            "visible_metric": "backward",
+        },
+    ),
+    "fsdp_rank_straggler": DiagnosisGolden(
+        kind="INPUT_STRAGGLER",
+        status="INPUT STRAGGLER",
+        severity="warn",
+        worst_rank=0,
+        issues=("INPUT_STRAGGLER", "INPUT_BOUND"),
+        score=0.75,
+        evidence={
+            "culprit_rank": 0,
+            "victim_rank": 1,
+            "visible_metric": "forward_backward",
+        },
+    ),
+}
+
+EXPECTED_METRIC_SUMMARIES: dict[
+    str,
+    dict[str, tuple[float, float, int, float | None]],
+] = {
+    "complete_gpu": {"step_time": (95.0, 95.0, 0, 0.0)},
+    "sparse_missing_forward": {
+        "forward": (30.0, 30.0, 0, None),
+        "residual_proxy": (5.0, 5.0, 0, None),
+    },
+    "measured_zero_forward": {
+        "forward": (15.0, 30.0, 0, 1.0),
+        "residual_proxy": (20.0, 35.0, 1, 0.75),
+    },
+    "single_rank_cpu": {"step_time": (95.0, 95.0, 0, None)},
+    "ddp_rank_straggler": {
+        "input_wait": (50.0, 100.0, 0, 1.0),
+        "step_time": (90.0, 140.0, 1, 5.0 / 9.0),
+    },
+    "fsdp_rank_straggler": {
+        "input_wait": (50.0, 100.0, 0, 1.0),
+        "step_time": (100.0, 160.0, 1, 0.6),
+    },
+}
+
+# Focused final-summary goldens. These pin public projection semantics without
+# turning every formatting detail into a refactor constraint.
+EXPECTED_PUBLIC_ROWS: dict[str, dict[int, dict[str, float | None]]] = {
+    "complete_gpu": {
+        0: {
+            "total_step_ms": 200.0,
+            "dataloader_ms": 10.0,
+            "input_wait_ms": 5.0,
+            "step_time_ms": 95.0,
+            "compute_ms": 85.0,
+            "residual_ms": 5.0,
+        }
+    },
+    "sparse_missing_forward": {
+        1: {
+            "forward_ms": None,
+            "compute_ms": None,
+            "residual_ms": None,
+            "step_time_ms": 95.0,
+        }
+    },
+    "measured_zero_forward": {
+        1: {
+            "forward_ms": 0.0,
+            "compute_ms": 55.0,
+            "residual_ms": 35.0,
+        }
+    },
+    "single_rank_cpu": {
+        0: {
+            "total_step_ms": 100.0,
+            "dataloader_ms": 5.0,
+            "input_wait_ms": 5.0,
+            "step_time_ms": 95.0,
+        }
+    },
+    "ddp_rank_straggler": {
+        0: {"total_step_ms": 140.0, "input_wait_ms": 100.0},
+        1: {"total_step_ms": 140.0, "compute_ms": 140.0},
+    },
+    "fsdp_rank_straggler": {
+        0: {"total_step_ms": 140.0, "input_wait_ms": 100.0},
+        1: {"total_step_ms": 160.0, "compute_ms": 160.0},
+    },
+}
+
+
+@pytest.fixture(params=SCENARIOS, ids=lambda scenario: scenario.name)
+def scenario_db(
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+) -> tuple[StepTimeScenario, Path]:
+    """Create one canonical scenario database for a contract test."""
+    scenario: StepTimeScenario = request.param
+    db_path = tmp_path / f"{scenario.name}.db"
+    create_step_time_database(db_path, scenario)
+    return scenario, db_path
+
+
+def _assert_optional_float(actual: Any, expected: float | None) -> None:
+    """Compare a possibly absent numeric contract value."""
+    if expected is None:
+        assert actual is None
+    else:
+        assert actual == pytest.approx(expected)
+
+
+def test_canonical_window_matches_golden(
+    scenario_db: tuple[StepTimeScenario, Path],
+) -> None:
+    """Freeze alignment, clock, sparsity, metrics, and diagnosis semantics."""
+    scenario, db_path = scenario_db
+    result = StepCombinedComputer(
+        str(db_path),
+        window_size=len(scenario.steps),
+    ).compute_cli()
+
+    assert result.window is not None
+    window = result.window
+    assert result.training_strategy == scenario.training_strategy
+    assert window.clock == scenario.clock
+    assert window.steps == list(scenario.steps)
+    assert window.rank_universe == tuple(sorted(scenario.profiles))
+    assert window.coverage.expected_steps == len(scenario.steps)
+    assert window.coverage.steps_used == len(scenario.steps)
+    assert window.coverage.completed_step == scenario.steps[-1]
+    assert window.coverage.world_size == len(scenario.profiles)
+    assert window.coverage.ranks_present == len(scenario.profiles)
+    assert window.coverage.incomplete is False
+
+    expected_rows = {
+        rank: {
+            **scenario.profiles[rank],
+            **EXPECTED_DERIVED_TIMING[scenario.name][rank],
+        }
+        for rank in scenario.profiles
+    }
+    assert set(window.per_rank_timing) == set(expected_rows)
+    for rank, expected in expected_rows.items():
+        actual = {
+            key: value
+            for key, value in window.per_rank_timing[rank].items()
+            if key in _WINDOW_KEYS
+        }
+        assert actual == pytest.approx(expected)
+
+    for metric in _WINDOW_KEYS - {"total_step"}:
+        expected_ranks = tuple(
+            rank for rank, row in expected_rows.items() if metric in row
+        )
+        assert window.ranks_for(metric) == expected_ranks
+
+    metrics = {metric.metric: metric for metric in window.metrics}
+    for metric_name, expected in EXPECTED_METRIC_SUMMARIES[
+        scenario.name
+    ].items():
+        median, worst, worst_rank, skew = expected
+        summary = metrics[metric_name].summary
+        assert summary.median_total == pytest.approx(median)
+        assert summary.worst_total == pytest.approx(worst)
+        assert summary.worst_rank == worst_rank
+        _assert_optional_float(summary.skew_pct, skew)
+
+    diagnosis = diagnose_step_time_window(
+        window,
+        policy=LIVE_STEP_TIME_POLICY,
+        training_strategy=result.training_strategy,
+    )
+    expected = EXPECTED_DIAGNOSIS[scenario.name]
+    assert diagnosis.primary.kind == expected.kind
+    assert diagnosis.primary.status == expected.status
+    assert diagnosis.primary.severity == expected.severity
+    assert diagnosis.primary.worst_rank == expected.worst_rank
+    assert diagnosis.primary.steps_used == len(scenario.steps)
+    assert tuple(issue.kind for issue in diagnosis.issues) == expected.issues
+    _assert_optional_float(diagnosis.issues[0].score, expected.score)
+    for key, value in expected.evidence.items():
+        assert diagnosis.issues[0].evidence[key] == value
+
+
+def test_cli_dashboard_summary_diagnosis_parity(
+    scenario_db: tuple[StepTimeScenario, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prove all user surfaces expose one diagnosis for the same window."""
+    scenario, db_path = scenario_db
+    captured: dict[str, Any] = {}
+
+    def capture_cli(diagnosis: Any) -> str:
+        captured["diagnosis"] = diagnosis
+        return diagnosis.status
+
+    monkeypatch.setattr(
+        cli_renderer_module,
+        "format_cli_diagnosis",
+        capture_cli,
+    )
+    cli_renderer = StepCombinedRenderer(str(db_path))
+    cli_renderer._computer = StepCombinedComputer(
+        str(db_path),
+        window_size=len(scenario.steps),
+    )
+    cli_renderer.get_panel_renderable()
+    cli_diagnosis = captured["diagnosis"]
+
+    dashboard_renderer = ModelDiagnosticsRenderer(str(db_path))
+    dashboard_renderer._step_time = StepCombinedComputer(
+        str(db_path),
+        window_size=len(scenario.steps),
+    )
+    monkeypatch.setattr(
+        dashboard_renderer._step_memory,
+        "compute_dashboard",
+        lambda: StepMemoryCombinedResult(
+            metrics=[],
+            status_message="No GPU detected",
+        ),
+    )
+    dashboard = dashboard_renderer.get_dashboard_renderable()
+    dashboard_diagnosis = next(
+        item for item in dashboard["items"] if item["source"] == "step_time"
+    )
+
+    summary = (
+        StepTimeSummarySection(max_rows=len(scenario.steps))
+        .build(str(db_path))
+        .payload
+    )
+    summary_diagnosis = summary["diagnosis"]
+
+    assert dashboard_diagnosis["kind"] == cli_diagnosis.kind
+    assert summary_diagnosis["kind"] == cli_diagnosis.kind
+    assert dashboard_diagnosis["status"] == cli_diagnosis.status
+    assert summary_diagnosis["status"] == cli_diagnosis.status
+    assert dashboard_diagnosis["severity"] == cli_diagnosis.severity
+    assert summary_diagnosis["severity"] == cli_diagnosis.severity
+    assert dashboard_diagnosis["reason"] == cli_diagnosis.reason
+    assert summary_diagnosis["summary"] == cli_diagnosis.reason
+    assert dashboard_diagnosis["action"] == cli_diagnosis.action
+    assert summary_diagnosis["action"] == cli_diagnosis.action
+    assert dashboard_diagnosis["steps_used"] == len(scenario.steps)
+    assert summary["global"]["window"]["steps_analyzed"] == len(scenario.steps)
+
+    expected_ranks = (
+        [] if cli_diagnosis.worst_rank is None else [cli_diagnosis.worst_rank]
+    )
+    assert dashboard_diagnosis["worst_rank"] == cli_diagnosis.worst_rank
+    assert summary_diagnosis["ranks"] == expected_ranks
+
+
+def test_final_summary_projection_matches_golden(
+    scenario_db: tuple[StepTimeScenario, Path],
+) -> None:
+    """Freeze public summary projection, especially absence versus zero."""
+    scenario, db_path = scenario_db
+    payload = (
+        StepTimeSummarySection(max_rows=len(scenario.steps))
+        .build(str(db_path))
+        .payload
+    )
+
+    window = payload["global"]["window"]
+    assert window["alignment"] == "common_steps"
+    assert window["steps_analyzed"] == len(scenario.steps)
+    assert window["start_step"] == scenario.steps[0]
+    assert window["end_step"] == scenario.steps[-1]
+    assert window["completed_step"] == scenario.steps[-1]
+    assert window["window_size"] == len(scenario.steps)
+    assert window["diagnosis_clock"] == scenario.clock
+
+    metadata = payload["metadata"]
+    assert metadata["global_ranks_seen"] == len(scenario.profiles)
+    assert metadata["global_ranks_used"] == len(scenario.profiles)
+    assert metadata["section_metric_names"] == STEP_TIME_METRIC_NAMES
+
+    rows = payload["groups"]["rows"]
+    assert set(rows) == {str(rank) for rank in scenario.profiles}
+    for rank, expected_metrics in EXPECTED_PUBLIC_ROWS[scenario.name].items():
+        metrics = rows[str(rank)]["metrics"]
+        assert list(metrics) == STEP_TIME_METRIC_NAMES
+        for metric, expected in expected_metrics.items():
+            _assert_optional_float(metrics[metric], expected)
+
+    # The same diagnosis object is projected as the first ordered issue.
+    assert payload["diagnosis"] == payload["issues"][0]

--- a/tests/step_time/test_query_baseline.py
+++ b/tests/step_time/test_query_baseline.py
@@ -1,0 +1,100 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Current SQLite query topology for Step Time consumers.
+
+These assertions are characterization baselines, not performance budgets.
+Query-consolidation PRs are expected to update them deliberately.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Callable
+from unittest.mock import patch
+
+import pytest
+
+from tests.step_time.scenarios import (
+    BALANCED_PROFILE,
+    SQLiteSelectRecorder,
+    StepTimeScenario,
+    create_step_time_database,
+)
+from traceml_ai.renderers.model_diagnostics.renderer import (
+    ModelDiagnosticsRenderer,
+)
+from traceml_ai.renderers.step_time.compute import StepCombinedComputer
+from traceml_ai.renderers.step_time.renderer import StepCombinedRenderer
+from traceml_ai.reporting.sections.step_time import StepTimeSummarySection
+
+
+@pytest.fixture(params=(1, 8), ids=lambda ranks: f"{ranks}-ranks")
+def ranked_db(
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+) -> tuple[int, Path]:
+    """Create a complete four-step CPU window at the requested rank count."""
+    rank_count = int(request.param)
+    scenario = StepTimeScenario(
+        name=f"query_{rank_count}_ranks",
+        profiles={rank: dict(BALANCED_PROFILE) for rank in range(rank_count)},
+        steps=(1, 2, 3, 4),
+    )
+    db_path = tmp_path / f"query-{rank_count}.db"
+    create_step_time_database(db_path, scenario)
+    return rank_count, db_path
+
+
+def _record_selects(call: Callable[[], object]) -> SQLiteSelectRecorder:
+    """Run one production callback with test-side SQLite tracing enabled."""
+    recorder = SQLiteSelectRecorder()
+    with patch.object(sqlite3, "connect", recorder.connect):
+        call()
+    return recorder
+
+
+def test_live_query_count_baseline_is_rank_plus_two(
+    ranked_db: tuple[int, Path],
+) -> None:
+    """Record rank discovery, per-rank reads, and strategy context."""
+    rank_count, db_path = ranked_db
+    computer = StepCombinedComputer(str(db_path), window_size=4)
+
+    recorder = _record_selects(computer.compute_cli)
+
+    assert recorder.count == rank_count + 2
+
+
+def test_dashboard_query_count_baseline_is_two_rank_plus_four(
+    ranked_db: tuple[int, Path],
+) -> None:
+    """The two current dashboard providers independently read Step Time."""
+    rank_count, db_path = ranked_db
+    hero = StepCombinedRenderer(str(db_path))
+    diagnostics = ModelDiagnosticsRenderer(str(db_path))
+
+    recorder = _record_selects(
+        lambda: (
+            hero.get_dashboard_renderable(),
+            diagnostics._step_time.compute_dashboard(),
+        )
+    )
+
+    assert recorder.count == (2 * rank_count) + 4
+
+
+def test_summary_query_count_baseline_is_two_rank_plus_three(
+    ranked_db: tuple[int, Path],
+) -> None:
+    """Summary adds one max-step read and one identity read for every rank."""
+    rank_count, db_path = ranked_db
+    section = StepTimeSummarySection(max_rows=4)
+
+    recorder = _record_selects(lambda: section.build(str(db_path)))
+
+    assert recorder.count == (2 * rank_count) + 3


### PR DESCRIPTION
## Summary

This is Child PR 1 of the Step Time pipeline redesign. It freezes the currentStep Time behavior and records the performance/query baseline before any production refactoring begins.

The PR intentionally changes only tests, test support, benchmarks, and documentation. There are no changes under `src/traceml_ai/`, no SQL changes, and no runtime behavior changes.

## Why

Step Time currently reaches the CLI, dashboard, and final summary through separate paths. The behavior is extensively tested within individual layers, but there was no compact contract proving that the same persisted telemetry produces the same clock, coverage, metrics, diagnosis, and public projection across all three surfaces.

The dashboard also currently owns two independent Step Time providers. Before consolidating those providers or changing the rank-scaled SQLite loading, this PR makes the existing behavior and cost measurable.

## Current architecture captured by this PR

```mermaid
flowchart LR
    DB[(step_time_samples)]
    A["StepCombinedRenderer provider"]
    B["ModelDiagnosticsRenderer provider"]
    L["SQLite loader"]
    W["Canonical StepTimeWindow"]
    D["Step Time diagnosis"]
    CLI["CLI"]
    HERO["Dashboard hero"]
    RAIL["Dashboard diagnostics"]
    SL["Final-summary loader"]
    SW["Canonical summary window"]
    SD["Summary diagnosis"]
    OUT["JSON and text"]

    DB --> A --> L --> W
    DB -. "second independent read" .-> B --> L
    W --> D
    W --> CLI
    W --> HERO
    D --> CLI
    D --> RAIL
    RAIL --> HERO
    DB --> SL --> SW --> SD --> OUT
```

The dashed path is current measured technical debt, not the desired final architecture.

## What changed

### Canonical cross-surface scenarios

Added one feature-local scenario module that owns both production-shaped `events_json` generation and SQLite persistence. Tests select a named scenario and write it directly, avoiding separate fixture implementations for each
surface.

The scenario matrix covers:

- complete multi-rank GPU timing;
- sparse timing with a required `forward` signal missing;
- an otherwise identical measured-zero `forward` control;
- complete single-rank CPU timing;
- a confident DDP rank straggler;
- an FSDP rank straggler with its warning severity cap.

### Contract goldens

Added cross-surface assertions for:

- selected CPU/GPU clock;
- aligned steps and expected global-rank universe;
- coverage and sparse measured-rank populations;
- selected per-rank metrics and derived total/residual values;
- median, worst value, worst rank, and skew;
- diagnosis kind, status, severity, score, evidence, and issue ordering;
- CLI, dashboard, and final-summary diagnosis parity;
- final-summary metadata and public projection;
- preservation of `null` for unavailable signals and `0.0` for measured zero;
- separation of CPU compatibility values from selected-clock diagnosis values.

The tests deliberately avoid freezing timestamps, cache internals, dictionary ordering, or complete Rich/NiceGUI markup.

### Query and provider baseline

Added test-side SQLite tracing with `sqlite3.Connection.set_trace_callback`. Only `SELECT`/`WITH` statements are
counted; fixture creation and writes are excluded.

The current query formulas are now characterized at one and eight ranks:

| Path | Current SELECT count |
|---|---:|
| One live provider | `R + 2` |
| One dashboard refresh | `2R + 4` |
| Final summary | `2R + 3` |

At eight ranks this is 10, 20, and 19 SELECTs respectively.

A production-path dashboard test executes a real registered dashboard tick and proves that the hero and diagnostics rail currently invoke two distinct `StepCombinedComputer` instances.

These are characterization assertions, not desirable permanent budgets. Later consolidation PRs should update them deliberately.

### Reproducible benchmark

Added a dependency-free benchmark for 1, 8, and 32 ranks. It records:

- load + JSON decode + window analysis;
- diagnosis;
- one live provider;
- the two-provider dashboard Step Time refresh;
- final-summary construction;
- exact query count, median time, and p95 time.

There are no wall-clock CI thresholds in this PR. Timing results are observational and should only be compared on a similar environment.

### Contributor documentation

Added two Developer Guide pages:

- the stable Step Time contract, ownership map, current pipeline diagram,  surface responsibilities, scenario catalogue, glossary, and change  checklist;
- the reproducible query/timing baseline with environment and results.

The pages are linked from the architecture, extending, contributing, and MkDocs navigation surfaces so contributors have one starting point instead of traversing multiple source folders first.

## Recorded benchmark

Environment: Python 3.13.5, SQLite 3.50.2, macOS arm64, 400 stored rows per rank, 100-step analysis window, two warmups, seven repetitions.

| Ranks | Stage | SELECTs | Median (ms) | p95 (ms) |
|---:|---|---:|---:|---:|
| 1 | load + decode + analyze | 3 | 8.350 | 8.565 |
| 1 | diagnose | 0 | 0.111 | 0.113 |
| 1 | one live provider | 3 | 8.362 | 8.553 |
| 1 | dashboard Step Time refresh | 6 | 16.591 | 16.862 |
| 1 | final summary | 5 | 7.454 | 7.547 |
| 8 | load + decode + analyze | 10 | 36.482 | 41.452 |
| 8 | diagnose | 0 | 0.183 | 0.196 |
| 8 | one live provider | 10 | 37.128 | 42.099 |
| 8 | dashboard Step Time refresh | 20 | 73.372 | 79.595 |
| 8 | final summary | 19 | 30.479 | 31.420 |
| 32 | load + decode + analyze | 34 | 176.220 | 182.028 |
| 32 | diagnose | 0 | 0.444 | 0.706 |
| 32 | one live provider | 34 | 176.025 | 179.283 |
| 32 | dashboard Step Time refresh | 68 | 371.727 | 422.793 |
| 32 | final summary | 67 | 193.767 | 216.140 |

## Suggested review order

1. `tests/step_time/scenarios.py`
2. `tests/step_time/test_contract_baseline.py`
3. `tests/step_time/test_query_baseline.py`
4. The new test in `tests/display/test_nicegui_driver.py`
5. `tests/benchmarks/bench_step_time_pipeline.py`
6. `docs/developer_guide/step-time-pipeline-contract.md`
7. `docs/developer_guide/step-time-pipeline-baseline.md`

No production implementation needs to be reviewed in this PR.

## How I tested

New contract and query suite:

```bash
PYTHONDONTWRITEBYTECODE=1 \
pytest -p no:cacheprovider tests/step_time -q
```

Result: `24 passed`.

Relevant Step Time regression suite:

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/diagnostics \
  tests/renderers \
  tests/display/test_model_combined_section.py \
  tests/display/test_nicegui_driver.py \
  tests/reporting/summary -q
```

Result: `329 passed`.

Benchmark:

```bash
PYTHONDONTWRITEBYTECODE=1 \
python tests/benchmarks/bench_step_time_pipeline.py
```

Result: completed; results are recorded above and in the baseline guide.

Documentation:

```bash
mkdocs build --strict
```

Result: passed from a clean tracked-tree overlay containing this PR. The working directory also contains an unrelated untracked `docs/README.md` that conflicts with `docs/index.md`, so the clean overlay was used to verify the PR
without modifying that file.

Whitespace validation:

```bash
git diff --check
```

Result: passed.

The complete repository suite was also run:

```bash
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider tests -q
```

Result: `792 passed, 2 skipped, 22 failed`. The failing tests are outside this Step Time change and include integration/runtime global-state ordering and two H2D instrumentation tests that also fail in isolation. The Step Time and directly affected suites pass together.

`black`, `ruff`, and `pre-commit` were unavailable in the current local environment. New Python files were checked against the configured 79-character line limit.

## Runtime impact

- [x] No training-path impact
- [x] No production-code changes
- [x] No SQL changes
- [x] No public schema changes
- [x] No dependency changes
- [x] No CLI or configuration changes

## Documentation

- [x] Developer pipeline contract added
- [x] Reproducible baseline added
- [x] Architecture and contributor navigation updated
- [x] Strict documentation build verified

## Not in this PR

- No production file moves or package redesign.
- No shared dashboard provider yet.
- No query consolidation or bulk SQL loading.
- No diagnosis, threshold, or presentation changes.
- No dead-code removal.
- No latency budgets enforced in CI.

## Follow-up

The next small PR can remove repository-proven behavior-neutral Step Time baggage while keeping every contract in this PR unchanged. Provider sharing, query consolidation, and production package restructuring should remain
separate reviewable PRs.
