### PR TITLE
add cli presenter

### DIFF
--- a/docs/developer_guide/extending.md
+++ b/docs/developer_guide/extending.md
@@ -38,6 +38,14 @@ run progress. Both accept `StepTimeLoadRequest`, return the same snapshot
 type, and feed the same analysis. Do not add rank-by-rank reads in renderers
 or reporting sections.
 
+Live Step Time orchestration belongs to `LiveStepTimeSession` in
+`traceml_ai.step_time.pipeline`. The session owns cursor reuse, last-good
+bridging, and monotonic expiry; a presenter receives `LiveStepTimeResult` and
+formats it. Do not open SQLite, call the analyzer, diagnose, or keep freshness
+state in a Rich or NiceGUI presenter. The CLI renderer's public `render()`
+method is the smallest example of this boundary and can be tested without a
+database.
+
 ## TraceML Lifecycle
 
 TraceML has two runtime pieces:

--- a/docs/developer_guide/step-time-pipeline-baseline.md
+++ b/docs/developer_guide/step-time-pipeline-baseline.md
@@ -175,6 +175,43 @@ because ordinary calls no longer allocate the compatibility rank map or the
 unconsumed attribution payload. Query topology remains 2/4/2 for one live
 provider, the current two-provider dashboard, and final summary.
 
+## PR6 live-session comparison
+
+PR6 moves live cache and freshness ownership into `LiveStepTimeSession` and
+makes the CLI a pure presenter. The repository retains PR5's proven bounded
+tail SQL. It compares the selected row cursor and rank universe before JSON
+decoding, so an unchanged refresh returns the exact prior immutable analysis
+without parsing, analysis, or diagnosis work.
+
+The `one live provider` row below deliberately invalidates the test session's
+cache before each repetition. It measures the changed/cold path and guards
+against hiding a regression behind reuse. The cache-hit and dashboard rows
+measure unchanged persisted windows after warm-up.
+
+Recorded on 2026-08-02 with the same environment and command as PR5:
+
+| Ranks | Stage | SELECTs | Median (ms) | Change from PR5 |
+|---:|---|---:|---:|---:|
+| 1 | one live provider (cache miss) | 2 | 8.540 | +4.4% |
+| 1 | unchanged live cache hit | 2 | 0.442 | -94.6% |
+| 1 | dashboard Step Time refresh | 4 | 0.883 | -94.6% |
+| 1 | final summary | 2 | 6.655 | +0.9% |
+| 8 | one live provider (cache miss) | 2 | 33.643 | +5.1% |
+| 8 | unchanged live cache hit | 2 | 3.117 | -90.3% |
+| 8 | dashboard Step Time refresh | 4 | 6.173 | -90.4% |
+| 8 | final summary | 2 | 16.268 | +2.0% |
+| 32 | one live provider (cache miss) | 2 | 120.724 | +4.0% |
+| 32 | unchanged live cache hit | 2 | 13.265 | -88.6% |
+| 32 | dashboard Step Time refresh | 4 | 26.716 | -88.9% |
+| 32 | final summary | 2 | 48.528 | +0.9% |
+
+Every cache-miss and summary median remains within 5.1% of PR5, below the 10%
+review threshold. Query topology remains 2/4/2. The unchanged path still reads
+the source cursor and run strategy in one SQLite snapshot, but it does not
+decode persisted JSON or rebuild semantic facts. Dashboard still owns two
+sessions until PR7; the improvement here is reuse within each session, not
+cross-presenter consolidation.
+
 ## Reproduce
 
 From the repository root:

--- a/docs/developer_guide/step-time-pipeline-contract.md
+++ b/docs/developer_guide/step-time-pipeline-contract.md
@@ -14,30 +14,20 @@ For the public final-summary shape, see
 ```mermaid
 flowchart LR
     DB[(step_time_samples)]
-    A["Live provider A<br/>StepCombinedRenderer"]
-    B["Live provider B<br/>ModelDiagnosticsRenderer"]
-    L["SQLite repository<br/>live or summary profile"]
-    ANALYZE["StepTimeAnalyzer<br/>one typed fact set"]
-    W["Canonical live StepTimeWindow"]
-    D["Live Step Time diagnosis"]
-    CLI["Live CLI"]
-    HERO["Dashboard hero"]
-    RAIL["Dashboard diagnostics rail"]
-    S["Final-summary loader"]
-    SW["Canonical summary StepTimeWindow"]
-    SD["Summary Step Time diagnosis"]
+    CLS["CLI LiveStepTimeSession<br/>calls StepTimePipeline"]
+    HLS["Dashboard hero session<br/>compatibility adapter"]
+    RLS["Dashboard rail session<br/>compatibility adapter"]
+    RESULT["Immutable StepTimeAnalysis<br/>window + diagnosis"]
+    CLI["Pure Rich CLI presenter"]
+    HERO["Dashboard hero adapter"]
+    RAIL["Dashboard rail adapter"]
+    SUM["Final-summary adapter"]
     OUT["JSON and text"]
 
-    DB --> A --> L --> ANALYZE --> W
-    DB -. "second independent read" .-> B
-    B --> L
-    W --> D
-    W --> CLI
-    W --> HERO
-    D --> CLI
-    D --> RAIL
-    RAIL --> HERO
-    DB --> S --> L --> ANALYZE --> SW --> SD --> OUT
+    DB --> CLS --> RESULT --> CLI
+    DB -. "independent refresh" .-> HLS --> HERO
+    DB -. "second independent refresh" .-> RLS --> RAIL
+    DB --> SUM --> OUT
 ```
 
 The repository has two SQL selection profiles, not three surface pipelines.
@@ -47,14 +37,17 @@ the same `StepTimeAnalyzer`.
 
 `StepTimePipeline.run(request)` is the application facade for that shared
 path. It selects one of the two data profiles, invokes the analyzer once, and
-passes the resulting `StepTimeWindow` directly to diagnosis. Existing surface
-wrappers remain in place until PR6 through PR8, so adding the facade does not
-mix presenter rewiring into this diagnosis-focused change.
+passes the resulting `StepTimeWindow` directly to diagnosis.
+
+`LiveStepTimeSession` is the sole live orchestration boundary. It owns
+last-good state, monotonic expiry, and cursor-based analysis reuse. The CLI
+injects one session into a pure Rich presenter. Dashboard and final summary
+remain on compatibility adapters until PR7 and PR8.
 
 The diagram shows remaining technical debt deliberately: a dashboard refresh
-owns two independent Step Time computers. Each now performs one constant-size
-query sequence, but the hero and diagnostics rail still load independently.
-A later consumer-migration PR will fan out one analysis snapshot.
+owns two independent live sessions. Each performs one constant-size query
+sequence, but the hero and diagnostics rail still load independently. PR7
+will inject one session result into both presenters.
 
 ## Where each decision belongs
 
@@ -65,6 +58,7 @@ A later consumer-migration PR will fan out one analysis snapshot.
 | Common-step alignment and analysis | `step_time/analysis.py` | clock, sparse-signal, derivation, cohort, or statistics semantics change |
 | SQLite selection and row decoding | `step_time/sqlite.py` | live-tail or summary selection, identity, progress, or clock normalization changes |
 | Load/analyze/diagnose orchestration | `step_time/pipeline.py` | application flow or live/summary data-profile selection changes |
+| Live caching and freshness | `step_time/pipeline.py` | cursor reuse, last-good bridging, or monotonic expiry changes |
 | Analyzed-window compatibility adapter | `utils/step_time_sqlite.py` | an existing loader caller needs migration support |
 | Diagnosis thresholds and priority | `diagnostics/step_time/` | a rule, policy, attribution, or issue order changes |
 | Live CLI presentation | `renderers/step_time/renderer.py` | terminal labels or layout change |
@@ -73,11 +67,11 @@ A later consumer-migration PR will fan out one analysis snapshot.
 | Cross-surface contract scenarios | `tests/step_time/` | any item above changes intentionally |
 
 Start with the contract scenarios before following a surface-specific call
-path. Read the short `step_time/pipeline.py` facade for orchestration, then
-`step_time/sqlite.py`, `step_time/analysis.py`, and `step_time/model.py` for
-the complete source-to-facts path. Diagnosis continues in
-`diagnostics/step_time/api.py`, then `context.py` and `rules.py`; none of those
-files rebuilds the historical rank map.
+path. For live behavior, read `step_time/pipeline.py` and then the pure CLI
+presenter in `renderers/step_time/renderer.py`. For domain facts, read
+`step_time/sqlite.py`, `step_time/analysis.py`, and `step_time/model.py`.
+Diagnosis continues in `diagnostics/step_time/api.py`, then `context.py` and
+`rules.py`; none of those files rebuilds the historical rank map.
 
 ## Data-shape budget
 
@@ -100,9 +94,10 @@ returns exactly one typed fact graph.
 
 `StepTimeWindow.rank_facts` replaces the former triple nested
 rank/step/metric dictionary. `per_rank_timing` remains a cached, read-only
-projection only for presenters that migrate in PR6 through PR8 and for the
-released mapping adapter. Canonical diagnosis reads `rank_facts` and
-precomputed window shares directly. No per-step legacy projection exists.
+projection only for dashboard/final-summary consumers that migrate in PR7
+and PR8 and for the released mapping adapter. Canonical diagnosis and the CLI
+read typed facts and precomputed window shares directly. No per-step legacy
+projection exists.
 
 ### Model dependency boundary
 
@@ -159,13 +154,38 @@ the selected diagnosis clock.
 
 | Surface | Loads | Diagnoses | Presents |
 |---|---|---|---|
-| Live CLI | One repository snapshot; recent aligned window with lookback | Live policy | Rich diagnosis and metric table |
-| Dashboard hero | One repository snapshot today | Verdict comes from diagnostics payload | Phase ribbon and compact KPIs |
-| Dashboard diagnostics rail | A second repository snapshot today | Live policy | Structured finding and evidence |
+| Live CLI | One `LiveStepTimeSession` refresh | Diagnosis is precomputed once by the live pipeline | Pure Rich diagnosis and metric table |
+| Dashboard hero | One compatibility-session refresh today | Verdict comes from diagnostics payload | Phase ribbon and compact KPIs |
+| Dashboard diagnostics rail | A second compatibility-session refresh today | Live policy | Structured finding and evidence |
 | Final summary | One repository snapshot with identity and progress | Summary policy | Stable JSON projection and text card |
 
 Built-in live and summary policies currently use the same thresholds. Their
 window sizes and presentation responsibilities differ.
+
+## Live-session contract
+
+One `LiveStepTimeSession` owns the state for one live consumer. Every refresh
+opens a short-lived SQLite connection, runs the two-statement live repository
+read in one snapshot, and closes the connection. A lock serializes concurrent
+refreshes of the same session.
+
+| Freshness | Meaning | Analysis exposed |
+|---|---|---|
+| `cold` | No usable window has ever been read. | Canonical empty analysis. |
+| `live` | The current read produced a usable window. | Current immutable analysis. |
+| `bridged` | A read was empty or failed within the last-good TTL. | Last good analysis. |
+| `expired` | A previous good window exists, but its bridge TTL elapsed. | Canonical empty analysis. |
+
+Expiry uses `time.monotonic()`, so wall-clock corrections cannot shorten or
+extend the bridge. An unchanged persisted window remains `live`; freshness is
+about read usability, not proof that the training process is still running.
+
+Before decoding, the live repository compares the selected source cursor and
+rank universe with the previous snapshot. If they are unchanged and the run
+strategy is unchanged, the exact prior `StepTimeAnalysis` object is returned.
+The persisted JSON is not parsed again, and analysis and diagnosis are not
+called. A strategy or rank-universe change invalidates reuse even if timing
+row ids are unchanged.
 
 ## Contract scenarios
 
@@ -194,11 +214,15 @@ Rich/NiceGUI markup, or dictionary ordering.
 
 ## Temporary compatibility seams
 
+- `StepCombinedComputer.compute_dashboard()` projects a live-session result
+  into the historical dashboard payload; PR7 removes this adapter.
+- `StepTimeDashboardAdapter` supplies that historical payload to the current
+  NiceGUI driver; PR7 replaces it with shared-session fan-out.
 - `utils/step_time_window.py` accepts historical raw-event fixtures and
   delegates to `StepTimeAnalyzer`; PR9 removes that input adapter.
 - `StepTimeWindow.per_rank_timing` lazily projects typed rank averages for
-  current presenters; PR6 through PR8 remove those consumers and PR9 removes
-  the projection.
+  remaining dashboard and final-summary consumers; PR7 and PR8 remove those
+  consumers and PR9 removes the projection.
 - The released mapping-based diagnosis functions adapt one sparse rank map to
   a typed window. Canonical diagnosis and rules accept only `StepTimeWindow`;
   PR9 removes the mapping adapter.
