### PR TITLE
Add Hugging Face Accelerate example and guide

### DIFF
--- a/docs/user_guide/integrations.md
+++ b/docs/user_guide/integrations.md
@@ -8,6 +8,7 @@ job already runs.
 |---|---|---|
 | Plain PyTorch loop | `traceml.trace_step(...)` | [Quickstart](quickstart.md) |
 | Hugging Face Trainer | `TraceMLTrainerCallback` | [Hugging Face](integrations/huggingface.md) |
+| Hugging Face Accelerate | `traceml.trace_step(...)` | [Hugging Face Accelerate](integrations/accelerate.md) |
 | PyTorch Lightning | `traceml_ai.integrations.lightning.init()` + `TraceMLCallback` | [PyTorch Lightning](integrations/lightning.md) |
 | Ray Train | `TraceMLTorchTrainer` | [Ray Train](integrations/ray.md) |
 | DeepSpeed | `traceml.trace_step(...)` | [DeepSpeed](integrations/deepspeed.md) |

--- a/docs/user_guide/integrations/accelerate.md
+++ b/docs/user_guide/integrations/accelerate.md
@@ -1,0 +1,170 @@
+# Hugging Face Accelerate Integration
+
+Use TraceML with a custom Hugging Face `Accelerate` training loop — for
+users who write their own loop with `Accelerator.prepare(...)` and
+`accelerator.backward(...)` instead of using `Trainer`.
+
+The integration is not a callback or a new API. It is the same
+`traceml.trace_step(...)` primitive used in any plain PyTorch loop, wrapped
+around the unwrapped model that `accelerator.prepare()` produces.
+
+## 1. Install
+
+```bash
+pip install "traceml-ai[hf]"
+```
+
+`accelerate` ships as part of the existing `hf` extra alongside
+`transformers` — there is no separate `accelerate` extra, and TraceML does
+not add `accelerate` as a core dependency.
+
+## 2. Initialize TraceML And Wrap The Prepared Model
+
+Create the `Accelerator` first, then call `traceml.init()`, then hand the
+model, optimizer, and dataloader to `accelerator.prepare(...)` before
+wrapping the *result* with `trace_step`:
+
+```python
+import traceml_ai as traceml
+from accelerate import Accelerator
+
+accelerator = Accelerator()
+traceml.init(mode="auto")
+
+model, optimizer, dataloader = accelerator.prepare(model, optimizer, dataloader)
+traced_model = accelerator.unwrap_model(model)
+
+for batch_x, batch_y in dataloader:
+    with traceml.trace_step(traced_model):
+        optimizer.zero_grad(set_to_none=True)
+        logits = model(batch_x)
+        loss = criterion(logits, batch_y)
+        accelerator.backward(loss)
+        optimizer.step()
+```
+
+`accelerator.unwrap_model(model)` matters even for a single-process run: it
+is what makes this code correct unchanged under multi-GPU too. TraceML's
+step-memory tracker keys instrumentation off `id(model)` and reads device
+placement from `model.parameters()`. If `accelerator.prepare()` wraps the
+model (which it does under distributed launch), passing the wrapped object
+into `trace_step` would hook an object that isn't the one actually running
+forward/backward. `unwrap_model()` is a no-op on CPU/single-GPU and strips
+the wrapper under distributed — so this line is what keeps the same code
+correct in both cases, not just a distributed-only concern.
+
+Note also what's *not* here: no `model.to(device)`, no `batch.to(device)`.
+`accelerator.prepare()` handles both — that's the actual value Accelerate
+adds over writing raw `DistributedDataParallel` by hand.
+
+## 3. Launch The Run
+
+CPU or single GPU:
+
+```bash
+traceml run examples/integrations/accelerate_minimal.py --mode=summary
+```
+
+Single-node multi-GPU:
+
+```bash
+traceml run examples/integrations/accelerate_minimal.py --mode=summary --nproc-per-node=2
+```
+
+For multi-node DDP launch commands, see
+[Distributed Training](../distributed-training.md).
+
+**Use `traceml run`, not `accelerate launch`.** `traceml run` is itself a
+launcher — under the hood it invokes `torch.distributed.run` with the
+`--nproc-per-node` you give it, the same mechanism `accelerate launch` uses.
+Running both would mean two launchers fighting over the same rendezvous.
+Wrapping `accelerate launch` directly is not supported in this first version;
+see Limitations.
+
+## Limitations
+
+- **Gradient accumulation is not modeled in the minimal example.** One call
+  to `accelerator.backward()` maps to one `trace_step`. If you accumulate
+  over several micro-batches before `optimizer.step()`, decide whether you
+  want each micro-batch to be its own TraceML step or the whole accumulation
+  window to be one step, and place `trace_step` accordingly — this guide
+  does not prescribe one, since the right choice depends on what you're
+  trying to measure.
+- **DeepSpeed and FSDP configurations routed through Accelerate are out of
+  scope for this first version.** This guide covers the plain `Accelerator()`
+  path only. Tune DeepSpeed/FSDP independently of TraceML for now.
+
+## Troubleshooting
+
+### The verdict says RESIDUAL-HEAVY / CRITICAL on the minimal example
+
+This is expected on this specific example, not a sign of a problem. The
+synthetic `TinyMLP` finishes each step in roughly a millisecond, so ordinary
+Python loop overhead (the periodic `accelerator.print`, function-call
+overhead, condition checks) becomes proportionally large next to the actual
+compute. Don't use this example's verdict as a reference point for
+interpreting a real training run — it's an artifact of the workload being
+deliberately tiny.
+
+### Step Memory shows NO DATA
+
+Step memory is only populated when running on GPU. On a CPU-only run this
+section is expected to be empty.
+
+### Multi-GPU run only shows one rank
+
+Make sure you launched through TraceML with `--nproc-per-node`, not plain
+`python`:
+
+```bash
+traceml run examples/integrations/accelerate_minimal.py --mode=summary --nproc-per-node=2
+```
+
+### I want a baseline without TraceML
+
+```bash
+traceml run examples/integrations/accelerate_minimal.py --disable-traceml
+```
+
+This launches the script natively through `torchrun` without TraceML
+telemetry.
+
+## Full Examples
+
+A complete, runnable version of the loop above lives at
+[`examples/integrations/accelerate_minimal.py`](../../../examples/integrations/accelerate_minimal.py).
+It trains a small MLP on synthetic data using the exact
+`Accelerator()` → `traceml.init()` → `accelerator.prepare()` →
+`accelerator.unwrap_model()` → `trace_step` sequence shown above, and
+produces a `TraceML Run Summary` at the end of the run.
+
+```bash
+traceml run examples/integrations/accelerate_minimal.py --mode=summary
+```
+
+## Reference
+
+`traceml.init(mode="auto")` installs TraceML's process-wide instrumentation
+(`DataLoader` fetch timing, H2D `Tensor.to`, forward/backward/optimizer
+auto-timers). Accepts `mode="auto"|"manual"|"selective"`. `"auto"` (the
+default, and what this integration uses) auto-installs forward/backward/
+optimizer timing, so unlike `manual` mode you don't need to explicitly wrap
+each phase — `trace_step(...)` around the loop is enough. Idempotent; call
+once, before `accelerator.prepare(...)`.
+
+`traceml.trace_step(model)` brackets one training step. Pass the object your
+loop actually runs forward/backward on — with Accelerate, that means
+`accelerator.unwrap_model(model)` after `accelerator.prepare(...)`, not the
+pre-`prepare()` model.
+
+This guide introduces no new TraceML API. `accelerator.prepare(...)` and
+`accelerator.unwrap_model(...)` are standard Accelerate methods; see
+[Accelerate's own documentation](https://huggingface.co/docs/accelerate)
+for their full behavior.
+
+## Next Steps
+
+- [How to Read Output](../reading-output.md)
+- [Distributed Training](../distributed-training.md)
+- [Hugging Face Trainer](huggingface.md)
+- [Open an issue](https://github.com/traceopt-ai/traceml/issues)

--- a/docs/user_guide/integrations/accelerate.md
+++ b/docs/user_guide/integrations/accelerate.md
@@ -106,6 +106,13 @@ compute. Don't use this example's verdict as a reference point for
 interpreting a real training run — it's an artifact of the workload being
 deliberately tiny.
 
+In general, converting a loss tensor to a Python value (`float(loss)` or
+`loss.item()`) forces the host to wait for the device inside the traced
+region. Keep any running total on-device and convert it only when you
+actually print or log, outside `trace_step`, as this example does. On the
+GPU-selected clock this does not change reported residual time, since that
+comes from CUDA event timestamps rather than CPU wall time.
+
 ### Step Memory shows NO DATA
 
 Step memory is only populated when running on GPU. On a CPU-only run this
@@ -132,7 +139,7 @@ telemetry.
 ## Full Examples
 
 A complete, runnable version of the loop above lives at
-[`examples/integrations/accelerate_minimal.py`](../../../examples/integrations/accelerate_minimal.py).
+`examples/integrations/accelerate_minimal.py`.
 It trains a small MLP on synthetic data using the exact
 `Accelerator()` → `traceml.init()` → `accelerator.prepare()` →
 `accelerator.unwrap_model()` → `trace_step` sequence shown above, and

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@ These are the main user-facing examples.
 | `ray/torchtrainer_minimal.py` | Minimal Ray Train example with Ray Data input timing | CPU / CUDA | Uses `TraceMLTorchTrainer` |
 | `ray/lightning_text_classifier.py` | Ray Train + Lightning text classifier | CPU / CUDA | Uses Ray Data, `TraceMLCallback`, and optional input/H2D demo knobs |
 | `integrations/huggingface_trainer_minimal.py` | Minimal Hugging Face `TraceMLTrainerCallback` example | CPU / CUDA | No model download required |
+| `integrations/accelerate_minimal.py` | Minimal Hugging Face `Accelerate` loop wrapped with `traceml.trace_step(...)` | CPU / CUDA | No model download required |
 | `integrations/lightning_minimal.py` | Minimal Lightning integration init + `TraceMLCallback` example | CPU / CUDA | No dataset download required |
 | `integrations/deepspeed_minimal.py` | Minimal DeepSpeed loop wrapped with `traceml.trace_step(...)` | CUDA | Requires `deepspeed`; exits cleanly without it |
 
@@ -207,6 +208,7 @@ Use:
 - `manual_custom_minimal.py` if you use a custom input pipeline or want full explicit control
 - `distributed/ddp_minimal.py` if you want single-node distributed training
 - `integrations/huggingface_trainer_minimal.py` if you use Hugging Face `Trainer`
+- `integrations/accelerate_minimal.py` if you use Hugging Face `Accelerate`
 - `integrations/lightning_minimal.py` if you use PyTorch Lightning
 - `ray/torchtrainer_minimal.py` if you use Ray Train
 - `integrations/deepspeed_minimal.py` if you use DeepSpeed

--- a/examples/integrations/accelerate_minimal.py
+++ b/examples/integrations/accelerate_minimal.py
@@ -40,12 +40,23 @@ def main():
     optimizer = optim.AdamW(model.parameters(), lr=1e-3)
     criterion = nn.CrossEntropyLoss()
 
+    # Build the Accelerator before calling traceml.init() so TraceML's
+    # instrumentation installs after the distributed/device context already
+    # exists.
     accelerator = Accelerator()
     traceml.init(mode="auto")
 
+    # accelerator.prepare() moves the model/data to the right device and,
+    # under a distributed launch, wraps the model (e.g. in DDP).
     model, optimizer, dataloader = accelerator.prepare(
         model, optimizer, dataloader
     )
+
+    # Pass the unwrapped model to trace_step, exactly like model.module for
+    # DDP and base_model for FSDP: TraceML keys instrumentation off id(model)
+    # and reads device placement from model.parameters(), so it needs the
+    # real underlying module, not a distributed wrapper. A no-op here
+    # (single process); strips the wrapper under --nproc-per-node.
     traced_model = accelerator.unwrap_model(model)
 
     model.train()

--- a/examples/integrations/accelerate_minimal.py
+++ b/examples/integrations/accelerate_minimal.py
@@ -63,7 +63,7 @@ def main():
     global_step = 0
 
     for epoch in range(EPOCHS):
-        running_loss = 0.0
+        running_loss = torch.zeros((), device=accelerator.device)
 
         for batch_x, batch_y in dataloader:
             global_step += 1
@@ -75,14 +75,18 @@ def main():
                 accelerator.backward(loss)
                 optimizer.step()
 
-                running_loss += float(loss.detach())
+                # Stay on-device inside trace_step: accumulating a raw
+                # tensor avoids a per-step host sync. Only convert to a
+                # Python float in the print block below, which runs
+                # outside trace_step and on a fixed cadence.
+                running_loss += loss.detach()
 
             if global_step % 25 == 0:
                 accelerator.print(
                     f"Epoch {epoch + 1} | Step {global_step} | "
-                    f"loss: {running_loss / 25:.4f}"
+                    f"loss: {float(running_loss) / 25:.4f}"
                 )
-                running_loss = 0.0
+                running_loss.zero_()
 
     accelerator.print("Done.")
 

--- a/examples/integrations/accelerate_minimal.py
+++ b/examples/integrations/accelerate_minimal.py
@@ -1,0 +1,80 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader, TensorDataset
+from accelerate import Accelerator
+
+import traceml_ai as traceml
+
+SEED = 42
+INPUT_DIM = 128
+HIDDEN_DIM = 256
+NUM_CLASSES = 10
+NUM_SAMPLES = 8192
+BATCH_SIZE = 64
+EPOCHS = 4
+
+
+class TinyMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(INPUT_DIM, HIDDEN_DIM),
+            nn.ReLU(),
+            nn.Linear(HIDDEN_DIM, NUM_CLASSES),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+def main():
+    torch.manual_seed(SEED)
+
+    x = torch.randn(NUM_SAMPLES, INPUT_DIM)
+    y = torch.randint(0, NUM_CLASSES, (NUM_SAMPLES,))
+    dataset = TensorDataset(x, y)
+    dataloader = DataLoader(dataset, batch_size=BATCH_SIZE, shuffle=True)
+
+    model = TinyMLP()
+    optimizer = optim.AdamW(model.parameters(), lr=1e-3)
+    criterion = nn.CrossEntropyLoss()
+
+    accelerator = Accelerator()
+    traceml.init(mode="auto")
+
+    model, optimizer, dataloader = accelerator.prepare(
+        model, optimizer, dataloader
+    )
+    traced_model = accelerator.unwrap_model(model)
+
+    model.train()
+    global_step = 0
+
+    for epoch in range(EPOCHS):
+        running_loss = 0.0
+
+        for batch_x, batch_y in dataloader:
+            global_step += 1
+
+            with traceml.trace_step(traced_model):
+                optimizer.zero_grad(set_to_none=True)
+                logits = model(batch_x)
+                loss = criterion(logits, batch_y)
+                accelerator.backward(loss)
+                optimizer.step()
+
+                running_loss += float(loss.detach())
+
+            if global_step % 25 == 0:
+                accelerator.print(
+                    f"Epoch {epoch + 1} | Step {global_step} | "
+                    f"loss: {running_loss / 25:.4f}"
+                )
+                running_loss = 0.0
+
+    accelerator.print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - Integrations:
           - Overview: user_guide/integrations.md
           - Hugging Face: user_guide/integrations/huggingface.md
+          - Hugging Face Accelerate: user_guide/integrations/accelerate.md
           - PyTorch Lightning: user_guide/integrations/lightning.md
           - Ray Train: user_guide/integrations/ray.md
           - DeepSpeed: user_guide/integrations/deepspeed.md

--- a/tests/integrations/test_accelerate.py
+++ b/tests/integrations/test_accelerate.py
@@ -262,3 +262,66 @@ def test_accelerate_unwrap_model_is_noop_single_process():
         "launch; if this ever changes, the docs' claim that unwrap_model() "
         "is a no-op on CPU/single-GPU needs to be revisited too."
     )
+
+
+@pytest.mark.skipif(not HAS_ACCELERATE, reason="accelerate not installed")
+def test_accelerate_recipe_over_real_prepare_and_backward():
+    """Runs the documented recipe through the real Accelerate library.
+
+    The fake accelerator above pins the TraceML-facing contract cheaply;
+    this test instead exercises the real `Accelerator.prepare()` (dataloader
+    included) and the real `accelerator.backward()`, so a future Accelerate
+    release that changes either path would surface here.
+    """
+    from accelerate import Accelerator
+    from torch.utils.data import DataLoader, TensorDataset
+
+    _reset_traceml_state()
+    _install_auto_instrumentation()
+
+    num_steps = 3
+    dataset = TensorDataset(
+        torch.randn(num_steps * BATCH_SIZE, INPUT_DIM),
+        torch.randint(0, NUM_CLASSES, (num_steps * BATCH_SIZE,)),
+    )
+    loader = DataLoader(dataset, batch_size=BATCH_SIZE)
+
+    model = _TinyMLP()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    criterion = nn.CrossEntropyLoss()
+    accelerator = Accelerator()
+
+    model, optimizer, loader = accelerator.prepare(model, optimizer, loader)
+    traced_model = accelerator.unwrap_model(model)
+
+    for batch_x, batch_y in loader:
+        with traceml.trace_step(traced_model):
+            optimizer.zero_grad(set_to_none=True)
+            logits = model(batch_x)
+            loss = criterion(logits, batch_y)
+            accelerator.backward(loss)
+            optimizer.step()
+
+    batches = _drain_step_time_queue()
+    assert len(batches) == num_steps, (
+        f"Expected one StepTimeBatch per step ({num_steps}), "
+        f"got {len(batches)}."
+    )
+
+    def _every_batch_has(event_name: str) -> bool:
+        return all(
+            any(evt.name == event_name for evt in batch.events)
+            for batch in batches
+        )
+
+    for event_name in (
+        "_traceml_internal:forward_time",
+        "_traceml_internal:backward_time",
+        "_traceml_internal:optimizer_step",
+        "_traceml_internal:step_time",
+        "_traceml_internal:dataloader_next",
+    ):
+        assert _every_batch_has(event_name), (
+            f"{event_name} should be captured for every step when running "
+            "the recipe through the real Accelerate prepare/backward path."
+        )

--- a/tests/integrations/test_accelerate.py
+++ b/tests/integrations/test_accelerate.py
@@ -1,0 +1,264 @@
+import pytest
+import torch
+import torch.nn as nn
+
+import traceml_ai as traceml
+from traceml_ai.runtime.arming import _set_tracing_armed, is_tracing_armed
+
+try:
+    import accelerate  # noqa: F401
+
+    HAS_ACCELERATE = True
+except ImportError:
+    HAS_ACCELERATE = False
+
+INPUT_DIM = 16
+HIDDEN_DIM = 32
+NUM_CLASSES = 4
+BATCH_SIZE = 8
+
+
+class _TinyMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(INPUT_DIM, HIDDEN_DIM),
+            nn.ReLU(),
+            nn.Linear(HIDDEN_DIM, NUM_CLASSES),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+class _FakeAccelerator:
+    """A minimal stand-in for ``accelerate.Accelerator``.
+
+    It reproduces the exact surface the TraceML recipe touches:
+
+    - ``.prepare(model, optimizer, dataloader)`` returns them unchanged,
+      matching real Accelerate's non-distributed behavior,
+    - ``.unwrap_model(model)`` returns the model unchanged, matching real
+      Accelerate when there is no distributed wrapper to strip,
+    - ``.backward(loss)`` calls ``loss.backward()`` (real Accelerate reaches
+      the same ``torch.Tensor.backward`` when not using mixed-precision
+      scaling), so TraceML's backward auto-timer fires.
+    """
+
+    def prepare(self, *args):
+        return args
+
+    def unwrap_model(self, model):
+        return model
+
+    def backward(self, loss):
+        loss.backward()
+
+
+def _drain_step_time_queue() -> list:
+    """Drain all StepTimeBatch entries from the shared queue."""
+    from traceml_ai.utils.timing import get_step_time_queue
+
+    queue = get_step_time_queue()
+    batches = []
+    while not queue.empty():
+        batches.append(queue.get_nowait())
+    return batches
+
+
+def _reset_traceml_state() -> None:
+    """Reset TraceML's step counter, recording state, and step-time queue."""
+    from traceml_ai.runtime.state import (
+        configure_trace_recording,
+        reset_trace_session_state,
+    )
+    from traceml_ai.utils.timing import _STEP_BUFFER
+
+    reset_trace_session_state()
+    configure_trace_recording(max_steps=None)
+    _drain_step_time_queue()
+    _STEP_BUFFER.clear()
+
+
+def _install_auto_instrumentation() -> None:
+    from traceml_ai.instrumentation.hooks.optimizer_hooks import (
+        ensure_optimizer_timing_installed,
+    )
+    from traceml_ai.instrumentation.patches.backward_auto_timer_patch import (
+        patch_backward,
+    )
+    from traceml_ai.instrumentation.patches.dataloader_patch import (
+        patch_dataloader,
+    )
+    from traceml_ai.instrumentation.patches.forward_auto_timer_patch import (
+        patch_forward,
+    )
+    from traceml_ai.instrumentation.patches.h2d_auto_timer_patch import (
+        patch_h2d,
+    )
+
+    patch_forward()
+    patch_backward()
+    patch_h2d()
+    patch_dataloader()
+    ensure_optimizer_timing_installed()
+
+
+@pytest.fixture(autouse=True)
+def _armed_tracing():
+    previous = is_tracing_armed()
+    _set_tracing_armed(True)
+    yield
+    _set_tracing_armed(previous)
+
+
+def test_accelerate_recipe_brackets_step():
+    from traceml_ai.runtime.state import get_trace_session_state
+
+    _reset_traceml_state()
+    _install_auto_instrumentation()
+
+    model = _TinyMLP()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    criterion = nn.CrossEntropyLoss()
+    accelerator = _FakeAccelerator()
+    num_steps = 3
+
+    model, optimizer = accelerator.prepare(model, optimizer)
+    traced_model = accelerator.unwrap_model(model)
+
+    step_before = get_trace_session_state().step
+
+    for _ in range(num_steps):
+        # This is exactly the recipe shown in the docs and example.
+        with traceml.trace_step(traced_model):
+            x = torch.randn(BATCH_SIZE, INPUT_DIM)
+            y = torch.randint(0, NUM_CLASSES, (BATCH_SIZE,))
+
+            optimizer.zero_grad(set_to_none=True)
+            logits = model(x)
+            loss = criterion(logits, y)
+
+            accelerator.backward(loss)
+            optimizer.step()
+
+    step_after = get_trace_session_state().step
+    assert step_after - step_before == num_steps, (
+        "trace_step must advance the TraceML step counter once per "
+        f"Accelerate step; advanced by {step_after - step_before}."
+    )
+
+    batches = _drain_step_time_queue()
+    assert len(batches) == num_steps, (
+        f"Expected one StepTimeBatch per step ({num_steps}), "
+        f"got {len(batches)}."
+    )
+
+    def _every_batch_has(event_name: str) -> bool:
+        return all(
+            any(evt.name == event_name for evt in batch.events)
+            for batch in batches
+        )
+
+    assert _every_batch_has(
+        "_traceml_internal:forward_time"
+    ), "forward timing should be captured on the unwrapped model."
+    assert _every_batch_has("_traceml_internal:backward_time"), (
+        "backward timing should be captured because accelerator.backward(loss) "
+        "reaches torch.Tensor.backward()."
+    )
+    assert _every_batch_has("_traceml_internal:optimizer_step"), (
+        "optimizer timing should be captured because optimizer.step() is a "
+        "real torch optimizer step."
+    )
+    assert _every_batch_has(
+        "_traceml_internal:step_time"
+    ), "step timing should be captured once per trace_step block."
+
+
+def test_accelerate_recipe_emits_dataloader_next_over_real_loader():
+    """The recipe must emit dataloader_next when iterating a real DataLoader.
+
+    dataloader_next is the fragile stream the docs promise (it records
+    DataLoader fetch time). It rides a class-level patch of
+    ``DataLoader.__iter__``, so it only lands when a real ``torch``
+    DataLoader is iterated. The recipe iterates the loader OUTSIDE
+    ``trace_step``; the fetch is buffered by the process-wide recording
+    gate and flushed into that step's StepTimeBatch, so every batch must
+    carry the event. Asserted as rows landed, not as "a patch ran".
+    """
+    from torch.utils.data import DataLoader, TensorDataset
+
+    _reset_traceml_state()
+    _install_auto_instrumentation()
+
+    num_steps = 3
+    dataset = TensorDataset(
+        torch.randn(num_steps * BATCH_SIZE, INPUT_DIM),
+        torch.randint(0, NUM_CLASSES, (num_steps * BATCH_SIZE,)),
+    )
+    loader = DataLoader(dataset, batch_size=BATCH_SIZE)
+
+    model = _TinyMLP()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    criterion = nn.CrossEntropyLoss()
+    accelerator = _FakeAccelerator()
+
+    model, optimizer, loader = accelerator.prepare(model, optimizer, loader)
+    traced_model = accelerator.unwrap_model(model)
+
+    for batch_x, batch_y in loader:
+        # Fetch happens OUTSIDE trace_step, exactly like the documented recipe.
+        with traceml.trace_step(traced_model):
+            optimizer.zero_grad(set_to_none=True)
+            logits = model(batch_x)
+            loss = criterion(logits, batch_y)
+            accelerator.backward(loss)
+            optimizer.step()
+
+    batches = _drain_step_time_queue()
+    assert len(batches) == num_steps, (
+        f"Expected one StepTimeBatch per step ({num_steps}), "
+        f"got {len(batches)}."
+    )
+
+    dark = [
+        i
+        for i, batch in enumerate(batches)
+        if not any(
+            evt.name == "_traceml_internal:dataloader_next"
+            for evt in batch.events
+        )
+    ]
+    assert not dark, (
+        "dataloader_next stream is dark for the Accelerate recipe over a "
+        f"real DataLoader: StepTimeBatch(es) {dark} of {num_steps} carry no "
+        "event."
+    )
+
+
+@pytest.mark.skipif(not HAS_ACCELERATE, reason="accelerate not installed")
+def test_accelerate_unwrap_model_is_noop_single_process():
+    """Verifies the actual design decision the docs are built around.
+
+    On a plain, non-distributed process there is nothing for Accelerate to
+    wrap, so accelerator.unwrap_model(model) should return the exact same
+    object accelerator.prepare() produced. The fake stand-in above assumes
+    this; this test checks it against the real library instead of just
+    assuming it.
+    """
+    from accelerate import Accelerator
+
+    accelerator = Accelerator()
+    model = _TinyMLP()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+
+    prepared_model, _ = accelerator.prepare(model, optimizer)
+    unwrapped = accelerator.unwrap_model(prepared_model)
+
+    assert unwrapped is prepared_model, (
+        "accelerator.unwrap_model() should return the same object "
+        "accelerator.prepare() produced when running outside a distributed "
+        "launch; if this ever changes, the docs' claim that unwrap_model() "
+        "is a no-op on CPU/single-GPU needs to be revisited too."
+    )


### PR DESCRIPTION
## What changed

- Adds `examples/integrations/accelerate_minimal.py`: a minimal Hugging Face
  `Accelerate` training loop instrumented with `traceml.trace_step(...)`.
- Adds `docs/user_guide/integrations/accelerate.md`: guide covering install,
  init/wrap ordering, launch, limitations, and troubleshooting — mirrors the
  structure of `integrations/huggingface.md`.
- Links the guide from `docs/user_guide/integrations.md` and the example
  from `examples/README.md`.
- Adds `tests/integrations/test_accelerate.py`: an import-skipped smoke test
  mirroring `test_deepspeed.py`'s pattern (fake `Accelerator` stand-in for
  unconditional coverage, one `skipif`-gated test against the real library).

