### PR TITLE
Make live Step Time output canonical

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_combined_section.py
@@ -24,15 +24,9 @@ from traceml_ai.step_time.pipeline import LiveStepTimeResult
 
 from . import theme
 
-# Fixed ribbon width for a phase that was never measured this window --
-# large enough to read as a deliberate marker, not a rounding artifact of
-# a real proportional segment.
-_UNMEASURED_SLIVER_PCT = 6.0
-
-# step_time is the envelope, not a ribbon phase, so it has no entry in
-# theme.PHASES. It still needs a name when it is the incomplete signal.
-# Matches the CLI table's abbreviation.
-_STEP_TIME_LABEL = "STEP"
+# Step Time is not a ribbon phase, so it has no entry in theme.PHASES. It
+# still needs a clear name when partial rank coverage makes it unavailable.
+_STEP_TIME_LABEL = "STEP TIME"
 
 
 def build_model_combined_section() -> Dict[str, Any]:
@@ -51,7 +45,7 @@ def build_model_combined_section() -> Dict[str, Any]:
             .classes("w-full items-center")
             .style("margin-bottom:14px; gap:12px;")
         ):
-            ui.label("Step time").classes("ctitle")
+            ui.label("Step Time").classes("ctitle")
             ui.element("div").style("flex:1;")
             win = ui.label("waiting for steps").classes("cmeta")
 