@@ -238,5 +262,6 @@ PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider tests/step_time -q
 | Rank universe | Expected global ranks retained by the canonical window. |
 | Measured rank | A rank carrying a particular sparse metric. |
 | Eligible cohort | Ranks carrying every signal required by one calculation or rule. |
-| Provider | A stateful live computer that reads SQLite and owns last-good behavior. |
+| Live session | Stateful orchestration that reads through the pipeline and owns cursor reuse, last-good bridging, and expiry. |
+| Presenter | Stateless surface formatting over an analyzed result; it never reads SQLite or diagnoses. |
 | Projection | A surface-specific view derived from the canonical window or diagnosis. |

--- a/src/traceml_ai/aggregator/display_drivers/cli.py
+++ b/src/traceml_ai/aggregator/display_drivers/cli.py
@@ -31,6 +31,7 @@ from traceml_ai.renderers.step_time.renderer import StepCombinedRenderer
 from traceml_ai.renderers.system.renderer import SystemRenderer
 from traceml_ai.runtime.settings import TraceMLSettings
 from traceml_ai.runtime.stdout_stderr_capture import StreamCapture
+from traceml_ai.step_time.pipeline import LiveStepTimeSession
 
 
 def _safe(logger: Any, label: str, fn: Callable[[], Any]) -> Any:
@@ -92,7 +93,9 @@ class CLIDisplayDriver(BaseDisplayDriver):
         # Run profile
         if not self._watch_profile:
             self._renderers += [
-                StepCombinedRenderer(db_path=self._settings.db_path),
+                StepCombinedRenderer(
+                    LiveStepTimeSession(db_path=self._settings.db_path)
+                ),
                 StepMemoryRenderer(db_path=self._settings.db_path),
             ]
 

--- a/src/traceml_ai/aggregator/display_drivers/nicegui.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui.py
@@ -66,7 +66,7 @@ from traceml_ai.renderers.model_diagnostics.renderer import (
 )
 from traceml_ai.renderers.process.renderer import ProcessRenderer
 from traceml_ai.renderers.step_memory.renderer import StepMemoryRenderer
-from traceml_ai.renderers.step_time.renderer import StepCombinedRenderer
+from traceml_ai.renderers.step_time.compute import StepTimeDashboardAdapter
 from traceml_ai.renderers.system.renderer import SystemRenderer
 from traceml_ai.runtime.settings import TraceMLSettings
 
@@ -154,7 +154,7 @@ class NiceGUIDisplayDriver(BaseDisplayDriver):
         self._renderers: List[DashboardRenderer] = [
             SystemRenderer(db_path=self._settings.db_path),
             ProcessRenderer(db_path=self._settings.db_path),
-            StepCombinedRenderer(db_path=self._settings.db_path),
+            StepTimeDashboardAdapter(db_path=self._settings.db_path),
             StepMemoryRenderer(db_path=self._settings.db_path),
             ModelDiagnosticsRenderer(db_path=self._settings.db_path),
         ]

--- a/src/traceml_ai/renderers/step_time/compute.py
+++ b/src/traceml_ai/renderers/step_time/compute.py
@@ -1,22 +1,43 @@
-import sqlite3
-import time
-from dataclasses import replace
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Temporary dashboard adapter for the canonical live Step Time session."""
+
+from __future__ import annotations
+
 from typing import Optional, Sequence
 
-from traceml_ai.loggers.error_log import get_error_logger
-from traceml_ai.step_time.model import StepTimeResult
-from traceml_ai.utils.step_time_sqlite import load_step_time_window_from_sqlite
+from traceml_ai.aggregator.display_drivers.layout import MODEL_COMBINED_LAYOUT
+from traceml_ai.renderers.base_renderer import BaseRenderer
+from traceml_ai.step_time.model import StepTimeLoadRequest, StepTimeResult
+from traceml_ai.step_time.pipeline import (
+    LiveStepTimeResult,
+    LiveStepTimeSession,
+)
 
 STEP_TIME_TABLE = "step_time_samples"
 
 
-class StepCombinedComputer:
-    """
-    Compute selected-clock Step Time diagnosis payloads from SQLite.
+def _legacy_result(result: LiveStepTimeResult) -> StepTimeResult:
+    """Project live state into the dashboard contract retained for PR7."""
+    visible = result.freshness in {"live", "bridged"}
+    window = result.analysis.window if visible else None
+    return StepTimeResult(
+        status_message=result.status_message,
+        window=window,
+        training_strategy=result.analysis.window.training_strategy,
+        had_ok=result.freshness != "cold",
+    )
 
-    Live delegates global-rank SQLite loading to the shared Step Time window
-    loader, then adds CLI/dashboard-specific empty-read bridging and status
-    text. Consumers receive that canonical window without copied metrics.
+
+class StepCombinedComputer:
+    """Keep current dashboard callers stable while they migrate in PR7.
+
+    The adapter owns no SQL, freshness, cache, or diagnosis behavior. It will
+    be removed after both dashboard Step Time consumers share one live session.
     """
 
     def __init__(
@@ -28,140 +49,41 @@ class StepCombinedComputer:
         lookback_factor: int = 4,
         rank_filter: Optional[Sequence[int]] = None,
     ) -> None:
