### PR TITLE
Complete the canonical Step Time migration

### DIFF
--- a/src/traceml_ai/step_time/analysis.py
+++ b/src/traceml_ai/step_time/analysis.py
@@ -28,7 +28,11 @@ from traceml_ai.step_time.model import (
 
 INPUT_WAIT_KEY = "input_wait"
 DATALOADER_FETCH_KEY = "dataloader_fetch"
-_STEP_TIME_CPU_KEY = "step_time_cpu"
+TRACED_STEP_TIME_KEY = "traced_step_time"
+_AGGREGATE_METRICS: tuple[str, ...] = (
+    INPUT_WAIT_KEY,
+    TRACED_STEP_TIME_KEY,
+)
 
 SELECTED_METRICS: tuple[str, ...] = (
     INPUT_WAIT_KEY,
@@ -36,7 +40,7 @@ SELECTED_METRICS: tuple[str, ...] = (
     "forward",
     "backward",
     "optimizer_step",
-    "step_time",
+    TRACED_STEP_TIME_KEY,
 )
 
 DISPLAY_METRICS: tuple[str, ...] = (
@@ -46,18 +50,21 @@ DISPLAY_METRICS: tuple[str, ...] = (
     "backward",
     "optimizer_step",
     "step_time",
+    TRACED_STEP_TIME_KEY,
     "residual_proxy",
 )
 
 STATISTIC_METRICS: tuple[str, ...] = (
     *DISPLAY_METRICS,
     "compute",
-    "total_step",
+    "step_time_cpu",
+    "step_time_gpu",
+    "traced_step_time_cpu",
+    "traced_step_time_gpu",
     DATALOADER_FETCH_KEY,
-    "total_step_cpu",
 )
 
-_REQUIRED_GPU_METRICS: tuple[str, ...] = (INPUT_WAIT_KEY, "step_time")
+_REQUIRED_GPU_METRICS: tuple[str, ...] = _AGGREGATE_METRICS
 OCCURRENCE_METRICS: frozenset[str] = frozenset(("optimizer_step", "h2d"))
 _COMPOSITION_KEYS: tuple[str, ...] = (
     INPUT_WAIT_KEY,
@@ -71,10 +78,18 @@ _RowIndex = Mapping[tuple[int, int], StepTimeSourceRow]
 
 
 class _Cohorts(NamedTuple):
-    iteration: tuple[int, ...]
+    step: tuple[int, ...]
     compute: tuple[int, ...]
     composition: tuple[int, ...]
     straggler: tuple[int, ...]
+
+
+class _RankAvailability(NamedTuple):
+    """Window-complete selected and aggregate signal availability."""
+
+    selected: frozenset[str]
+    cpu_aggregate: frozenset[str]
+    gpu_aggregate: frozenset[str]
 
 
 class StepTimeAnalyzer:
@@ -119,11 +134,28 @@ class StepTimeAnalyzer:
         observed_ranks = tuple(sorted(steps_by_rank))
         clock = _select_clock(row_index, observed_ranks, steps)
         availability = {
-            rank: _rank_availability(
-                row_index,
-                rank,
-                steps,
-                clock=clock,
+            rank: _RankAvailability(
+                selected=_rank_availability(
+                    row_index,
+                    rank,
+                    steps,
+                    clock=clock,
+                    metrics=SELECTED_METRICS,
+                ),
+                cpu_aggregate=_rank_availability(
+                    row_index,
+                    rank,
+                    steps,
+                    clock="cpu",
+                    metrics=_AGGREGATE_METRICS,
+                ),
+                gpu_aggregate=_rank_availability(
+                    row_index,
+                    rank,
+                    steps,
+                    clock="gpu",
+                    metrics=_AGGREGATE_METRICS,
+                ),
             )
             for rank in observed_ranks
         }
@@ -160,7 +192,7 @@ class StepTimeAnalyzer:
             coverage=coverage,
             rank_facts=rank_facts,
             metrics=metrics,
-            iteration_ranks=cohorts.iteration,
+            step_ranks=cohorts.step,
             compute_ranks=cohorts.compute,
             straggler_ranks=cohorts.straggler,
             composition_representative_rank=(
@@ -252,6 +284,7 @@ def _rank_availability(
     steps: Sequence[int],
     *,
     clock: DiagnosisClock,
+    metrics: Sequence[str],
 ) -> frozenset[str]:
     """Return signals trusted across one rank's aligned window.
 
@@ -262,23 +295,16 @@ def _rank_availability(
     counts: dict[str, int] = {}
     for step in steps:
         row = row_index[(int(rank), int(step))]
-        for metric in SELECTED_METRICS:
+        for metric in metrics:
             if _clock_value(row, metric, clock=clock) is not None:
                 counts[metric] = counts.get(metric, 0) + 1
-        input_values = row.metrics.get(INPUT_WAIT_KEY)
-        if input_values is not None and input_values.cpu_ms is not None:
-            counts[DATALOADER_FETCH_KEY] = (
-                counts.get(DATALOADER_FETCH_KEY, 0) + 1
-            )
-        step_values = row.metrics.get("step_time")
-        if step_values is not None and step_values.cpu_ms is not None:
-            counts[_STEP_TIME_CPU_KEY] = counts.get(_STEP_TIME_CPU_KEY, 0) + 1
 
     step_count = len(steps)
     return frozenset(
         metric
         for metric, count in counts.items()
-        if count == step_count or metric in OCCURRENCE_METRICS
+        if count == step_count
+        or (metric in OCCURRENCE_METRICS and metric in metrics)
     )
 
 
@@ -287,7 +313,7 @@ def _build_rank_facts(
     rank: int,
     steps: Sequence[int],
     *,
-    availability: frozenset[str],
+    availability: _RankAvailability,
     clock: DiagnosisClock,
 ) -> StepTimeRankFacts:
     step_facts = tuple(
@@ -311,19 +337,19 @@ def _build_rank_facts(
 def _build_step_values(
     row: StepTimeSourceRow,
     *,
-    availability: frozenset[str],
+    availability: _RankAvailability,
     clock: DiagnosisClock,
 ) -> StepTimeValues:
     selected = {
         metric: (
             _clock_value(row, metric, clock=clock)
-            if metric in availability
+            if metric in availability.selected
             else None
         )
         for metric in SELECTED_METRICS
     }
     for metric in OCCURRENCE_METRICS:
-        if metric in availability and selected[metric] is None:
+        if metric in availability.selected and selected[metric] is None:
             selected[metric] = 0.0
 
     input_wait = selected[INPUT_WAIT_KEY]
@@ -331,37 +357,36 @@ def _build_step_values(
     forward = selected["forward"]
     backward = selected["backward"]
     optimizer = selected["optimizer_step"]
-    step_time = selected["step_time"]
+    traced_step_time = selected[TRACED_STEP_TIME_KEY]
     compute = (
         float(forward + backward + optimizer)
         if None not in (forward, backward, optimizer)
         else None
     )
     residual = (
-        max(0.0, float(step_time - (h2d or 0.0) - compute))
-        if step_time is not None and compute is not None
+        max(0.0, float(traced_step_time - (h2d or 0.0) - compute))
+        if traced_step_time is not None and compute is not None
         else None
     )
-    total_step = (
-        float(input_wait + step_time)
-        if input_wait is not None and step_time is not None
+    step_time = (
+        float(input_wait + traced_step_time)
+        if input_wait is not None and traced_step_time is not None
         else None
     )
 
-    dataloader_cpu = _cpu_compatibility_value(
-        row,
-        INPUT_WAIT_KEY,
-        available=DATALOADER_FETCH_KEY in availability,
+    cpu_input_wait, traced_step_time_cpu, step_time_cpu = (
+        _clock_aggregate_values(
+            row,
+            clock="cpu",
+            availability=availability.cpu_aggregate,
+        )
     )
-    step_time_cpu = _cpu_compatibility_value(
-        row,
-        "step_time",
-        available=_STEP_TIME_CPU_KEY in availability,
-    )
-    total_step_cpu = (
-        float(dataloader_cpu + step_time_cpu)
-        if dataloader_cpu is not None and step_time_cpu is not None
-        else None
+    _gpu_input_wait, traced_step_time_gpu, step_time_gpu = (
+        _clock_aggregate_values(
+            row,
+            clock="gpu",
+            availability=availability.gpu_aggregate,
+        )
     )
     return StepTimeValues(
         input_wait_ms=input_wait,
@@ -370,25 +395,40 @@ def _build_step_values(
         backward_ms=backward,
         optimizer_step_ms=optimizer,
         step_time_ms=step_time,
+        traced_step_time_ms=traced_step_time,
         compute_ms=compute,
         residual_ms=residual,
-        total_step_ms=total_step,
-        dataloader_cpu_ms=dataloader_cpu,
-        total_step_cpu_ms=total_step_cpu,
+        step_time_cpu_ms=step_time_cpu,
+        step_time_gpu_ms=step_time_gpu,
+        traced_step_time_cpu_ms=traced_step_time_cpu,
+        traced_step_time_gpu_ms=traced_step_time_gpu,
+        dataloader_fetch_cpu_ms=cpu_input_wait,
     )
 
 
-def _cpu_compatibility_value(
+def _clock_aggregate_values(
     row: StepTimeSourceRow,
-    metric: str,
     *,
-    available: bool,
-) -> Optional[float]:
-    if not available:
-        return None
-    values = row.metrics.get(metric)
-    value = values.cpu_ms if values is not None else None
-    return float(value) if value is not None else 0.0
+    clock: DiagnosisClock,
+    availability: frozenset[str],
+) -> tuple[Optional[float], Optional[float], Optional[float]]:
+    """Return one clock's input, traced envelope, and outer Step Time."""
+    input_wait = (
+        _clock_value(row, INPUT_WAIT_KEY, clock=clock)
+        if INPUT_WAIT_KEY in availability
+        else None
+    )
+    traced_step_time = (
+        _clock_value(row, TRACED_STEP_TIME_KEY, clock=clock)
+        if TRACED_STEP_TIME_KEY in availability
+        else None
+    )
+    step_time = (
+        float(input_wait + traced_step_time)
+        if input_wait is not None and traced_step_time is not None
+        else None
+    )
+    return input_wait, traced_step_time, step_time
 
 
 def _average_values(steps: Sequence[StepTimeStepFacts]) -> StepTimeValues:
@@ -404,29 +444,25 @@ def _average_values(steps: Sequence[StepTimeStepFacts]) -> StepTimeValues:
     forward = average("forward_ms")
     backward = average("backward_ms")
     optimizer = average("optimizer_step_ms")
-    step_time = average("step_time_ms")
-    dataloader_cpu = average("dataloader_cpu_ms")
     return StepTimeValues(
         input_wait_ms=input_wait,
         h2d_ms=average("h2d_ms"),
         forward_ms=forward,
         backward_ms=backward,
         optimizer_step_ms=optimizer,
-        step_time_ms=step_time,
+        step_time_ms=average("step_time_ms"),
+        traced_step_time_ms=average("traced_step_time_ms"),
         compute_ms=(
             float(forward + backward + optimizer)
             if None not in (forward, backward, optimizer)
             else None
         ),
         residual_ms=average("residual_ms"),
-        # Preserve the historical avg(input wait) + avg(step time) order.
-        total_step_ms=(
-            float(input_wait + step_time)
-            if input_wait is not None and step_time is not None
-            else None
-        ),
-        dataloader_cpu_ms=dataloader_cpu,
-        total_step_cpu_ms=average("total_step_cpu_ms"),
+        step_time_cpu_ms=average("step_time_cpu_ms"),
+        step_time_gpu_ms=average("step_time_gpu_ms"),
+        traced_step_time_cpu_ms=average("traced_step_time_cpu_ms"),
+        traced_step_time_gpu_ms=average("traced_step_time_gpu_ms"),
+        dataloader_fetch_cpu_ms=average("dataloader_fetch_cpu_ms"),
     )
 
 
@@ -543,9 +579,8 @@ def _build_cohorts(
             )
         )
 
-    iteration = carrying(INPUT_WAIT_KEY, "step_time")
+    step = carrying("step_time")
     compute = carrying(
-        INPUT_WAIT_KEY,
         "step_time",
         "forward",
         "backward",
@@ -568,7 +603,7 @@ def _build_cohorts(
         and (not fsdp or (facts.average.forward_ms or 0.0) > 0.0)
     )
     return _Cohorts(
-        iteration=iteration,
+        step=step,
         compute=compute,
         composition=composition,
         straggler=straggler,
@@ -581,11 +616,7 @@ def _composition_representative_rank(
 ) -> Optional[int]:
     cohort_set = set(int(rank) for rank in cohort)
     anchors = {
-        facts.global_rank: (
-            facts.average.total_step_ms
-            if facts.average.total_step_ms is not None
-            else facts.average.step_time_ms
-        )
+        facts.global_rank: facts.average.step_time_ms
         for facts in rank_facts
         if facts.global_rank in cohort_set
     }
@@ -610,15 +641,11 @@ def _component_share(
     for facts in rank_facts:
         values = facts.average
         numerator = values.value(component)
-        if (
-            numerator is None
-            or values.input_wait_ms is None
-            or values.step_time_ms is None
-        ):
+        step_time = values.step_time_ms
+        if numerator is None or step_time is None:
             continue
-        iteration = values.input_wait_ms + values.step_time_ms
-        if iteration > 0.0:
-            shares.append(float(numerator) / iteration)
+        if step_time > 0.0:
+            shares.append(float(numerator) / step_time)
     if not shares:
         return None
     return float(np.median(np.asarray(shares, dtype=np.float64)))

--- a/src/traceml_ai/step_time/model.py
+++ b/src/traceml_ai/step_time/model.py
@@ -21,9 +21,11 @@ STEP_TIME_EVENT_NAMES: Mapping[str, str] = {
     "forward": "_traceml_internal:forward_time",
     "backward": "_traceml_internal:backward_time",
     "optimizer_step": "_traceml_internal:optimizer_step",
-    "step_time": "_traceml_internal:step_time",
+    # The raw event is renamed by the instrumentation migration. Until then,
+    # this decoder maps its historical spelling to the canonical inner metric.
+    "traced_step_time": "_traceml_internal:step_time",
 }
-"""Persisted event names keyed by their canonical Step Time metric."""
+"""Persisted event names keyed by canonical timing metrics."""
 
 _VALUE_FIELDS: Mapping[str, str] = {
     "input_wait": "input_wait_ms",
@@ -32,11 +34,14 @@ _VALUE_FIELDS: Mapping[str, str] = {
     "backward": "backward_ms",
     "optimizer_step": "optimizer_step_ms",
     "step_time": "step_time_ms",
+    "traced_step_time": "traced_step_time_ms",
     "compute": "compute_ms",
     "residual_proxy": "residual_ms",
-    "total_step": "total_step_ms",
-    "dataloader_fetch": "dataloader_cpu_ms",
-    "total_step_cpu": "total_step_cpu_ms",
+    "step_time_cpu": "step_time_cpu_ms",
+    "step_time_gpu": "step_time_gpu_ms",
+    "traced_step_time_cpu": "traced_step_time_cpu_ms",
+    "traced_step_time_gpu": "traced_step_time_gpu_ms",
+    "dataloader_fetch": "dataloader_fetch_cpu_ms",
 }
 
 
@@ -115,9 +120,11 @@ class StepTimeValues:
     """Typed timing values for one step or one rank-window average.
 
     The phase fields use the clock selected for the complete analysis window.
+    ``step_time_ms`` is the selected-clock outer duration and
+    ``traced_step_time_ms`` is the selected-clock inner trace envelope.
+    Clock-qualified fields preserve both aggregate clocks independently.
     ``None`` means the signal was unavailable; a measured zero remains
-    ``0.0``. The two ``*_cpu_ms`` fields retain the historical CPU-clock
-    values required by final-summary compatibility output.
+    ``0.0``.
     """
 
     input_wait_ms: Optional[float] = None
@@ -126,11 +133,14 @@ class StepTimeValues:
     backward_ms: Optional[float] = None
     optimizer_step_ms: Optional[float] = None
     step_time_ms: Optional[float] = None
+    traced_step_time_ms: Optional[float] = None
     compute_ms: Optional[float] = None
     residual_ms: Optional[float] = None
-    total_step_ms: Optional[float] = None
-    dataloader_cpu_ms: Optional[float] = None
-    total_step_cpu_ms: Optional[float] = None
+    step_time_cpu_ms: Optional[float] = None
+    step_time_gpu_ms: Optional[float] = None
+    traced_step_time_cpu_ms: Optional[float] = None
+    traced_step_time_gpu_ms: Optional[float] = None
+    dataloader_fetch_cpu_ms: Optional[float] = None
 
     def value(self, metric: str) -> Optional[float]:
         """Return one canonical value by its internal metric key."""
@@ -217,7 +227,7 @@ class StepTimeWindow:
     )
     rank_facts: tuple[StepTimeRankFacts, ...] = ()
     metrics: list[StepTimeMetric] = field(default_factory=list)
-    iteration_ranks: tuple[int, ...] = ()
+    step_ranks: tuple[int, ...] = ()
     compute_ranks: tuple[int, ...] = ()
     straggler_ranks: tuple[int, ...] = ()
     composition_representative_rank: Optional[int] = None

--- a/tests/step_time/factories.py
+++ b/tests/step_time/factories.py
@@ -87,23 +87,28 @@ def timing_row(
         "forward": forward,
         "backward": backward,
         "optimizer_step": optimizer,
-        "step_time": local_step,
+        "traced_step_time": local_step,
         "residual_proxy": residual,
-        "total_step": (
+        "step_time": (
             dataloader + local_step if total_step is None else total_step
         ),
     }
     if input_wait_cpu is not None and step_time_cpu is not None:
         row.update(
             input_wait=input_wait_cpu,
-            step_time=step_time_cpu,
-            total_step=input_wait_cpu + step_time_cpu,
+            traced_step_time=step_time_cpu,
+            step_time=input_wait_cpu + step_time_cpu,
+            dataloader_fetch=input_wait_cpu,
+            traced_step_time_cpu=step_time_cpu,
+            step_time_cpu=input_wait_cpu + step_time_cpu,
         )
     if input_wait_gpu is not None and step_time_gpu is not None:
         row.update(
             input_wait=input_wait_gpu,
-            step_time=step_time_gpu,
-            total_step=input_wait_gpu + step_time_gpu,
+            traced_step_time=step_time_gpu,
+            step_time=input_wait_gpu + step_time_gpu,
+            traced_step_time_gpu=step_time_gpu,
+            step_time_gpu=input_wait_gpu + step_time_gpu,
         )
     return row
 
@@ -121,6 +126,7 @@ def metrics_from_rank_timings(
         "forward",
         "backward",
         "optimizer_step",
+        "traced_step_time",
         "step_time",
         "residual_proxy",
     ):
@@ -216,18 +222,27 @@ def values_from_mapping(
         compute = float(forward + backward + optimizer)
 
     input_wait = optional("input_wait")
+    traced_step_time = optional("traced_step_time")
     step_time = optional("step_time")
-    total_step = optional("total_step")
-    if total_step is None and input_wait is not None and step_time is not None:
-        total_step = input_wait + step_time
+    if (
+        step_time is None
+        and input_wait is not None
+        and traced_step_time is not None
+    ):
+        step_time = input_wait + traced_step_time
 
-    dataloader_cpu = optional("dataloader_fetch")
+    dataloader_fetch_cpu = optional("dataloader_fetch")
+    traced_step_time_cpu = optional("traced_step_time_cpu")
     step_time_cpu = optional("step_time_cpu")
-    total_step_cpu = (
-        dataloader_cpu + step_time_cpu
-        if dataloader_cpu is not None and step_time_cpu is not None
-        else None
-    )
+    if (
+        step_time_cpu is None
+        and dataloader_fetch_cpu is not None
+        and traced_step_time_cpu is not None
+    ):
+        step_time_cpu = dataloader_fetch_cpu + traced_step_time_cpu
+
+    traced_step_time_gpu = optional("traced_step_time_gpu")
+    step_time_gpu = optional("step_time_gpu")
     return StepTimeValues(
         input_wait_ms=input_wait,
         h2d_ms=optional("h2d"),
@@ -235,11 +250,14 @@ def values_from_mapping(
         backward_ms=backward,
         optimizer_step_ms=optimizer,
         step_time_ms=step_time,
+        traced_step_time_ms=traced_step_time,
         compute_ms=compute,
         residual_ms=optional("residual_proxy"),
-        total_step_ms=total_step,
-        dataloader_cpu_ms=dataloader_cpu,
-        total_step_cpu_ms=total_step_cpu,
+        step_time_cpu_ms=step_time_cpu,
+        step_time_gpu_ms=step_time_gpu,
+        traced_step_time_cpu_ms=traced_step_time_cpu,
+        traced_step_time_gpu_ms=traced_step_time_gpu,
+        dataloader_fetch_cpu_ms=dataloader_fetch_cpu,
     )
 
 
@@ -327,9 +345,8 @@ def window_from_rank_averages(
         ),
         rank_facts=rank_facts,
         metrics=metrics if isinstance(metrics, list) else list(metrics),
-        iteration_ranks=carrying("input_wait", "step_time"),
+        step_ranks=carrying("step_time"),
         compute_ranks=carrying(
-            "input_wait",
             "step_time",
             "forward",
             "backward",
@@ -426,7 +443,8 @@ def single_rank_step_metrics(
 ) -> tuple[StepTimeMetric, ...]:
     """Build the standard complete single-rank metric cohort."""
     values = {
-        "step_time": step,
+        "traced_step_time": step,
+        "step_time": step + dataloader,
         "input_wait": dataloader,
         "forward": forward,
         "backward": backward,
@@ -512,17 +530,18 @@ def step_time_values(
     )
     residual = max(0.0, effective_step - known_step)
     return StepTimeValues(
-        dataloader_cpu_ms=dataloader,
+        dataloader_fetch_cpu_ms=dataloader,
         input_wait_ms=dataloader,
-        step_time_ms=effective_step,
+        step_time_ms=dataloader + effective_step,
+        traced_step_time_ms=effective_step,
         h2d_ms=h2d,
         forward_ms=forward,
         backward_ms=backward,
         optimizer_step_ms=optimizer,
         compute_ms=compute,
         residual_ms=residual,
-        total_step_ms=dataloader + effective_step,
-        total_step_cpu_ms=dataloader + effective_step,
+        step_time_cpu_ms=dataloader + effective_step,
+        traced_step_time_cpu_ms=effective_step,
     )
 
 
@@ -533,12 +552,12 @@ def step_events_from_values(
 ) -> dict[int, dict]:
     """Expand canonical rank values into a repeated CPU event window."""
     events = {
-        "_traceml_internal:dataloader_next": values.dataloader_cpu_ms,
+        "_traceml_internal:dataloader_next": values.dataloader_fetch_cpu_ms,
         "_traceml_internal:h2d_time": values.h2d_ms,
         "_traceml_internal:forward_time": values.forward_ms,
         "_traceml_internal:backward_time": values.backward_ms,
         "_traceml_internal:optimizer_step": values.optimizer_step_ms,
-        "_traceml_internal:step_time": values.step_time_ms,
+        "_traceml_internal:step_time": values.traced_step_time_ms,
     }
     return {
         step: {
@@ -630,11 +649,7 @@ def _composition_representative(
 ) -> Optional[int]:
     ranks = set(cohort)
     anchors = {
-        facts.global_rank: (
-            facts.average.total_step_ms
-            if facts.average.total_step_ms is not None
-            else facts.average.step_time_ms
-        )
+        facts.global_rank: facts.average.step_time_ms
         for facts in rank_facts
         if facts.global_rank in ranks
     }
@@ -658,15 +673,11 @@ def _component_share(
     for facts in rank_facts:
         values = facts.average
         numerator = values.value(component)
-        if (
-            numerator is None
-            or values.input_wait_ms is None
-            or values.step_time_ms is None
-        ):
+        step_time = values.step_time_ms
+        if numerator is None or step_time is None:
             continue
-        total = values.input_wait_ms + values.step_time_ms
-        if total > 0.0:
-            shares.append(float(numerator) / total)
+        if step_time > 0.0:
+            shares.append(float(numerator) / step_time)
     return float(statistics.median(shares)) if shares else None
 
 

--- a/tests/step_time/scenarios.py
+++ b/tests/step_time/scenarios.py
@@ -29,7 +29,9 @@ EVENT_NAMES: Mapping[str, str] = {
     "forward": "_traceml_internal:forward_time",
     "backward": "_traceml_internal:backward_time",
     "optimizer_step": "_traceml_internal:optimizer_step",
-    "step_time": "_traceml_internal:step_time",
+    # Instrumentation still emits this historical raw event until its own
+    # migration. The scenario key uses the canonical inner-envelope name.
+    "traced_step_time": "_traceml_internal:step_time",
 }
 
 BALANCED_PROFILE: Mapping[str, float] = {
@@ -38,7 +40,7 @@ BALANCED_PROFILE: Mapping[str, float] = {
     "forward": 30.0,
     "backward": 45.0,
     "optimizer_step": 10.0,
-    "step_time": 95.0,
+    "traced_step_time": 95.0,
 }
 
 
@@ -142,7 +144,7 @@ SCENARIOS: tuple[StepTimeScenario, ...] = (
                 forward=20.0,
                 backward=20.0,
                 optimizer_step=0.0,
-                step_time=40.0,
+                traced_step_time=40.0,
             ),
             1: _profile(
                 input_wait=0.0,
@@ -150,7 +152,7 @@ SCENARIOS: tuple[StepTimeScenario, ...] = (
                 forward=20.0,
                 backward=120.0,
                 optimizer_step=0.0,
-                step_time=140.0,
+                traced_step_time=140.0,
             ),
         },
         steps=tuple(range(50, 74)),
@@ -165,7 +167,7 @@ SCENARIOS: tuple[StepTimeScenario, ...] = (
                 forward=20.0,
                 backward=20.0,
                 optimizer_step=0.0,
-                step_time=40.0,
+                traced_step_time=40.0,
             ),
             1: _profile(
                 input_wait=0.0,
@@ -173,7 +175,7 @@ SCENARIOS: tuple[StepTimeScenario, ...] = (
                 forward=80.0,
                 backward=80.0,
                 optimizer_step=0.0,
-                step_time=160.0,
+                traced_step_time=160.0,
             ),
         },
         steps=tuple(range(80, 104)),

--- a/tests/step_time/test_analyzer.py
+++ b/tests/step_time/test_analyzer.py
@@ -21,13 +21,11 @@ from traceml_ai.step_time.model import (
     StepTimeClockValues,
     StepTimeRepositorySnapshot,
     StepTimeSourceRow,
+    StepTimeValues,
     StepTimeWindow,
 )
 from traceml_ai.step_time.sqlite import normalize_step_time_events
-from tests.step_time.factories import (
-    rank_average,
-    window_from_events,
-)
+from tests.step_time.factories import window_from_events
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _SOURCE_ROOT = _PROJECT_ROOT / "src" / "traceml_ai"
@@ -38,7 +36,7 @@ _COMPLETE = {
     "forward": 30.0,
     "backward": 45.0,
     "optimizer_step": 10.0,
-    "step_time": 95.0,
+    "traced_step_time": 95.0,
 }
 
 
@@ -119,11 +117,15 @@ def test_analyzer_builds_one_typed_fact_set() -> None:
     assert rank.steps[0].values.forward_ms == 30.0
     assert rank.average.compute_ms == 85.0
     assert rank.average.residual_ms == 5.0
-    assert rank.average.total_step_ms == 100.0
-    assert rank.average.dataloader_cpu_ms == 10.0
-    assert rank.average.total_step_cpu_ms == 200.0
+    assert rank.average.step_time_ms == 100.0
+    assert rank.average.traced_step_time_ms == 95.0
+    assert rank.average.step_time_cpu_ms == 200.0
+    assert rank.average.step_time_gpu_ms == 100.0
+    assert rank.average.traced_step_time_cpu_ms == 190.0
+    assert rank.average.traced_step_time_gpu_ms == 95.0
+    assert rank.average.dataloader_fetch_cpu_ms == 10.0
 
-    assert window.iteration_ranks == (0,)
+    assert window.step_ranks == (0,)
     assert window.compute_ranks == (0,)
     assert window.straggler_ranks == (0,)
     assert window.input_wait_share == pytest.approx(0.05)
@@ -134,13 +136,30 @@ def test_analyzer_builds_one_typed_fact_set() -> None:
     summary_statistics = {
         metric.metric: metric
         for metric in window.metrics
-        if metric.metric in {"compute", "dataloader_fetch", "total_step_cpu"}
+        if metric.metric
+        in {
+            "compute",
+            "dataloader_fetch",
+            "step_time_cpu",
+            "step_time_gpu",
+            "traced_step_time_cpu",
+            "traced_step_time_gpu",
+        }
     }
     assert summary_statistics["compute"].median_total == pytest.approx(85.0)
     dataloader = summary_statistics["dataloader_fetch"]
     assert dataloader.median_total == pytest.approx(10.0)
-    assert summary_statistics["total_step_cpu"].median_total == pytest.approx(
+    assert summary_statistics["step_time_cpu"].median_total == pytest.approx(
         200.0
+    )
+    assert summary_statistics["step_time_gpu"].median_total == pytest.approx(
+        100.0
+    )
+    assert summary_statistics["traced_step_time_cpu"].median_total == (
+        pytest.approx(190.0)
+    )
+    assert summary_statistics["traced_step_time_gpu"].median_total == (
+        pytest.approx(95.0)
     )
     assert all(metric.series is None for metric in summary_statistics.values())
 
@@ -228,7 +247,7 @@ def test_cpu_fallback_and_strategy_specific_straggler_cohorts() -> None:
         0: {
             "input_wait": 5.0,
             "backward": 45.0,
-            "step_time": 95.0,
+            "traced_step_time": 95.0,
         },
         1: _COMPLETE,
     }
@@ -242,8 +261,43 @@ def test_cpu_fallback_and_strategy_specific_straggler_cohorts() -> None:
     )
 
     assert ddp.clock == "cpu"
+    assert ddp.rank(0).average.step_time_cpu_ms == 100.0
+    assert ddp.rank(0).average.traced_step_time_cpu_ms == 95.0
+    assert ddp.rank(0).average.step_time_gpu_ms is None
+    assert ddp.rank(0).average.traced_step_time_gpu_ms is None
     assert ddp.straggler_ranks == (0, 1)
     assert fsdp.straggler_ranks == (1,)
+
+    gpu_rows = _snapshot({0: _COMPLETE}).rows
+    partial_gpu = StepTimeAnalyzer().analyze(
+        StepTimeRepositorySnapshot(
+            rows=tuple(
+                StepTimeSourceRow(
+                    source_id=row.source_id,
+                    global_rank=row.global_rank,
+                    step=row.step,
+                    metrics={
+                        metric: StepTimeClockValues(
+                            cpu_ms=timing.cpu_ms,
+                            gpu_ms=(
+                                None if metric == "forward" else timing.gpu_ms
+                            ),
+                        )
+                        for metric, timing in row.metrics.items()
+                    },
+                )
+                for row in gpu_rows
+            ),
+            global_ranks=(0,),
+        ),
+        window_size=2,
+    )
+    partial_values = partial_gpu.rank(0).average
+    assert partial_gpu.clock == "cpu"
+    assert partial_values.step_time_ms == 200.0
+    assert partial_values.traced_step_time_ms == 190.0
+    assert partial_values.step_time_gpu_ms == 100.0
+    assert partial_values.traced_step_time_gpu_ms == 95.0
 
 
 @pytest.mark.parametrize(
@@ -254,14 +308,14 @@ def test_cpu_fallback_and_strategy_specific_straggler_cohorts() -> None:
         ({0: 100.0, 1: 300.0, 2: 300.0}, 300.0, 1, 1),
     ],
 )
-def test_total_step_metric_names_median_representative_and_worst(
+def test_step_time_metric_names_median_representative_and_worst(
     profiles: Mapping[int, float],
     median: float,
     representative: int,
     worst: int,
 ) -> None:
     rank_profiles = {
-        rank: {"input_wait": 0.0, "step_time": total}
+        rank: {"input_wait": 0.0, "traced_step_time": total}
         for rank, total in profiles.items()
     }
     window = StepTimeAnalyzer().analyze(
@@ -269,12 +323,12 @@ def test_total_step_metric_names_median_representative_and_worst(
         window_size=2,
     )
 
-    total_step = _metric(window, "total_step")
-    assert total_step.median_total == median
-    assert total_step.representative_rank == representative
-    assert total_step.representative_total == profiles[representative]
-    assert total_step.worst_rank == worst
-    assert total_step.worst_total == profiles[worst]
+    step_time = _metric(window, "step_time")
+    assert step_time.median_total == median
+    assert step_time.representative_rank == representative
+    assert step_time.representative_total == profiles[representative]
+    assert step_time.worst_rank == worst
+    assert step_time.worst_total == profiles[worst]
 
 
 def test_alignment_uses_latest_common_suffix() -> None:
@@ -347,6 +401,25 @@ def test_analyzer_has_one_input_and_no_removed_shapes() -> None:
         field.name for field in fields(StepTimeWindow)
     }
     assert not hasattr(StepTimeWindow(), "per_rank_timing")
+    assert "iteration_ranks" not in {
+        field.name for field in fields(StepTimeWindow)
+    }
+    assert "step_ranks" in {field.name for field in fields(StepTimeWindow)}
+
+    value_fields = {field.name for field in fields(StepTimeValues)}
+    assert {
+        "step_time_ms",
+        "traced_step_time_ms",
+        "step_time_cpu_ms",
+        "step_time_gpu_ms",
+        "traced_step_time_cpu_ms",
+        "traced_step_time_gpu_ms",
+    }.issubset(value_fields)
+    assert {
+        "total_step_ms",
+        "total_step_cpu_ms",
+        "dataloader_cpu_ms",
+    }.isdisjoint(value_fields)
 
     production = tuple(_SOURCE_ROOT.glob("**/*.py"))
     mapping_owners = {

--- a/tests/step_time/test_model_boundary.py
+++ b/tests/step_time/test_model_boundary.py
@@ -87,6 +87,27 @@ def test_typed_analysis_facts_are_exported_without_loading_analyzer() -> None:
     assert "traceml_ai.step_time.analysis" not in dependencies
     assert "traceml_ai.step_time.pipeline" not in dependencies
 
+    value_fields = {field.name for field in fields(model.StepTimeValues)}
+    assert {
+        "step_time_ms",
+        "traced_step_time_ms",
+        "step_time_cpu_ms",
+        "step_time_gpu_ms",
+        "traced_step_time_cpu_ms",
+        "traced_step_time_gpu_ms",
+    }.issubset(value_fields)
+    assert {
+        "total_step_ms",
+        "total_step_cpu_ms",
+        "dataloader_cpu_ms",
+    }.isdisjoint(value_fields)
+
+    window_fields = {field.name for field in fields(model.StepTimeWindow)}
+    assert "step_ranks" in window_fields
+    assert "iteration_ranks" not in window_fields
+    assert "traced_step_time" in model.STEP_TIME_EVENT_NAMES
+    assert "step_time" not in model.STEP_TIME_EVENT_NAMES
+
 
 def test_pipeline_is_the_only_builtin_orchestrator() -> None:
     """Keep direct diagnosis limited to its implementation and pipeline."""


### PR DESCRIPTION
## Summary

This closes the internal consumer migration for the canonical Step Time
contract.

- **Step Time** is the outer selected-clock duration:
  `input_wait + traced_step_time`.
- **Traced Step Time** is the inner traced training envelope.
- CPU and GPU aggregate values remain independent; diagnosis still selects one
  clock for phase selection and policy decisions.

This PR deliberately preserves the current public summary ABI and current
CLI/dashboard presentation. The public schema and UI naming cleanup remain
follow-up work.

## What changed

### Diagnostics

- Migrated internal diagnostics from `iteration_*`, `iteration_ranks`, and
  `total_step` fallback semantics to canonical Step Time terminology.
- Uses outer Step Time as the denominator for input, H2D, compute, residual,
  and rank-straggler shares.
- Rank-straggler scoring now uses victim Step Time directly, so input wait is
  not added twice.
- Keeps residual defined as:

  ```text
  residual_ms = traced_step_time_ms - h2d_ms - compute_ms
  ```

- Emits canonical evidence internally:
  `traced_step_time_ms` for the inner envelope and `step_time_ms` for the
  outer duration.
- A present traced envelope with missing input wait now produces
  `INCOMPLETE_DATA` instead of falling through to `NO_DATA`.
- Updated policy documentation and diagnostic text to say “Step Time.”

### Compatibility boundaries

- Kept public summary keys unchanged:
  `total_step_ms`, `dataloader_ms`, `step_time_ms`, and legacy diagnosis
  evidence keys remain stable.
- Summary projection now maps canonical values to that legacy schema:

  ```text
  public total_step_ms  <- canonical step_time_cpu_ms
  public dataloader_ms  <- canonical dataloader_fetch_cpu_ms
  public step_time_ms   <- canonical traced_step_time_ms
  ```

- Summary diagnosis evidence is projected only at the reporting boundary:
  canonical traced/outer values map back to legacy
  `step_time_ms` / `iteration_time_ms` evidence keys. No aliases were added
  back to `StepTimeValues` or `StepTimeWindow`.

### Current presentation behavior

- The terminal table's existing `STEP` column continues to show Traced Step
  Time, matching its current visible definition.
- The dashboard ribbon continues to use
  `input_wait + traced_step_time` for its existing envelope display.
- Dashboard composition can still render the traced envelope when input wait
  is unavailable; diagnostic shares remain unavailable in that case, rather
  than inventing an outer Step Time.

## Non-goals

- No raw event rename: `_traceml_internal:step_time` remains the persisted
  event and decodes to canonical `traced_step_time`.
- No threshold or policy-value changes.
- No public summary-schema rename or migration.
- No visible CLI/dashboard label or layout redesign.
- No new test files.

## Verification

- Updated existing diagnostics tests for input-bound, H2D, residual,
  rank-straggler, missing-signal, and trend-adjacent behavior.
- Updated existing contract, renderer, dashboard, summary, and live-session
  fixtures to distinguish outer Step Time from Traced Step Time.
- Repository audit confirms `total_step`, `iteration_ranks`, and
  `iteration_time_*` are absent from canonical model, analyzer, and internal
  diagnostics code. Legacy names remain only at explicit reporting/
  compatibility boundaries.

```text
877 passed, 2 skipped
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Summary mode is now the default for single-node and distributed runs; live CLI and dashboard views remain available where supported.
  * Added unified Step Time analysis across live views, dashboards, comparisons, and final reports.
  * Added clearer handling for missing instrumentation, including `INCOMPLETE DATA` diagnoses and unavailable metrics.
  * Reports now distinguish unavailable values from measured zeroes and use schema version 1.7.
  * Hugging Face integrations warn about missing telemetry without interrupting training.

* **Documentation**
  * Updated installation, quickstart, operating modes, troubleshooting, comparisons, and Step Time guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->