### PR TITLE
ci: run tests/integrations with the hf extra so the #276 regression tests are guarded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[torch,dashboard]"
+          # hf pulls transformers+accelerate so tests/integrations
+          # actually RUNS the HuggingFace suite (incl. the #276 H2D
+          # coverage-window regression tests) instead of skipping it.
+          pip install -e ".[torch,dashboard,hf]"
           pip install pytest
       - name: Run integration tests
         run: |

--- a/src/dev/repro/hf_accelerate_h2d_window.py
+++ b/src/dev/repro/hf_accelerate_h2d_window.py
@@ -172,7 +172,24 @@ def main() -> int:
     print(f"positive control (transfer inside window):  {control} ms")
     print(f"TraceML reported H2D (GA=2, pre-step move):  {reported} ms")
     print("-" * 60)
-    if control and control > 0.0 and (reported in (0.0, None)):
+    if control is None:
+        # A None control means the run could not MEASURE, not that the bug
+        # is absent: init() degrades to a disabled no-op when no aggregator
+        # is reachable, so neither the control nor the trainer run recorded
+        # anything. Saying "did not reproduce" here would be a false
+        # all-clear from a rig that never armed.
+        print(
+            "INCONCLUSIVE: the in-window positive control captured nothing, "
+            "which means TraceML tracing never armed in this process "
+            "(init() is a no-op without a reachable aggregator). Run this "
+            "script through the launcher instead:\n"
+            "    traceml run src/dev/repro/hf_accelerate_h2d_window.py "
+            "--mode=summary\n"
+            "and read h2d in the final summary: n/a for the GA run means "
+            "the transfer stayed outside the window."
+        )
+        return 1
+    if control > 0.0 and (reported in (0.0, None)):
         print(
             "REPRODUCED: the timer captures an in-window transfer but not "
             "the Accelerate pre-step transfer, so H2D reads as "


### PR DESCRIPTION
Closes the testing follow-up from #276. Two small changes; most of the original scope of this PR landed independently in #302, which this now builds on.

## What #302 already solved

#302 wired `tests/integrations` into the integration job and added the `conftest.py` init-isolation fixture. That fixture also fixes the four aggregator-dependent tests this PR originally had to quarantine: on the current tip the whole directory passes with no deselects. The earlier revision of this PR is superseded by that, and this revision drops all of it.

## What was still missing

1. The integration job installs `.[torch,dashboard]`, and every HuggingFace test guards with `importorskip("transformers")` / `importorskip("accelerate")`. So `tests/integrations` is collected but the HF suite, including the #276 H2D coverage-window regression tests from #286, still silently skips in CI. First commit adds the `hf` extra so those tests actually execute.
2. The standalone repro (`src/dev/repro/hf_accelerate_h2d_window.py`) printed "did not reproduce" when tracing had never armed, because `init()` degrades to a no-op without a reachable aggregator and both readings come back `None`. That reads as an all-clear from a rig that could not measure. It now reports INCONCLUSIVE with the working invocation (`traceml run ...`). Found by running it during this verification pass.

## Verification (current tip, plus real CUDA)

- Exact integration-job selection with the `hf` extra, locally: 490 passed, 2 skipped, zero deselects.
- Same integrations suite on a CUDA box (g4dn.xlarge T4, transformers 5.14 / accelerate 1.14 fresh resolve): green.
- End-to-end #276 check on that box, real Trainer + Accelerate at GA=2 through `traceml run`: `final_summary.json` reports `h2d_ms: null` (schema 1.7, full 60-step window), summary card prints `H2D  n/a`, while an independent CUDA-event copy on the same box measured 43.549 ms. The transfer is never misreported as `0.0`.
- Window-ordering probe with a real Trainer at GA=1/GA=2: zero batch fetches covered by the step window, window arms correctly, matching the #286 tests.

GATE: integration selection ran with the hf extra, 490 passed / 0 failed locally; integrations suite green on CUDA
TRANSITIONS: n/a, a one-line extras change and a repro-script message fix, no stateful surface
RANKS: n/a, no per-rank logic touched
TRIPWIRE: yes, without the hf extra the HF suite visibly skips; the repro fix path exercised live (no-aggregator run now exits INCONCLUSIVE, rc=1)
PLATFORM: n/a, no platform-conditional code in this diff
ENV: remaining unverifiable-in-CI: the GPU repro needs a CUDA box; lightning/ray extras stay uninstalled by design