@@ -91,8 +85,8 @@ def build_model_combined_section() -> Dict[str, Any]:
             .style("gap:11px; margin-top:16px; flex-wrap:wrap;")
         ):
             for key, lab, acc in [
-                ("median", "MEDIAN STEP", theme.C_GPU),
-                ("worst", "WORST STEP", "#512da8"),
+                ("median", "MEDIAN STEP TIME", theme.C_GPU),
+                ("worst", "WORST STEP TIME", "#512da8"),
                 ("gap", "GAP", "#f9a825"),
                 ("residual", "RESIDUAL SHARE", theme.C_CPU),
                 ("rank", "WORST RANK", "#2e7d32"),
@@ -192,20 +186,24 @@ def update_model_combined_section(
         _clear_view(panel, _EXPIRED_SIG, "window expired")
         return
     m = _index(window.metrics)
-    if "traced_step_time" not in m:
-        _clear_view(panel, _NO_ENVELOPE_SIG, "step envelope unavailable")
+    if "step_time" not in m:
+        _clear_view(
+            panel,
+            _NO_ENVELOPE_SIG,
+            f"{window.clock.upper()} selected · Step Time unavailable",
+        )
         return
 
-    traced_step_metric = m["traced_step_time"]
-    st = traced_step_metric
+    step_time_metric = m["step_time"]
     steps_used = window.coverage.steps_used
-    _update_kpis(panel, window, traced_step_metric)
+    _update_kpis(panel, window, step_time_metric)
     representative = window.composition_representative_rank
     if representative is None:
         _clear_ribbon(
             panel,
             _NO_COHORT_SIG,
-            f"{int(steps_used)} aligned steps · no coherent phase cohort",
+            f"{int(steps_used)} aligned steps · "
+            f"{window.clock.upper()} selected · no coherent phase cohort",
         )
         return
 
@@ -222,32 +220,25 @@ def update_model_combined_section(
             value = rank_values.value(key)
             vals[key] = float(value) if value is not None else None
 
-    measured = {key: value for key, value in vals.items() if value is not None}
     unmeasured = [
         key for key, value in vals.items() if value is None and key != "h2d"
     ]
     universe_size = len(window.rank_universe)
     partial_metrics = [
         key
-        for key in [phase[1] for phase in theme.PHASES] + ["traced_step_time"]
+        for key in [phase[1] for phase in theme.PHASES] + ["step_time"]
         if key != "h2d" and 0 < len(window.ranks_for(key)) < universe_size
     ]
 
-    input_wait_value = vals.get("input_wait")
-    envelope = float(rank_values.traced_step_time_ms or 0.0) + (
-        input_wait_value if input_wait_value is not None else 0.0
-    )
-    tot = max(sum(measured.values()), envelope) or 1.0
-
-    # A measured-zero segment and a genuinely unmeasured one must never
-    # render identically -- an absent input_wait would otherwise let the
-    # OTHER phases sum to exactly traced Step Time (residual is a remainder), so
-    # the ribbon fills to 100% and a dark dataloader stream reads as a
-    # confirmed-fast one. Non-h2d unmeasured phases get a fixed hatched
-    # sliver instead of a proportional width; measured phases give up
-    # that width so the row still totals 100%.
-    reserved_pct = _UNMEASURED_SLIVER_PCT * len(unmeasured)
-    measured_scale = max(0.0, (100.0 - reserved_pct) / 100.0)
+    step_time_ms = rank_values.step_time_ms
+    if step_time_ms is None or step_time_ms <= 0.0:
+        _clear_ribbon(
+            panel,
+            _NO_COHORT_SIG,
+            f"{window.clock.upper()} selected · Step Time unavailable for "
+            "phase shares",
+        )
+        return
 
     sig = (
         tuple(
@@ -257,10 +248,14 @@ def update_model_combined_section(
         + tuple(sorted(partial_metrics))
         + (
             representative,
-            round(float(st.median_total), 3),
-            round(float(st.worst_total), 3),
+            round(float(step_time_metric.median_total), 3),
+            round(float(step_time_metric.worst_total), 3),
             int(steps_used),
-            int(st.worst_rank if st.worst_rank is not None else -1),
+            int(
+                step_time_metric.worst_rank
+                if step_time_metric.worst_rank is not None
+                else -1
+            ),
         )
     )
     if panel.get("_last_sig") == sig:
@@ -272,28 +267,13 @@ def update_model_combined_section(
     ):
         value = vals[key]
         if key in unmeasured:
-            # Unmeasured phase: a hatched sliver in the PHASE'S OWN color
-            # marks "unknown, not zero" (a dark stream must never read as
-            # confirmed-fast). The color still identifies the phase (blue =
-            # forward, gold = residual, matching the legend); the diagonal
-            # hatch overlay is what says "unmeasured". No on-sliver text --
-            # it would overlap the hatch illegibly at this width, and the
-            # window meta already names the missing phases.
-            seg.style(
-                f"width:{_UNMEASURED_SLIVER_PCT:.1f}%; "
-                "background:repeating-linear-gradient(45deg, "
-                f"{col} 0 2px, transparent 2px 5px);"
-            )
+            # The existing window metadata names missing signals. Leave the
+            # corresponding width blank rather than inventing a visual share
+            # or rescaling the measured phases.
+            seg.style("width:0%; background:transparent;")
             sl.text = ""
             continue
-        pct = (
-            (value / tot * 100.0 * measured_scale)
-            if value is not None
-            else 0.0
-        )
-        # Always restate the background. Style updates MERGE, so a phase
-        # that was hatched while unmeasured would keep the hatch forever
-        # once it recovers if this path only set the width.
+        pct = float(value / step_time_ms * 100.0) if value is not None else 0.0
         seg.style(f"width:{pct:.3f}%; background:{col};")
         sl.text = lab if pct >= 7.0 else ""
 
@@ -301,16 +281,17 @@ def update_model_combined_section(
     # engine and set via update_step_verdict (fed the model-diagnostics
     # payload), so the card never asserts a classification of its own.
 
-    steps_text = f"{int(steps_used)} aligned steps"
+    steps_text = (
+        f"{int(steps_used)} aligned steps · {window.clock.upper()} selected"
+    )
     steps_text += f" · representative r{representative}"
     if unmeasured or partial_metrics:
         incomplete = set(unmeasured) | set(partial_metrics)
         names = [lab for lab, key, _c in theme.PHASES if key in incomplete]
-        # traced_step_time has no ribbon segment, so it is not in PHASES, but it
-        # can still be the thing that is incomplete. Name it with the same
-        # abbreviation the CLI table uses rather than dropping it and
-        # printing a bare "partial:".
-        if "traced_step_time" in incomplete:
+        # step_time has no ribbon segment, so it is not in PHASES, but it can
+        # still be the incomplete signal. Name it rather than printing a bare
+        # "partial:".
+        if "step_time" in incomplete:
             names.append(_STEP_TIME_LABEL)
         steps_text += f" · partial: {','.join(names)}"
     panel["win"].text = steps_text

--- a/src/traceml_ai/renderers/step_time/renderer.py
+++ b/src/traceml_ai/renderers/step_time/renderer.py
@@ -219,8 +219,8 @@ class StepTimeRenderer(BaseRenderer):
             f"{window.clock.upper()} | "
             "IW=input wait | H2D=host-to-device | FWD=forward | "
             "BWD=backward | OPT=optimizer | "
-            "Step Time=IW + inner trace envelope | "
-            "RESIDUAL=inner trace envelope−H2D−FWD−BWD−OPT"
+            "Step Time=IW + Traced Step Time | "
+            "RESIDUAL=Traced Step Time−H2D−FWD−BWD−OPT"
             "[/dim]"
         )
         return Panel(

--- a/src/traceml_ai/renderers/step_time/renderer.py
+++ b/src/traceml_ai/renderers/step_time/renderer.py
@@ -29,22 +29,22 @@ from traceml_ai.step_time.pipeline import (
 )
 
 METRIC_LABELS = {
+    "step_time": "Step Time",
     "input_wait": "IW",
     "h2d": "H2D",
     "forward": "FWD",
     "backward": "BWD",
     "optimizer_step": "OPT",
-    "traced_step_time": "STEP",
     "residual_proxy": "RESIDUAL",
 }
 
 TABLE_METRIC_ORDER = (
+    "step_time",
     "input_wait",
     "h2d",
     "forward",
     "backward",
     "optimizer_step",
-    "traced_step_time",
     "residual_proxy",
 )
 
@@ -124,8 +124,8 @@ class StepTimeRenderer(BaseRenderer):
                 border_style="cyan",
             )
 
-        traced_step_metric = next(
-            (m for m in metrics if m.metric == "traced_step_time"), None
+        step_time_metric = next(
+            (m for m in metrics if m.metric == "step_time"), None
         )
         residual_metric = next(
             (m for m in metrics if m.metric == "residual_proxy"), None
@@ -192,7 +192,7 @@ class StepTimeRenderer(BaseRenderer):
             table.add_row("")
 
         # Optional residual share line (still meaningful in both modes)
-        if traced_step_metric and residual_metric:
+        if step_time_metric and residual_metric:
             residual_share = window.residual_share
             table.add_row(
                 "Residual Share (%)",
@@ -215,11 +215,12 @@ class StepTimeRenderer(BaseRenderer):
 
         footer = (
             "\n\n[dim]"
-            "Clock="
+            "Selected clock="
             f"{window.clock.upper()} | "
             "IW=input wait | H2D=host-to-device | FWD=forward | "
-            "BWD=backward | OPT=optimizer | STEP=traced step | "
-            "RESIDUAL=STEP−H2D−FWD−BWD−OPT"
+            "BWD=backward | OPT=optimizer | "
+            "Step Time=IW + inner trace envelope | "
+            "RESIDUAL=inner trace envelope−H2D−FWD−BWD−OPT"
             "[/dim]"
         )
         return Panel(

--- a/tests/display/test_model_combined_section.py
+++ b/tests/display/test_model_combined_section.py
@@ -15,7 +15,6 @@ pytest.importorskip("nicegui")
 
 from traceml_ai.aggregator.display_drivers.nicegui_sections import theme
 from traceml_ai.aggregator.display_drivers.nicegui_sections.model_combined_section import (
-    _UNMEASURED_SLIVER_PCT,
     update_model_combined_section,
     update_step_verdict,
 )
@@ -214,31 +213,26 @@ def test_step_time_dashboard_hero_renders_sparse_metrics() -> None:
     # window and names the missing signal.
     assert (
         panel["win"].text
-        == "5 aligned steps · representative r0 · partial: RESIDUAL"
+        == "5 aligned steps · CPU selected · representative r0 · partial: "
+        "RESIDUAL"
     )
     # H2D is occurrence-driven and absent, so it's plain measured-zero.
-    # residual_proxy is genuinely unmeasured (non-h2d), so it gets the
-    # hatched sliver, not an empty segment indistinguishable from zero.
-    # Measured phases scale against the iteration envelope (input_wait
-    # 10 + step 100 = 110) minus the sliver's reserved width.
+    # residual_proxy is genuinely unmeasured, so it has no visual share.
+    # Measured phases use the canonical 110 ms Step Time denominator directly.
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
     by_lab = dict(zip(keys, panel["seg_labs"]))
     assert by_key["h2d"].width == "0.000%"
     residual_seg = by_key["residual_proxy"]
-    assert residual_seg.width == f"{_UNMEASURED_SLIVER_PCT:.1f}%"
-    # The hatch is drawn in the PHASE'S OWN color (residual = gold), so the
-    # sliver still identifies which phase, matching the legend dot.
-    residual_color = dict((k, c) for _, k, c in theme.PHASES)["residual_proxy"]
-    assert residual_seg.hatched
-    assert residual_color in residual_seg.background
-    # The sliver carries NO on-segment text -- it would overlap the hatch
-    # illegibly; the missing phases are named in the window meta instead.
+    assert residual_seg.width == "0%"
+    assert residual_seg.background == "transparent"
+    # Missing signals are named in the existing window metadata instead of
+    # receiving a fabricated proportional ribbon segment.
     assert by_lab["residual_proxy"].text == ""
-    assert by_key["input_wait"].width == "8.545%"
+    assert by_key["input_wait"].width == "9.091%"
     # An underivable residual shows n/a, never a fake 0%.
     assert "n/a" in panel["kpis"]["residual"].content
-    assert panel["kpis"]["median"].content.startswith("100")
+    assert panel["kpis"]["median"].content.startswith("110")
 
 
 def test_step_time_dashboard_hero_measured_zero_is_not_partial() -> None:
@@ -251,7 +245,9 @@ def test_step_time_dashboard_hero_measured_zero_is_not_partial() -> None:
     update_model_combined_section(panel, payload)
 
     # A measured-zero H2D is complete coverage, not partial signals.
-    assert panel["win"].text == "5 aligned steps · representative r0"
+    assert panel["win"].text == (
+        "5 aligned steps · CPU selected · representative r0"
+    )
     assert "n/a" not in panel["kpis"]["residual"].content
 
 
@@ -267,7 +263,9 @@ def test_step_time_dashboard_hero_absent_h2d_is_not_partial() -> None:
 
     update_model_combined_section(panel, payload)
 
-    assert panel["win"].text == "5 aligned steps · representative r0"
+    assert panel["win"].text == (
+        "5 aligned steps · CPU selected · representative r0"
+    )
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
     assert by_key["h2d"].width == "0.000%"
@@ -279,30 +277,13 @@ def test_step_time_dashboard_hero_step_time_only_extreme() -> None:
 
     update_model_combined_section(panel, payload)
 
-    # Only h2d is exempt. Occurrence-driven governs INTERMITTENT presence
-    # (seen once, gaps zero-filled); a phase never seen at all is
-    # unavailable even when occurrence-driven, which is what
-    # `_rank_metric_availability` does by only considering metrics it
-    # actually observed. So a wholly absent optimizer_step IS partial.
-    assert (
-        panel["win"].text == "5 aligned steps · representative r0 · partial: "
-        "IW,FWD,BWD,OPT,RESIDUAL"
+    # The inner envelope alone is not a canonical Step Time denominator.
+    # Clear the existing card state rather than substituting it for Step Time.
+    assert panel["win"].text == "CPU selected · Step Time unavailable"
+    assert all(seg.width == "0%" for seg in panel["seg_divs"])
+    assert all(
+        kpi.content == theme.kval("—") for kpi in panel["kpis"].values()
     )
-    keys = [key for _, key, _ in theme.PHASES]
-    by_key = dict(zip(keys, panel["seg_divs"]))
-    assert by_key["h2d"].width == "0.000%"
-    assert not by_key["h2d"].hatched
-    for key in (
-        "input_wait",
-        "forward",
-        "backward",
-        "optimizer_step",
-        "residual_proxy",
-    ):
-        assert by_key[key].width == f"{_UNMEASURED_SLIVER_PCT:.1f}%"
-        assert by_key[key].hatched
-    assert "n/a" in panel["kpis"]["residual"].content
-    assert panel["kpis"]["median"].content.startswith("100")
 
 
 def test_absent_optimizer_step_is_not_a_measured_zero() -> None:
@@ -317,30 +298,36 @@ def test_absent_optimizer_step_is_not_a_measured_zero() -> None:
 
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
-    assert by_key["optimizer_step"].hatched
+    assert by_key["optimizer_step"].width == "0%"
+    assert by_key["optimizer_step"].background == "transparent"
     assert (
         panel["win"].text
-        == "5 aligned steps · representative r0 · partial: OPT"
+        == "5 aligned steps · CPU selected · representative r0 · partial: "
+        "OPT"
     )
 
 
-def test_residual_share_is_na_when_input_wait_is_unavailable() -> None:
-    # residual_proxy derives from step_time and the compute phases, so it
-    # survives an unmeasured input_wait -- but the DENOMINATOR does not.
-    # The envelope substitutes zero for the missing wait, so any share
-    # computed against it is a confident percentage of an unknown total.
+def test_dashboard_clears_when_input_wait_makes_step_time_unavailable() -> (
+    None
+):
+    # residual_proxy can survive an unmeasured input wait, but canonical Step
+    # Time cannot. The dashboard must not substitute the inner envelope.
     payload = _payload(
-        _metrics(omit=("input_wait",), overrides={"residual_proxy": 10.0})
+        _metrics(
+            omit=("input_wait", "step_time"),
+            overrides={"residual_proxy": 10.0},
+        )
     )
     panel = _panel()
     update_model_combined_section(panel, payload)
 
-    assert "n/a" in panel["kpis"]["residual"].content
+    assert panel["win"].text == "CPU selected · Step Time unavailable"
+    assert all(
+        kpi.content == theme.kval("—") for kpi in panel["kpis"].values()
+    )
 
-    # Control twin: with input_wait measured the denominator is whole, so
-    # the same residual reports a real share.
-    window = payload.analysis.window
-    with_wait = _payload(list(window.metrics) + [_metric("input_wait", 10.0)])
+    # Control twin: canonical Step Time restores the existing card.
+    with_wait = _payload(_metrics(overrides={"residual_proxy": 10.0}))
     control = _panel()
     update_model_combined_section(control, with_wait)
     assert "n/a" not in control["kpis"]["residual"].content
@@ -362,32 +349,22 @@ def test_partial_rank_coverage_includes_step_time() -> None:
 
     assert (
         panel["win"].text
-        == "5 aligned steps · representative r0 · partial: RESIDUAL,STEP"
+        == "5 aligned steps · CPU selected · representative r0 · partial: "
+        "RESIDUAL,STEP TIME"
     )
 
 
 def test_step_time_dashboard_hero_dark_input_wait_is_not_measured_zero() -> (
     None
 ):
-    # #88/#135 shape: the dataloader stream goes dark while everything
-    # else keeps reporting. residual_proxy is a remainder (step_time -
-    # h2d - forward - backward - optimizer_step) so it stays derivable
-    # even though input_wait itself is unmeasured -- the ribbon must not
-    # let the OTHER phases silently fill to 100% and read as "confirmed
-    # no wait", which is exactly the class of bug this test pins.
-    dark_input_wait = _payload(_metrics(omit=("input_wait",)))
+    # #88/#135 shape: the input stream goes dark while everything else keeps
+    # reporting. The card must not derive Step Time from the remaining phases.
+    dark_input_wait = _payload(_metrics(omit=("input_wait", "step_time")))
     panel = _panel()
     update_model_combined_section(panel, dark_input_wait)
 
-    keys = [key for _, key, _ in theme.PHASES]
-    by_key = dict(zip(keys, panel["seg_divs"]))
-    # Unmeasured, not a confirmed-zero: the hatched sliver, not 0%.
-    assert by_key["input_wait"].width == f"{_UNMEASURED_SLIVER_PCT:.1f}%"
-    assert by_key["input_wait"].hatched
-    assert (
-        panel["win"].text
-        == "5 aligned steps · representative r0 · partial: IW"
-    )
+    assert panel["win"].text == "CPU selected · Step Time unavailable"
+    assert all(seg.width == "0%" for seg in panel["seg_divs"])
 
     # Control twin: input_wait genuinely measured as 0ms must render as
     # a real 0%-width segment, distinct from the unmeasured case above.
@@ -396,9 +373,13 @@ def test_step_time_dashboard_hero_dark_input_wait_is_not_measured_zero() -> (
     )
     control_panel = _panel()
     update_model_combined_section(control_panel, measured_zero_input_wait)
+    keys = [key for _, key, _ in theme.PHASES]
     control_by_key = dict(zip(keys, control_panel["seg_divs"]))
     assert control_by_key["input_wait"].width == "0.000%"
-    assert control_panel["win"].text == "5 aligned steps · representative r0"
+    assert (
+        control_panel["win"].text
+        == "5 aligned steps · CPU selected · representative r0"
+    )
 
 
 def test_step_time_dashboard_hero_dead_run_shows_expired() -> None:
@@ -408,8 +389,10 @@ def test_step_time_dashboard_hero_dead_run_shows_expired() -> None:
     good = _payload(_metrics())
     panel = _panel()
     update_model_combined_section(panel, good)
-    assert panel["win"].text == "5 aligned steps · representative r0"
-    assert panel["kpis"]["median"].content.startswith("100")
+    assert panel["win"].text == (
+        "5 aligned steps · CPU selected · representative r0"
+    )
+    assert panel["kpis"]["median"].content.startswith("110")
 
     # A never-had-data payload (cold start) must NOT clear the panel --
     # there is nothing to clear yet.
@@ -440,9 +423,9 @@ def test_fake_segment_matches_nicegui_style_merge() -> None:
     """Pin the double against the real widget.
 
     ``Element.style()`` MERGES declarations, so a background set while a
-    phase was unmeasured outlives a later width-only update. A double
+    phase is unmeasured must be explicitly cleared. A double
     that only appended style strings could never express that, which is
-    how the stale-hatch bug reached review: the test could not fail.
+    how a stale segment could reach review: the test could not fail.
     """
     from nicegui import ui
 
@@ -450,34 +433,34 @@ def test_fake_segment_matches_nicegui_style_merge() -> None:
     fake = _FakeSegment()
     for call in (
         "background:#1976d2; width:0%;",
-        "width:6.0%; background:repeating-linear-gradient(45deg, "
-        "#1976d2 0 2px, transparent 2px 5px);",
+        "width:0%; background:transparent;",
         "width:33.000%; background:#1976d2;",
     ):
         real.style(call)
         fake.style(call)
 
     assert dict(real._style) == fake.declarations
-    # And the property the production fix depends on: restating the
-    # background is what clears a previously-hatched segment.
-    assert not fake.hatched
+    # The production path must restate the background when a signal changes.
+    assert fake.background == "#1976d2"
 
 
-def test_step_time_dashboard_hero_recovered_phase_drops_the_hatch() -> None:
-    # Stateful sparse -> complete. NiceGUI merges styles, so a phase that
-    # was hatched while unmeasured must have its solid background
-    # restored on recovery; otherwise it stays visually "unmeasured"
-    # forever while reporting a real width.
+def test_step_time_dashboard_hero_recovered_phase_restores_its_segment() -> (
+    None
+):
+    # Stateful sparse -> complete. NiceGUI merges styles, so a cleared phase
+    # must restore its solid background and real width when it recovers.
     sparse = _payload(_metrics(omit=("forward",)))
     panel = _panel()
     update_model_combined_section(panel, sparse)
 
     keys = [key for _, key, _ in theme.PHASES]
     by_key = dict(zip(keys, panel["seg_divs"]))
-    assert by_key["forward"].hatched
+    assert by_key["forward"].width == "0%"
+    assert by_key["forward"].background == "transparent"
     assert (
         panel["win"].text
-        == "5 aligned steps · representative r0 · partial: FWD"
+        == "5 aligned steps · CPU selected · representative r0 · partial: "
+        "FWD"
     )
 
     # Forward starts reporting again.
@@ -485,10 +468,12 @@ def test_step_time_dashboard_hero_recovered_phase_drops_the_hatch() -> None:
     update_model_combined_section(panel, complete)
 
     forward_color = dict((k, c) for _, k, c in theme.PHASES)["forward"]
-    assert not by_key["forward"].hatched
     assert by_key["forward"].background == forward_color
-    assert by_key["forward"].width != f"{_UNMEASURED_SLIVER_PCT:.1f}%"
-    assert panel["win"].text == "5 aligned steps · representative r0"
+    assert by_key["forward"].width != "0%"
+    assert (
+        panel["win"].text
+        == "5 aligned steps · CPU selected · representative r0"
+    )
 
 
 def test_step_time_dashboard_hero_flags_partial_rank_coverage() -> None:
@@ -508,7 +493,8 @@ def test_step_time_dashboard_hero_flags_partial_rank_coverage() -> None:
 
     assert (
         panel["win"].text
-        == "5 aligned steps · representative r0 · partial: BWD,RESIDUAL"
+        == "5 aligned steps · CPU selected · representative r0 · partial: "
+        "BWD,RESIDUAL"
     )
 
     # Control twin: every rank measured everything -> not partial.
@@ -519,19 +505,24 @@ def test_step_time_dashboard_hero_flags_partial_rank_coverage() -> None:
     )
     control = _panel()
     update_model_combined_section(control, symmetric)
-    assert control["win"].text == "5 aligned steps · representative r0"
+    assert (
+        control["win"].text
+        == "5 aligned steps · CPU selected · representative r0"
+    )
 
 
-def test_step_time_dashboard_hero_clears_when_step_envelope_missing() -> None:
+def test_step_time_dashboard_hero_clears_when_step_time_missing() -> None:
     # Stateful: a COMPLETE window is drawn first, then a window arrives
-    # with no step_time. Without the envelope there is no denominator, so
+    # with no canonical Step Time. Without that denominator, so
     # every share would be invented -- the card must clear rather than
     # leave the previous ribbon and KPIs standing as if they were current.
     complete = _payload(_metrics())
     panel = _panel()
     update_model_combined_section(panel, complete)
-    assert panel["win"].text == "5 aligned steps · representative r0"
-    assert panel["kpis"]["median"].content.startswith("100")
+    assert panel["win"].text == (
+        "5 aligned steps · CPU selected · representative r0"
+    )
+    assert panel["kpis"]["median"].content.startswith("110")
 
     no_envelope = _payload(
         _metrics(
@@ -541,12 +532,13 @@ def test_step_time_dashboard_hero_clears_when_step_envelope_missing() -> None:
                 "optimizer_step",
                 "residual_proxy",
                 "traced_step_time",
+                "step_time",
             )
         )
     )
     update_model_combined_section(panel, no_envelope)
 
-    assert panel["win"].text == "step envelope unavailable"
+    assert panel["win"].text == "CPU selected · Step Time unavailable"
     assert all(seg.width == "0%" for seg in panel["seg_divs"])
     assert all(
         kpi.content == theme.kval("—") for kpi in panel["kpis"].values()
@@ -556,8 +548,8 @@ def test_step_time_dashboard_hero_clears_when_step_envelope_missing() -> None:
 def test_step_time_dashboard_hero_uses_diagnosis_metrics() -> None:
     assert theme.PHASES[0][:2] == ("IW", "input_wait")
 
-    # Self-consistent window shape: phases sum to input_wait + step.
-    diagnosis_metrics = _metrics(worst={"traced_step_time": 200.0})
+    # Self-consistent window shape: phases sum to canonical Step Time.
+    diagnosis_metrics = _metrics(worst={"step_time": 210.0})
     payload = _payload(diagnosis_metrics, clock="gpu")
     panel = _panel()
 
@@ -566,9 +558,11 @@ def test_step_time_dashboard_hero_uses_diagnosis_metrics() -> None:
     assert panel["seg_labs"][0].text == "IW"
     # input_wait 10 of the 110 ms iteration envelope.
     assert panel["seg_divs"][0].width == "9.091%"
-    assert panel["win"].text == "5 aligned steps · representative r0"
-    assert panel["kpis"]["median"].content.startswith("100")
-    assert panel["kpis"]["worst"].content.startswith("200")
+    assert panel["win"].text == (
+        "5 aligned steps · GPU selected · representative r0"
+    )
+    assert panel["kpis"]["median"].content.startswith("110")
+    assert panel["kpis"]["worst"].content.startswith("210")
     assert not panel["kpis"]["median"].content.startswith("20")
 
 
@@ -650,7 +644,7 @@ def test_disjoint_rank_populations_clear_only_the_ribbon() -> None:
 
     assert "no coherent phase cohort" in panel["win"].text
     assert all(segment.width == "0%" for segment in panel["seg_divs"])
-    assert panel["kpis"]["median"].content.startswith("100")
+    assert panel["kpis"]["median"].content.startswith("110")
     assert panel["kpis"]["gap"].content != theme.kval("—")
 
 

--- a/tests/renderers/test_step_time_renderer.py
+++ b/tests/renderers/test_step_time_renderer.py
@@ -67,13 +67,14 @@ def _sparse_payload() -> LiveStepTimeResult:
 def test_cli_columns_exclude_summary_only_statistics() -> None:
     metrics = [
         _metric("traced_step_time", 100.0),
+        _metric("step_time", 120.0),
         _metric("compute", 80.0),
         _metric("dataloader_fetch", 10.0),
         _metric("step_time_cpu", 120.0),
     ]
 
     assert [metric.metric for metric in _table_metrics(metrics)] == [
-        "traced_step_time"
+        "step_time"
     ]
 
 
@@ -109,9 +110,13 @@ def test_step_time_cli_uses_the_precomputed_selected_clock_analysis() -> None:
     assert "WARMUP" in text
     assert "IW" in text
     assert "DL" not in text
+    assert "Step Time" in text
     assert "Average (1 steps)" in text
     assert "Sum (" not in text
     assert "40.0 ms" in text
+    assert "140.0 ms" in text
+    assert "100.0 ms" not in text
+    assert "Selected clock=GPU" in text
     assert "12.0 ms" not in text
 
 
@@ -178,7 +183,7 @@ def test_step_time_cli_refreshes_its_injected_session_once() -> None:
     text = _render_text(renderer.get_panel_renderable())
 
     session.refresh.assert_called_once_with()
-    assert "STEP" in text
+    assert "Step Time" in text
 
 
 def test_cli_omits_missing_phase_and_shows_incomplete_data() -> None:
@@ -192,6 +197,7 @@ def test_cli_omits_missing_phase_and_shows_incomplete_data() -> None:
     assert "RESIDUAL" not in header
     assert "BWD" in header
     assert "H2D" in header
+    assert "Step Time" in header
     assert "0.0 ms" in text
     assert "60.0 ms" in text
 
@@ -272,8 +278,11 @@ def test_cli_renders_multi_rank_sparse_table() -> None:
     header = next(line for line in text.splitlines() if "Metric" in line)
     assert "FWD" not in header
     assert "BWD" in header
+    assert "Step Time" in header
     assert "Median avg" in text
     assert "Worst avg" in text
     assert "60.0 ms" in text
     assert "120.0 ms" in text
+    assert "92.0 ms" in text
+    assert "184.0 ms" in text
     assert "Worst Rank" in text


### PR DESCRIPTION
## Summary

Correct the existing live CLI and NiceGUI dashboard so **Step Time** always
means the canonical selected-clock outer duration:

```text
Step Time = Input Wait + Traced Step Time
```

This is a presentation correction only. It does not add live views, change the
analyzer, alter telemetry, or modify the persisted SQLite format.

## What changed

- CLI replaces its inner-envelope `STEP` column with selected-clock **Step
  Time**. It continues to show Input Wait, not DataLoader-fetch timing.
- CLI footer now uses the canonical terms:

  ```text
  Step Time = IW + Traced Step Time
  RESIDUAL = Traced Step Time − H2D − FWD − BWD − OPT
  ```

- Dashboard `MEDIAN STEP TIME` and `WORST STEP TIME` KPIs now use outer
  selected-clock `step_time`, rather than inner `traced_step_time`.
- Both surfaces clearly identify the selected diagnosis clock. GPU-selected
  windows display GPU values; CPU-fallback windows display CPU values.
- Dashboard ribbon widths now use the analyzer-provided
  `rank_values.step_time_ms` directly. The UI no longer reconstructs a
  denominator from phase sums or Input Wait plus the inner envelope.
- Missing phases remain blank and are named by the existing partial-data text;
  known phases are never rescaled to fill the ribbon. If selected Step Time is
  unavailable, the existing dashboard state clears instead of substituting the
  inner envelope.

## Non-goals

- No separate Traced Step Time column, CPU/GPU comparison view, or new KPI.
- No change to `trace_step`, SDK/Lightning instrumentation, sampler behavior,
  analyzer calculation, diagnostics, summary schema, or SQLite storage.
- No DataLoader-fetch metric is added to the live surfaces.

## Tests

- Updated existing CLI and dashboard tests for outer Step Time, selected-clock
  labeling, direct ribbon shares, missing evidence, and measured zero behavior.
- No test files were added.

```text
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/renderers/test_step_time_renderer.py \
  tests/display/test_model_combined_section.py \
  tests/step_time/test_contract_baseline.py -q

46 passed
```

`git diff --check` also passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Summary mode is now the default for single-node and multi-node runs, with live CLI and dashboard views available explicitly.
  * Added unified Step Time reporting across CLI, dashboard, and final summaries.
  * Live views reuse unchanged analysis and bridge transient read gaps.
* **Bug Fixes**
  * Missing timing signals now appear as unavailable or `INCOMPLETE DATA`, rather than misleading zero values.
  * Improved H2D timing coverage and straggler attribution.
* **Documentation**
  * Updated quickstarts, FAQs, output guidance, comparison behavior, and developer documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->