-        self.db_path = str(db_path)
-        self.window_size = max(1, int(window_size))
-        self.table = str(table)
-        self.lookback_factor = max(1, int(lookback_factor))
-        self.rank_filter = (
-            {int(r) for r in rank_filter} if rank_filter is not None else None
+        self._session = LiveStepTimeSession(
+            db_path,
+            request=StepTimeLoadRequest(
+                window_size=window_size,
+                lookback_factor=lookback_factor,
+                rank_filter=(
+                    tuple(rank_filter) if rank_filter is not None else None
+                ),
+            ),
+            stale_ttl_s=stale_ttl_s,
+            table=table,
         )
-
-        self.logger = get_error_logger("StepCombinedComputer")
-        self._last_ok: Optional[StepTimeResult] = None
-        self._last_ok_ts = 0.0
-        self._stale_ttl_s = (
-            float(stale_ttl_s) if stale_ttl_s is not None else None
-        )
-
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
-
-    def compute_cli(self) -> StepTimeResult:
-        return self._compute()
 
     def compute_dashboard(self) -> StepTimeResult:
-        return self._compute()
+        """Return the historical dashboard payload from one live refresh."""
+        return _legacy_result(self._session.refresh())
 
-    @property
-    def had_ok(self) -> bool:
-        """Whether any compute ever produced diagnosis metrics.
 
-        Lets renderers distinguish "no data yet" from an expired last-good
-        bridge after repeated empty computes. It does not claim process
-        liveness.
-        """
-        return self._last_ok is not None
+class StepTimeDashboardAdapter(BaseRenderer):
+    """Temporary dashboard provider retained until the PR7 shared fan-out."""
 
-    def _compute(self) -> StepTimeResult:
-        try:
-            with self._connect() as conn:
-                result = self._compute_impl(conn)
-        except Exception as exc:
-            self.logger.exception("StepCombined compute failed")
-            return self._stale_or_empty(
-                f"STALE (exception: {type(exc).__name__})"
-            )
-
-        if result.window is None or not result.window.metrics:
-            return self._stale_or_empty("STALE (no metrics this tick)")
-
-        now = time.time()
-        self._last_ok = result
-        self._last_ok_ts = now
-        return replace(result, had_ok=True)
-
-    # ------------------------------------------------------------------
-    # Core compute
-    # ------------------------------------------------------------------
-
-    def _compute_impl(
-        self,
-        conn: sqlite3.Connection,
-    ) -> StepTimeResult:
-        loaded = load_step_time_window_from_sqlite(
-            conn,
-            max_rows=self.window_size,
-            lookback_factor=self.lookback_factor,
-            table=self.table,
-            rank_filter=(
-                tuple(self.rank_filter)
-                if self.rank_filter is not None
-                else None
-            ),
+    def __init__(self, db_path: str) -> None:
+        super().__init__(
+            name="Model Step Summary",
+            layout_section_name=MODEL_COMBINED_LAYOUT,
         )
-        ranks = loaded.global_ranks
-        if not ranks:
-            return StepTimeResult(
-                status_message="No ranks available",
-            )
+        self._computer = StepCombinedComputer(db_path=db_path)
 
-        window = loaded.window
-        if window.coverage.ranks_present <= 0:
-            return StepTimeResult(
-                status_message="No StepTime data available",
-            )
-        if not window.metrics:
-            return StepTimeResult(
-                status_message="No common step window yet",
-            )
+    def get_dashboard_renderable(self) -> StepTimeResult:
+        """Return the compatibility payload expected by the current UI."""
+        return self._computer.compute_dashboard()
 
-        status = "OK"
-        diagnosis_worst_rank = window.worst_rank
-        if diagnosis_worst_rank is not None:
-            status += f" | diagnosis_worst_rank=r{diagnosis_worst_rank}"
 
-        return StepTimeResult(
-            status_message=status,
-            window=window,
-            training_strategy=loaded.training_strategy,
-        )
-
-    # ------------------------------------------------------------------
-    # SQLite loading
-    # ------------------------------------------------------------------
-
-    def _connect(self) -> sqlite3.Connection:
-        """
-        Open a short-lived read connection.
-
-        One connection per compute call keeps the implementation simple and
-        avoids cross-thread SQLite issues.
-        """
-        conn = sqlite3.connect(self.db_path)
-        conn.row_factory = sqlite3.Row
-        return conn
-
-    # ------------------------------------------------------------------
-    # Stale handling
-    # ------------------------------------------------------------------
-
-    def _stale_or_empty(self, msg: str) -> StepTimeResult:
-        """Bridge transient empty reads without inferring producer liveness."""
-        now = time.time()
-        had_ok = self._last_ok is not None
-        if self._last_ok is not None:
-            if (
-                self._stale_ttl_s is None
-                or (now - self._last_ok_ts) <= self._stale_ttl_s
-            ):
-                return StepTimeResult(
-                    status_message=msg,
-                    window=self._last_ok.window,
-                    training_strategy=self._last_ok.training_strategy,
-                    had_ok=True,
-                )
-        return StepTimeResult(
-            status_message="No fresh step-combined data",
-            had_ok=had_ok,
-        )
+__all__ = [
+    "STEP_TIME_TABLE",
+    "StepCombinedComputer",
+    "StepTimeDashboardAdapter",
+]

--- a/src/traceml_ai/renderers/step_time/renderer.py
+++ b/src/traceml_ai/renderers/step_time/renderer.py
@@ -17,11 +17,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from traceml_ai.aggregator.display_drivers.layout import MODEL_COMBINED_LAYOUT
-from traceml_ai.diagnostics.step_time import (
-    LIVE_STEP_TIME_POLICY,
-    build_step_diagnosis,
-    format_cli_diagnosis,
-)
+from traceml_ai.diagnostics.step_time import format_cli_diagnosis
 from traceml_ai.diagnostics.trends import (
     DEFAULT_TREND_CONFIG,
     compute_trend_pct,
@@ -29,10 +25,11 @@ from traceml_ai.diagnostics.trends import (
 )
 from traceml_ai.renderers.base_renderer import BaseRenderer
 from traceml_ai.renderers.utils import fmt_time_run
-from traceml_ai.step_time.model import StepTimeMetric, StepTimeResult
-from traceml_ai.utils.step_time_window import diagnose_step_time_window
-
-from .compute import StepCombinedComputer
+from traceml_ai.step_time.model import StepTimeMetric
+from traceml_ai.step_time.pipeline import (
+    LiveStepTimeResult,
+    LiveStepTimeSession,
+)
 
 METRIC_LABELS = {
     "input_wait": "IW",
@@ -56,33 +53,23 @@ TABLE_METRIC_ORDER = (
 
 
 class StepCombinedRenderer(BaseRenderer):
-    """
-    CLI renderer for the selected-clock step-time diagnosis summary.
-    """
+    """Pure Rich presenter for one canonical live Step Time result."""
 
-    def __init__(self, db_path):
+    def __init__(self, session: LiveStepTimeSession) -> None:
         super().__init__(
             name="Model Step Summary",
             layout_section_name=MODEL_COMBINED_LAYOUT,
         )
-        self._computer = StepCombinedComputer(db_path=db_path)
-
-    def _payload(self) -> StepTimeResult:
-        """
-        CLI compute is summary-only (cheap).
-
-        The computer bridges transient empty reads from its own last-ok
-        window. Persisted rows are not treated as proof of producer liveness.
-        """
-        return self._computer.compute_cli()
+        self._session = session
 
     def get_panel_renderable(self) -> Panel:
-        payload = self._payload()
+        """Refresh once and render the session's immutable result."""
+        return self.render(self._session.refresh())
 
-        window = payload.window
-        if (
-            window is None or not window.metrics
-        ) and not self._computer.had_ok:
+    def render(self, payload: LiveStepTimeResult) -> Panel:
+        """Format one live result without loading or diagnosing telemetry."""
+        window = payload.analysis.window
+        if payload.freshness == "cold":
             # Never had data: normal warm-up, keep the calm waiting state
             # instead of alarming with a NO DATA diagnosis.
             return Panel(
@@ -90,17 +77,8 @@ class StepCombinedRenderer(BaseRenderer):
                 title="Model Step Summary",
             )
 
-        diag = (
-            diagnose_step_time_window(
-                window,
-                policy=LIVE_STEP_TIME_POLICY,
-                training_strategy=payload.training_strategy,
-            ).primary
-            if window is not None
-            else build_step_diagnosis([])
-        )
-        diag_text = format_cli_diagnosis(diag)
-        metrics = _table_metrics(window.metrics if window is not None else [])
+        diag_text = format_cli_diagnosis(payload.analysis.diagnosis.primary)
+        metrics = _table_metrics(window.metrics)
 
         if not metrics:
             # Had data before, none now: the last-good empty-read bridge
@@ -123,11 +101,9 @@ class StepCombinedRenderer(BaseRenderer):
         )
 
         # All metrics share the same window size by construction
-        K = window.coverage.steps_used if window is not None else 0
-        world_size = window.coverage.world_size if window is not None else 0
-        ranks_present = (
-            window.coverage.ranks_present if window is not None else 0
-        )
+        K = window.coverage.steps_used
+        world_size = window.coverage.world_size
+        ranks_present = window.coverage.ranks_present
         single_rank = (world_size <= 1) or (ranks_present <= 1)
 
         table = Table(
@@ -185,7 +161,7 @@ class StepCombinedRenderer(BaseRenderer):
             table.add_row("")
 
         # Optional residual share line (still meaningful in both modes)
-        if step_metric and residual_metric and window is not None:
+        if step_metric and residual_metric:
             residual_share = window.residual_share
             table.add_row(
                 "Residual Share (%)",
@@ -209,7 +185,7 @@ class StepCombinedRenderer(BaseRenderer):
         footer = (
             "\n\n[dim]"
             "Clock="
-            f"{(window.clock if window is not None else 'cpu').upper()} | "
+            f"{window.clock.upper()} | "
             "IW=input wait | H2D=host-to-device | FWD=forward | "
             "BWD=backward | OPT=optimizer | STEP=traced step | "
             "RESIDUAL=STEP−H2D−FWD−BWD−OPT"
@@ -221,12 +197,6 @@ class StepCombinedRenderer(BaseRenderer):
             border_style="cyan",
             width=width,
         )
-
-    def get_dashboard_renderable(self) -> StepTimeResult:
-        """
-        Dashboard uses the same selected-clock Step Time payload as the CLI.
-        """
-        return self._computer.compute_dashboard()
 
 
 def _table_metrics(

--- a/src/traceml_ai/step_time/pipeline.py
+++ b/src/traceml_ai/step_time/pipeline.py
@@ -14,8 +14,12 @@ terminal and dashboard both use the bounded live profile.
 
 from __future__ import annotations
 
+import sqlite3
+import time
+from contextlib import closing
 from dataclasses import dataclass, field
-from typing import Literal, Optional
+from threading import Lock
+from typing import Callable, Literal, Optional
 
 from traceml_ai.diagnostics.common import DiagnosticResult
 from traceml_ai.diagnostics.step_time.api import (
@@ -27,6 +31,7 @@ from traceml_ai.diagnostics.step_time.policy import (
     SUMMARY_STEP_TIME_POLICY,
     StepTimeDiagnosisPolicy,
 )
+from traceml_ai.loggers.error_log import get_error_logger
 from traceml_ai.step_time.analysis import StepTimeAnalyzer
 from traceml_ai.step_time.model import (
     StepTimeLoadRequest,
@@ -36,15 +41,31 @@ from traceml_ai.step_time.model import (
 from traceml_ai.step_time.sqlite import SQLiteStepTimeRepository
 
 StepTimeProfile = Literal["live", "summary"]
+LiveStepTimeFreshness = Literal["cold", "live", "bridged", "expired"]
 
 
 @dataclass(frozen=True, slots=True)
 class StepTimeAnalysis:
     """Immutable result shared by future Step Time presenters."""
 
+    request: StepTimeLoadRequest
     snapshot: StepTimeRepositorySnapshot
     window: StepTimeWindow
     diagnosis: DiagnosticResult[StepDiagnosis]
+
+
+@dataclass(frozen=True, slots=True)
+class LiveStepTimeResult:
+    """One presentation-ready live analysis and its freshness state.
+
+    ``freshness`` describes the read, not training-process liveness. Repeated
+    reads of an unchanged persisted window remain ``live``. Only empty or
+    failed reads enter the last-good bridge and eventually expire it.
+    """
+
+    freshness: LiveStepTimeFreshness
+    analysis: StepTimeAnalysis
+    status_message: str
 
 
 @dataclass(slots=True)
@@ -72,29 +93,198 @@ class StepTimePipeline:
                 f"got {self.profile!r}"
             )
 
-    def run(self, request: StepTimeLoadRequest) -> StepTimeAnalysis:
-        """Return one canonical analysis for ``request``."""
+    def run(
+        self,
+        request: StepTimeLoadRequest,
+        *,
+        previous: Optional[StepTimeAnalysis] = None,
+    ) -> StepTimeAnalysis:
+        """Return one canonical analysis, reusing an unchanged live result."""
         if self.profile == "live":
-            snapshot = self.repository.load_live(request)
+            reusable = (
+                previous
+                if previous is not None and previous.request == request
+                else None
+            )
+            snapshot = (
+                self.repository.load_live(
+                    request,
+                    previous=reusable.snapshot,
+                )
+                if reusable is not None
+                else self.repository.load_live(request)
+            )
+            if reusable is not None and snapshot is reusable.snapshot:
+                return reusable
             default_policy = LIVE_STEP_TIME_POLICY
         else:
+            if previous is not None:
+                raise ValueError(
+                    "Previous analysis reuse is supported only for live "
+                    "Step Time reads"
+                )
             snapshot = self.repository.load_summary(request)
             default_policy = SUMMARY_STEP_TIME_POLICY
 
-        window = self.analyzer.analyze(
-            snapshot,
-            window_size=request.window_size,
-        )
-        diagnosis = diagnose_step_time_window(
-            window,
-            policy=self.policy or default_policy,
-            include_attribution=False,
-        )
-        return StepTimeAnalysis(
+        return _analyze_snapshot(
+            request=request,
             snapshot=snapshot,
-            window=window,
-            diagnosis=diagnosis,
+            analyzer=self.analyzer,
+            policy=self.policy or default_policy,
         )
 
 
-__all__ = ["StepTimeAnalysis", "StepTimePipeline", "StepTimeProfile"]
+def _analyze_snapshot(
+    *,
+    request: StepTimeLoadRequest,
+    snapshot: StepTimeRepositorySnapshot,
+    analyzer: StepTimeAnalyzer,
+    policy: StepTimeDiagnosisPolicy,
+) -> StepTimeAnalysis:
+    """Build one analysis from source facts without presentation concerns."""
+    window = analyzer.analyze(
+        snapshot,
+        window_size=request.window_size,
+    )
+    diagnosis = diagnose_step_time_window(
+        window,
+        policy=policy,
+        include_attribution=False,
+    )
+    return StepTimeAnalysis(
+        request=request,
+        snapshot=snapshot,
+        window=window,
+        diagnosis=diagnosis,
+    )
+
+
+class LiveStepTimeSession:
+    """Own one live Step Time cache, bridge, and monotonic expiry clock.
+
+    The session keeps SQLite connections refresh-local, making it safe to
+    move between display threads. A lock serializes refreshes so a future
+    dashboard fan-out cannot duplicate work for the same session.
+    """
+
+    def __init__(
+        self,
+        db_path: str,
+        *,
+        request: Optional[StepTimeLoadRequest] = None,
+        stale_ttl_s: Optional[float] = 30.0,
+        table: str = "step_time_samples",
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        selected = request or StepTimeLoadRequest(
+            window_size=100,
+            lookback_factor=4,
+        )
+        self.db_path = str(db_path)
+        self.request = StepTimeLoadRequest(
+            window_size=max(1, int(selected.window_size)),
+            lookback_factor=max(1, int(selected.lookback_factor)),
+            rank_filter=(
+                tuple(int(rank) for rank in selected.rank_filter)
+                if selected.rank_filter is not None
+                else None
+            ),
+        )
+        self.table = str(table)
+        self._stale_ttl_s = (
+            float(stale_ttl_s) if stale_ttl_s is not None else None
+        )
+        self._monotonic = monotonic
+        self._logger = get_error_logger("LiveStepTimeSession")
+        self._analyzer = StepTimeAnalyzer()
+        self._lock = Lock()
+        self._last_observed: Optional[StepTimeAnalysis] = None
+        self._last_good: Optional[StepTimeAnalysis] = None
+        self._last_good_at: Optional[float] = None
+        self._empty_analysis = _analyze_snapshot(
+            request=self.request,
+            snapshot=StepTimeRepositorySnapshot(),
+            analyzer=self._analyzer,
+            policy=LIVE_STEP_TIME_POLICY,
+        )
+
+    def refresh(self) -> LiveStepTimeResult:
+        """Read once and return a live, bridged, cold, or expired result."""
+        with self._lock:
+            try:
+                analysis = self._run_pipeline()
+            except Exception as exc:
+                self._logger.exception("Live Step Time refresh failed")
+                return self._missing_result(
+                    message=f"STALE (exception: {type(exc).__name__})",
+                    empty_analysis=self._empty_analysis,
+                )
+
+            self._last_observed = analysis
+            if not analysis.window.metrics:
+                return self._missing_result(
+                    message="STALE (no metrics this tick)",
+                    empty_analysis=analysis,
+                )
+
+            self._last_good = analysis
+            self._last_good_at = float(self._monotonic())
+            message = "OK"
+            if analysis.window.worst_rank is not None:
+                message += (
+                    " | diagnosis_worst_rank=" f"r{analysis.window.worst_rank}"
+                )
+            return LiveStepTimeResult(
+                freshness="live",
+                analysis=analysis,
+                status_message=message,
+            )
+
+    def _run_pipeline(self) -> StepTimeAnalysis:
+        """Run the canonical live pipeline on one short-lived connection."""
+        with closing(sqlite3.connect(self.db_path)) as conn:
+            conn.row_factory = sqlite3.Row
+            repository = SQLiteStepTimeRepository(conn, table=self.table)
+            return StepTimePipeline(
+                repository=repository,
+                profile="live",
+                analyzer=self._analyzer,
+            ).run(
+                self.request,
+                previous=self._last_observed,
+            )
+
+    def _missing_result(
+        self,
+        *,
+        message: str,
+        empty_analysis: StepTimeAnalysis,
+    ) -> LiveStepTimeResult:
+        """Bridge a transient gap, or expose a cold/expired empty result."""
+        if self._last_good is not None and self._last_good_at is not None:
+            age = float(self._monotonic()) - self._last_good_at
+            if self._stale_ttl_s is None or age <= self._stale_ttl_s:
+                return LiveStepTimeResult(
+                    freshness="bridged",
+                    analysis=self._last_good,
+                    status_message=message,
+                )
+
+        freshness: LiveStepTimeFreshness = (
+            "cold" if self._last_good is None else "expired"
+        )
+        return LiveStepTimeResult(
+            freshness=freshness,
+            analysis=empty_analysis,
+            status_message="No fresh step-combined data",
+        )
+
+
+__all__ = [
+    "LiveStepTimeFreshness",
+    "LiveStepTimeResult",
+    "LiveStepTimeSession",
+    "StepTimeAnalysis",
+    "StepTimePipeline",
+    "StepTimeProfile",
+]

--- a/src/traceml_ai/step_time/sqlite.py
+++ b/src/traceml_ai/step_time/sqlite.py
@@ -13,6 +13,7 @@ import math
 import re
 import sqlite3
 from contextlib import contextmanager
+from dataclasses import replace
 from typing import Any, Iterator, Optional
 
 from traceml_ai.step_time.model import (
@@ -168,18 +169,36 @@ class SQLiteStepTimeRepository:
     def load_live(
         self,
         request: StepTimeLoadRequest,
+        *,
+        previous: Optional[StepTimeRepositorySnapshot] = None,
     ) -> StepTimeRepositorySnapshot:
         """Load the bounded tail needed by terminal and dashboard refreshes.
 
         The query performs an index-ordered, early-stopping scan for each rank.
         It intentionally omits rank identities and run progress, which live
         diagnosis does not read. Cost therefore follows the requested lookback
-        instead of the total number of persisted training steps.
+        instead of the total number of persisted training steps. When the
+        selected row cursor is unchanged, persisted JSON is not decoded again.
         """
         with self._read_snapshot():
             rows = self._load_live_rows(request)
+            cursor = self._live_cursor(rows)
+            global_ranks = tuple(dict.fromkeys(int(row[0]) for row in rows))
             strategy = load_training_strategy_from_sqlite(self._conn)
-            return self._snapshot_from_rows(rows, strategy=strategy)
+            if (
+                previous is not None
+                and cursor == previous.cursor
+                and global_ranks == previous.global_ranks
+            ):
+                if strategy == previous.training_strategy:
+                    return previous
+                return replace(previous, training_strategy=strategy)
+            return self._snapshot_from_rows(
+                rows,
+                strategy=strategy,
+                latest_step=cursor.latest_step,
+                last_row_id=cursor.last_row_id,
+            )
 
     def load_summary(
         self,
@@ -314,6 +333,24 @@ class SQLiteStepTimeRepository:
         """
         parameters.append(lookback)
         return self._conn.execute(query, parameters).fetchall()
+
+    @staticmethod
+    def _live_cursor(
+        rows: list[sqlite3.Row | tuple[Any, ...]],
+    ) -> StepTimeSourceCursor:
+        """Build the cache key from selected rows before JSON decoding."""
+        source_ids = [_optional_int(row[1]) for row in rows]
+        steps = [_optional_int(row[2]) for row in rows]
+        return StepTimeSourceCursor(
+            last_row_id=max(
+                (value for value in source_ids if value is not None),
+                default=None,
+            ),
+            latest_step=max(
+                (value for value in steps if value is not None),
+                default=None,
+            ),
+        )
 
     def _load_summary_rows(
         self,

--- a/tests/benchmarks/bench_step_time_pipeline.py
+++ b/tests/benchmarks/bench_step_time_pipeline.py
@@ -50,6 +50,8 @@ from traceml_ai.renderers.step_time.compute import (  # noqa: E402
 from traceml_ai.reporting.sections.step_time import (  # noqa: E402
     StepTimeSummarySection,
 )
+from traceml_ai.step_time.model import StepTimeLoadRequest  # noqa: E402
+from traceml_ai.step_time.pipeline import LiveStepTimeSession  # noqa: E402
 from traceml_ai.utils.step_time_sqlite import (  # noqa: E402
     load_step_time_window_from_sqlite,
 )
@@ -128,7 +130,13 @@ def _benchmark_rank_count(
             )
 
     loaded = load_window()
-    live = StepCombinedComputer(str(db_path), window_size=window_size)
+    live = LiveStepTimeSession(
+        str(db_path),
+        request=StepTimeLoadRequest(
+            window_size=window_size,
+            lookback_factor=4,
+        ),
+    )
     dashboard_hero = StepCombinedComputer(
         str(db_path),
         window_size=window_size,
@@ -138,6 +146,10 @@ def _benchmark_rank_count(
         window_size=window_size,
     )
     summary = StepTimeSummarySection(max_rows=window_size)
+
+    def live_cache_miss():
+        live._last_observed = None
+        return live.refresh()
 
     calls = (
         ("load + decode + analyze", load_window),
@@ -149,7 +161,8 @@ def _benchmark_rank_count(
                 training_strategy=loaded.training_strategy,
             ),
         ),
-        ("one live provider", live.compute_cli),
+        ("one live provider", live_cache_miss),
+        ("unchanged live cache hit", live.refresh),
         (
             "dashboard Step Time refresh",
             lambda: (

--- a/tests/display/test_model_combined_section.py
+++ b/tests/display/test_model_combined_section.py
@@ -21,10 +21,12 @@ from traceml_ai.diagnostics.step_time import LIVE_STEP_TIME_POLICY
 from traceml_ai.renderers.step_time.compute import StepCombinedComputer
 from traceml_ai.renderers.step_time.renderer import StepCombinedRenderer
 from traceml_ai.step_time.model import (
+    StepTimeLoadRequest,
     StepTimeMetric,
     StepTimeResult,
     StepTimeWindow,
 )
+from traceml_ai.step_time.pipeline import LiveStepTimeSession
 from traceml_ai.reporting.sections.step_time.loader import (
     load_step_time_section_data,
 )
@@ -416,7 +418,7 @@ def test_step_time_dashboard_hero_dark_input_wait_is_not_measured_zero() -> (
 
 def test_step_time_dashboard_hero_dead_run_shows_expired() -> None:
     # The CLI sibling distinguishes "no data yet" from "had data, now
-    # expired" via StepCombinedComputer.had_ok; the dashboard hero must
+    # expired" via live-session freshness; the compatibility projection must
     # do the same instead of freezing on the last complete view forever.
     good = _payload(
         [
@@ -809,7 +811,10 @@ def test_sqlite_window_has_one_share_across_live_and_summary_consumers(
     finally:
         conn.close()
 
-    result = StepCombinedComputer(str(db_path), window_size=30).compute_cli()
+    result = StepCombinedComputer(
+        str(db_path),
+        window_size=30,
+    ).compute_dashboard()
     assert result.window is not None
     assert result.window.per_rank_timing[0]["residual_proxy"] == pytest.approx(
         10.0
@@ -829,8 +834,15 @@ def test_sqlite_window_has_one_share_across_live_and_summary_consumers(
     )
     assert summary.per_global_rank_summary[0].avg_h2d_ms is None
 
-    renderer = StepCombinedRenderer(str(db_path))
-    monkeypatch.setattr(renderer, "_payload", lambda: result)
+    renderer = StepCombinedRenderer(
+        LiveStepTimeSession(
+            str(db_path),
+            request=StepTimeLoadRequest(
+                window_size=30,
+                lookback_factor=4,
+            ),
+        )
+    )
     console = Console(record=True, width=140, color_system=None)
     console.print(renderer.get_panel_renderable())
     assert "5.0%" in console.export_text()

--- a/tests/display/test_nicegui_driver.py
+++ b/tests/display/test_nicegui_driver.py
@@ -27,9 +27,7 @@ from traceml_ai.renderers.step_memory.schema import (  # noqa: E402
 )
 from traceml_ai.renderers.step_time.compute import (  # noqa: E402
     StepCombinedComputer,
-)
-from traceml_ai.renderers.step_time.renderer import (  # noqa: E402
-    StepCombinedRenderer,
+    StepTimeDashboardAdapter,
 )
 from traceml_ai.step_time.model import (  # noqa: E402
     StepTimeResult,
@@ -182,7 +180,7 @@ def test_dashboard_tick_currently_invokes_two_step_time_providers(
 
     The Step Time hero and diagnostics rail currently own independent
     computers. A later pipeline PR should change this test to one shared
-    provider; PR1 records the existing two-call behavior without changing it.
+    provider; PR6 keeps this boundary explicit for the PR7 consolidation.
     """
     calls: list[StepCombinedComputer] = []
 
@@ -208,7 +206,7 @@ def test_dashboard_tick_currently_invokes_two_step_time_providers(
                     status_message="No GPU detected",
                 ),
             )
-        elif not isinstance(renderer, StepCombinedRenderer):
+        elif not isinstance(renderer, StepTimeDashboardAdapter):
             monkeypatch.setattr(
                 renderer,
                 "get_dashboard_renderable",

--- a/tests/renderers/test_step_time_compute.py
+++ b/tests/renderers/test_step_time_compute.py
@@ -1,109 +1,48 @@
-import json
-import sqlite3
+from __future__ import annotations
 
-from tests.step_time.factories import window_from_rank_averages
+from pathlib import Path
+
+from tests.step_time.factories import (
+    live_result_from_window,
+    window_from_rank_averages,
+)
+from tests.step_time.scenarios import (
+    StepTimeScenario,
+    create_step_time_database,
+)
 from traceml_ai.renderers.step_time.compute import StepCombinedComputer
+from traceml_ai.step_time.model import StepTimeMetric, StepTimeWindow
 
 
-def test_step_time_compute_uses_selected_gpu_diagnosis_clock(
-    tmp_path,
+def test_dashboard_adapter_preserves_selected_gpu_clock(
+    tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "telemetry.db"
-    conn = sqlite3.connect(db_path)
-    try:
-        conn.execute(
-            """
-            CREATE TABLE step_time_samples (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                rank INTEGER,
-                global_rank INTEGER,
-                step INTEGER,
-                events_json TEXT NOT NULL
-            );
-            """
-        )
-        events_1 = {
-            "_traceml_internal:dataloader_next": {
-                "cuda:0": {
-                    "duration_ms": 12.0,
-                    "cpu_ms": 12.0,
-                    "gpu_ms": 4.0,
-                    "is_gpu": False,
-                    "n_calls": 1,
-                }
-            },
-            "_traceml_internal:step_time": {
-                "cuda:0": {
-                    "duration_ms": 60.0,
-                    "cpu_ms": 60.0,
-                    "gpu_ms": 20.0,
-                    "is_gpu": False,
-                    "n_calls": 1,
-                }
-            },
-        }
-        events_2 = {
-            "_traceml_internal:dataloader_next": {
-                "cuda:0": {
-                    "duration_ms": 18.0,
-                    "cpu_ms": 18.0,
-                    "gpu_ms": 6.0,
-                    "is_gpu": False,
-                    "n_calls": 1,
-                }
-            },
-            "_traceml_internal:step_time": {
-                "cuda:0": {
-                    "duration_ms": 90.0,
-                    "cpu_ms": 90.0,
-                    "gpu_ms": 40.0,
-                    "is_gpu": False,
-                    "n_calls": 1,
-                }
-            },
-        }
-        conn.execute(
-            """
-            INSERT INTO step_time_samples(rank, global_rank, step, events_json)
-            VALUES (?, ?, ?, ?);
-            """,
-            (0, 0, 1, json.dumps(events_1)),
-        )
-        conn.execute(
-            """
-            INSERT INTO step_time_samples(rank, global_rank, step, events_json)
-            VALUES (?, ?, ?, ?);
-            """,
-            (0, 0, 2, json.dumps(events_2)),
-        )
-        conn.commit()
-    finally:
-        conn.close()
+    create_step_time_database(
+        db_path,
+        StepTimeScenario(
+            name="gpu_adapter",
+            profiles={0: {"input_wait": 5.0, "step_time": 30.0}},
+            steps=(1, 2),
+            clock="gpu",
+        ),
+    )
 
     result = StepCombinedComputer(
         db_path=str(db_path),
         window_size=2,
-    ).compute_cli()
+    ).compute_dashboard()
 
     assert result.window is not None
     metrics = {metric.metric: metric for metric in result.window.metrics}
-    assert "dataloader_fetch" not in metrics
     assert metrics["input_wait"].worst_total == 5.0
     assert metrics["step_time"].worst_total == 30.0
-    assert metrics["input_wait"].series is not None
-    assert metrics["input_wait"].series.worst == [4.0, 6.0]
-    assert metrics["input_wait"].series.sum == [4.0, 6.0]
     assert result.window.clock == "gpu"
     assert result.training_strategy == "ddp"
-
-    per_rank = result.window.per_rank_timing[0]
-    assert per_rank["input_wait"] == 5.0
-    assert per_rank["step_time"] == 30.0
+    assert result.window.per_rank_timing[0]["input_wait"] == 5.0
 
 
 def test_worst_rank_requires_measured_total_step() -> None:
-    # Ranks without a measured total step (input wait never measured)
-    # cannot win the status-line worst-rank pick with a fake zero.
     assert (
         window_from_rank_averages(
             {
@@ -124,19 +63,7 @@ def test_worst_rank_requires_measured_total_step() -> None:
     )
 
 
-def test_computer_bridges_transients_then_expires(monkeypatch) -> None:
-    """The last-ok window is the only flicker/dead-view bridge (issue #259).
-
-    A transient empty compute re-serves the last good metrics with a
-    STALE status; once the TTL passes, the empty result comes through
-    and had_ok records that data existed before.
-    """
-    from traceml_ai.renderers.step_time import compute as compute_module
-    from traceml_ai.step_time.model import (
-        StepTimeMetric,
-        StepTimeResult,
-    )
-
+def _live_window() -> StepTimeWindow:
     metric = StepTimeMetric(
         metric="step_time",
         series=None,
@@ -149,126 +76,41 @@ def test_computer_bridges_transients_then_expires(monkeypatch) -> None:
         skew_pct=0.0,
         measured_ranks=(0,),
     )
-    good = StepTimeResult(
-        status_message="OK",
-        window=window_from_rank_averages(
-            {0: {"step_time": 10.0, "total_step": 10.0}},
-            expected_ranks=(0,),
-            metrics=[metric],
-        ),
-    )
-    empty = StepTimeResult(status_message="no rows")
-
-    computer = StepCombinedComputer(db_path=":memory:", stale_ttl_s=30.0)
-    assert computer.had_ok is False
-
-    results = iter([good, empty, empty])
-    monkeypatch.setattr(computer, "_compute_impl", lambda conn: next(results))
-
-    first = computer.compute_cli()
-    assert first.window is not None and first.window.metrics == [metric]
-    assert computer.had_ok is True
-    # The payload itself carries had_ok too (dashboard subscribers only
-    # ever see the payload, never the computer instance directly).
-    assert first.had_ok is True
-
-    # Within the TTL a transient gap re-serves the last good metrics.
-    bridged = computer.compute_cli()
-    assert bridged.window is not None and bridged.window.metrics == [metric]
-    assert bridged.status_message.startswith("STALE")
-    assert bridged.had_ok is True
-
-    # Past the TTL the empty result comes through unbridged.
-    monkeypatch.setattr(
-        compute_module.time,
-        "time",
-        lambda: computer._last_ok_ts + 31.0,
-    )
-    expired = computer.compute_cli()
-    assert expired.window is None
-    assert expired.status_message == "No fresh step-combined data"
-    assert computer.had_ok is True
-    assert expired.had_ok is True
-
-
-def test_non_advancing_nonempty_window_does_not_claim_source_expiry(
-    monkeypatch,
-) -> None:
-    """Persisted rows cannot establish whether their producer is alive."""
-    from traceml_ai.renderers.step_time import compute as compute_module
-    from traceml_ai.step_time.model import (
-        StepTimeMetric,
-        StepTimeResult,
+    return window_from_rank_averages(
+        {0: {"step_time": 10.0, "total_step": 10.0}},
+        expected_ranks=(0,),
+        metrics=(metric,),
     )
 
-    def _result(completed_step: int) -> StepTimeResult:
-        metric = StepTimeMetric(
-            metric="step_time",
-            series=None,
-            window_size=1,
-            steps_used=1,
-            median_total=10.0,
-            worst_total=10.0,
-            worst_rank=0,
-            skew_ratio=0.0,
-            skew_pct=0.0,
-            measured_ranks=(0,),
-        )
-        return StepTimeResult(
-            status_message="OK",
-            window=window_from_rank_averages(
-                {0: {"step_time": 10.0, "total_step": 10.0}},
-                expected_ranks=(0,),
-                metrics=[metric],
+
+def test_dashboard_adapter_projects_live_freshness(monkeypatch) -> None:
+    computer = StepCombinedComputer(db_path=":memory:")
+    window = _live_window()
+    results = iter(
+        (
+            live_result_from_window(window, freshness="live"),
+            live_result_from_window(
+                window,
+                freshness="bridged",
+                status_message="STALE (no metrics this tick)",
             ),
+            live_result_from_window(StepTimeWindow(), freshness="cold"),
+            live_result_from_window(StepTimeWindow(), freshness="expired"),
         )
-
-    computer = StepCombinedComputer(db_path=":memory:", stale_ttl_s=30.0)
-
-    now = [1000.0]
-    monkeypatch.setattr(compute_module.time, "time", lambda: now[0])
-
-    # Live run: the window advances, so every tick stays fresh.
-    step = [1]
-    monkeypatch.setattr(
-        computer, "_compute_impl", lambda conn: _result(step[0])
     )
-    assert computer.compute_cli().window is not None
-    now[0] += 60.0
-    step[0] = 2
-    assert computer.compute_cli().window is not None
+    monkeypatch.setattr(computer._session, "refresh", lambda: next(results))
 
-    # The same persisted window remains a valid snapshot. Its unchanged
-    # completed-step cursor is not a process-liveness signal.
-    now[0] += 10.0
-    assert computer.compute_cli().window is not None
+    live = computer.compute_dashboard()
+    bridged = computer.compute_dashboard()
+    cold = computer.compute_dashboard()
+    expired = computer.compute_dashboard()
 
-    # Even past the empty-read bridge TTL, a non-empty snapshot is retained.
-    now[0] += 31.0
-    persisted = computer.compute_cli()
-    assert persisted.window is not None
-    assert persisted.had_ok is True
-    assert persisted.status_message.startswith("OK")
-
-    # And it recovers if the producer comes back.
-    step[0] = 3
-    assert computer.compute_cli().window is not None
+    assert live.window is window and live.had_ok is True
+    assert bridged.window is window and bridged.had_ok is True
+    assert bridged.status_message.startswith("STALE")
+    assert cold.window is None and cold.had_ok is False
+    assert expired.window is None and expired.had_ok is True
 
 
-def test_computer_had_ok_stays_false_on_cold_start(monkeypatch) -> None:
-    """A payload that never had good data reports had_ok=False on itself,
-    not just on the computer -- distinguishes cold start from an expired bridge
-    for any consumer that only sees the payload (issue #259)."""
-    from traceml_ai.step_time.model import StepTimeResult
-
-    computer = StepCombinedComputer(db_path=":memory:", stale_ttl_s=30.0)
-    monkeypatch.setattr(
-        computer,
-        "_compute_impl",
-        lambda conn: StepTimeResult(status_message="no rows"),
-    )
-
-    result = computer.compute_cli()
-    assert result.window is None
-    assert result.had_ok is False
-    assert computer.had_ok is False
+def test_dashboard_adapter_has_no_cli_alias() -> None:
+    assert not hasattr(StepCombinedComputer, "compute_cli")

--- a/tests/renderers/test_step_time_renderer.py
+++ b/tests/renderers/test_step_time_renderer.py
@@ -1,18 +1,15 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
+from unittest.mock import Mock
 
 from rich.console import Console
 
-from tests.step_time.factories import window_from_rank_averages
-from traceml_ai.diagnostics.step_time.api import StepDiagnosis
-from traceml_ai.renderers.step_time import renderer as renderer_module
-from traceml_ai.renderers.step_time.renderer import StepCombinedRenderer
-from traceml_ai.step_time.model import (
-    StepTimeMetric,
-    StepTimeResult,
-    StepTimeWindow,
+from tests.step_time.factories import (
+    live_result_from_window,
+    window_from_rank_averages,
 )
+from traceml_ai.renderers.step_time.renderer import StepCombinedRenderer
+from traceml_ai.step_time.model import StepTimeMetric
 
 
 def _metric(
@@ -39,51 +36,29 @@ def _render_text(renderable) -> str:
     return console.export_text()
 
 
-def test_step_time_cli_diagnosis_uses_selected_metrics(monkeypatch) -> None:
+def test_step_time_cli_uses_the_precomputed_selected_clock_analysis() -> None:
     diagnosis_metrics = [
         _metric("input_wait", 40.0),
         _metric("step_time", 100.0),
         _metric("residual_proxy", 0.0),
     ]
-    payload = StepTimeResult(
-        window=window_from_rank_averages(
+    payload = live_result_from_window(
+        window_from_rank_averages(
             {0: {"input_wait": 40.0, "step_time": 100.0}},
             clock="gpu",
             expected_ranks=(0,),
             metrics=diagnosis_metrics,
+            training_strategy="fsdp",
         ),
-        training_strategy="fsdp",
-    )
-    seen = {}
-
-    def fake_diagnose(window, **kwargs):
-        seen["metrics"] = window.metrics
-        seen["diagnosis_clock"] = window.clock
-        seen["training_strategy"] = kwargs.get("training_strategy")
-        return SimpleNamespace(
-            primary=StepDiagnosis(
-                kind="INPUT_BOUND",
-                status="INPUT-BOUND",
-                severity="warn",
-                reason="Input wait is high.",
-                action="Increase workers.",
-                steps_used=1,
-            )
-        )
-
-    monkeypatch.setattr(
-        renderer_module,
-        "diagnose_step_time_window",
-        fake_diagnose,
     )
 
-    renderer = StepCombinedRenderer(db_path=":memory:")
-    monkeypatch.setattr(renderer, "_payload", lambda: payload)
-    text = _render_text(renderer.get_panel_renderable())
+    renderer = StepCombinedRenderer(session=Mock())
+    text = _render_text(renderer.render(payload))
 
-    assert seen["metrics"] is diagnosis_metrics
-    assert seen["diagnosis_clock"] == "gpu"
-    assert seen["training_strategy"] == "fsdp"
+    assert payload.analysis.window.metrics is diagnosis_metrics
+    assert payload.analysis.window.clock == "gpu"
+    assert payload.analysis.window.training_strategy == "fsdp"
+    assert "WARMUP" in text
     assert "IW" in text
     assert "DL" not in text
     assert "Average (1 steps)" in text
@@ -92,7 +67,7 @@ def test_step_time_cli_diagnosis_uses_selected_metrics(monkeypatch) -> None:
     assert "12.0 ms" not in text
 
 
-def test_step_time_cli_renders_zero_timings_as_zero(monkeypatch) -> None:
+def test_step_time_cli_renders_zero_timings_as_zero() -> None:
     diagnosis_metrics = [
         _metric("input_wait", 0.0),
         _metric("h2d", 0.0),
@@ -102,8 +77,8 @@ def test_step_time_cli_renders_zero_timings_as_zero(monkeypatch) -> None:
         _metric("step_time", 31.2),
         _metric("residual_proxy", 6.0),
     ]
-    payload = StepTimeResult(
-        window=window_from_rank_averages(
+    payload = live_result_from_window(
+        window_from_rank_averages(
             {
                 0: {
                     "input_wait": 0.0,
@@ -120,29 +95,28 @@ def test_step_time_cli_renders_zero_timings_as_zero(monkeypatch) -> None:
         ),
     )
 
-    def fake_diagnose(window, **kwargs):
-        return SimpleNamespace(
-            primary=StepDiagnosis(
-                kind="RESIDUAL_HEAVY",
-                status="RESIDUAL-HEAVY",
-                severity="warn",
-                reason="Residual time is high.",
-                action="Inspect work outside traced phases.",
-                steps_used=1,
-            )
-        )
-
-    monkeypatch.setattr(
-        renderer_module,
-        "diagnose_step_time_window",
-        fake_diagnose,
-    )
-
-    renderer = StepCombinedRenderer(db_path=":memory:")
-    monkeypatch.setattr(renderer, "_payload", lambda: payload)
-    text = _render_text(renderer.get_panel_renderable())
+    renderer = StepCombinedRenderer(session=Mock())
+    text = _render_text(renderer.render(payload))
 
     assert "IW" in text
     assert "H2D" in text
     assert text.count("0.0 ms") >= 2
     assert "4.5 ms" in text
+
+
+def test_step_time_cli_refreshes_its_injected_session_once() -> None:
+    payload = live_result_from_window(
+        window_from_rank_averages(
+            {0: {"step_time": 10.0}},
+            expected_ranks=(0,),
+            metrics=[_metric("step_time", 10.0)],
+        )
+    )
+    session = Mock()
+    session.refresh.return_value = payload
+
+    renderer = StepCombinedRenderer(session=session)
+    text = _render_text(renderer.get_panel_renderable())
+
+    session.refresh.assert_called_once_with()
+    assert "STEP" in text

--- a/tests/renderers/test_step_time_sparse_ui.py
+++ b/tests/renderers/test_step_time_sparse_ui.py
@@ -8,19 +8,25 @@
 
 An unavailable phase is omitted (never rendered as a measured zero), the
 canonical INCOMPLETE_DATA diagnosis reaches the terminal, and a stale
-complete view is never re-served once the computer's own window expires.
+complete view is never re-served once the live session expires its bridge.
 """
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 from rich.console import Console
 
-from tests.step_time.factories import window_from_rank_averages
+from tests.step_time.factories import (
+    live_result_from_window,
+    window_from_rank_averages,
+)
 from traceml_ai.renderers.step_time.renderer import StepCombinedRenderer
 from traceml_ai.step_time.model import (
     StepTimeMetric,
-    StepTimeResult,
+    StepTimeWindow,
 )
+from traceml_ai.step_time.pipeline import LiveStepTimeResult
 
 
 def _metric(name: str, value: float) -> StepTimeMetric:
@@ -44,7 +50,7 @@ def _render_text(renderable) -> str:
     return console.export_text()
 
 
-def _sparse_payload() -> StepTimeResult:
+def _sparse_payload() -> LiveStepTimeResult:
     # forward was never measured: no forward metric, no residual, and the
     # per-rank timing carries no forward key.
     per_rank_timing = {
@@ -57,8 +63,8 @@ def _sparse_payload() -> StepTimeResult:
             "total_step": 92.0,
         }
     }
-    return StepTimeResult(
-        window=window_from_rank_averages(
+    return live_result_from_window(
+        window_from_rank_averages(
             per_rank_timing,
             expected_ranks=(0,),
             metrics=[
@@ -72,12 +78,9 @@ def _sparse_payload() -> StepTimeResult:
     )
 
 
-def test_cli_omits_missing_phase_and_shows_incomplete_data(
-    monkeypatch,
-) -> None:
-    renderer = StepCombinedRenderer(db_path=":memory:")
-    monkeypatch.setattr(renderer, "_payload", _sparse_payload)
-    text = _render_text(renderer.get_panel_renderable())
+def test_cli_omits_missing_phase_and_shows_incomplete_data() -> None:
+    renderer = StepCombinedRenderer(session=Mock())
+    text = _render_text(renderer.render(_sparse_payload()))
 
     # The canonical diagnosis for the sparse window reaches the terminal.
     assert "INCOMPLETE DATA" in text
@@ -94,27 +97,21 @@ def test_cli_omits_missing_phase_and_shows_incomplete_data(
     assert "60.0 ms" in text
 
 
-def test_cli_drops_dead_view_when_computer_window_expires(
-    monkeypatch,
-) -> None:
-    renderer = StepCombinedRenderer(db_path=":memory:")
+def test_cli_drops_dead_view_when_session_window_expires() -> None:
+    renderer = StepCombinedRenderer(session=Mock())
 
     live_payload = _sparse_payload()
-    monkeypatch.setattr(
-        renderer._computer, "compute_cli", lambda: live_payload
-    )
-    # Mirror the computer's own bookkeeping for a successful compute.
-    renderer._computer._last_ok = live_payload
-    live_text = _render_text(renderer.get_panel_renderable())
+    live_text = _render_text(renderer.render(live_payload))
     assert "60.0 ms" in live_text
 
-    # The computer only returns an empty result once its own stale window
+    # The session only returns an expired result once its last-good window
     # is exhausted; the renderer must not re-serve the old table.
-    expired = StepTimeResult(
+    expired = live_result_from_window(
+        StepTimeWindow(),
+        freshness="expired",
         status_message="No fresh step-combined data",
     )
-    monkeypatch.setattr(renderer._computer, "compute_cli", lambda: expired)
-    stale_text = _render_text(renderer.get_panel_renderable())
+    stale_text = _render_text(renderer.render(expired))
 
     assert "60.0 ms" not in stale_text
     assert "NO DATA" in stale_text
@@ -122,16 +119,23 @@ def test_cli_drops_dead_view_when_computer_window_expires(
 
 
 def test_cli_startup_shows_calm_waiting_panel() -> None:
-    renderer = StepCombinedRenderer(db_path=":memory:")
+    renderer = StepCombinedRenderer(session=Mock())
 
-    text = _render_text(renderer.get_panel_renderable())
+    text = _render_text(
+        renderer.render(
+            live_result_from_window(
+                StepTimeWindow(),
+                freshness="cold",
+            )
+        )
+    )
 
     # Never had data: normal warm-up must not alarm with NO DATA.
     assert "Waiting for first fully completed step" in text
     assert "NO DATA" not in text
 
 
-def test_cli_renders_multi_rank_sparse_table(monkeypatch) -> None:
+def test_cli_renders_multi_rank_sparse_table() -> None:
     def _multi_metric(name: str, value: float) -> StepTimeMetric:
         metric = _metric(name, value)
         return StepTimeMetric(
@@ -163,8 +167,8 @@ def test_cli_renders_multi_rank_sparse_table(monkeypatch) -> None:
             "total_step": 182.0,
         },
     }
-    payload = StepTimeResult(
-        window=window_from_rank_averages(
+    payload = live_result_from_window(
+        window_from_rank_averages(
             per_rank_timing,
             expected_ranks=(0, 1),
             metrics=[
@@ -175,9 +179,8 @@ def test_cli_renders_multi_rank_sparse_table(monkeypatch) -> None:
             ],
         )
     )
-    renderer = StepCombinedRenderer(db_path=":memory:")
-    monkeypatch.setattr(renderer, "_payload", lambda: payload)
-    text = _render_text(renderer.get_panel_renderable())
+    renderer = StepCombinedRenderer(session=Mock())
+    text = _render_text(renderer.render(payload))
 
     header = next(line for line in text.splitlines() if "Metric" in line)
     assert "FWD" not in header

--- a/tests/step_time/factories.py
+++ b/tests/step_time/factories.py
@@ -10,13 +10,25 @@ from __future__ import annotations
 import statistics
 from typing import Mapping, Optional, Sequence
 
+from traceml_ai.diagnostics.step_time import (
+    LIVE_STEP_TIME_POLICY,
+    diagnose_step_time_window,
+)
 from traceml_ai.step_time.model import (
     DiagnosisClock,
     StepTimeCoverage,
+    StepTimeLoadRequest,
     StepTimeMetric,
     StepTimeRankFacts,
+    StepTimeRepositorySnapshot,
+    StepTimeSourceCursor,
     StepTimeValues,
     StepTimeWindow,
+)
+from traceml_ai.step_time.pipeline import (
+    LiveStepTimeFreshness,
+    LiveStepTimeResult,
+    StepTimeAnalysis,
 )
 
 
@@ -211,6 +223,40 @@ def window_from_rank_averages(
     )
 
 
+def live_result_from_window(
+    window: StepTimeWindow,
+    *,
+    freshness: LiveStepTimeFreshness = "live",
+    status_message: str = "OK",
+) -> LiveStepTimeResult:
+    """Wrap one typed fixture window in the canonical live result shape."""
+    request = StepTimeLoadRequest(
+        window_size=max(1, int(window.coverage.expected_steps)),
+        lookback_factor=4,
+    )
+    cursor_value = window.steps[-1] if window.steps else None
+    snapshot = StepTimeRepositorySnapshot(
+        cursor=StepTimeSourceCursor(
+            last_row_id=cursor_value,
+            latest_step=cursor_value,
+        ),
+        training_strategy=window.training_strategy,
+    )
+    return LiveStepTimeResult(
+        freshness=freshness,
+        analysis=StepTimeAnalysis(
+            request=request,
+            snapshot=snapshot,
+            window=window,
+            diagnosis=diagnose_step_time_window(
+                window,
+                policy=LIVE_STEP_TIME_POLICY,
+            ),
+        ),
+        status_message=status_message,
+    )
+
+
 def _composition_representative(
     rank_facts: Sequence[StepTimeRankFacts],
     cohort: Sequence[int],
@@ -257,4 +303,8 @@ def _component_share(
     return float(statistics.median(shares)) if shares else None
 
 
-__all__ = ["values_from_legacy", "window_from_rank_averages"]
+__all__ = [
+    "live_result_from_window",
+    "values_from_legacy",
+    "window_from_rank_averages",
+]

--- a/tests/step_time/test_contract_baseline.py
+++ b/tests/step_time/test_contract_baseline.py
@@ -37,6 +37,8 @@ from traceml_ai.reporting.sections.step_time import StepTimeSummarySection
 from traceml_ai.reporting.sections.step_time.model import (
     STEP_TIME_METRIC_NAMES,
 )
+from traceml_ai.step_time.model import StepTimeLoadRequest
+from traceml_ai.step_time.pipeline import LiveStepTimeSession
 from traceml_ai.utils.step_time_window import diagnose_step_time_window
 
 _WINDOW_KEYS = {
@@ -247,14 +249,17 @@ def test_canonical_window_matches_golden(
 ) -> None:
     """Freeze alignment, clock, sparsity, metrics, and diagnosis semantics."""
     scenario, db_path = scenario_db
-    result = StepCombinedComputer(
+    result = LiveStepTimeSession(
         str(db_path),
-        window_size=len(scenario.steps),
-    ).compute_cli()
+        request=StepTimeLoadRequest(
+            window_size=len(scenario.steps),
+            lookback_factor=4,
+        ),
+    ).refresh()
 
-    assert result.window is not None
-    window = result.window
-    assert result.training_strategy == scenario.training_strategy
+    window = result.analysis.window
+    assert result.freshness == "live"
+    assert window.training_strategy == scenario.training_strategy
     assert window.clock == scenario.clock
     assert window.steps == list(scenario.steps)
     assert window.rank_universe == tuple(sorted(scenario.profiles))
@@ -301,7 +306,7 @@ def test_canonical_window_matches_golden(
     diagnosis = diagnose_step_time_window(
         window,
         policy=LIVE_STEP_TIME_POLICY,
-        training_strategy=result.training_strategy,
+        training_strategy=window.training_strategy,
     )
     expected = EXPECTED_DIAGNOSIS[scenario.name]
     assert diagnosis.primary.kind == expected.kind
@@ -332,10 +337,14 @@ def test_cli_dashboard_summary_diagnosis_parity(
         "format_cli_diagnosis",
         capture_cli,
     )
-    cli_renderer = StepCombinedRenderer(str(db_path))
-    cli_renderer._computer = StepCombinedComputer(
-        str(db_path),
-        window_size=len(scenario.steps),
+    cli_renderer = StepCombinedRenderer(
+        LiveStepTimeSession(
+            str(db_path),
+            request=StepTimeLoadRequest(
+                window_size=len(scenario.steps),
+                lookback_factor=4,
+            ),
+        )
     )
     cli_renderer.get_panel_renderable()
     cli_diagnosis = captured["diagnosis"]

--- a/tests/step_time/test_live_session.py
+++ b/tests/step_time/test_live_session.py
@@ -1,0 +1,273 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Freshness and unchanged-cursor contracts for the live Step Time session."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import patch
+
+from tests.step_time.factories import window_from_rank_averages
+from tests.step_time.scenarios import (
+    BALANCED_PROFILE,
+    SQLiteSelectRecorder,
+    StepTimeScenario,
+    create_step_time_database,
+)
+from traceml_ai.diagnostics.step_time import (
+    LIVE_STEP_TIME_POLICY,
+    diagnose_step_time_window,
+)
+from traceml_ai.step_time.model import (
+    StepTimeLoadRequest,
+    StepTimeMetric,
+    StepTimeRepositorySnapshot,
+    StepTimeSourceCursor,
+    StepTimeWindow,
+)
+from traceml_ai.step_time.pipeline import (
+    LiveStepTimeSession,
+    StepTimeAnalysis,
+)
+
+_REQUEST = StepTimeLoadRequest(window_size=2, lookback_factor=4)
+
+
+def _analysis(*, metrics: bool, cursor: int = 1) -> StepTimeAnalysis:
+    metric = StepTimeMetric(
+        metric="step_time",
+        series=None,
+        window_size=2,
+        steps_used=2,
+        median_total=10.0,
+        worst_total=10.0,
+        worst_rank=0,
+        skew_ratio=0.0,
+        skew_pct=0.0,
+        measured_ranks=(0,),
+    )
+    window = (
+        window_from_rank_averages(
+            {0: {"step_time": 10.0, "total_step": 10.0}},
+            expected_ranks=(0,),
+            metrics=(metric,),
+        )
+        if metrics
+        else StepTimeWindow()
+    )
+    snapshot = StepTimeRepositorySnapshot(
+        cursor=StepTimeSourceCursor(
+            last_row_id=cursor,
+            latest_step=cursor,
+        )
+    )
+    return StepTimeAnalysis(
+        request=_REQUEST,
+        snapshot=snapshot,
+        window=window,
+        diagnosis=diagnose_step_time_window(
+            window,
+            policy=LIVE_STEP_TIME_POLICY,
+        ),
+    )
+
+
+def test_cold_empty_read_does_not_claim_prior_data(monkeypatch) -> None:
+    session = LiveStepTimeSession(":memory:", request=_REQUEST)
+    empty = _analysis(metrics=False)
+    monkeypatch.setattr(session, "_run_pipeline", lambda: empty)
+
+    result = session.refresh()
+
+    assert result.freshness == "cold"
+    assert result.analysis is empty
+    assert result.status_message == "No fresh step-combined data"
+
+
+def test_last_good_bridges_then_expires_with_monotonic_time(
+    monkeypatch,
+) -> None:
+    now = [0.0]
+    session = LiveStepTimeSession(
+        ":memory:",
+        request=_REQUEST,
+        stale_ttl_s=30.0,
+        monotonic=lambda: now[0],
+    )
+    good = _analysis(metrics=True)
+    empty = _analysis(metrics=False, cursor=2)
+    results = iter((good, empty, empty))
+    monkeypatch.setattr(session, "_run_pipeline", lambda: next(results))
+
+    live = session.refresh()
+    now[0] = 10.0
+    bridged = session.refresh()
+    now[0] = 31.0
+    expired = session.refresh()
+
+    assert live.freshness == "live"
+    assert live.analysis is good
+    assert bridged.freshness == "bridged"
+    assert bridged.analysis is good
+    assert bridged.status_message.startswith("STALE")
+    assert expired.freshness == "expired"
+    assert expired.analysis is empty
+    assert not expired.analysis.window.metrics
+
+
+def test_unlimited_ttl_keeps_the_last_good_analysis(monkeypatch) -> None:
+    now = [0.0]
+    session = LiveStepTimeSession(
+        ":memory:",
+        request=_REQUEST,
+        stale_ttl_s=None,
+        monotonic=lambda: now[0],
+    )
+    good = _analysis(metrics=True)
+    empty = _analysis(metrics=False, cursor=2)
+    results = iter((good, empty))
+    monkeypatch.setattr(session, "_run_pipeline", lambda: next(results))
+
+    assert session.refresh().freshness == "live"
+    now[0] = 10_000.0
+    bridged = session.refresh()
+
+    assert bridged.freshness == "bridged"
+    assert bridged.analysis is good
+
+
+def test_failed_reads_use_the_same_bridge_and_expiry_policy(
+    monkeypatch,
+) -> None:
+    now = [0.0]
+    session = LiveStepTimeSession(
+        ":memory:",
+        request=_REQUEST,
+        stale_ttl_s=5.0,
+        monotonic=lambda: now[0],
+    )
+    good = _analysis(metrics=True)
+
+    monkeypatch.setattr(session, "_run_pipeline", lambda: good)
+    assert session.refresh().freshness == "live"
+
+    def fail() -> StepTimeAnalysis:
+        raise sqlite3.OperationalError("temporary read failure")
+
+    monkeypatch.setattr(session, "_run_pipeline", fail)
+    now[0] = 3.0
+    bridged = session.refresh()
+    now[0] = 6.0
+    expired = session.refresh()
+
+    assert bridged.freshness == "bridged"
+    assert bridged.analysis is good
+    assert "OperationalError" in bridged.status_message
+    assert expired.freshness == "expired"
+    assert not expired.analysis.window.metrics
+
+
+def _database(tmp_path: Path) -> Path:
+    db_path = tmp_path / "live-session.db"
+    create_step_time_database(
+        db_path,
+        StepTimeScenario(
+            name="live_session",
+            profiles={0: BALANCED_PROFILE},
+            steps=(1, 2),
+        ),
+    )
+    return db_path
+
+
+def test_unchanged_cursor_reuses_analysis_without_recomputing(
+    tmp_path: Path,
+) -> None:
+    db_path = _database(tmp_path)
+    session = LiveStepTimeSession(str(db_path), request=_REQUEST)
+    first = session.refresh()
+    recorder = SQLiteSelectRecorder()
+
+    with (
+        patch.object(sqlite3, "connect", recorder.connect),
+        patch(
+            "traceml_ai.step_time.sqlite.json.loads",
+            wraps=json.loads,
+        ) as loads,
+        patch.object(
+            session._analyzer,
+            "analyze",
+            wraps=session._analyzer.analyze,
+        ) as analyze,
+        patch(
+            "traceml_ai.step_time.pipeline.diagnose_step_time_window"
+        ) as diagnose,
+    ):
+        second = session.refresh()
+
+    assert second.freshness == "live"
+    assert second.analysis is first.analysis
+    assert recorder.count == 2
+    assert loads.call_count == 0
+    assert analyze.call_count == 0
+    assert diagnose.call_count == 0
+
+
+def test_changed_cursor_builds_one_new_analysis(tmp_path: Path) -> None:
+    db_path = _database(tmp_path)
+    session = LiveStepTimeSession(str(db_path), request=_REQUEST)
+    first = session.refresh()
+    with sqlite3.connect(db_path) as conn:
+        events_json = conn.execute(
+            "SELECT events_json FROM step_time_samples LIMIT 1"
+        ).fetchone()[0]
+        conn.execute(
+            """
+            INSERT INTO step_time_samples(
+                recv_ts_ns, rank, global_rank, step, events_json
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (3, 0, 0, 3, events_json),
+        )
+        conn.commit()
+
+    with (
+        patch(
+            "traceml_ai.step_time.sqlite.json.loads",
+            wraps=json.loads,
+        ) as loads,
+        patch.object(
+            session._analyzer,
+            "analyze",
+            wraps=session._analyzer.analyze,
+        ) as analyze,
+        patch(
+            "traceml_ai.step_time.pipeline.diagnose_step_time_window",
+            wraps=diagnose_step_time_window,
+        ) as diagnose,
+    ):
+        second = session.refresh()
+
+    assert second.analysis is not first.analysis
+    assert second.analysis.snapshot.cursor.last_row_id == 3
+    assert loads.call_count == len(second.analysis.snapshot.rows)
+    assert analyze.call_count == 1
+    assert diagnose.call_count == 1
+
+
+def test_concurrent_refreshes_share_one_analysis(tmp_path: Path) -> None:
+    session = LiveStepTimeSession(str(_database(tmp_path)), request=_REQUEST)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = executor.map(lambda _: session.refresh(), range(2))
+        first, second = tuple(results)
+
+    assert first.freshness == second.freshness == "live"
+    assert first.analysis is second.analysis

--- a/tests/step_time/test_model_boundary.py
+++ b/tests/step_time/test_model_boundary.py
@@ -159,3 +159,46 @@ def test_removed_renderer_schema_does_not_return() -> None:
         / "step_time"
         / "schema.py"
     ).exists()
+
+
+def test_cli_presenter_has_no_data_or_diagnosis_dependencies() -> None:
+    """Keep Rich formatting downstream of the completed live analysis."""
+    renderer = (
+        _PROJECT_ROOT
+        / "src"
+        / "traceml_ai"
+        / "renderers"
+        / "step_time"
+        / "renderer.py"
+    )
+    dependencies = set(_imports(renderer))
+    source = renderer.read_text(encoding="utf-8")
+
+    assert "sqlite3" not in dependencies
+    assert "traceml_ai.step_time.sqlite" not in dependencies
+    assert "traceml_ai.step_time.analysis" not in dependencies
+    assert "traceml_ai.diagnostics.step_time.policy" not in dependencies
+    assert "diagnose_step_time_window" not in source
+    assert "build_step_diagnosis" not in source
+    assert "StepCombinedComputer" not in source
+    assert "StepTimeDashboardAdapter" not in source
+
+
+def test_dashboard_computer_is_only_a_compatibility_projection() -> None:
+    """Do not let SQL, clocks, or freshness return to the PR7 adapter."""
+    computer = (
+        _PROJECT_ROOT
+        / "src"
+        / "traceml_ai"
+        / "renderers"
+        / "step_time"
+        / "compute.py"
+    )
+    dependencies = set(_imports(computer))
+    source = computer.read_text(encoding="utf-8")
+
+    assert "sqlite3" not in dependencies
+    assert "time" not in dependencies
+    assert "traceml_ai.utils.step_time_sqlite" not in dependencies
+    assert "def compute_cli(" not in source
+    assert "def _stale_or_empty(" not in source

--- a/tests/step_time/test_pipeline.py
+++ b/tests/step_time/test_pipeline.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 
@@ -23,7 +23,7 @@ from traceml_ai.step_time.model import (
     StepTimeRepositorySnapshot,
     StepTimeWindow,
 )
-from traceml_ai.step_time.pipeline import StepTimePipeline
+from traceml_ai.step_time.pipeline import StepTimeAnalysis, StepTimePipeline
 from traceml_ai.step_time.sqlite import SQLiteStepTimeRepository
 
 
@@ -70,6 +70,7 @@ def test_run_calls_each_pipeline_stage_once(
     assert result.snapshot is snapshot
     assert result.window is window
     assert result.diagnosis is diagnosis
+    assert result.request is request
 
 
 def test_run_honors_an_explicit_diagnosis_policy() -> None:
@@ -99,3 +100,61 @@ def test_invalid_data_profile_is_rejected_at_construction() -> None:
 
     with pytest.raises(ValueError, match="profile"):
         StepTimePipeline(repository=repository, profile="dashboard")
+
+
+def test_live_run_reuses_the_exact_previous_analysis() -> None:
+    request = StepTimeLoadRequest(window_size=100, lookback_factor=4)
+    snapshot = StepTimeRepositorySnapshot()
+    window = StepTimeWindow()
+    repository = Mock(spec=SQLiteStepTimeRepository)
+    analyzer = Mock(spec=StepTimeAnalyzer)
+    repository.load_live.return_value = snapshot
+    analyzer.analyze.return_value = window
+    pipeline = StepTimePipeline(repository=repository, analyzer=analyzer)
+
+    with patch(
+        "traceml_ai.step_time.pipeline.diagnose_step_time_window"
+    ) as diagnose:
+        first = pipeline.run(request)
+        second = pipeline.run(request, previous=first)
+
+    assert second is first
+    assert repository.load_live.call_args_list == [
+        call(request),
+        call(request, previous=snapshot),
+    ]
+    assert analyzer.analyze.call_count == 1
+    assert diagnose.call_count == 1
+
+
+def test_live_run_does_not_reuse_an_analysis_for_another_request() -> None:
+    first_request = StepTimeLoadRequest(window_size=100, lookback_factor=4)
+    second_request = StepTimeLoadRequest(window_size=20, lookback_factor=2)
+    first_snapshot = StepTimeRepositorySnapshot()
+    second_snapshot = StepTimeRepositorySnapshot()
+    repository = Mock(spec=SQLiteStepTimeRepository)
+    analyzer = Mock(spec=StepTimeAnalyzer)
+    repository.load_live.side_effect = (first_snapshot, second_snapshot)
+    analyzer.analyze.return_value = StepTimeWindow()
+    pipeline = StepTimePipeline(repository=repository, analyzer=analyzer)
+
+    first = pipeline.run(first_request)
+    pipeline.run(second_request, previous=first)
+
+    assert repository.load_live.call_args_list == [
+        call(first_request),
+        call(second_request),
+    ]
+    assert analyzer.analyze.call_count == 2
+
+
+def test_summary_rejects_live_cache_input() -> None:
+    request = StepTimeLoadRequest(window_size=10)
+    previous = Mock(spec=StepTimeAnalysis)
+    repository = Mock(spec=SQLiteStepTimeRepository)
+
+    with pytest.raises(ValueError, match="only for live"):
+        StepTimePipeline(repository, profile="summary").run(
+            request,
+            previous=previous,
+        )

--- a/tests/step_time/test_query_baseline.py
+++ b/tests/step_time/test_query_baseline.py
@@ -28,9 +28,10 @@ from tests.step_time.scenarios import (
 from traceml_ai.renderers.model_diagnostics.renderer import (
     ModelDiagnosticsRenderer,
 )
-from traceml_ai.renderers.step_time.compute import StepCombinedComputer
-from traceml_ai.renderers.step_time.renderer import StepCombinedRenderer
+from traceml_ai.renderers.step_time.compute import StepTimeDashboardAdapter
 from traceml_ai.reporting.sections.step_time import StepTimeSummarySection
+from traceml_ai.step_time.model import StepTimeLoadRequest
+from traceml_ai.step_time.pipeline import LiveStepTimeSession
 
 
 @pytest.fixture(params=(1, 8, 32), ids=lambda ranks: f"{ranks}-ranks")
@@ -63,11 +64,32 @@ def test_live_query_count_is_constant_two(
 ) -> None:
     """One set-based source read plus one strategy read serves all ranks."""
     _, db_path = ranked_db
-    computer = StepCombinedComputer(str(db_path), window_size=4)
+    session = LiveStepTimeSession(
+        str(db_path),
+        request=StepTimeLoadRequest(window_size=4, lookback_factor=4),
+    )
 
-    recorder = _record_selects(computer.compute_cli)
+    recorder = _record_selects(session.refresh)
 
     assert recorder.count == 2
+
+
+def test_unchanged_live_query_count_remains_constant_two(
+    ranked_db: tuple[int, Path],
+) -> None:
+    """Cursor reuse avoids payload work without adding a polling query."""
+    _, db_path = ranked_db
+    session = LiveStepTimeSession(
+        str(db_path),
+        request=StepTimeLoadRequest(window_size=4, lookback_factor=4),
+    )
+    first = session.refresh()
+
+    recorder = _record_selects(session.refresh)
+    second = session.refresh()
+
+    assert recorder.count == 2
+    assert second.analysis is first.analysis
 
 
 def test_dashboard_query_count_is_constant_four(
@@ -75,7 +97,7 @@ def test_dashboard_query_count_is_constant_four(
 ) -> None:
     """The two current providers each perform one constant-cost load."""
     _, db_path = ranked_db
-    hero = StepCombinedRenderer(str(db_path))
+    hero = StepTimeDashboardAdapter(str(db_path))
     diagnostics = ModelDiagnosticsRenderer(str(db_path))
 
     recorder = _record_selects(

--- a/tests/step_time/test_sqlite_repository.py
+++ b/tests/step_time/test_sqlite_repository.py
@@ -120,6 +120,103 @@ def test_repository_decodes_each_selected_row_once(
     assert snapshot.cursor.last_row_id == 8
 
 
+def test_live_reuses_unchanged_snapshot_without_decoding_json(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "unchanged.db"
+    create_step_time_database(
+        db_path,
+        StepTimeScenario(
+            name="unchanged",
+            profiles={0: BALANCED_PROFILE, 1: BALANCED_PROFILE},
+            steps=(1, 2, 3, 4),
+        ),
+    )
+    request = StepTimeLoadRequest(window_size=3)
+
+    with sqlite3.connect(db_path) as conn:
+        repository = SQLiteStepTimeRepository(conn)
+        first = repository.load_live(request)
+        with patch(
+            "traceml_ai.step_time.sqlite.json.loads",
+            wraps=json.loads,
+        ) as loads:
+            second = repository.load_live(request, previous=first)
+
+    assert second is first
+    assert loads.call_count == 0
+
+
+def test_live_strategy_change_reuses_rows_but_invalidates_analysis(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "strategy-change.db"
+    create_step_time_database(
+        db_path,
+        StepTimeScenario(
+            name="strategy_change",
+            profiles={0: BALANCED_PROFILE},
+            steps=(1, 2),
+            training_strategy="ddp",
+        ),
+    )
+    request = StepTimeLoadRequest(window_size=2)
+
+    with sqlite3.connect(db_path) as conn:
+        repository = SQLiteStepTimeRepository(conn)
+        first = repository.load_live(request)
+        conn.execute(
+            "INSERT INTO runtime_environment(training_strategy) "
+            "VALUES ('fsdp');"
+        )
+        conn.commit()
+        with patch(
+            "traceml_ai.step_time.sqlite.json.loads",
+            wraps=json.loads,
+        ) as loads:
+            second = repository.load_live(request, previous=first)
+
+    assert second is not first
+    assert second.rows is first.rows
+    assert second.cursor == first.cursor
+    assert second.training_strategy == "fsdp"
+    assert loads.call_count == 0
+
+
+def test_live_rank_universe_change_invalidates_cached_snapshot(
+    tmp_path: Path,
+) -> None:
+    """A newly observed rank matters even before it has valid timings."""
+    db_path = tmp_path / "rank-universe-change.db"
+    create_step_time_database(
+        db_path,
+        StepTimeScenario(
+            name="rank_universe_change",
+            profiles={0: BALANCED_PROFILE},
+            steps=(1,),
+        ),
+    )
+    request = StepTimeLoadRequest(window_size=1)
+
+    with sqlite3.connect(db_path) as conn:
+        repository = SQLiteStepTimeRepository(conn)
+        first = repository.load_live(request)
+        conn.execute(
+            """
+            INSERT INTO step_time_samples(
+                recv_ts_ns, rank, global_rank, step, events_json
+            ) VALUES (2, 1, 1, NULL, '');
+            """
+        )
+        conn.commit()
+        second = repository.load_live(request, previous=first)
+
+    assert second is not first
+    assert first.global_ranks == (0,)
+    assert second.global_ranks == (0, 1)
+    assert second.cursor == first.cursor
+
+
 def test_live_and_summary_profiles_feed_the_same_analysis(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

This PR adds `LiveStepTimeSession` as the single owner of live Step Time orchestration, cursor reuse, last-good bridging, and expiry. The Rich CLI is now a pure presenter over one immutable `LiveStepTimeResult`; it does not open SQLite, analyze telemetry, diagnose, or keep freshness state.

The dashboard and final summary remain on explicit compatibility adapters for PR7 and PR8. Their behavior and public payloads are unchanged.

```mermaid
flowchart LR
    DB[(step_time_samples)]
    SESSION["LiveStepTimeSession<br/>cursor cache + monotonic freshness"]
    PIPE["StepTimePipeline<br/>load -> analyze -> diagnose"]
    RESULT["Immutable LiveStepTimeResult"]
    CLI["Pure Rich presenter"]

    DB --> SESSION --> PIPE --> RESULT --> CLI
```

## Comparison with `version_0.3.6`

| Concern | `version_0.3.6` | This branch |
|---|---|---|
| Live state owner | `StepCombinedComputer` inside the renderer package | `LiveStepTimeSession` around the central pipeline |
| Time source | Wall clock | Monotonic clock |
| CLI input | Database path and a stateful computer | Injected session result |
| CLI diagnosis | Rebuilt inside the Rich renderer | Precomputed once by `StepTimePipeline` |
| Unchanged refresh | Decode, analyze, and diagnose again | Return the exact previous analysis object |
| CLI test boundary | Requires SQLite or compute monkeypatches | Public `render(result)` needs no SQLite |
| Step Time aliases | Identical `compute_cli()` and `compute_dashboard()` | CLI alias removed; dashboard adapter remains for PR7 |
| One live refresh | 2 SELECTs | 2 SELECTs |
| Current dashboard refresh | 4 SELECTs | 4 SELECTs until PR7 |
| Final summary | 2 SELECTs | 2 SELECTs |

## Changes

### Add one live-session boundary

`LiveStepTimeSession` now owns:

- a normalized `StepTimeLoadRequest`;
- one previous observed analysis for cursor reuse;
- one last-good analysis and its monotonic timestamp;
- cold, live, bridged, and expired state transitions;
- short-lived SQLite connections safe to use across display threads;
- a lock preventing concurrent refreshes from duplicating work.

The session catches a failed live read at this boundary, logs it, and applies the same bridge/expiry policy used for an empty read. Domain facts and presentation remain outside the state machine.

| Freshness | Meaning | Presented analysis |
|---|---|---|
| `cold` | No usable window has been read. | Canonical empty analysis |
| `live` | The current read has usable metrics. | Current analysis |
| `bridged` | An empty/failed read is still inside the TTL. | Last good analysis |
| `expired` | The last-good TTL elapsed. | Canonical empty analysis |

An unchanged persisted window remains `live`. This state describes whether a read is usable; it does not infer that the training process is still alive.

### Reuse unchanged analysis without slowing changed reads

The repository retains PR5's index-bounded tail query. It derives a cursor from the selected row ids and steps before JSON decoding, then compares:

- source cursor;
- global-rank universe;
- training strategy;
- normalized load request at the pipeline boundary.

When all inputs are unchanged, the repository and pipeline return the exact previous snapshot and `StepTimeAnalysis` objects. JSON is not parsed and the analyzer and diagnoser are not called.

The first implementation experiment used a marker CTE. The benchmark showed that shape made cache misses 12–18% slower, so it was removed. Keeping the proven tail query and skipping work above it gives cheap unchanged refreshes
without regressing changed/cold refreshes or adding a polling query.

Rank-universe and strategy changes explicitly invalidate reuse even when the timing cursor is unchanged. This prevents a fast path from hiding a new sparse rank or a DDP/FSDP context change.

### Make the CLI a pure presenter

`StepCombinedRenderer` now has two small public operations:

```python
renderer = StepCombinedRenderer(session)
panel = renderer.get_panel_renderable()  # refresh once, then present

panel = renderer.render(result)          # presentation-only unit test
```

The renderer reads the canonical window and precomputed diagnosis. It has no SQLite, analyzer, diagnosis-policy, or dashboard-computer dependency. Cold-start, sparse, measured-zero, bridged, and expired output remains covered
by the PR1 cross-surface fixtures and focused renderer tests.

### Keep later migrations isolated

`StepCombinedComputer` is reduced to a dashboard-only projection over `LiveStepTimeSession`. It owns no SQL, clock, cache, expiry, or diagnosis logic. `StepTimeDashboardAdapter` lives beside it so the CLI renderer file contains only CLI presentation.

PR7 removes both compatibility types when the dashboard hero and diagnostics rail receive the same session result. Final-summary loading and projection are unchanged for PR8.

Removed from the old Step Time computer/CLI path:

- `_payload()`;
- `compute_cli()`;
- duplicate `_compute()` and `_compute_impl()` orchestration;
- renderer-owned SQLite connection handling;
- renderer-owned wall-clock and last-good state;
- renderer-side diagnosis;
- the `had_ok` property as a semantic state source.

## Behavior guarantees

- Complete, sparse, measured-zero, CPU/GPU, single-rank, DDP, and FSDP  contract scenarios remain unchanged.
- Missing values remain missing; measured `0.0` remains measured.
- Clock selection, cohorts, statistics, shares, diagnosis, labels, thresholds,  and final-summary schema are unchanged.
- One refresh opens and closes one short-lived SQLite connection.
- Caller-visible freshness uses a monotonic TTL.
- Concurrent calls on one session cannot reparse or rediagnose the same  unchanged snapshot.
- Query counts remain constant with rank count: 2 / 4 / 2.

## Performance

Recorded on 2026-08-02 with Python 3.13.5, SQLite 3.50.2, macOS arm64, 400 stored steps per logical rank, a 100-step window, 4x live lookback, three warmups, and 25 repetitions.

The cache-miss row deliberately invalidates reuse before every repetition, so the comparison cannot hide a regression behind the cache.

| Ranks | PR5 live median | PR6 cache miss | Change | PR6 unchanged hit | Current dashboard hit |
|---:|---:|---:|---:|---:|---:|
| 1 | 8.183 ms | 8.540 ms | +4.4% | 0.442 ms | 0.883 ms |
| 8 | 32.015 ms | 33.643 ms | +5.1% | 3.117 ms | 6.173 ms |
| 32 | 116.096 ms | 120.724 ms | +4.0% | 13.265 ms | 26.716 ms |

Cache-miss medians remain within 5.1% of PR5, below the 10% review threshold. At 32 logical ranks, unchanged refresh is 88.6% cheaper than the PR5 live path. Dashboard still performs two independent session reads until PR7; its unchanged row is faster because each session reuses its own analysis, not because this PR consolidates providers.

Final-summary medians were 6.655, 16.268, and 48.528 ms at 1, 8, and 32 ranks, all within 2.0% of PR5. These are synthetic SQLite rank streams, not a multi-GPU training-throughput measurement.

## Verification

- Focused Step Time/renderer/dashboard suite: 123 passed, 1 sandbox socket  test deselected.
- Exact core CI invocation: 232 passed.
- Integration CI scope: 243 passed, with only three sandbox socket tests  deselected.
- Runnable full-suite remainder: 873 passed, 2 skipped. Remaining failures are  unchanged base/environment issues: two missing fixture imports, one  unavailable Hugging Face telemetry harness, and four sandbox socket binds.
- The unmodified full command stops during collection on the pre-existing  `HAS_TRANSFORMERS` NameError in `tests/integrations/test_hf_trainer.py`.
- Query-count contracts pass at 1, 8, and 32 ranks: 2 / 4 / 2.
- Tests prove zero `json.loads`, analyzer, and diagnosis calls on an unchange  cursor and exact analysis identity reuse.
- Tests cover request, rank-universe, strategy, and source-cursor invalidation;  successful, empty, failed, bridged, expired, and concurrent refreshes.
- `git diff --check`, syntax parsing, and the 79-column check pass.
- Strict MkDocs reaches all tracked pages and stops only because the unrelated  untracked `docs/README.md` conflicts with tracked `docs/index.md`; that user  file remains untouched.

## Acceptance

- [x] One live session owns cursor reuse, last-good bridging, and expiry.
- [x] Expiry uses monotonic time.
- [x] The CLI presenter can be tested without SQLite.
- [x] The CLI presenter does not load, analyze, diagnose, or own freshness.
- [x] Unchanged data is not reparsed, reanalyzed, or rediagnosed.
- [x] The exact previous immutable analysis is reused when inputs are equal.
- [x] Cache misses do not regress by more than 10%.
- [x] CLI cold, live, sparse, bridged, and expired behavior matches baseline.
- [x] The identical CLI/dashboard compute aliases are removed from the CLI      path.
- [x] Query counts remain 2 / 4 / 2.
- [x] Dashboard and final summary remain scoped to later PRs.

## Suggested review order

1. `step_time/pipeline.py` — session state machine and pipeline reuse.
2. `step_time/sqlite.py` — pre-decode cursor comparison.
3. `renderers/step_time/renderer.py` — pure CLI presentation.
4. `renderers/step_time/compute.py` — isolated PR7 compatibility adapter.
5. CLI/NiceGUI wiring and structural boundary tests.
6. Live-session, repository, query-count, and renderer tests.
7. Contributor contract and benchmark record.

## Not in this PR

- no dashboard provider consolidation or UI redesign (PR7);
- no final-summary pipeline/projector migration (PR8);
- no legacy utility or rank-projection removal (PR9);
- no SQL selection-strategy, diagnosis-rule, threshold, schema, or label
  change;
- no generic telemetry framework or abstract session/repository interface.