No changes to `src/`. No new public API, no new core or optional
dependency — `accelerate` is already available via the existing `hf` extra.

## Why

Closes #190. TraceML has a documented path for Hugging Face `Trainer`
(`TraceMLTrainerCallback`), but no documented path for users who write their
own loop with `Accelerator.prepare(...)` / `accelerator.backward(...)`. This
adds that missing guide and example, as scoped in the issue — no new
callback API.

## How I tested

- [x] Tests added or updated
- [x] Existing tests run
- [x] Manual smoke test

```bash
traceml run examples/integrations/accelerate_minimal.py --mode=summary
pytest tests/integrations/test_accelerate.py -v
pre-commit run --files examples/integrations/accelerate_minimal.py \
  docs/user_guide/integrations/accelerate.md \
  docs/user_guide/integrations.md \
  examples/README.md \
  tests/integrations/test_accelerate.py
```

All pass. Also confirmed the smoke test degrades correctly without
`accelerate` installed: the two unconditional tests still exercise real
TraceML instrumentation via a fake `Accelerator` stand-in; only the test
against the real library skips.

Tested on WSL2/Ubuntu. For context: native Windows currently hits two
pre-existing, unrelated platform issues when running `traceml run`
end-to-end (`SO_REUSEPORT` — already fixed in #264 — and a separate
`torch.distributed.run`/libuv rendezvous issue that's still open). Neither
is related to this change; the example script itself was independently
verified correct via plain `python` execution, unaffected by either issue.

## Runtime impact

- [x] No training-path impact

Notes: Purely additive — example, docs, and test only. No changes to
tracing, runtime, telemetry, or distributed code paths.

## Docs

- [x] Updated

## Extra context

**Design decision worth flagging for review:** the guide documents
`accelerator.unwrap_model(model)` before passing to `trace_step()`, rather
than the raw object `accelerator.prepare()` returns. TraceML's step-memory
tracker keys off `id(model)` and reads device placement from
`model.parameters()`; under a distributed launch `prepare()` can wrap the
model (e.g. DDP), so the wrapped object isn't what actually runs
forward/backward. This follows the same `model.module`-unwrapping pattern
already used in `ddp_minimal.py` and `deepspeed_minimal.py`'s
`model_engine.module`.

Final summary output from a real run (WSL2, CPU):

```
+----------------------------------------------------------------------------+
|  TraceML Run Summary | duration 2.3s                                       |
+----------------------------------------------------------------------------+
|  TraceML Verdict: RESIDUAL-HEAVY / CRITICAL                                |
|  Why: Residual time is 25.2% of the typical cpu iteration time.            |
...
```

(Noted in the guide's Troubleshooting section as expected for this
minimal example — a millisecond-scale synthetic workload makes ordinary
loop overhead proportionally large, not a real regression signal.)

Unrelated observation, not addressed here: `tests/integrations/` doesn't
currently run in any CI job (verified via `grep -rn "tests/integrations"
.github/workflows/*.yml` — no matches). Pre-existing, affects
`test_hf_trainer.py`, `test_lightning.py`, `test_ray.py`, and
`test_deepspeed.py` identically, not specific to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hugging Face Accelerate integration support for CPU, single-GPU, and multi-GPU training.
  * Added guidance for initializing TraceML, instrumenting training steps, and launching traced runs.
  * Added a runnable minimal Accelerate training example with per-step tracing.
* **Documentation**
  * Added the Accelerate integration guide, including setup, usage, limitations, troubleshooting, and examples.
  * Added Accelerate to the integrations and examples documentation.
* **Tests**
  * Added coverage for tracing, timing, data loading, and model handling with Accelerate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->