### PR TITLE
Abhinav/issue310

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
@@ -192,14 +192,14 @@ def update_model_combined_section(
         _clear_view(panel, _EXPIRED_SIG, "window expired")
         return
     m = _index(window.metrics)
-    if "step_time" not in m:
+    if "traced_step_time" not in m:
         _clear_view(panel, _NO_ENVELOPE_SIG, "step envelope unavailable")
         return
 
-    step_metric = m["step_time"]
-    st = step_metric
+    traced_step_metric = m["traced_step_time"]
+    st = traced_step_metric
     steps_used = window.coverage.steps_used
-    _update_kpis(panel, window, step_metric)
+    _update_kpis(panel, window, traced_step_metric)
     representative = window.composition_representative_rank
     if representative is None:
         _clear_ribbon(
@@ -229,19 +229,19 @@ def update_model_combined_section(
     universe_size = len(window.rank_universe)
     partial_metrics = [
         key
-        for key in [phase[1] for phase in theme.PHASES] + ["step_time"]
+        for key in [phase[1] for phase in theme.PHASES] + ["traced_step_time"]
         if key != "h2d" and 0 < len(window.ranks_for(key)) < universe_size
     ]
 
     input_wait_value = vals.get("input_wait")
-    envelope = float(rank_values.step_time_ms or 0.0) + (
+    envelope = float(rank_values.traced_step_time_ms or 0.0) + (
         input_wait_value if input_wait_value is not None else 0.0
     )
     tot = max(sum(measured.values()), envelope) or 1.0
 
     # A measured-zero segment and a genuinely unmeasured one must never
     # render identically -- an absent input_wait would otherwise let the
-    # OTHER phases sum to exactly step_time (residual is a remainder), so
+    # OTHER phases sum to exactly traced Step Time (residual is a remainder), so
     # the ribbon fills to 100% and a dark dataloader stream reads as a
     # confirmed-fast one. Non-h2d unmeasured phases get a fixed hatched
     # sliver instead of a proportional width; measured phases give up
@@ -306,11 +306,11 @@ def update_model_combined_section(
     if unmeasured or partial_metrics:
         incomplete = set(unmeasured) | set(partial_metrics)
         names = [lab for lab, key, _c in theme.PHASES if key in incomplete]
-        # step_time has no ribbon segment, so it is not in PHASES, but it
+        # traced_step_time has no ribbon segment, so it is not in PHASES, but it
         # can still be the thing that is incomplete. Name it with the same
         # abbreviation the CLI table uses rather than dropping it and
         # printing a bare "partial:".
-        if "step_time" in incomplete:
+        if "traced_step_time" in incomplete:
             names.append(_STEP_TIME_LABEL)
         steps_text += f" · partial: {','.join(names)}"
     panel["win"].text = steps_text

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -78,12 +78,13 @@ Training-step timing.
   materially higher forward time than the victim rank.
 - `H2D_STRAGGLER`: the culprit rank has materially higher host-to-device
   transfer time than the victim rank.
-- `INPUT_BOUND`: selected-clock input wait is a material typical iteration cost.
-- `H2D_BOUND`: selected-clock GPU H2D transfer is a material typical iteration
+- `INPUT_BOUND`: selected-clock input wait is a material typical Step Time cost.
+- `H2D_BOUND`: selected-clock GPU H2D transfer is a material typical Step Time
   cost.
-- `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical step;
+- `COMPUTE_BOUND`: forward/backward/optimizer time dominates the typical Step
+  Time;
   this is informational when no material overhead is visible.
-- `RESIDUAL_HEAVY`: unattributed residual time is a material typical iteration
+- `RESIDUAL_HEAVY`: unattributed residual time is a material typical Step Time
   cost.
 
 Missing signals and measured zeros are different things. A timing event that
@@ -94,15 +95,15 @@ legitimately skip steps: the optimizer under gradient accumulation, and H2D
 when a step performs no host-to-device copies. They are available for a rank
 when measured in at least one aligned step, and their absent steps count as
 zero work. Every other metric (`input_wait`, `forward`, `backward`,
-`step_time`) must occur on every bracketed step, so it is available only
+`traced_step_time`) must occur on every bracketed step, so it is available only
 when measured in every aligned step of the rank's window; intermittent
 presence means the instrumentation dropped out mid-window and drops
 availability instead of synthesizing zeros that would leak the missing work
 into the residual. An absent H2D means "no observed transfers", contributes
 zero to derived metrics, and is never reported as a missing signal. Derived
 metrics exist only when their inputs are available: `compute` needs forward,
-backward, and optimizer; `total_step` needs input wait plus the step
-envelope; `residual_proxy` needs the step envelope plus every compute
+backward, and optimizer; outer `step_time` needs input wait plus the traced
+step envelope; `residual_proxy` needs the traced step envelope plus every compute
 phase.
 
 The canonical `StepTimeWindow` carries the expected rank universe and sparse
@@ -113,36 +114,38 @@ from aggregate values.
 
 The public final-summary projection preserves absence rather than
 re-deriving declined values. Each rule abstains when
-its required signals are unavailable: input needs input wait + step time;
-H2D needs GPU-clock H2D + input wait + step time; compute and residual need
-every compute phase + input wait + step time; rank stragglers need their
-visible-phase anchors + input wait + step time. Rules still fire from the
+its required signals are unavailable: input needs input wait + outer Step
+Time; H2D needs GPU-clock H2D + outer Step Time; compute and residual need
+every compute phase + outer Step Time; rank stragglers need their visible-phase
+anchors + outer Step Time. Rules still fire from the
 ranks that measured their signals, so one dark rank does not silence an
 otherwise measured finding. When no rule fires and at least one abstained
 for missing signals, Step Time reports `INCOMPLETE_DATA` instead of
 `BALANCED`.
 
 Step-time diagnosis uses one selected clock for the analyzed window. It uses
-GPU event timing when every rank/step has GPU timing for the step envelope,
+GPU event timing when every rank/step has GPU timing for the traced envelope,
 input wait, and traced phase events present in the window. Otherwise it uses
 explicit `cpu_ms` timing. The live CLI Step Time table, dashboard, and final
 summary use the same global-rank SQLite loader and selected-clock window
 builder for diagnosis-facing timing; they differ only by row window sizing.
-Summary JSON exposes selected-clock `input_wait_ms` and `step_time_ms`.
-The compatibility `dataloader_ms` field remains CPU dataloader fetch time, and
-`total_step_ms` remains CPU dataloader fetch plus CPU step envelope timing.
+The canonical model exposes selected-clock `input_wait_ms`, outer
+`step_time_ms`, and inner `traced_step_time_ms`. Summary JSON retains its
+legacy compatibility names: public `step_time_ms` is the selected traced
+envelope, `dataloader_ms` remains CPU dataloader fetch time, and
+`total_step_ms` remains CPU Step Time.
 These compatibility fields are not selected-clock phase-share denominators.
 `duration_ms` stays stored compatibility timing and is not used for Step Time
 display or diagnosis. In the final text report, selected-clock phase shares
-are divided by `input_wait_ms + step_time_ms`; CPU compatibility rows are
+are divided by public `input_wait_ms + step_time_ms`; CPU compatibility rows are
 labeled separately. These report-table shares are observational and do not
 replace the median per-rank diagnosis score.
 
-Typical overhead diagnoses use selected-clock per-rank iteration shares:
+Typical overhead diagnoses use selected-clock per-rank Step Time shares:
 
 ```text
-iteration_r = input_wait_r + step_time_r
-component_share_r = component_r / iteration_r
+step_time_r = input_wait_r + traced_step_time_r
+component_share_r = component_r / step_time_r
 typical_component_share = median(component_share_r across ranks)
 ```
 
@@ -153,11 +156,11 @@ host-call duration is not reported as transfer cost. Cross-rank skew remains
 evidence in a typical-bottleneck finding, but does not suppress one. In
 contrast, `H2D_STRAGGLER` identifies one rank's excess H2D time.
 `COMPUTE_BOUND` remains an informational finding when the median per-rank
-compute share reaches 90% of selected-clock iteration time and no material
+compute share reaches 90% of selected-clock Step Time and no material
 input, H2D, or residual overhead is visible. Built-in live and summary policies
 use this same threshold; their analyzed window sizes differ.
 
-Step Time uses `DiagnosticIssue.score` as normalized iteration impact for
+Step Time uses `DiagnosticIssue.score` as normalized Step Time impact for
 `INPUT_BOUND`, `H2D_BOUND`, `RESIDUAL_HEAVY`, and all rank-straggler findings.
 Typical findings use the median per-rank share above; stragglers use the
 culprit/victim score below. `COMPUTE_BOUND` has no score because its
@@ -192,10 +195,10 @@ unattributed step time averaged from per-step clamped residuals:
 ```text
 compute_ms = forward_ms + backward_ms + optimizer_ms
 known_step_ms = h2d_ms + compute_ms
-traced_step_ms = selected step envelope timing
-iteration_time_ms = selected input_wait_ms + selected traced_step_ms
-residual_ms = average(max(0, traced_step_ms - known_step_ms))
-total_step_ms = CPU dataloader_ms + CPU step envelope timing
+traced_step_time_ms = selected traced envelope timing
+step_time_ms = selected input_wait_ms + selected traced_step_time_ms
+residual_ms = average(max(0, traced_step_time_ms - known_step_ms))
+public total_step_ms = CPU Step Time (compatibility projection)
 ```
 
 Rank stragglers use culprit/victim evidence from selected-clock timing. TraceML
@@ -206,8 +209,8 @@ visible_r = backward_r              # DDP/default
 visible_r = forward_r + backward_r  # FSDP
 ```
 
-Only ranks with measured visible-phase anchors, a measured step envelope, and
-a measured input wait are eligible:
+Only ranks with measured visible-phase anchors and measured outer Step Time
+are eligible:
 
 ```text
 DDP/default: input_wait measured and backward_r > 0 and step_time_r > 0
@@ -225,8 +228,7 @@ that likely arrived late and therefore waited least in the visible phase. The
 victim rank is the upper actual median rank by visible value.
 
 ```text
-denom = input_wait_victim + step_time_victim
-score = (visible_victim - visible_culprit) / denom
+score = (visible_victim - visible_culprit) / step_time_victim
 ```
 
 If `score < 0.10`, TraceML does not report a rank straggler. At 10% it reports

--- a/src/traceml_ai/diagnostics/step_time/api.py
+++ b/src/traceml_ai/diagnostics/step_time/api.py
@@ -232,10 +232,45 @@ def diagnose_step_time_window(
     by_key = {metric.metric: metric for metric in metrics}
     step_metric = by_key.get("step_time")
     if step_metric is None:
+        context = build_step_time_context(
+            window=window,
+            thresholds=thresholds,
+        )
+        if context.missing_signals:
+            primary = _mk_diag(
+                kind="INCOMPLETE_DATA",
+                severity="info",
+                reason=(
+                    "Missing timing signals prevent a reliable diagnosis: "
+                    + ", ".join(context.missing_signals)
+                    + "."
+                ),
+                action=(
+                    "Instrument the missing phases (auto mode or the "
+                    "matching wrap_* helpers) to restore coverage."
+                ),
+                steps_used=int(window.coverage.steps_used),
+            )
+            return DiagnosticResult(
+                primary=primary,
+                issues=(
+                    DiagnosticIssue(
+                        kind=primary.kind,
+                        status=primary.status,
+                        severity=primary.severity,
+                        summary=primary.reason,
+                        action=primary.action,
+                        evidence={
+                            "missing_signals": list(context.missing_signals),
+                            "signal_coverage": dict(context.signal_coverage),
+                        },
+                    ),
+                ),
+            )
         primary = _mk_diag(
             kind="NO_DATA",
             severity="info",
-            reason="step_time metric is missing.",
+            reason="Step Time metric is missing.",
             action="Wait for the first complete window.",
             steps_used=0,
         )
@@ -244,9 +279,7 @@ def diagnose_step_time_window(
     coverage = window.coverage
     single_rank = (coverage.world_size <= 1) or (coverage.ranks_present <= 1)
     steps_used = int(coverage.steps_used)
-    overall_worst_rank = metric_worst_rank(
-        by_key.get("total_step") or step_metric
-    )
+    overall_worst_rank = metric_worst_rank(step_metric)
     step_total = metric_total(step_metric, single_rank=single_rank)
 
     if step_total <= 0.0:
@@ -337,7 +370,8 @@ def diagnose_step_time_window(
                 None if context.single_rank else context.overall_worst_rank
             ),
             note=(
-                "residual_ms = selected step_time_ms - h2d_ms - compute_ms."
+                "residual_ms = selected traced_step_time_ms - h2d_ms - "
+                "compute_ms."
             ),
         )
     elif primary_issue is not None and primary_issue.kind == "COMPUTE_BOUND":

--- a/src/traceml_ai/diagnostics/step_time/context.py
+++ b/src/traceml_ai/diagnostics/step_time/context.py
@@ -50,7 +50,7 @@ class _RankStragglerEvidence:
     visible_culprit_ms: float
     visible_victim_ms: float
     visible_cost_ms: float
-    iteration_time_ms: float
+    step_time_ms: float
     component_excesses_ms: Dict[str, float]
     component_coverage: Dict[str, float]
 
@@ -65,7 +65,7 @@ class StepTimeAnalysisContext:
     overall_worst_rank: Optional[int]
     training_strategy: str
 
-    step_metric: StepTimeMetric
+    step_metric: Optional[StepTimeMetric]
     input_wait_metric: Optional[StepTimeMetric]
     h2d_metric: Optional[StepTimeMetric]
     residual_metric: Optional[StepTimeMetric]
@@ -80,8 +80,8 @@ class StepTimeAnalysisContext:
     input_bound_worst_rank: Optional[int]
     diagnosis_clock: str
     input_wait_total: float
-    input_bound_step_total: float
-    iteration_time_total: float
+    traced_step_time_total: float
+    step_time_total: float
 
     largest_compute: Optional[str]
     rank_straggler: Optional[_RankStragglerEvidence]
@@ -227,11 +227,10 @@ def _build_rank_straggler_evidence(
     by_rank = {facts.global_rank: facts for facts in eligible}
     culprit = by_rank[pair.culprit_rank]
     victim = by_rank[pair.victim_rank]
-    iteration_time = _rank_value(victim, "input_wait") + _rank_value(
-        victim,
-        "step_time",
-    )
-    score = pair.cost_ms / iteration_time
+    step_time = _rank_value(victim, "step_time")
+    if step_time <= 0.0:
+        return None, len(eligible)
+    score = pair.cost_ms / step_time
     if score < non_negative_finite(score_threshold):
         return None, len(eligible)
 
@@ -319,7 +318,7 @@ def _build_rank_straggler_evidence(
         visible_culprit_ms=pair.culprit_value_ms,
         visible_victim_ms=pair.victim_value_ms,
         visible_cost_ms=pair.cost_ms,
-        iteration_time_ms=iteration_time,
+        step_time_ms=step_time,
         component_excesses_ms=component_excesses,
         component_coverage=coverage,
     ), len(eligible)
@@ -353,7 +352,7 @@ _MISSING_SIGNAL_ORDER: tuple[str, ...] = (
     "forward",
     "backward",
     "optimizer_step",
-    "step_time",
+    "traced_step_time",
 )
 
 
@@ -378,7 +377,7 @@ def _missing_signal_facts(
     if len(window.rank_facts) < ranks:
         needed.update(_MISSING_SIGNAL_ORDER)
     if input_share is None:
-        needed.update(("input_wait", "step_time"))
+        needed.update(("input_wait", "traced_step_time"))
     if compute_share is None or residual_share is None:
         needed.update(
             (
@@ -386,11 +385,11 @@ def _missing_signal_facts(
                 "backward",
                 "optimizer_step",
                 "input_wait",
-                "step_time",
+                "traced_step_time",
             )
         )
     if ranks > 1 and rank_straggler is None and straggler_eligible_ranks < 2:
-        needed.update(("backward", "input_wait", "step_time"))
+        needed.update(("backward", "input_wait", "traced_step_time"))
         if training_strategy == "fsdp":
             needed.add("forward")
 
@@ -411,36 +410,44 @@ def build_step_time_context(
 ) -> StepTimeAnalysisContext:
     """Build diagnosis-specific facts from one canonical window."""
     metrics = {metric.metric: metric for metric in window.metrics}
-    step_metric = metrics["step_time"]
+    step_metric = metrics.get("step_time")
     input_wait_metric = metrics.get("input_wait")
     h2d_metric = metrics.get("h2d")
     residual_metric = metrics.get("residual_proxy")
-    total_step_metric = metrics.get("total_step")
 
     coverage = window.coverage
     single_rank = coverage.world_size <= 1 or coverage.ranks_present <= 1
     strategy = normalize_training_strategy(window.training_strategy)
-    iteration_cohort = tuple(
+    step_cohort = tuple(
         facts
-        for rank in window.iteration_ranks
+        for rank in window.step_ranks
         if (facts := window.rank(rank)) is not None
     )
     input_median, input_worst, input_worst_rank, input_excess = _rank_stats(
         tuple(
             (facts.global_rank, _rank_value(facts, "input_wait"))
-            for facts in iteration_cohort
+            for facts in step_cohort
+        )
+    )
+    traced_step_median, traced_step_worst, _rank, _excess = _rank_stats(
+        tuple(
+            (facts.global_rank, _rank_value(facts, "traced_step_time"))
+            for facts in step_cohort
         )
     )
     step_median, step_worst, _rank, _excess = _rank_stats(
         tuple(
             (facts.global_rank, _rank_value(facts, "step_time"))
-            for facts in iteration_cohort
+            for facts in step_cohort
         )
     )
     input_total = input_worst if single_rank else input_median
-    input_step_total = step_worst if single_rank else step_median
+    traced_step_total = (
+        traced_step_worst if single_rank else traced_step_median
+    )
+    step_total = step_worst if single_rank else step_median
     input_skew = None
-    if len(iteration_cohort) >= 2:
+    if len(step_cohort) >= 2:
         if input_median > 0.0:
             input_skew = input_excess / input_median
         elif input_worst <= 0.0:
@@ -483,7 +490,7 @@ def build_step_time_context(
         thresholds=thresholds,
         single_rank=single_rank,
         steps_used=int(coverage.steps_used),
-        overall_worst_rank=metric_worst_rank(total_step_metric or step_metric),
+        overall_worst_rank=metric_worst_rank(step_metric),
         training_strategy=strategy,
         step_metric=step_metric,
         input_wait_metric=input_wait_metric,
@@ -498,8 +505,8 @@ def build_step_time_context(
         input_bound_worst_rank=input_worst_rank,
         diagnosis_clock=window.clock,
         input_wait_total=input_total,
-        input_bound_step_total=input_step_total,
-        iteration_time_total=input_total + input_step_total,
+        traced_step_time_total=traced_step_total,
+        step_time_total=step_total,
         largest_compute=largest_compute_phase(window),
         rank_straggler=rank_straggler,
         missing_signals=missing,

--- a/src/traceml_ai/diagnostics/step_time/policy.py
+++ b/src/traceml_ai/diagnostics/step_time/policy.py
@@ -14,9 +14,9 @@ class DiagnosisThresholds:
     their selected timing windows. Explicit callers may still supply a custom
     policy.
 
-    Typical overhead diagnoses use selected-clock per-rank iteration shares.
+    Typical overhead diagnoses use selected-clock per-rank Step Time shares.
     The context takes the median of those shares across ranks, where
-    ``iteration_time_ms = input_wait_ms + step_time_ms``. The shared overhead
+    ``step_time_ms = input_wait_ms + traced_step_time_ms``. The shared overhead
     thresholds are the future configuration surface for input, residual, and
     H2D policies. Compute-bound uses the same denominator and a separate
     informational dominance threshold.

--- a/src/traceml_ai/diagnostics/step_time/rules.py
+++ b/src/traceml_ai/diagnostics/step_time/rules.py
@@ -164,7 +164,7 @@ class RankStragglerRule(_BaseStepTimeRule):
                 "visible_culprit_ms": evidence.visible_culprit_ms,
                 "visible_victim_ms": evidence.visible_victim_ms,
                 "visible_cost_ms": evidence.visible_cost_ms,
-                "iteration_time_ms": evidence.iteration_time_ms,
+                "step_time_ms": evidence.step_time_ms,
                 "component_excesses_ms": evidence.component_excesses_ms,
                 "component_coverage": evidence.component_coverage,
             },
@@ -184,7 +184,7 @@ class InputBoundRule(_BaseStepTimeRule):
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
         if context.input_bound_share is None:
-            # Input wait or the step envelope was never measured: abstain
+            # Input wait or outer Step Time was never measured: abstain
             # rather than diagnose from a fake zero.
             return None
         if context.input_bound_share < context.thresholds.overhead_share_warn:
@@ -199,7 +199,7 @@ class InputBoundRule(_BaseStepTimeRule):
             ),
             summary=(
                 f"Input wait is {_pct(context.input_bound_share)} of the "
-                f"typical {context.diagnosis_clock} iteration time."
+                f"typical {context.diagnosis_clock.upper()} Step Time."
             ),
             action="Increase workers, prefetch, or storage throughput.",
             metric="input_wait",
@@ -210,8 +210,8 @@ class InputBoundRule(_BaseStepTimeRule):
             ranks=(context.input_bound_worst_rank,),
             evidence={
                 "input_wait_ms": context.input_wait_total,
-                "step_time_ms": context.input_bound_step_total,
-                "iteration_time_ms": context.iteration_time_total,
+                "traced_step_time_ms": context.traced_step_time_total,
+                "step_time_ms": context.step_time_total,
                 "input_bound_share": context.input_bound_share,
                 "diagnosis_clock": context.diagnosis_clock,
             },
@@ -231,7 +231,7 @@ class H2DBoundRule(_BaseStepTimeRule):
         if context.diagnosis_clock != "gpu":
             return None
         if context.h2d_share is None:
-            # H2D, input wait, or the step envelope was never measured.
+            # H2D or outer Step Time was never measured.
             return None
         if context.h2d_share < context.thresholds.overhead_share_warn:
             return None
@@ -246,7 +246,7 @@ class H2DBoundRule(_BaseStepTimeRule):
             ),
             summary=(
                 f"H2D transfer is {_pct(context.h2d_share)} of the "
-                "typical GPU iteration time."
+                "typical GPU Step Time."
             ),
             action=(
                 "Inspect pinned memory, batch transfer, and host-to-device "
@@ -300,7 +300,7 @@ class ResidualHeavyRule(_BaseStepTimeRule):
             ),
             summary=(
                 f"Residual time is {_pct(context.residual_share)} of the "
-                f"typical {context.diagnosis_clock} iteration time."
+                f"typical {context.diagnosis_clock.upper()} Step Time."
             ),
             action=(
                 "Inspect work outside traced phases, CPU stalls, logging, "
@@ -327,7 +327,7 @@ class ComputeBoundRule(_BaseStepTimeRule):
         context: StepTimeAnalysisContext,
     ) -> Optional[DiagnosticIssue]:
         if context.compute_share is None:
-            # A compute phase, input wait, or the step envelope was never
+            # A compute phase or outer Step Time was never
             # measured: dominance cannot be established.
             return None
         if context.compute_share < context.thresholds.compute_bound_share_warn:

--- a/src/traceml_ai/renderers/step_time/renderer.py
+++ b/src/traceml_ai/renderers/step_time/renderer.py
@@ -34,7 +34,7 @@ METRIC_LABELS = {
     "forward": "FWD",
     "backward": "BWD",
     "optimizer_step": "OPT",
-    "step_time": "STEP",
+    "traced_step_time": "STEP",
     "residual_proxy": "RESIDUAL",
 }
 
@@ -44,7 +44,7 @@ TABLE_METRIC_ORDER = (
     "forward",
     "backward",
     "optimizer_step",
-    "step_time",
+    "traced_step_time",
     "residual_proxy",
 )
 
@@ -124,8 +124,8 @@ class StepTimeRenderer(BaseRenderer):
                 border_style="cyan",
             )
 
-        step_metric = next(
-            (m for m in metrics if m.metric == "step_time"), None
+        traced_step_metric = next(
+            (m for m in metrics if m.metric == "traced_step_time"), None
         )
         residual_metric = next(
             (m for m in metrics if m.metric == "residual_proxy"), None
@@ -192,7 +192,7 @@ class StepTimeRenderer(BaseRenderer):
             table.add_row("")
 
         # Optional residual share line (still meaningful in both modes)
-        if step_metric and residual_metric:
+        if traced_step_metric and residual_metric:
             residual_share = window.residual_share
             table.add_row(
                 "Residual Share (%)",

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -52,10 +52,10 @@ STEP_TIME_METRIC_NAMES = [
 ]
 
 _PUBLIC_METRICS = {
-    "total_step_ms": ("total_step_cpu_ms", "total_step_cpu"),
-    "dataloader_ms": ("dataloader_cpu_ms", "dataloader_fetch"),
+    "total_step_ms": ("step_time_cpu_ms", "step_time_cpu"),
+    "dataloader_ms": ("dataloader_fetch_cpu_ms", "dataloader_fetch"),
     "input_wait_ms": ("input_wait_ms", "input_wait"),
-    "step_time_ms": ("step_time_ms", "step_time"),
+    "step_time_ms": ("traced_step_time_ms", "traced_step_time"),
     "h2d_ms": ("h2d_ms", "h2d"),
     "compute_ms": ("compute_ms", "compute"),
     "residual_ms": ("residual_ms", "residual_proxy"),
@@ -63,6 +63,13 @@ _PUBLIC_METRICS = {
     "backward_ms": ("backward_ms", "backward"),
     "optimizer_ms": ("optimizer_step_ms", "optimizer_step"),
 }
+"""Stable public fields projected from the canonical timing contract.
+
+The public summary schema predates the Step Time terminology migration:
+``step_time_ms`` still means the traced inner envelope and
+``total_step_ms`` still means CPU Step Time. Keep that compatibility at this
+projection boundary until the versioned public-schema migration.
+"""
 
 
 class _MetricProjection(NamedTuple):
@@ -95,6 +102,33 @@ def _public_metric_values(
         metric: _optional_float(getattr(values, field_name))
         for metric, (field_name, _statistic) in _PUBLIC_METRICS.items()
     }
+
+
+def _legacy_issue_json(issue: Mapping[str, Any]) -> Dict[str, Any]:
+    """Project canonical diagnosis evidence to the stable summary schema."""
+    projected = dict(issue)
+    evidence = dict(projected.get("evidence") or {})
+    traced_step_time = evidence.pop("traced_step_time_ms", None)
+    step_time = evidence.pop("step_time_ms", None)
+
+    if traced_step_time is not None:
+        evidence["step_time_ms"] = traced_step_time
+    if step_time is not None:
+        evidence["iteration_time_ms"] = step_time
+
+    projected["evidence"] = evidence
+    return projected
+
+
+def _legacy_diagnosis_json(
+    diagnosis: Mapping[str, Any],
+    issues: list[Mapping[str, Any]],
+) -> tuple[Dict[str, Any], list[Dict[str, Any]]]:
+    """Return public diagnosis JSON without leaking new internal key names."""
+    projected_issues = [_legacy_issue_json(issue) for issue in issues]
+    if projected_issues:
+        return dict(projected_issues[0]), projected_issues
+    return _legacy_issue_json(diagnosis), projected_issues
 
 
 def _project_metric(
@@ -339,6 +373,10 @@ def project_step_time_summary(analysis: StepTimeAnalysis) -> Dict[str, Any]:
         {metric.metric: metric for metric in window.metrics},
     )
     diagnosis_json, issues_json = diagnostic_result_to_json(analysis.diagnosis)
+    diagnosis_json, issues_json = _legacy_diagnosis_json(
+        diagnosis_json,
+        issues_json,
+    )
     card = _build_card(
         analysis,
         metrics,

--- a/src/traceml_ai/step_time/analysis.py
+++ b/src/traceml_ai/step_time/analysis.py
@@ -591,7 +591,11 @@ def _build_cohorts(
         for metric in _COMPOSITION_KEYS
         if any(facts.average.value(metric) is not None for facts in rank_facts)
     )
-    composition = carrying("step_time", *present_composition)
+    # The dashboard ribbon visualizes the traced envelope and can still show
+    # its measured phases when input wait is unavailable. Diagnosis shares
+    # remain anchored to outer Step Time above; this presentation cohort must
+    # not manufacture that unavailable denominator.
+    composition = carrying(TRACED_STEP_TIME_KEY, *present_composition)
 
     fsdp = str(training_strategy).strip().lower() == "fsdp"
     straggler = tuple(
@@ -616,7 +620,7 @@ def _composition_representative_rank(
 ) -> Optional[int]:
     cohort_set = set(int(rank) for rank in cohort)
     anchors = {
-        facts.global_rank: facts.average.step_time_ms
+        facts.global_rank: facts.average.traced_step_time_ms
         for facts in rank_facts
         if facts.global_rank in cohort_set
     }

--- a/tests/diagnostics/test_registry.py
+++ b/tests/diagnostics/test_registry.py
@@ -112,8 +112,16 @@ def test_model_diagnostics_payload_uses_registered_domains():
 
 def test_model_step_time_diagnostics_receive_canonical_window():
     per_rank_timing = {
-        0: {"input_wait": 1.0, "total_step": 10.0},
-        1: {"input_wait": 2.0, "total_step": 11.0},
+        0: {
+            "input_wait": 1.0,
+            "traced_step_time": 9.0,
+            "step_time": 10.0,
+        },
+        1: {
+            "input_wait": 2.0,
+            "traced_step_time": 9.0,
+            "step_time": 11.0,
+        },
     }
     window = window_from_rank_averages(
         per_rank_timing,
@@ -147,14 +155,16 @@ def test_model_step_time_diagnostics_receive_canonical_window():
 def test_model_step_time_diagnostics_use_selected_metrics():
     diagnosis_metrics = (
         _step_time_metric("input_wait", 40.0),
-        _step_time_metric("step_time", 100.0),
+        _step_time_metric("traced_step_time", 100.0),
+        _step_time_metric("step_time", 140.0),
         _step_time_metric("residual_proxy", 0.0),
     )
     window = window_from_rank_averages(
         {
             0: {
                 "input_wait": 40.0,
-                "step_time": 100.0,
+                "traced_step_time": 100.0,
+                "step_time": 140.0,
                 "residual_proxy": 0.0,
             }
         },
@@ -187,7 +197,13 @@ def test_model_step_time_diagnostics_use_selected_metrics():
 
 def test_model_diagnostics_uses_precomputed_step_time_diagnosis():
     window = window_from_rank_averages(
-        {0: {"step_time": 100.0, "total_step": 100.0}},
+        {
+            0: {
+                "input_wait": 0.0,
+                "traced_step_time": 100.0,
+                "step_time": 100.0,
+            }
+        },
         expected_ranks=(0,),
         metrics=[_step_time_metric("step_time", 100.0)],
     )
@@ -216,7 +232,13 @@ def test_model_diagnostics_uses_precomputed_step_time_diagnosis():
 def test_model_diagnostics_requires_precomputed_step_time_diagnosis():
     """The composer must not repeat analysis or diagnosis work."""
     window = window_from_rank_averages(
-        {0: {"step_time": 100.0, "total_step": 100.0}},
+        {
+            0: {
+                "input_wait": 0.0,
+                "traced_step_time": 100.0,
+                "step_time": 100.0,
+            }
+        },
         expected_ranks=(0,),
         metrics=[_step_time_metric("step_time", 100.0)],
     )

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -94,7 +94,8 @@ def test_diagnosis_clock_selection_prefers_gpu_then_cpu() -> None:
     assert selected.clock == "gpu"
     average = rank_average(selected, 0)
     assert average.input_wait_ms == pytest.approx(4.0)
-    assert average.step_time_ms == pytest.approx(20.0)
+    assert average.traced_step_time_ms == pytest.approx(20.0)
+    assert average.step_time_ms == pytest.approx(24.0)
     # optimizer_step and h2d were never measured: the residual must not
     # silently absorb them as zeros.
     assert average.residual_ms is None
@@ -103,7 +104,8 @@ def test_diagnosis_clock_selection_prefers_gpu_then_cpu() -> None:
     assert rank_facts is not None
     step_values = rank_facts.steps[0].values
     assert step_values.input_wait_ms == pytest.approx(4.0)
-    assert step_values.step_time_ms == pytest.approx(20.0)
+    assert step_values.traced_step_time_ms == pytest.approx(20.0)
+    assert step_values.step_time_ms == pytest.approx(24.0)
 
     events["_traceml_internal:dataloader_next"]["cuda:0"]["gpu_ms"] = None
     selected = window_from_events(
@@ -115,7 +117,8 @@ def test_diagnosis_clock_selection_prefers_gpu_then_cpu() -> None:
     assert selected.clock == "cpu"
     average = rank_average(selected, 0)
     assert average.input_wait_ms == pytest.approx(12.0)
-    assert average.step_time_ms == pytest.approx(60.0)
+    assert average.traced_step_time_ms == pytest.approx(60.0)
+    assert average.step_time_ms == pytest.approx(72.0)
     # optimizer_step was never measured, so compute and residual stay
     # underivable on the cpu clock as well.
     assert average.residual_ms is None
@@ -163,8 +166,8 @@ def test_input_bound_rule_uses_cpu_clock_when_gpu_is_absent() -> None:
     assert issue.score == issue.share_pct
     assert issue.evidence["diagnosis_clock"] == "cpu"
     assert issue.evidence["input_wait_ms"] == pytest.approx(35.0)
-    assert issue.evidence["step_time_ms"] == pytest.approx(100.0)
-    assert issue.evidence["iteration_time_ms"] == pytest.approx(135.0)
+    assert issue.evidence["traced_step_time_ms"] == pytest.approx(100.0)
+    assert issue.evidence["step_time_ms"] == pytest.approx(135.0)
 
 
 def test_input_bound_rule_ignores_duration_without_explicit_clocks() -> None:
@@ -175,7 +178,7 @@ def test_input_bound_rule_ignores_duration_without_explicit_clocks() -> None:
     assert InputBoundRule().evaluate(ctx) is None
 
 
-def test_input_bound_uses_median_per_rank_iteration_share() -> None:
+def test_input_bound_uses_median_per_rank_step_time_share() -> None:
     ctx = _rank_context(
         {
             0: _timing_row(
@@ -206,7 +209,7 @@ def test_input_bound_uses_median_per_rank_iteration_share() -> None:
     ("input_wait", "step_time", "expected_severity"),
     [(10.0, 90.0, "warn"), (20.0, 80.0, "crit")],
 )
-def test_input_bound_uses_iteration_share_thresholds(
+def test_input_bound_uses_step_time_share_thresholds(
     input_wait: float,
     step_time: float,
     expected_severity: str,
@@ -276,7 +279,7 @@ def test_h2d_bound_conditions(
     ("residual", "expected_severity"),
     [(10.0, "warn"), (20.0, "crit")],
 )
-def test_residual_heavy_uses_iteration_share_thresholds(
+def test_residual_heavy_uses_step_time_share_thresholds(
     residual: float,
     expected_severity: str,
 ) -> None:
@@ -329,7 +332,7 @@ def test_compute_bound_is_informational_despite_compute_skew() -> None:
     ("compute", "expected"),
     [(89.9, False), (90.0, True)],
 )
-def test_compute_bound_uses_iteration_share_threshold(
+def test_compute_bound_uses_step_time_share_threshold(
     compute: float,
     expected: bool,
 ) -> None:
@@ -351,7 +354,7 @@ def test_compute_bound_uses_iteration_share_threshold(
         assert issue.score is None
 
 
-def test_compute_share_is_median_of_per_rank_iteration_shares() -> None:
+def test_compute_share_is_median_of_per_rank_step_time_shares() -> None:
     per_rank = {
         0: _timing_row(
             dataloader=0.0,
@@ -815,7 +818,7 @@ def test_fsdp_rank_straggler_uses_input_h2d_or_unattributed(
     ("visible_cost", "expected_severity"),
     [(5.0, None), (9.0, None), (10.0, "warn"), (20.0, "crit")],
 )
-def test_rank_straggler_uses_victim_iteration_impact_thresholds(
+def test_rank_straggler_uses_victim_step_time_impact_thresholds(
     visible_cost: float,
     expected_severity: str | None,
 ) -> None:
@@ -1009,7 +1012,7 @@ def test_rank_straggler_keeps_confidence_and_fsdp_severity_caps() -> None:
                     step_time=140.0,
                 ),
             },
-            ("INPUT_STRAGGLER", 1, 2),
+            ("INPUT_STRAGGLER", 0, 1),
         ),
         (
             "fsdp",
@@ -1173,9 +1176,10 @@ def test_summary_input_bound_uses_explicit_input_clocks() -> None:
     assert high_wait.primary.kind == "INPUT_BOUND"
     assert high_wait.issues[0].evidence["diagnosis_clock"] == "gpu"
     assert high_wait.issues[0].evidence["input_wait_ms"] == pytest.approx(25.0)
-    assert high_wait.issues[0].evidence["iteration_time_ms"] == pytest.approx(
-        85.0
-    )
+    assert high_wait.issues[0].evidence[
+        "traced_step_time_ms"
+    ] == pytest.approx(60.0)
+    assert high_wait.issues[0].evidence["step_time_ms"] == pytest.approx(85.0)
 
 
 def test_summary_h2d_bound_uses_gpu_selected_h2d_timing() -> None:

--- a/tests/diagnostics/test_step_time.py
+++ b/tests/diagnostics/test_step_time.py
@@ -151,7 +151,7 @@ def test_input_bound_rule_uses_cpu_clock_when_gpu_is_absent() -> None:
             0: _timing_row(
                 dataloader=5.0,
                 input_wait_cpu=35.0,
-                step_time_cpu=100.0,
+                traced_step_time_cpu=100.0,
             )
         },
     )
@@ -184,12 +184,12 @@ def test_input_bound_uses_median_per_rank_step_time_share() -> None:
             0: _timing_row(
                 dataloader=10.0,
                 input_wait_gpu=10.0,
-                step_time_gpu=100.0,
+                traced_step_time_gpu=100.0,
             ),
             1: _timing_row(
                 dataloader=10.0,
                 input_wait_gpu=60.0,
-                step_time_gpu=100.0,
+                traced_step_time_gpu=100.0,
             ),
         }
     )
@@ -206,18 +206,18 @@ def test_input_bound_uses_median_per_rank_step_time_share() -> None:
 
 
 @pytest.mark.parametrize(
-    ("input_wait", "step_time", "expected_severity"),
+    ("input_wait", "traced_step_time", "expected_severity"),
     [(10.0, 90.0, "warn"), (20.0, 80.0, "crit")],
 )
 def test_input_bound_uses_step_time_share_thresholds(
     input_wait: float,
-    step_time: float,
+    traced_step_time: float,
     expected_severity: str,
 ) -> None:
     per_rank = {
         0: _timing_row(
             dataloader=input_wait,
-            step_time=step_time,
+            traced_step_time=traced_step_time,
         )
     }
 
@@ -251,7 +251,7 @@ def test_h2d_bound_conditions(
             forward=0.0,
             backward=0.0,
             optimizer=0.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         )
         for rank, h2d in enumerate(h2d_by_rank)
     }
@@ -290,7 +290,7 @@ def test_residual_heavy_uses_step_time_share_thresholds(
             backward=0.0,
             optimizer=0.0,
             residual=residual,
-            step_time=100.0,
+            traced_step_time=100.0,
         )
     }
 
@@ -309,14 +309,14 @@ def test_compute_bound_is_informational_despite_compute_skew() -> None:
             forward=90.0,
             backward=0.0,
             optimizer=0.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
         1: _timing_row(
             dataloader=0.0,
             forward=150.0,
             backward=0.0,
             optimizer=0.0,
-            step_time=160.0,
+            traced_step_time=160.0,
         ),
     }
 
@@ -342,7 +342,7 @@ def test_compute_bound_uses_step_time_share_threshold(
             forward=compute,
             backward=0.0,
             optimizer=0.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         )
     }
 
@@ -361,14 +361,14 @@ def test_compute_share_is_median_of_per_rank_step_time_shares() -> None:
             forward=100.0,
             backward=0.0,
             optimizer=0.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
         1: _timing_row(
             dataloader=100.0,
             forward=80.0,
             backward=0.0,
             optimizer=0.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
     }
 
@@ -395,13 +395,21 @@ def test_compute_share_is_median_of_per_rank_step_time_shares() -> None:
             id="material-h2d",
         ),
         pytest.param(
-            {"dataloader": 10.0, "forward": 90.0, "step_time": 90.0},
+            {
+                "dataloader": 10.0,
+                "forward": 90.0,
+                "traced_step_time": 90.0,
+            },
             "cpu",
             0.90,
             id="material-input-wait",
         ),
         pytest.param(
-            {"forward": 90.0, "residual": 10.0, "step_time": 100.0},
+            {
+                "forward": 90.0,
+                "residual": 10.0,
+                "traced_step_time": 100.0,
+            },
             "cpu",
             0.90,
             id="material-residual",
@@ -419,7 +427,7 @@ def test_compute_bound_abstains_for_competing_costs(
         "forward": 0.0,
         "backward": 0.0,
         "optimizer": 0.0,
-        "step_time": 100.0,
+        "traced_step_time": 100.0,
         **overrides,
     }
     per_rank = {0: _timing_row(**row)}
@@ -438,7 +446,7 @@ def test_cpu_h2d_does_not_suppress_compute_bound() -> None:
             forward=90.0,
             backward=0.0,
             optimizer=0.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         )
     }
 
@@ -456,7 +464,7 @@ def test_input_bound_remains_primary_when_h2d_is_also_material() -> None:
             forward=0.0,
             backward=0.0,
             optimizer=0.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         )
     }
 
@@ -481,7 +489,7 @@ def test_step_time_primary_orders_by_severity_before_impact() -> None:
             backward=0.0,
             optimizer=0.0,
             residual=30.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         )
     }
 
@@ -507,7 +515,7 @@ def test_step_time_primary_orders_equal_severity_by_impact() -> None:
             backward=0.0,
             optimizer=0.0,
             residual=19.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         )
     }
 
@@ -532,14 +540,14 @@ def test_rank_straggler_wins_only_an_exact_impact_tie() -> None:
             forward=0.0,
             backward=20.0,
             optimizer=0.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
         1: _timing_row(
             dataloader=20.0,
             forward=0.0,
             backward=40.0,
             optimizer=0.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
     }
     higher_typical = {
@@ -548,14 +556,14 @@ def test_rank_straggler_wins_only_an_exact_impact_tie() -> None:
             forward=0.0,
             backward=20.0,
             optimizer=0.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
         1: _timing_row(
             dataloader=20.0,
             forward=0.0,
             backward=35.0,
             optimizer=0.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
     }
 
@@ -591,7 +599,7 @@ def test_step_time_primary_uses_capped_severity_before_impact() -> None:
             backward=0.0,
             optimizer=0.0,
             residual=30.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         )
     }
 
@@ -633,14 +641,14 @@ def test_compute_bound_is_secondary_to_rank_straggler() -> None:
             forward=90.0,
             backward=10.0,
             optimizer=0.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
         1: _timing_row(
             dataloader=0.0,
             forward=90.0,
             backward=30.0,
             optimizer=0.0,
-            step_time=120.0,
+            traced_step_time=120.0,
         ),
     }
 
@@ -826,12 +834,12 @@ def test_rank_straggler_uses_victim_step_time_impact_thresholds(
         0: _timing_row(
             dataloader=0.0,
             backward=10.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
         1: _timing_row(
             dataloader=0.0,
             backward=10.0 + visible_cost,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
     }
 
@@ -845,6 +853,8 @@ def test_rank_straggler_uses_victim_step_time_impact_thresholds(
     assert issue.kind == "STRAGGLER"
     assert issue.severity == expected_severity
     assert issue.score == pytest.approx(visible_cost / 100.0)
+    assert issue.evidence["step_time_ms"] == pytest.approx(100.0)
+    assert "iteration_time_ms" not in issue.evidence
 
 
 @pytest.mark.parametrize(
@@ -868,12 +878,12 @@ def test_rank_straggler_requires_component_coverage_for_attribution(
     culprit = _timing_row(
         dataloader=0.0,
         backward=20.0,
-        step_time=100.0,
+        traced_step_time=100.0,
     )
     victim = _timing_row(
         dataloader=0.0,
         backward=120.0,
-        step_time=100.0,
+        traced_step_time=100.0,
     )
     if component == "input":
         culprit["input_wait"] = excess
@@ -915,12 +925,12 @@ def test_rank_straggler_keeps_confidence_and_fsdp_severity_caps() -> None:
         0: _timing_row(
             dataloader=100.0,
             backward=20.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
         1: _timing_row(
             dataloader=0.0,
             backward=120.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
     }
     early = _diagnose_rank_map(
@@ -942,13 +952,13 @@ def test_rank_straggler_keeps_confidence_and_fsdp_severity_caps() -> None:
             dataloader=100.0,
             forward=20.0,
             backward=20.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
         1: _timing_row(
             dataloader=0.0,
             forward=80.0,
             backward=80.0,
-            step_time=100.0,
+            traced_step_time=100.0,
         ),
     }
     fsdp = _diagnose_rank_map(
@@ -970,17 +980,17 @@ def test_rank_straggler_keeps_confidence_and_fsdp_severity_caps() -> None:
                 0: _timing_row(
                     dataloader=200.0,
                     backward=0.0,
-                    step_time=200.0,
+                    traced_step_time=200.0,
                 ),
                 1: _timing_row(
                     dataloader=80.0,
                     backward=20.0,
-                    step_time=100.0,
+                    traced_step_time=100.0,
                 ),
                 2: _timing_row(
                     dataloader=0.0,
                     backward=120.0,
-                    step_time=140.0,
+                    traced_step_time=140.0,
                 ),
             },
             ("INPUT_STRAGGLER", 1, 2),
@@ -988,8 +998,8 @@ def test_rank_straggler_keeps_confidence_and_fsdp_severity_caps() -> None:
         (
             "ddp",
             {
-                0: _timing_row(backward=0.0, step_time=100.0),
-                1: _timing_row(backward=0.0, step_time=120.0),
+                0: _timing_row(backward=0.0, traced_step_time=100.0),
+                1: _timing_row(backward=0.0, traced_step_time=120.0),
             },
             None,
         ),
@@ -999,17 +1009,17 @@ def test_rank_straggler_keeps_confidence_and_fsdp_severity_caps() -> None:
                 0: _timing_row(
                     dataloader=200.0,
                     backward=1.0,
-                    step_time=0.0,
+                    traced_step_time=0.0,
                 ),
                 1: _timing_row(
                     dataloader=80.0,
                     backward=20.0,
-                    step_time=100.0,
+                    traced_step_time=100.0,
                 ),
                 2: _timing_row(
                     dataloader=0.0,
                     backward=120.0,
-                    step_time=140.0,
+                    traced_step_time=140.0,
                 ),
             },
             ("INPUT_STRAGGLER", 0, 1),
@@ -1084,7 +1094,7 @@ def test_step_time_primary_prefers_rank_straggler_over_residual_heavy() -> (
 
 def test_step_time_early_warning_band_caps_severity() -> None:
     per_rank = {
-        0: _timing_row(dataloader=50.0, step_time=100.0),
+        0: _timing_row(dataloader=50.0, traced_step_time=100.0),
     }
 
     warmup = _diagnose_rank_map(
@@ -1229,6 +1239,32 @@ def test_summary_input_bound_trend_uses_selected_input_wait_series() -> None:
     assert result.primary.note is not None
     assert result.primary.note.startswith("Trend: input wait is ")
     assert "dataloader" not in result.primary.note
+
+
+def test_summary_compute_trend_uses_outer_step_time_series() -> None:
+    steps = 240
+    per_step: dict[int, dict] = {}
+    for step in range(steps):
+        input_wait = 0.0 if step < steps // 2 else 10.0
+        per_step[step] = {
+            "_traceml_internal:dataloader_next": _event_stats(
+                gpu_ms=input_wait
+            ),
+            "_traceml_internal:h2d_time": _event_stats(gpu_ms=0.0),
+            "_traceml_internal:forward_time": _event_stats(gpu_ms=50.0),
+            "_traceml_internal:backward_time": _event_stats(gpu_ms=30.0),
+            "_traceml_internal:optimizer_step": _event_stats(gpu_ms=10.0),
+            "_traceml_internal:step_time": _event_stats(gpu_ms=90.0),
+        }
+
+    result = _diagnose_summary_events(
+        {0: per_step},
+        max_rows=steps,
+    )
+
+    assert result.primary.kind == "COMPUTE_BOUND"
+    assert result.primary.note is not None
+    assert result.primary.note.startswith("Trend: step time is worsening")
 
 
 @pytest.mark.parametrize(

--- a/tests/diagnostics/test_step_time_invariants.py
+++ b/tests/diagnostics/test_step_time_invariants.py
@@ -230,14 +230,15 @@ def test_step_time_share_preserves_unavailable_and_measured_zero() -> None:
     rows = {
         0: {
             "input_wait": 100.0,
+            "h2d": 10.0,
             "traced_step_time": 100.0,
             "step_time": 200.0,
             "residual_proxy": 10.0,
         }
     }
-    assert window_from_rank_averages(rows).residual_share == pytest.approx(
-        0.05
-    )
+    window = window_from_rank_averages(rows)
+    assert window.h2d_share == pytest.approx(0.05)
+    assert window.residual_share == pytest.approx(0.05)
     rows[0]["residual_proxy"] = 0.0
     assert window_from_rank_averages(rows).residual_share == pytest.approx(0.0)
     del rows[0]["residual_proxy"]

--- a/tests/diagnostics/test_step_time_invariants.py
+++ b/tests/diagnostics/test_step_time_invariants.py
@@ -44,7 +44,7 @@ _EVENT_NAMES = {
     "forward": "_traceml_internal:forward_time",
     "backward": "_traceml_internal:backward_time",
     "optimizer_step": "_traceml_internal:optimizer_step",
-    "step_time": "_traceml_internal:step_time",
+    "traced_step_time": "_traceml_internal:step_time",
 }
 
 _BASE_MS = {
@@ -53,7 +53,7 @@ _BASE_MS = {
     "forward": 20.0,
     "backward": 30.0,
     "optimizer_step": 10.0,
-    "step_time": 64.0,
+    "traced_step_time": 64.0,
 }
 
 # Every metric that is not occurrence-driven must be measured on every
@@ -226,11 +226,12 @@ def test_skew_is_unavailable_when_zero_median_hides_a_nonzero_rank() -> None:
     assert backward.skew_pct is None
 
 
-def test_iteration_share_preserves_unavailable_and_measured_zero() -> None:
+def test_step_time_share_preserves_unavailable_and_measured_zero() -> None:
     rows = {
         0: {
             "input_wait": 100.0,
-            "step_time": 100.0,
+            "traced_step_time": 100.0,
+            "step_time": 200.0,
             "residual_proxy": 10.0,
         }
     }
@@ -245,7 +246,8 @@ def test_iteration_share_preserves_unavailable_and_measured_zero() -> None:
     invalid_compute = {
         0: {
             "input_wait": 10.0,
-            "step_time": 100.0,
+            "traced_step_time": 100.0,
+            "step_time": 110.0,
             "backward": 20.0,
             "optimizer_step": 10.0,
         }
@@ -301,14 +303,18 @@ def test_worst_value_and_rank_are_self_consistent(
     slow_rank_lacks_input: bool,
 ) -> None:
     # Two ranks, the slower one optionally missing input wait so its
-    # total_step is underivable. The step-time summary must never pair a
+    # outer Step Time is underivable. Its metric summary must never pair a
     # value from one rank with a rank id from another.
-    def fill(target, rank, step_time, drop_input):
+    def fill(target, rank, traced_step_time, drop_input):
         row = {}
         for metric in _EVENT_NAMES:
             if drop_input and metric == "input_wait":
                 continue
-            value = step_time if metric == "step_time" else _BASE_MS[metric]
+            value = (
+                traced_step_time
+                if metric == "traced_step_time"
+                else _BASE_MS[metric]
+            )
             row[_EVENT_NAMES[metric]] = _stat(value)
         for step in range(_WINDOW):
             target[rank][step] = dict(row)
@@ -320,8 +326,10 @@ def test_worst_value_and_rank_are_self_consistent(
 
     assert_metric_worst_is_self_consistent(window)
     step_metric = next(m for m in window.metrics if m.metric == "step_time")
-    assert step_metric.worst_total == pytest.approx(400.0)
-    assert step_metric.worst_rank == 1
+    expected_worst = 104.0 if slow_rank_lacks_input else 404.0
+    expected_rank = 0 if slow_rank_lacks_input else 1
+    assert step_metric.worst_total == pytest.approx(expected_worst)
+    assert step_metric.worst_rank == expected_rank
 
 
 def test_self_consistency_holds_across_many_presence_patterns() -> None:
@@ -380,9 +388,16 @@ def test_typed_values_null_residual_when_compute_incomplete(
 
 def test_typed_values_keep_measured_zero_distinct_from_absent() -> None:
     measured_zero = values_from_mapping(
-        {"h2d": 0.0, "input_wait": 4.0, "step_time": 64.0}
+        {
+            "h2d": 0.0,
+            "input_wait": 4.0,
+            "traced_step_time": 60.0,
+            "step_time": 64.0,
+        }
     )
-    absent = values_from_mapping({"input_wait": 4.0, "step_time": 64.0})
+    absent = values_from_mapping(
+        {"input_wait": 4.0, "traced_step_time": 60.0, "step_time": 64.0}
+    )
 
     assert measured_zero.h2d_ms == 0.0
     assert absent.h2d_ms is None
@@ -407,5 +422,5 @@ def test_metric_partition_is_exhaustive_and_intended() -> None:
         "input_wait",
         "forward",
         "backward",
-        "step_time",
+        "traced_step_time",
     }

--- a/tests/diagnostics/test_step_time_missing_signals.py
+++ b/tests/diagnostics/test_step_time_missing_signals.py
@@ -50,7 +50,7 @@ _EVENT_NAMES = {
     "forward": "_traceml_internal:forward_time",
     "backward": "_traceml_internal:backward_time",
     "optimizer_step": "_traceml_internal:optimizer_step",
-    "step_time": "_traceml_internal:step_time",
+    "traced_step_time": "_traceml_internal:step_time",
 }
 
 _DEFAULT_MS = {
@@ -59,7 +59,7 @@ _DEFAULT_MS = {
     "forward": 20.0,
     "backward": 30.0,
     "optimizer_step": 10.0,
-    "step_time": 62.0,
+    "traced_step_time": 62.0,
 }
 
 
@@ -150,7 +150,7 @@ def test_missing_forward_blocks_compute_bound_and_reports_incomplete() -> None:
                 input_wait=2.0,
                 backward=60.0,
                 optimizer_step=10.0,
-                step_time=90.0,
+                traced_step_time=90.0,
             )
         }
     )
@@ -170,7 +170,7 @@ def test_complete_compute_dominance_still_reports_compute_bound() -> None:
                 forward=60.0,
                 backward=20.0,
                 optimizer_step=8.0,
-                step_time=90.0,
+                traced_step_time=90.0,
             )
         }
     )
@@ -186,7 +186,7 @@ def test_missing_optimizer_blocks_residual_heavy() -> None:
                 input_wait=2.0,
                 forward=40.0,
                 backward=30.0,
-                step_time=100.0,
+                traced_step_time=100.0,
             )
         }
     )
@@ -203,7 +203,7 @@ def test_measured_zero_optimizer_still_reports_residual_heavy() -> None:
                 forward=40.0,
                 backward=30.0,
                 optimizer_step=0.0,
-                step_time=100.0,
+                traced_step_time=100.0,
             )
         }
     )
@@ -224,7 +224,7 @@ def test_missing_input_wait_reports_incomplete_data() -> None:
                 forward=30.0,
                 backward=30.0,
                 optimizer_step=10.0,
-                step_time=80.0,
+                traced_step_time=80.0,
             )
         }
     )
@@ -243,7 +243,7 @@ def test_missing_h2d_still_emits_input_bound_on_gpu_clock() -> None:
                 forward=30.0,
                 backward=30.0,
                 optimizer_step=10.0,
-                step_time=80.0,
+                traced_step_time=80.0,
             )
         }
     )
@@ -263,7 +263,7 @@ _BALANCED_RANK = dict(
     forward=30.0,
     backward=30.0,
     optimizer_step=10.0,
-    step_time=76.0,
+    traced_step_time=76.0,
 )
 
 
@@ -304,7 +304,7 @@ def test_missing_backward_blocks_ddp_straggler() -> None:
 
 
 def test_visible_backward_skew_still_reports_straggler() -> None:
-    slow = dict(_BALANCED_RANK, backward=60.0, step_time=106.0)
+    slow = dict(_BALANCED_RANK, backward=60.0, traced_step_time=106.0)
     result = _diagnose(
         {
             0: _step_events(**_BALANCED_RANK),
@@ -321,7 +321,7 @@ def test_visible_backward_skew_still_reports_straggler() -> None:
 
 
 def test_missing_forward_blocks_fsdp_straggler() -> None:
-    slow = dict(_BALANCED_RANK, backward=60.0, step_time=106.0)
+    slow = dict(_BALANCED_RANK, backward=60.0, traced_step_time=106.0)
     result = _diagnose(
         {
             0: _step_events(
@@ -442,7 +442,7 @@ def test_incomplete_data_serializes_and_formats() -> None:
                 input_wait=2.0,
                 backward=60.0,
                 optimizer_step=10.0,
-                step_time=90.0,
+                traced_step_time=90.0,
             )
         }
     )
@@ -479,7 +479,7 @@ def test_incomplete_data_routes_to_insufficient_primary() -> None:
                 input_wait=2.0,
                 backward=60.0,
                 optimizer_step=10.0,
-                step_time=90.0,
+                traced_step_time=90.0,
             )
         }
     )
@@ -556,7 +556,7 @@ def test_gpu_missing_forward_reports_incomplete_data() -> None:
                 h2d=1.0,
                 backward=60.0,
                 optimizer_step=10.0,
-                step_time=90.0,
+                traced_step_time=90.0,
             )
         }
     )

--- a/tests/display/test_model_combined_section.py
+++ b/tests/display/test_model_combined_section.py
@@ -110,7 +110,8 @@ _COMPLETE_METRIC_VALUES = {
     "backward": 30.0,
     "optimizer_step": 20.0,
     "residual_proxy": 20.0,
-    "step_time": 100.0,
+    "traced_step_time": 100.0,
+    "step_time": 110.0,
 }
 
 
@@ -135,10 +136,19 @@ def _timing(
     **overrides: float,
 ) -> dict[str, float]:
     values = {**_COMPLETE_METRIC_VALUES, **overrides}
-    values["total_step"] = values.get("input_wait", 0.0) + values.get(
-        "step_time", 0.0
+    return _canonical_timing(
+        {name: value for name, value in values.items() if name not in omit}
     )
-    return {name: value for name, value in values.items() if name not in omit}
+
+
+def _canonical_timing(values: dict[str, float]) -> dict[str, float]:
+    """Keep direct dashboard fixtures within the canonical timing contract."""
+    row = dict(values)
+    if "input_wait" not in row or "traced_step_time" not in row:
+        row.pop("step_time", None)
+    else:
+        row["step_time"] = row["input_wait"] + row["traced_step_time"]
+    return row
 
 
 def _payload(
@@ -151,9 +161,16 @@ def _payload(
     """Build a live result around one canonical Step Time window."""
     if per_rank_timing is None:
         row = {metric.metric: float(metric.median_total) for metric in metrics}
-        if "input_wait" in row and "step_time" in row:
-            row["total_step"] = row["input_wait"] + row["step_time"]
+        if "input_wait" not in row or "traced_step_time" not in row:
+            row.pop("step_time", None)
+        else:
+            row["step_time"] = row["input_wait"] + row["traced_step_time"]
         per_rank_timing = {0: row}
+    else:
+        per_rank_timing = {
+            rank: _canonical_timing(values)
+            for rank, values in per_rank_timing.items()
+        }
     return live_result_from_window(
         window_from_rank_averages(
             per_rank_timing,
@@ -257,7 +274,7 @@ def test_step_time_dashboard_hero_absent_h2d_is_not_partial() -> None:
 
 
 def test_step_time_dashboard_hero_step_time_only_extreme() -> None:
-    payload = _payload([_metric("step_time", 100.0)])
+    payload = _payload([_metric("traced_step_time", 100.0)])
     panel = _panel()
 
     update_model_combined_section(panel, payload)
@@ -337,7 +354,7 @@ def test_partial_rank_coverage_includes_step_time() -> None:
         _metrics(),
         per_rank_timing={
             0: _timing(),
-            1: _timing(omit=("residual_proxy", "step_time")),
+            1: _timing(omit=("residual_proxy", "traced_step_time")),
         },
     )
     panel = _panel()
@@ -523,7 +540,7 @@ def test_step_time_dashboard_hero_clears_when_step_envelope_missing() -> None:
                 "backward",
                 "optimizer_step",
                 "residual_proxy",
-                "step_time",
+                "traced_step_time",
             )
         )
     )
@@ -540,7 +557,7 @@ def test_step_time_dashboard_hero_uses_diagnosis_metrics() -> None:
     assert theme.PHASES[0][:2] == ("IW", "input_wait")
 
     # Self-consistent window shape: phases sum to input_wait + step.
-    diagnosis_metrics = _metrics(worst={"step_time": 200.0})
+    diagnosis_metrics = _metrics(worst={"traced_step_time": 200.0})
     payload = _payload(diagnosis_metrics, clock="gpu")
     panel = _panel()
 
@@ -619,11 +636,11 @@ def test_disjoint_rank_populations_clear_only_the_ribbon() -> None:
                     "h2d",
                     "forward",
                     "residual_proxy",
-                    "total_step",
+                    "traced_step_time",
                 ),
                 backward=40.0,
                 optimizer_step=10.0,
-                step_time=120.0,
+                traced_step_time=120.0,
             ),
         },
     )

--- a/tests/renderers/test_step_time_renderer.py
+++ b/tests/renderers/test_step_time_renderer.py
@@ -46,8 +46,8 @@ def _sparse_payload() -> LiveStepTimeResult:
                     "h2d": 0.0,
                     "backward": 60.0,
                     "optimizer_step": 10.0,
-                    "step_time": 90.0,
-                    "total_step": 92.0,
+                    "traced_step_time": 90.0,
+                    "step_time": 92.0,
                 }
             },
             expected_ranks=(0,),
@@ -56,7 +56,8 @@ def _sparse_payload() -> LiveStepTimeResult:
                 _metric("h2d", 0.0),
                 _metric("backward", 60.0),
                 _metric("optimizer_step", 10.0),
-                _metric("step_time", 90.0),
+                _metric("traced_step_time", 90.0),
+                _metric("step_time", 92.0),
             ],
             steps_used=30,
         )
@@ -65,26 +66,33 @@ def _sparse_payload() -> LiveStepTimeResult:
 
 def test_cli_columns_exclude_summary_only_statistics() -> None:
     metrics = [
-        _metric("step_time", 100.0),
+        _metric("traced_step_time", 100.0),
         _metric("compute", 80.0),
         _metric("dataloader_fetch", 10.0),
-        _metric("total_step_cpu", 120.0),
+        _metric("step_time_cpu", 120.0),
     ]
 
     assert [metric.metric for metric in _table_metrics(metrics)] == [
-        "step_time"
+        "traced_step_time"
     ]
 
 
 def test_step_time_cli_uses_the_precomputed_selected_clock_analysis() -> None:
     diagnosis_metrics = [
         _metric("input_wait", 40.0),
-        _metric("step_time", 100.0),
+        _metric("traced_step_time", 100.0),
+        _metric("step_time", 140.0),
         _metric("residual_proxy", 0.0),
     ]
     payload = live_result_from_window(
         window_from_rank_averages(
-            {0: {"input_wait": 40.0, "step_time": 100.0}},
+            {
+                0: {
+                    "input_wait": 40.0,
+                    "traced_step_time": 100.0,
+                    "step_time": 140.0,
+                }
+            },
             clock="gpu",
             expected_ranks=(0,),
             metrics=diagnosis_metrics,
@@ -114,6 +122,7 @@ def test_step_time_cli_renders_zero_timings_as_zero() -> None:
         _metric("forward", 4.5),
         _metric("backward", 8.7),
         _metric("optimizer_step", 12.0),
+        _metric("traced_step_time", 31.2),
         _metric("step_time", 31.2),
         _metric("residual_proxy", 6.0),
     ]
@@ -126,6 +135,7 @@ def test_step_time_cli_renders_zero_timings_as_zero() -> None:
                     "forward": 4.5,
                     "backward": 8.7,
                     "optimizer_step": 12.0,
+                    "traced_step_time": 31.2,
                     "step_time": 31.2,
                     "residual_proxy": 6.0,
                 }
@@ -147,9 +157,18 @@ def test_step_time_cli_renders_zero_timings_as_zero() -> None:
 def test_step_time_cli_refreshes_its_injected_session_once() -> None:
     payload = live_result_from_window(
         window_from_rank_averages(
-            {0: {"step_time": 10.0}},
+            {
+                0: {
+                    "input_wait": 0.0,
+                    "traced_step_time": 10.0,
+                    "step_time": 10.0,
+                }
+            },
             expected_ranks=(0,),
-            metrics=[_metric("step_time", 10.0)],
+            metrics=[
+                _metric("traced_step_time", 10.0),
+                _metric("step_time", 10.0),
+            ],
         )
     )
     session = Mock()
@@ -223,15 +242,15 @@ def test_cli_renders_multi_rank_sparse_table() -> None:
             "input_wait": 2.0,
             "backward": 60.0,
             "optimizer_step": 10.0,
-            "step_time": 90.0,
-            "total_step": 92.0,
+            "traced_step_time": 90.0,
+            "step_time": 92.0,
         },
         1: {
             "input_wait": 2.0,
             "backward": 120.0,
             "optimizer_step": 10.0,
-            "step_time": 180.0,
-            "total_step": 182.0,
+            "traced_step_time": 180.0,
+            "step_time": 182.0,
         },
     }
     payload = live_result_from_window(
@@ -242,7 +261,8 @@ def test_cli_renders_multi_rank_sparse_table() -> None:
                 _multi_metric("input_wait", 2.0),
                 _multi_metric("backward", 60.0),
                 _multi_metric("optimizer_step", 10.0),
-                _multi_metric("step_time", 90.0),
+                _multi_metric("traced_step_time", 90.0),
+                _multi_metric("step_time", 92.0),
             ],
             steps_used=30,
         )

--- a/tests/reporting/summary/test_fixtures.py
+++ b/tests/reporting/summary/test_fixtures.py
@@ -270,7 +270,7 @@ def test_summary_sections_cover_single_rank_gpu_run(tmp_path: Path) -> None:
                 row_id=step,
                 rank=0,
                 step=step,
-                step_time=10.0,
+                traced_step_time=10.0,
             )
             _insert_step_memory_sample(
                 conn,
@@ -352,7 +352,7 @@ def test_summary_sections_cover_multi_rank_aligned_run(tmp_path: Path) -> None:
                     row_id=row_id,
                     rank=rank,
                     step=step,
-                    step_time=10.0 + rank,
+                    traced_step_time=10.0 + rank,
                 )
                 _insert_step_memory_sample(
                     conn,

--- a/tests/reporting/summary/test_step_time.py
+++ b/tests/reporting/summary/test_step_time.py
@@ -40,7 +40,7 @@ def _create_step_time_db(path: str) -> None:
                 forward=5.0,
                 backward=10.0,
                 optimizer=4.0,
-                step_time=30.0,
+                traced_step_time=30.0,
             )
 
 

--- a/tests/reporting/summary/test_step_time.py
+++ b/tests/reporting/summary/test_step_time.py
@@ -99,9 +99,11 @@ def test_rank_summary_extracts_input_bound_clocks_from_events() -> None:
     assert rank_facts.steps[0].step == 1
     values = rank_facts.steps[0].values
     assert values.input_wait_ms == 4.0
-    assert values.step_time_ms == 20.0
+    assert values.traced_step_time_ms == 20.0
+    assert values.step_time_ms == 24.0
     assert rank_average(window, 0).input_wait_ms == 4.0
-    assert rank_average(window, 0).step_time_ms == 20.0
+    assert rank_average(window, 0).traced_step_time_ms == 20.0
+    assert rank_average(window, 0).step_time_ms == 24.0
 
 
 def test_step_time_section_uses_summary_pipeline_and_sqlite_fixture(

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -96,7 +96,7 @@ def test_step_time_no_data_card_is_compact() -> None:
     assert payload["diagnosis"]["kind"] == "NO_DATA"
     assert "- Diagnosis: NO DATA" in payload["card"]
     assert "- Stats: n/a" in payload["card"]
-    assert "- Why: step_time metric is missing." in payload["card"]
+    assert "- Why: Step Time metric is missing." in payload["card"]
     _assert_compact_card(payload["card"])
 
 
@@ -203,8 +203,8 @@ def test_card_median_and_json_representative_are_explicit() -> None:
                 },
                 "public_dataloader": True,
                 "card": (
-                    "- Why: Input wait is 28.6% of the typical gpu "
-                    "iteration time.",
+                    "- Why: Input wait is 28.6% of the typical GPU Step "
+                    "Time.",
                 ),
             },
             id="input-bound",
@@ -230,8 +230,8 @@ def test_card_median_and_json_representative_are_explicit() -> None:
                 "diagnosis": {"metric": "h2d", "phase": "h2d"},
                 "evidence": {"h2d_ms": 20.0, "diagnosis_clock": "gpu"},
                 "card": (
-                    "- Why: H2D transfer is 20.0% of the typical GPU "
-                    "iteration time.",
+                    "- Why: H2D transfer is 20.0% of the typical GPU Step "
+                    "Time.",
                 ),
             },
             id="h2d-bound",
@@ -247,8 +247,8 @@ def test_card_median_and_json_representative_are_explicit() -> None:
                 ),
                 "status": "RESIDUAL-HEAVY",
                 "card": (
-                    "- Why: Residual time is 29.4% of the typical cpu "
-                    "iteration time.",
+                    "- Why: Residual time is 29.4% of the typical CPU Step "
+                    "Time.",
                 ),
             },
             id="residual-heavy",
@@ -305,7 +305,7 @@ def test_step_time_card_uses_h2d_diagnosis_score_not_worst_rollups() -> None:
     assert payload["diagnosis"]["status"] == "H2D-BOUND"
     assert payload["diagnosis"]["score"] == 0.425
     assert (
-        "- Why: H2D transfer is 42.5% of the typical GPU iteration time."
+        "- Why: H2D transfer is 42.5% of the typical GPU Step Time."
         in payload["card"]
     )
     assert "90.0ms/312.0ms" not in payload["card"]

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -109,7 +109,7 @@ def test_step_time_balanced_card_is_compact() -> None:
                 forward=20.0,
                 backward=35.0,
                 optimizer=5.0,
-                step_cpu=75.0,
+                traced_step_time_cpu=75.0,
             ),
             1: _rank(
                 dataloader=5.0,
@@ -117,7 +117,7 @@ def test_step_time_balanced_card_is_compact() -> None:
                 forward=21.0,
                 backward=34.0,
                 optimizer=5.0,
-                step_cpu=75.0,
+                traced_step_time_cpu=75.0,
             ),
         }
     )
@@ -139,8 +139,8 @@ def test_step_time_balanced_card_is_compact() -> None:
 def test_card_median_and_json_representative_are_explicit() -> None:
     payload = _summary(
         {
-            0: _rank(dataloader=0.0, step_cpu=100.0),
-            1: _rank(dataloader=0.0, step_cpu=200.0),
+            0: _rank(dataloader=0.0, traced_step_time_cpu=100.0),
+            1: _rank(dataloader=0.0, traced_step_time_cpu=200.0),
         }
     )
 
@@ -161,7 +161,7 @@ def test_card_median_and_json_representative_are_explicit() -> None:
                     forward=20.0,
                     backward=65.0,
                     optimizer=5.0,
-                    step_cpu=95.0,
+                    traced_step_time_cpu=95.0,
                 ),
                 "status": "COMPUTE-BOUND",
                 "card": (
@@ -180,11 +180,11 @@ def test_card_median_and_json_representative_are_explicit() -> None:
                     forward=20.0,
                     backward=35.0,
                     optimizer=5.0,
-                    step_cpu=100.0,
+                    traced_step_time_cpu=100.0,
                 ),
                 "steps": _input_bound_step_metrics(
                     input_wait_gpu=40.0,
-                    step_time_gpu=100.0,
+                    traced_step_time_gpu=100.0,
                     compute_gpu=90.0,
                 ),
                 "status": "INPUT-BOUND",
@@ -217,14 +217,14 @@ def test_card_median_and_json_representative_are_explicit() -> None:
                     forward=20.0,
                     backward=35.0,
                     optimizer=5.0,
-                    step_cpu=100.0,
+                    traced_step_time_cpu=100.0,
                 ),
                 "steps": _input_bound_step_metrics(
                     input_wait_gpu=0.0,
                     h2d_gpu=20.0,
                     compute_gpu=70.0,
-                    step_time_cpu=100.0,
-                    step_time_gpu=100.0,
+                    traced_step_time_cpu=100.0,
+                    traced_step_time_gpu=100.0,
                 ),
                 "status": "H2D-BOUND",
                 "diagnosis": {"metric": "h2d", "phase": "h2d"},
@@ -243,7 +243,7 @@ def test_card_median_and_json_representative_are_explicit() -> None:
                     forward=20.0,
                     backward=45.0,
                     optimizer=5.0,
-                    step_cpu=100.0,
+                    traced_step_time_cpu=100.0,
                 ),
                 "status": "RESIDUAL-HEAVY",
                 "card": (
@@ -289,15 +289,15 @@ def test_step_time_card_uses_h2d_diagnosis_score_not_worst_rollups() -> None:
                 input_wait_gpu=0.0,
                 h2d_gpu=10.0,
                 compute_gpu=90.0,
-                step_time_cpu=300.0,
-                step_time_gpu=100.0,
+                traced_step_time_cpu=300.0,
+                traced_step_time_gpu=100.0,
             ),
             1: _input_bound_step_metrics(
                 input_wait_gpu=20.0,
                 h2d_gpu=90.0,
                 compute_gpu=10.0,
-                step_time_cpu=120.0,
-                step_time_gpu=100.0,
+                traced_step_time_cpu=120.0,
+                traced_step_time_gpu=100.0,
             ),
         },
     )

--- a/tests/sqlite_fixtures.py
+++ b/tests/sqlite_fixtures.py
@@ -226,7 +226,7 @@ def step_time_events(
     forward: float,
     backward: float,
     optimizer: float,
-    step_time: float,
+    traced_step_time: float,
     h2d: float | None = None,
     clock: str = "cpu",
 ) -> dict[str, dict[str, dict[str, float | bool | int | None]]]:
@@ -236,7 +236,7 @@ def step_time_events(
         "_traceml_internal:forward_time": forward,
         "_traceml_internal:backward_time": backward,
         "_traceml_internal:optimizer_step": optimizer,
-        "_traceml_internal:step_time": step_time,
+        "_traceml_internal:step_time": traced_step_time,
     }
     if h2d is not None:
         values["_traceml_internal:h2d_time"] = h2d
@@ -262,7 +262,7 @@ def insert_step_time_sample(
     row_id: int,
     rank: int,
     step: int,
-    step_time: float,
+    traced_step_time: float,
     events: Mapping[str, Any] | None = None,
     dataloader: float = 1.0,
     h2d: float | None = None,
@@ -285,7 +285,7 @@ def insert_step_time_sample(
         forward=2.0 + rank if forward is None else forward,
         backward=3.0 + rank if backward is None else backward,
         optimizer=optimizer,
-        step_time=step_time,
+        traced_step_time=traced_step_time,
         clock=clock,
     )
     _insert_row(

--- a/tests/step_time/factories.py
+++ b/tests/step_time/factories.py
@@ -307,7 +307,7 @@ def window_from_rank_averages(
         )
         if any(facts.average.value(name) is not None for facts in rank_facts)
     )
-    composition = carrying("step_time", *composition_names)
+    composition = carrying("traced_step_time", *composition_names)
     strategy = str(training_strategy).strip().lower()
     straggler = tuple(
         facts.global_rank
@@ -649,7 +649,7 @@ def _composition_representative(
 ) -> Optional[int]:
     ranks = set(cohort)
     anchors = {
-        facts.global_rank: facts.average.step_time_ms
+        facts.global_rank: facts.average.traced_step_time_ms
         for facts in rank_facts
         if facts.global_rank in ranks
     }

--- a/tests/step_time/factories.py
+++ b/tests/step_time/factories.py
@@ -71,44 +71,46 @@ def timing_row(
     backward: float = 30.0,
     optimizer: float = 10.0,
     residual: float = 0.0,
+    traced_step_time: float | None = None,
     step_time: float | None = None,
-    total_step: float | None = None,
     input_wait_cpu: float | None = None,
     input_wait_gpu: float | None = None,
-    step_time_cpu: float | None = None,
-    step_time_gpu: float | None = None,
+    traced_step_time_cpu: float | None = None,
+    traced_step_time_gpu: float | None = None,
 ) -> dict[str, float]:
     """Build one concise per-rank aggregate timing row."""
     known_step = h2d + forward + backward + optimizer
-    local_step = known_step + residual if step_time is None else step_time
+    inner_step = (
+        known_step + residual if traced_step_time is None else traced_step_time
+    )
     row = {
         "input_wait": dataloader,
         "h2d": h2d,
         "forward": forward,
         "backward": backward,
         "optimizer_step": optimizer,
-        "traced_step_time": local_step,
+        "traced_step_time": inner_step,
         "residual_proxy": residual,
         "step_time": (
-            dataloader + local_step if total_step is None else total_step
+            dataloader + inner_step if step_time is None else step_time
         ),
     }
-    if input_wait_cpu is not None and step_time_cpu is not None:
+    if input_wait_cpu is not None and traced_step_time_cpu is not None:
         row.update(
             input_wait=input_wait_cpu,
-            traced_step_time=step_time_cpu,
-            step_time=input_wait_cpu + step_time_cpu,
+            traced_step_time=traced_step_time_cpu,
+            step_time=input_wait_cpu + traced_step_time_cpu,
             dataloader_fetch=input_wait_cpu,
-            traced_step_time_cpu=step_time_cpu,
-            step_time_cpu=input_wait_cpu + step_time_cpu,
+            traced_step_time_cpu=traced_step_time_cpu,
+            step_time_cpu=input_wait_cpu + traced_step_time_cpu,
         )
-    if input_wait_gpu is not None and step_time_gpu is not None:
+    if input_wait_gpu is not None and traced_step_time_gpu is not None:
         row.update(
             input_wait=input_wait_gpu,
-            traced_step_time=step_time_gpu,
-            step_time=input_wait_gpu + step_time_gpu,
-            traced_step_time_gpu=step_time_gpu,
-            step_time_gpu=input_wait_gpu + step_time_gpu,
+            traced_step_time=traced_step_time_gpu,
+            step_time=input_wait_gpu + traced_step_time_gpu,
+            traced_step_time_gpu=traced_step_time_gpu,
+            step_time_gpu=input_wait_gpu + traced_step_time_gpu,
         )
     return row
 
@@ -486,7 +488,7 @@ def summary_step_events(
     *,
     input_wait_gpu: float | None,
     h2d: float = 0.0,
-    step_time_gpu: float = 60.0,
+    traced_step_time_gpu: float = 60.0,
     steps: int = 60,
 ) -> dict[int, dict]:
     """Build a repeated complete phase window for summary diagnosis tests."""
@@ -500,7 +502,7 @@ def summary_step_events(
         "_traceml_internal:backward_time": 30.0,
         "_traceml_internal:optimizer_step": 10.0,
         "_traceml_internal:step_time": (
-            step_time_gpu if clock == "gpu" else 60.0
+            traced_step_time_gpu if clock == "gpu" else 60.0
         ),
     }
     return {
@@ -519,29 +521,33 @@ def step_time_values(
     forward: float = 30.0,
     backward: float = 50.0,
     optimizer: float = 10.0,
-    step_cpu: float | None = None,
+    traced_step_time_cpu: float | None = None,
 ) -> StepTimeValues:
     """Build canonical values for summary-card fixtures."""
     compute = forward + backward + optimizer
     known_step = h2d + compute
-    effective_step = max(
-        step_cpu if step_cpu is not None else known_step,
+    effective_traced_step_time = max(
+        (
+            traced_step_time_cpu
+            if traced_step_time_cpu is not None
+            else known_step
+        ),
         known_step,
     )
-    residual = max(0.0, effective_step - known_step)
+    residual = max(0.0, effective_traced_step_time - known_step)
     return StepTimeValues(
         dataloader_fetch_cpu_ms=dataloader,
         input_wait_ms=dataloader,
-        step_time_ms=dataloader + effective_step,
-        traced_step_time_ms=effective_step,
+        step_time_ms=dataloader + effective_traced_step_time,
+        traced_step_time_ms=effective_traced_step_time,
         h2d_ms=h2d,
         forward_ms=forward,
         backward_ms=backward,
         optimizer_step_ms=optimizer,
         compute_ms=compute,
         residual_ms=residual,
-        step_time_cpu_ms=dataloader + effective_step,
-        traced_step_time_cpu_ms=effective_step,
+        step_time_cpu_ms=dataloader + effective_traced_step_time,
+        traced_step_time_cpu_ms=effective_traced_step_time,
     )
 
 
@@ -570,9 +576,9 @@ def step_events_from_values(
 def input_bound_step_events(
     *,
     dataloader_cpu: float = 12.0,
-    step_time_cpu: float = 90.0,
+    traced_step_time_cpu: float = 90.0,
     input_wait_gpu: float,
-    step_time_gpu: float,
+    traced_step_time_gpu: float,
     h2d_gpu: float = 0.0,
     compute_gpu: float = 0.0,
     steps: int = 64,
@@ -586,8 +592,8 @@ def input_bound_step_events(
         "_traceml_internal:h2d_time": event_stats(gpu_ms=h2d_gpu),
         "_traceml_internal:forward_time": event_stats(gpu_ms=compute_gpu),
         "_traceml_internal:step_time": event_stats(
-            cpu_ms=step_time_cpu,
-            gpu_ms=step_time_gpu,
+            cpu_ms=traced_step_time_cpu,
+            gpu_ms=traced_step_time_gpu,
         ),
     }
     return {step: events for step in range(steps)}
@@ -597,7 +603,7 @@ def alternating_residual_step_events(steps: int = 64) -> dict[int, dict]:
     """Build the alternating residual-clamp regression fixture."""
     out: dict[int, dict] = {}
     for step in range(steps):
-        compute_ms, step_time_ms = (
+        compute_ms, traced_step_time_ms = (
             (50.0, 100.0) if step % 2 == 0 else (100.0, 50.0)
         )
         out[step] = {
@@ -606,7 +612,9 @@ def alternating_residual_step_events(steps: int = 64) -> dict[int, dict]:
             "_traceml_internal:forward_time": event_stats(cpu_ms=compute_ms),
             "_traceml_internal:backward_time": event_stats(cpu_ms=0.0),
             "_traceml_internal:optimizer_step": event_stats(cpu_ms=0.0),
-            "_traceml_internal:step_time": event_stats(cpu_ms=step_time_ms),
+            "_traceml_internal:step_time": event_stats(
+                cpu_ms=traced_step_time_ms
+            ),
         }
     return out
 

--- a/tests/step_time/test_contract_baseline.py
+++ b/tests/step_time/test_contract_baseline.py
@@ -47,9 +47,9 @@ _WINDOW_KEYS = {
     "forward",
     "backward",
     "optimizer_step",
+    "traced_step_time",
     "step_time",
     "residual_proxy",
-    "total_step",
 }
 
 
@@ -71,27 +71,27 @@ class DiagnosisGolden:
 # assertion table and keeps missing keys visible.
 EXPECTED_DERIVED_TIMING: dict[str, dict[int, dict[str, float]]] = {
     "complete_gpu": {
-        0: {"residual_proxy": 5.0, "total_step": 100.0},
-        1: {"residual_proxy": 5.0, "total_step": 100.0},
+        0: {"residual_proxy": 5.0, "step_time": 100.0},
+        1: {"residual_proxy": 5.0, "step_time": 100.0},
     },
     "sparse_missing_forward": {
-        0: {"residual_proxy": 5.0, "total_step": 100.0},
-        1: {"total_step": 100.0},
+        0: {"residual_proxy": 5.0, "step_time": 100.0},
+        1: {"step_time": 100.0},
     },
     "measured_zero_forward": {
-        0: {"residual_proxy": 5.0, "total_step": 100.0},
-        1: {"residual_proxy": 35.0, "total_step": 100.0},
+        0: {"residual_proxy": 5.0, "step_time": 100.0},
+        1: {"residual_proxy": 35.0, "step_time": 100.0},
     },
     "single_rank_cpu": {
-        0: {"residual_proxy": 5.0, "total_step": 100.0},
+        0: {"residual_proxy": 5.0, "step_time": 100.0},
     },
     "ddp_rank_straggler": {
-        0: {"residual_proxy": 0.0, "total_step": 140.0},
-        1: {"residual_proxy": 0.0, "total_step": 140.0},
+        0: {"residual_proxy": 0.0, "step_time": 140.0},
+        1: {"residual_proxy": 0.0, "step_time": 140.0},
     },
     "fsdp_rank_straggler": {
-        0: {"residual_proxy": 0.0, "total_step": 140.0},
-        1: {"residual_proxy": 0.0, "total_step": 160.0},
+        0: {"residual_proxy": 0.0, "step_time": 140.0},
+        1: {"residual_proxy": 0.0, "step_time": 160.0},
     },
 }
 
@@ -157,23 +157,35 @@ EXPECTED_METRIC_SUMMARIES: dict[
     str,
     dict[str, tuple[float, float, int, float | None]],
 ] = {
-    "complete_gpu": {"step_time": (95.0, 95.0, 0, 0.0)},
+    "complete_gpu": {
+        "traced_step_time": (95.0, 95.0, 0, 0.0),
+        "step_time": (100.0, 100.0, 0, 0.0),
+    },
     "sparse_missing_forward": {
         "forward": (30.0, 30.0, 0, None),
         "residual_proxy": (5.0, 5.0, 0, None),
+        "traced_step_time": (95.0, 95.0, 0, 0.0),
+        "step_time": (100.0, 100.0, 0, 0.0),
     },
     "measured_zero_forward": {
         "forward": (15.0, 30.0, 0, 1.0),
         "residual_proxy": (20.0, 35.0, 1, 0.75),
+        "traced_step_time": (95.0, 95.0, 0, 0.0),
+        "step_time": (100.0, 100.0, 0, 0.0),
     },
-    "single_rank_cpu": {"step_time": (95.0, 95.0, 0, None)},
+    "single_rank_cpu": {
+        "traced_step_time": (95.0, 95.0, 0, None),
+        "step_time": (100.0, 100.0, 0, None),
+    },
     "ddp_rank_straggler": {
         "input_wait": (50.0, 100.0, 0, 1.0),
-        "step_time": (90.0, 140.0, 1, 5.0 / 9.0),
+        "traced_step_time": (90.0, 140.0, 1, 5.0 / 9.0),
+        "step_time": (140.0, 140.0, 0, 0.0),
     },
     "fsdp_rank_straggler": {
         "input_wait": (50.0, 100.0, 0, 1.0),
-        "step_time": (100.0, 160.0, 1, 0.6),
+        "traced_step_time": (100.0, 160.0, 1, 0.6),
+        "step_time": (150.0, 160.0, 1, 1.0 / 15.0),
     },
 }
 
@@ -287,7 +299,7 @@ def test_canonical_window_matches_golden(
         }
         assert actual == pytest.approx(expected)
 
-    for metric in _WINDOW_KEYS - {"total_step"}:
+    for metric in _WINDOW_KEYS:
         expected_ranks = tuple(
             rank for rank, row in expected_rows.items() if metric in row
         )

--- a/tests/step_time/test_live_session.py
+++ b/tests/step_time/test_live_session.py
@@ -51,7 +51,13 @@ def _analysis(*, metrics: bool, cursor: int = 1) -> StepTimeAnalysis:
     )
     window = (
         window_from_rank_averages(
-            {0: {"step_time": 10.0, "total_step": 10.0}},
+            {
+                0: {
+                    "input_wait": 0.0,
+                    "traced_step_time": 10.0,
+                    "step_time": 10.0,
+                }
+            },
             expected_ranks=(0,),
             metrics=(metric,),
             steps_used=2,


### PR DESCRIPTION
## Summary

This PR completes the diagnostics migration to the canonical Step Time contract.

- **Step Time** is the outer selected-clock duration:
  `input_wait + traced_step_time`.
- **Traced Step Time** is the inner traced training envelope.
- CPU and GPU timings remain independent; a single selected clock is used for
  diagnosis and phase selection.

The production migration is in `29598d9`; this PR locks that behavior with
canonical test fixtures and acceptance assertions. It does not change the
public summary ABI or visible UI labels.

## What changed

### Diagnostics use the canonical contract

- Phase shares, rank-straggler scoring, and trend decisions use outer
  selected-clock Step Time directly.
- Rank-straggler scoring no longer re-adds Input Wait to its denominator.
- Residual remains the inner-envelope subtotal:

  ```text
  residual_ms = traced_step_time_ms - h2d_ms - compute_ms
  ```

- Diagnostic evidence distinguishes `traced_step_time_ms` from
  `step_time_ms`; diagnostics no longer use `iteration_*`, `iteration_ranks`,
  or `total_step` semantics.
- Thresholds and clock-selection policy are unchanged.

### Existing fixture and acceptance coverage

- Renamed existing fixture inputs so inner values are always
  `traced_step_time` and outer values are always `step_time`.
- Updated existing diagnostics, live-session, registry, and summary fixtures
  that still used test-only `total_step` or treated `step_time` as the inner
  envelope.
- Strengthened existing tests to prove:
  - a 10 ms H2D phase in a 200 ms outer Step Time is a 5% share;
  - rank-straggler evidence includes `step_time_ms`, never
    `iteration_time_ms`;
  - a flat Traced Step Time with a rising outer Step Time produces a Step Time
    trend note;
  - CPU/GPU fallback keeps same-clock values and preserves missing versus
    measured-zero behavior.

## Compatibility and non-goals

- Public summary keys and legacy public diagnosis evidence stay unchanged,
  including `total_step_ms`, `dataloader_ms`, `step_time_ms`, and
  `iteration_time_ms` at the explicit reporting compatibility boundary.
- The persisted raw event remains `_traceml_internal:step_time`; it decodes
  to canonical `traced_step_time`.
- No raw-event rename, threshold change, public-schema migration, or UI
  redesign is included. The final public naming removal belongs to #307.
- No new test files were added.

## Verification

```text
379 passed
  diagnostics + Step Time + summary + renderer/dashboard focused suites

878 passed, 2 skipped
  full test suite
```

`git diff --check` and a canonical-path audit were also run. Legacy names are
retained only in public reporting compatibility projections and public-schema
tests.
