### PR TITLE
Publish canonical Step Time summary schema and compare compatibility

### DIFF
--- a/docs/developer_guide/step-time-pipeline-contract.md
+++ b/docs/developer_guide/step-time-pipeline-contract.md
@@ -150,15 +150,16 @@ contract does not load the analyzer or NumPy.
 | Required metrics | Input wait, forward, backward, and step envelope must be measured on every aligned step for a rank. Partial presence makes that metric unavailable for the rank. |
 | Occurrence-driven metrics | H2D and optimizer may legitimately occur on only some steps. Once observed, absent steps contribute zero work. An entirely absent H2D means no observed transfers, not incomplete instrumentation. |
 | Missing versus zero | An unavailable metric is absent from the sparse rank row and projects to `null`. A measured `0.0` remains present and projects to `0.0`. |
-| Derived metrics | Compute needs forward, backward, and optimizer. Residual needs the step envelope and every compute phase; absent H2D contributes zero. Total step needs input wait and the step envelope. |
+| Derived metrics | Compute needs forward, backward, and optimizer. Residual needs the traced envelope and every compute phase; absent H2D contributes zero. Step Time needs input wait and the traced envelope. |
 | Rank cohorts | A diagnosis uses only ranks carrying all metrics required by that rule. Consumers must not reconstruct another availability policy. |
 | Metric statistics | Median, worst value, worst rank, and skew are computed from ranks that measured that metric. The worst value and rank must describe the same rank. |
 | Representative rank | Choose the real rank nearest the mathematical median, then the lower value, then the lower rank id. |
 | Residual meaning | `max(0, step - h2d - forward - backward - optimizer)` is unattributed time, not proof of communication or NCCL overhead. |
 
-In `final_summary.json`, `dataloader_ms` and `total_step_ms` are CPU-clocked.
-`input_wait_ms`, `step_time_ms`, and phase metrics use the selected diagnosis
-clock.
+In `final_summary.json`, `step_time_ms`, `traced_step_time_ms`, and phase
+metrics use the selected diagnosis clock. The explicit CPU/GPU Step Time and
+Traced Step Time fields preserve both clocks, while `dataloader_fetch_cpu_ms`
+is supplemental CPU evidence.
 
 ## Surface responsibilities
 

--- a/docs/user_guide/compare.md
+++ b/docs/user_guide/compare.md
@@ -193,8 +193,11 @@ That means:
 This helps keep compare useful across incremental TraceML releases.
 For Step Time input timing, schema 1.6 compares selected-clock `input_wait_ms`
 when present and falls back to legacy `dataloader_ms` for older summaries.
-Since schema 1.7, a Step Time metric can be `null` when its timing signal was
-never measured in the analyzed window; compare treats a null side as
+Schema 1.8 normalizes historical outer Step Time to canonical `step_time_ms`
+at the compare boundary. It compares Step Time and selected-clock phases only
+when both summaries use the same diagnosis clock; CPU and GPU values are never
+mixed. Since schema 1.7, a Step Time metric can be `null` when its timing
+signal was never measured in the analyzed window; compare treats a null side as
 unavailable (no delta) instead of reading it as zero.
 
 ---

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -130,16 +130,14 @@ explicit `cpu_ms` timing. The live CLI Step Time table, dashboard, and final
 summary use the same global-rank SQLite loader and selected-clock window
 builder for diagnosis-facing timing; they differ only by row window sizing.
 The canonical model exposes selected-clock `input_wait_ms`, outer
-`step_time_ms`, and inner `traced_step_time_ms`. Summary JSON retains its
-legacy compatibility names: public `step_time_ms` is the selected traced
-envelope, `dataloader_ms` remains CPU dataloader fetch time, and
-`total_step_ms` remains CPU Step Time.
-These compatibility fields are not selected-clock phase-share denominators.
+`step_time_ms`, and inner `traced_step_time_ms`. Summary JSON also publishes
+explicit CPU and GPU Step Time and Traced Step Time aggregates.
+`dataloader_fetch_cpu_ms` remains supplemental CPU fetch evidence and is not a
+selected-clock phase-share denominator.
 `duration_ms` stays stored compatibility timing and is not used for Step Time
 display or diagnosis. In the final text report, selected-clock phase shares
-are divided by public `input_wait_ms + step_time_ms`; CPU compatibility rows are
-labeled separately. These report-table shares are observational and do not
-replace the median per-rank diagnosis score.
+are divided directly by public `step_time_ms`. These report-table shares are
+observational and do not replace the median per-rank diagnosis score.
 
 Typical overhead diagnoses use selected-clock per-rank Step Time shares:
 
@@ -198,7 +196,6 @@ known_step_ms = h2d_ms + compute_ms
 traced_step_time_ms = selected traced envelope timing
 step_time_ms = selected input_wait_ms + selected traced_step_time_ms
 residual_ms = average(max(0, traced_step_time_ms - known_step_ms))
-public total_step_ms = CPU Step Time (compatibility projection)
 ```
 
 Rank stragglers use culprit/victim evidence from selected-clock timing. TraceML

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -1,10 +1,11 @@
 # Final Summary JSON
 
-TraceML writes one end-of-run JSON file. The current schema version is `1.7`.
+TraceML writes one end-of-run JSON file. The current schema version is `1.8`.
 Each section has the same outer shape so the output is easy to store, diff, and
 consume from tooling.
 
-Schema `1.7` made every public Step Time metric nullable. `null` means the
+Schema `1.8` publishes canonical Step Time vocabulary. Every public timing
+metric is nullable: `null` means the
 underlying timing signal was never measured in the analyzed window (missing
 instrumentation), while a measured zero stays `0.0`. Null metrics are
 excluded from `global.average`, `global.median`, and `global.worst` and from
@@ -23,7 +24,7 @@ Sections:
 
 ```json
 {
-  "schema_version": 1.7,
+  "schema_version": 1.8,
   "generated_at": "...",
   "duration_s": null,
   "meta": {
@@ -115,18 +116,17 @@ Primary diagnosis evidence uses a small union:
   "type": "phase_share",
   "basis": "average",
   "steps_analyzed": 256,
-  "total_step_ms": 200.0,
-  "dataloader_ms": 40.0,
   "input_wait_ms": 80.0,
-  "step_time_ms": 160.0,
-  "iteration_time_ms": 240.0,
+  "step_time_ms": 240.0,
+  "traced_step_time_ms": 160.0,
   "diagnosis_clock": "gpu",
+  "dataloader_fetch_cpu_ms": 40.0,
   "h2d_ms": 0.4,
   "compute_ms": 120.0,
   "residual_ms": 39.6,
   "score": 0.333,
-  "score_basis": "median_per_rank_iteration_share",
-  "score_denominator": "input_wait_ms + step_time_ms per rank",
+  "score_basis": "median_per_rank_step_time_share",
+  "score_denominator": "selected-clock Step Time per rank",
   "gpu_util_avg_percent": 37.8
 }
 ```
@@ -134,9 +134,9 @@ Primary diagnosis evidence uses a small union:
 `phase_share` is used for `INPUT_BOUND`, `H2D_BOUND`, `RESIDUAL_HEAVY`, and
 `COMPUTE_BOUND`. Millisecond values come from `step_time.global.average` and
 are supporting observations only. For scored typical bottlenecks, `score` is
-the authoritative median per-rank iteration-impact fraction. Informational
+the authoritative median per-rank Step Time fraction. Informational
 `COMPUTE_BOUND` uses the median per-rank
-`(forward_ms + backward_ms + optimizer_ms) / iteration_time_ms` share with a
+`(forward_ms + backward_ms + optimizer_ms) / step_time_ms` share with a
 90% threshold, but has no score because it is excluded from impact-based
 primary ordering.
 
@@ -263,8 +263,8 @@ Fallback evidence types are:
 - `summary` is the short explanation. Older `reason` fields should be treated
   as pre-`1.4` input, not the current final-summary contract.
 - `score` is an optional section-specific ranking signal. In Step Time, scored
-  typical bottlenecks use median per-rank iteration impact and stragglers use
-  visible wait cost divided by victim iteration time.
+  typical bottlenecks use median per-rank Step Time impact and stragglers use
+  visible wait cost divided by victim Step Time.
 - Section-specific details such as `scope`, `samples_used`, `steps_used`,
   `note`, and `confidence` belong in `evidence`.
 - `groups.rows` contains row data only: `identity` and `metrics`.
@@ -312,10 +312,14 @@ in `global_ranks_used`.
     "gpu_mem_headroom_bytes"
   ],
   "step_time": [
-    "total_step_ms",
-    "dataloader_ms",
     "input_wait_ms",
     "step_time_ms",
+    "traced_step_time_ms",
+    "step_time_cpu_ms",
+    "step_time_gpu_ms",
+    "traced_step_time_cpu_ms",
+    "traced_step_time_gpu_ms",
+    "dataloader_fetch_cpu_ms",
     "h2d_ms",
     "compute_ms",
     "residual_ms",
@@ -342,13 +346,19 @@ Metric suffixes are units:
 
 Step Time uses one selected clock per aligned window. GPU timing is used when
 the window has complete GPU event timings; otherwise explicit CPU timing is
-used. `input_wait_ms` and `step_time_ms` expose this selected-clock timing.
-The public `dataloader_ms` key is kept for compatibility and represents CPU
-dataloader fetch wall time.
-The public `total_step_ms` key is also CPU-clocked for compatibility; it is
-not the denominator for selected-clock phase shares. The final text report
-uses derived `iteration_time_ms = input_wait_ms + step_time_ms` for every
-selected-clock phase share and labels CPU compatibility rows separately.
+used. `input_wait_ms`, `step_time_ms`, and `traced_step_time_ms` expose
+selected-clock values. The four explicit aggregate fields preserve both clocks:
+
+```text
+step_time_cpu_ms
+step_time_gpu_ms
+traced_step_time_cpu_ms
+traced_step_time_gpu_ms
+```
+
+`dataloader_fetch_cpu_ms` is supplemental CPU DataLoader-fetch evidence. It
+is never added into Input Wait or Step Time and has no phase-share percentage.
+Every displayed phase share uses the selected `step_time_ms` denominator.
 Those table shares are observational averages and may differ from the
 authoritative median per-rank diagnosis `score`.
 
@@ -358,20 +368,23 @@ per-step clamped residuals, not recomputed from already-averaged phase totals:
 ```text
 compute_ms = forward_ms + backward_ms + optimizer_ms
 known_step_ms = h2d_ms + compute_ms
-traced_step_ms = selected step envelope timing
-iteration_time_ms = selected input_wait_ms + selected traced_step_ms
-residual_ms = average(max(0, traced_step_ms - known_step_ms))
-total_step_ms = CPU dataloader_ms + CPU step envelope timing
+traced_step_time_ms = selected traced envelope timing
+step_time_ms = selected input_wait_ms + selected traced_step_time_ms
+residual_ms = average(max(0, traced_step_time_ms - known_step_ms))
 ```
 
 The selected-clock diagnosis contract is:
 
 ```text
 input_wait_ms = selected-clock input wait
-step_time_ms = selected-clock traced step envelope
-iteration_time_ms = input_wait_ms + step_time_ms, emitted only as diagnosis evidence
+traced_step_time_ms = selected-clock traced step envelope
+step_time_ms = complete selected-clock step duration
 diagnosis_clock = "cpu" | "gpu"
 ```
+
+Schema `1.8` does not publish historical timing aliases. Readers that support
+older summary files must use an explicit schema-versioned compatibility adapter
+at their input boundary; new output remains canonical.
 
 `duration_ms` is stored compatibility timing and is not a Step Time display or
 diagnosis fallback. `residual_ms` can include validation, checkpointing,

--- a/src/traceml_ai/reporting/compare/core.py
+++ b/src/traceml_ai/reporting/compare/core.py
@@ -62,9 +62,9 @@ def _schema_warnings(
         (
             "Summary schema versions differ: A uses "
             f"{lhs_version}, B uses {rhs_version}. Step Time fields changed "
-            "in schema 1.6 and became nullable in schema 1.7, so Step "
-            "Time deltas may not be directly "
-            "comparable."
+            "in schema 1.6, became nullable in schema 1.7, and were "
+            "renamed in schema 1.8; Step Time deltas require matching "
+            "selected clocks."
         )
     ]
 

--- a/src/traceml_ai/reporting/compare/formatters.py
+++ b/src/traceml_ai/reporting/compare/formatters.py
@@ -23,7 +23,7 @@ COMPARE_INNER_WIDTH = COMPARE_WIDTH - 4
 
 TEXT_METRIC_ORDER_BY_SECTION: Dict[str, tuple[str, ...]] = {
     "step_time": (
-        "total_step_ms",
+        "step_time_ms",
         "input_ms",
         "h2d_ms",
         "compute_ms",

--- a/src/traceml_ai/reporting/compare/sections/step_time.py
+++ b/src/traceml_ai/reporting/compare/sections/step_time.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from traceml_ai.reporting.compare.model import CompareSection
 from traceml_ai.reporting.compare.sections.base import (
@@ -32,82 +32,136 @@ class StepTimeComparer:
     ) -> CompareSection:
         lhs = lhs_payload.get(self.name)
         rhs = rhs_payload.get(self.name)
+        lhs_step_clock = self._step_time_clock(lhs_payload, lhs)
+        rhs_step_clock = self._step_time_clock(rhs_payload, rhs)
+        step_clocks_match = (
+            lhs_step_clock is not None
+            and rhs_step_clock is not None
+            and lhs_step_clock == rhs_step_clock
+        )
+        lhs_selected_clock = self._selected_clock(lhs)
+        rhs_selected_clock = self._selected_clock(rhs)
+        selected_clocks_match = (
+            lhs_selected_clock is not None
+            and rhs_selected_clock is not None
+            and lhs_selected_clock == rhs_selected_clock
+        )
+        notes: tuple[str, ...] = ()
+        if not step_clocks_match:
+            notes += (
+                "Step Time metrics are unavailable because the selected "
+                "clocks differ or are missing "
+                f"(A: {lhs_step_clock or 'n/a'}, "
+                f"B: {rhs_step_clock or 'n/a'}).",
+            )
+        if not selected_clocks_match:
+            notes += (
+                "Selected-clock phase metrics are unavailable because "
+                f"their clocks differ or are missing "
+                f"(A: {lhs_selected_clock or 'n/a'}, "
+                f"B: {rhs_selected_clock or 'n/a'}).",
+            )
+
+        def selected_value(section: Any, key: str) -> Any:
+            return self._value(section, key) if selected_clocks_match else None
+
+        def selected_input(section: Any) -> Any:
+            return (
+                self._input_value(section) if selected_clocks_match else None
+            )
+
+        def selected_dominant_phase(section: Any) -> Any:
+            return (
+                self._dominant_phase(section)
+                if selected_clocks_match
+                else None
+            )
+
         return CompareSection(
             name=self.name,
             available=section_available(lhs, rhs),
             diagnosis=section_diagnosis(lhs, rhs),
             metrics={
-                "total_step_ms": numeric_metric(
-                    key="total_step_ms",
-                    label="Total step",
+                "step_time_ms": numeric_metric(
+                    key="step_time_ms",
+                    label="Step Time",
                     unit="ms",
-                    lhs=self._value(lhs, "total_step_ms"),
-                    rhs=self._value(rhs, "total_step_ms"),
+                    lhs=self._step_time_value(
+                        lhs_payload,
+                        lhs,
+                        clocks_match=step_clocks_match,
+                    ),
+                    rhs=self._step_time_value(
+                        rhs_payload,
+                        rhs,
+                        clocks_match=step_clocks_match,
+                    ),
                     direction="higher_is_worse",
                 ),
                 "input_ms": numeric_metric(
                     key="input_ms",
                     label="Input",
                     unit="ms",
-                    lhs=self._input_value(lhs),
-                    rhs=self._input_value(rhs),
+                    lhs=selected_input(lhs),
+                    rhs=selected_input(rhs),
                     direction="higher_is_worse",
                 ),
                 "h2d_ms": numeric_metric(
                     key="h2d_ms",
                     label="H2D",
                     unit="ms",
-                    lhs=self._value(lhs, "h2d_ms"),
-                    rhs=self._value(rhs, "h2d_ms"),
+                    lhs=selected_value(lhs, "h2d_ms"),
+                    rhs=selected_value(rhs, "h2d_ms"),
                     direction="higher_is_worse",
                 ),
                 "compute_ms": numeric_metric(
                     key="compute_ms",
                     label="Compute",
                     unit="ms",
-                    lhs=self._value(lhs, "compute_ms"),
-                    rhs=self._value(rhs, "compute_ms"),
+                    lhs=selected_value(lhs, "compute_ms"),
+                    rhs=selected_value(rhs, "compute_ms"),
                     direction="higher_is_worse",
                 ),
                 "residual_ms": numeric_metric(
                     key="residual_ms",
                     label="Residual",
                     unit="ms",
-                    lhs=self._value(lhs, "residual_ms"),
-                    rhs=self._value(rhs, "residual_ms"),
+                    lhs=selected_value(lhs, "residual_ms"),
+                    rhs=selected_value(rhs, "residual_ms"),
                     direction="higher_is_worse",
                 ),
                 "forward_ms": numeric_metric(
                     key="forward_ms",
                     label="Forward",
                     unit="ms",
-                    lhs=self._value(lhs, "forward_ms"),
-                    rhs=self._value(rhs, "forward_ms"),
+                    lhs=selected_value(lhs, "forward_ms"),
+                    rhs=selected_value(rhs, "forward_ms"),
                     direction="higher_is_worse",
                 ),
                 "backward_ms": numeric_metric(
                     key="backward_ms",
                     label="Backward",
                     unit="ms",
-                    lhs=self._value(lhs, "backward_ms"),
-                    rhs=self._value(rhs, "backward_ms"),
+                    lhs=selected_value(lhs, "backward_ms"),
+                    rhs=selected_value(rhs, "backward_ms"),
                     direction="higher_is_worse",
                 ),
                 "optimizer_ms": numeric_metric(
                     key="optimizer_ms",
                     label="Optimizer",
                     unit="ms",
-                    lhs=self._value(lhs, "optimizer_ms"),
-                    rhs=self._value(rhs, "optimizer_ms"),
+                    lhs=selected_value(lhs, "optimizer_ms"),
+                    rhs=selected_value(rhs, "optimizer_ms"),
                     direction="higher_is_worse",
                 ),
                 "dominant_phase": text_metric(
                     key="dominant_phase",
                     label="Dominant phase",
-                    lhs=self._dominant_phase(lhs),
-                    rhs=self._dominant_phase(rhs),
+                    lhs=selected_dominant_phase(lhs),
+                    rhs=selected_dominant_phase(rhs),
                 ),
             },
+            notes=notes,
         )
 
     def _value(self, section: Any, key: str) -> Any:
@@ -145,6 +199,61 @@ class StepTimeComparer:
         if not present:
             return None
         return max(present, key=lambda phase: present[phase])
+
+    @staticmethod
+    def _schema_version(payload: Dict[str, Any]) -> Optional[float]:
+        """Return one numeric input schema version when it is available."""
+        try:
+            return float(payload.get("schema_version"))
+        except (TypeError, ValueError):
+            return None
+
+    def _step_time_clock(
+        self,
+        payload: Dict[str, Any],
+        section: Any,
+    ) -> Optional[str]:
+        """Return the clock represented by this payload's Step Time values."""
+        schema = self._schema_version(payload)
+        if schema is None or schema < 1.8:
+            # Historical outer Step Time was explicitly CPU-clocked.
+            return "cpu"
+        window = (
+            section.get("global", {}).get("window", {})
+            if isinstance(section, dict)
+            else {}
+        )
+        clock = str(window.get("diagnosis_clock") or "").lower()
+        return clock if clock in {"cpu", "gpu"} else None
+
+    @staticmethod
+    def _selected_clock(section: Any) -> Optional[str]:
+        """Return the clock behind selected-clock phase values."""
+        window = (
+            section.get("global", {}).get("window", {})
+            if isinstance(section, dict)
+            else {}
+        )
+        clock = str(window.get("diagnosis_clock") or "").lower()
+        return clock if clock in {"cpu", "gpu"} else None
+
+    def _step_time_value(
+        self,
+        payload: Dict[str, Any],
+        section: Any,
+        *,
+        clocks_match: bool,
+    ) -> Any:
+        """Read outer Step Time through the schema-version compatibility seam."""
+        if not clocks_match:
+            return None
+        schema = self._schema_version(payload)
+        key = (
+            "step_time_ms"
+            if schema is not None and schema >= 1.8
+            else "total_step_ms"
+        )
+        return global_average(section, key)
 
 
 __all__ = ["StepTimeComparer"]

--- a/src/traceml_ai/reporting/compare/verdict.py
+++ b/src/traceml_ai/reporting/compare/verdict.py
@@ -80,7 +80,7 @@ def _metric_has_both(metric: Dict[str, Any]) -> bool:
 
 
 def _primary_availability(context: CompareVerdictContext) -> str:
-    step = _metric_has_both(context.metric("step_time", "total_step_ms"))
+    step = _metric_has_both(context.metric("step_time", "step_time_ms"))
     memory = _metric_has_both(
         context.metric("step_memory", "peak_reserved_bytes")
     )
@@ -121,9 +121,7 @@ class MissingPrimarySignalsRule:
         state = _primary_availability(context)
         if state != "insufficient":
             return None
-        step_state = _metric_state(
-            context.metric("step_time", "total_step_ms")
-        )
+        step_state = _metric_state(context.metric("step_time", "step_time_ms"))
         memory_state = _metric_state(
             context.metric("step_memory", "peak_reserved_bytes")
         )
@@ -190,7 +188,7 @@ class MixedPrimarySignalsRule:
         self,
         context: CompareVerdictContext,
     ) -> Optional[CompareFinding]:
-        step = _signed_pct(context.metric("step_time", "total_step_ms"))
+        step = _signed_pct(context.metric("step_time", "step_time_ms"))
         memory = _signed_pct(
             context.metric("step_memory", "peak_reserved_bytes")
         )
@@ -224,7 +222,7 @@ class StepTimeRegressionRule:
         self,
         context: CompareVerdictContext,
     ) -> Optional[CompareFinding]:
-        metric = context.metric("step_time", "total_step_ms")
+        metric = context.metric("step_time", "step_time_ms")
         pct = _signed_pct(metric)
         if pct is None or pct < context.policy.step_avg_pct_moderate:
             return None
@@ -233,7 +231,7 @@ class StepTimeRegressionRule:
             severity="warning",
             priority=VerdictPriority.STEP_TIME_REGRESSION,
             domain="step_time",
-            metric="total_step_ms",
+            metric="step_time_ms",
             why=f"Step time increased by {pct:.1f}%.",
         )
 
@@ -243,7 +241,7 @@ class StepTimeImprovementRule:
         self,
         context: CompareVerdictContext,
     ) -> Optional[CompareFinding]:
-        metric = context.metric("step_time", "total_step_ms")
+        metric = context.metric("step_time", "step_time_ms")
         pct = _signed_pct(metric)
         if pct is None or pct > -context.policy.step_avg_pct_moderate:
             return None
@@ -252,7 +250,7 @@ class StepTimeImprovementRule:
             severity="info",
             priority=VerdictPriority.STEP_TIME_IMPROVEMENT,
             domain="step_time",
-            metric="total_step_ms",
+            metric="step_time_ms",
             why=f"Step time decreased by {abs(pct):.1f}%.",
         )
 
@@ -431,9 +429,7 @@ def build_compare_verdict(
             "reason": primary.why if state != "comparable" else None,
         },
         "step_time": {
-            "state": _metric_state(
-                context.metric("step_time", "total_step_ms")
-            )
+            "state": _metric_state(context.metric("step_time", "step_time_ms"))
         },
         "step_memory": {
             "state": _metric_state(

--- a/src/traceml_ai/reporting/final.py
+++ b/src/traceml_ai/reporting/final.py
@@ -41,10 +41,10 @@ from traceml_ai.sdk.protocol import (
 )
 from traceml_ai.utils.atomic_io import write_json_atomic, write_text_atomic
 
-# Version of the final_summary.json contract. 1.7 made every public
-# Step Time metric nullable: null means the signal was never measured in
-# the analyzed window, while a measured zero stays 0.0.
-SCHEMA_VERSION = 1.7
+# Version of the final_summary.json contract. 1.8 publishes canonical Step
+# Time and Traced Step Time values, including both explicit clock aggregates.
+# A timing signal that was never measured remains null; a measured zero is 0.0.
+SCHEMA_VERSION = 1.8
 
 SUMMARY_WIDTH = 78
 SUMMARY_INNER_TEXT_WIDTH = SUMMARY_WIDTH - 4
@@ -56,15 +56,15 @@ _SYSTEM_EVIDENCE_METRICS = (
     ("GPU Temp", "gpu_temp_c"),
 )
 _STEP_TIME_EVIDENCE_METRICS = (
-    ("Total", "total_step_ms"),
-    ("Dataloader", "dataloader_ms"),
-    ("Input Wait", "input_wait_ms"),
     ("Step Time", "step_time_ms"),
+    ("Traced Step Time", "traced_step_time_ms"),
+    ("Input Wait", "input_wait_ms"),
     ("Compute", "compute_ms"),
     ("Residual", "residual_ms"),
     ("H2D", "h2d_ms"),
+    ("DataLoader Fetch (CPU)", "dataloader_fetch_cpu_ms"),
 )
-_STEP_TIME_CPU_COMPAT_METRICS = frozenset(("total_step_ms", "dataloader_ms"))
+_STEP_TIME_SUPPLEMENTAL_METRICS = frozenset(("dataloader_fetch_cpu_ms",))
 _SEVERITY_LABELS = {
     "crit": "CRITICAL",
     "critical": "CRITICAL",
@@ -606,15 +606,9 @@ def _append_step_time_evidence_single(
     lines: List[str],
     step_time_summary: Dict[str, Any],
 ) -> None:
-    """Append selected-clock average/share Step Time evidence."""
-    widths = (16, 16, 12)
+    """Append canonical selected-clock average/share Step Time evidence."""
+    widths = (22, 16, 12)
     step_time = _average_value(step_time_summary, "step_time_ms")
-    input_wait = _average_value(step_time_summary, "input_wait_ms")
-    iteration_time = (
-        input_wait + step_time
-        if input_wait is not None and step_time is not None
-        else None
-    )
     lines.append(row("Step Time Evidence", width=SUMMARY_WIDTH))
     lines.append(
         row(
@@ -625,12 +619,10 @@ def _append_step_time_evidence_single(
     lines.append(row(_table_rule(widths), width=SUMMARY_WIDTH))
     for label, metric in _STEP_TIME_EVIDENCE_METRICS:
         value = _average_value(step_time_summary, metric)
-        if metric in _STEP_TIME_CPU_COMPAT_METRICS:
-            # These fields stay CPU-clocked for compatibility; selected-clock
-            # phase shares use selected-clock iteration time as the denominator.
-            share = "compat"
+        if metric in _STEP_TIME_SUPPLEMENTAL_METRICS:
+            share = "supplemental"
         else:
-            share = _format_share(value, iteration_time)
+            share = _format_share(value, step_time)
         lines.append(
             row(
                 _table_line(

--- a/src/traceml_ai/reporting/html/sections.py
+++ b/src/traceml_ai/reporting/html/sections.py
@@ -130,7 +130,10 @@ def _section_bars(
 ) -> str:
     """Section-specific inline chart, between the diagnosis and the tables."""
     if name == "step_time":
-        return phase_bar(section)
+        return phase_bar(
+            section,
+            schema_version=payload.get("schema_version"),
+        )
     if name == "step_memory":
         return memory_bars(section, payload.get("process") or {})
     return ""

--- a/src/traceml_ai/reporting/html/svg.py
+++ b/src/traceml_ai/reporting/html/svg.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from .sections_helpers import sorted_rows
 from .textutils import esc, fmt_value
@@ -24,11 +24,52 @@ _PHASES = (
 )
 
 
-def phase_bar(step_time_section: Dict[str, Any]) -> str:
-    """Stacked horizontal bar of the average step's phase breakdown."""
+def _schema_number(value: Any) -> Optional[float]:
+    """Return a usable schema number from a final-summary payload value."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _phase_bar_denominator(
+    avg: Dict[str, Any],
+    *,
+    schema_version: Any,
+) -> Optional[float]:
+    """Return canonical Step Time, adapting only pre-1.8 report payloads."""
+    schema = _schema_number(schema_version)
+    if schema is not None and schema >= 1.8:
+        value = avg.get("step_time_ms")
+        return float(value) if isinstance(value, (int, float)) else None
+
+    # Compatibility reader for historical final summaries only: before 1.8,
+    # step_time_ms was the traced envelope and the outer duration was absent.
+    traced = avg.get("step_time_ms")
+    input_wait = avg.get("input_wait_ms")
+    if input_wait is None and "input_wait_ms" not in avg:
+        input_wait = avg.get("dataloader_ms")
+    if isinstance(traced, (int, float)) and isinstance(
+        input_wait, (int, float)
+    ):
+        return float(traced) + float(input_wait)
+    return None
+
+
+def phase_bar(
+    step_time_section: Dict[str, Any],
+    *,
+    schema_version: Any = 1.8,
+) -> str:
+    """Render phase widths against canonical Step Time without rescaling."""
     avg = (step_time_section.get("global") or {}).get("average") or {}
+    if not isinstance(avg, dict):
+        return ""
+    step_time = _phase_bar_denominator(avg, schema_version=schema_version)
+    if step_time is None or step_time <= 0.0:
+        return ""
+
     present: List[Tuple[str, str, float]] = []
-    total = 0.0
     for metric, label, color in _PHASES:
         value = avg.get(metric)
         if (
@@ -36,23 +77,22 @@ def phase_bar(step_time_section: Dict[str, Any]) -> str:
             and metric == "input_wait_ms"
             and "input_wait_ms" not in avg
         ):
-            # Back-compat: a pre-1.6 report never carried this key at
-            # all. A schema>=1.6 report always carries the key, so a
+            # Pre-1.6 reports never carried this key at all. A newer report
+            # always carries the key, so a
             # present-but-null value here means genuinely unmeasured,
             # not "borrow dataloader_ms" -- fall through to the isinstance
             # check below and drop this phase from the chart.
             value = avg.get("dataloader_ms")
         if isinstance(value, (int, float)) and value > 0:
             present.append((label, color, float(value)))
-            total += float(value)
-    if total <= 0:
+    if not present:
         return ""
 
     rects: List[str] = []
     legend: List[str] = []
     x = 0.0
     for label, color, value in present:
-        width = 100.0 * value / total
+        width = 100.0 * value / step_time
         rects.append(
             f'<rect x="{x:.2f}%" y="4" width="{width:.2f}%" height="18" '
             f'fill="{color}"/>'

--- a/src/traceml_ai/reporting/html/textutils.py
+++ b/src/traceml_ai/reporting/html/textutils.py
@@ -38,10 +38,14 @@ def esc(value: Any) -> str:
 
 # Friendly display labels for known metric keys; unknown keys render raw.
 _METRIC_LABELS = {
-    "total_step_ms": "Total step",
-    "dataloader_ms": "Dataloader",
     "input_wait_ms": "Input wait",
-    "step_time_ms": "Step time",
+    "step_time_ms": "Step Time",
+    "traced_step_time_ms": "Traced Step Time",
+    "step_time_cpu_ms": "CPU Step Time",
+    "step_time_gpu_ms": "GPU Step Time",
+    "traced_step_time_cpu_ms": "CPU Traced Step Time",
+    "traced_step_time_gpu_ms": "GPU Traced Step Time",
+    "dataloader_fetch_cpu_ms": "DataLoader Fetch (CPU)",
     "h2d_ms": "H2D",
     "compute_ms": "Compute",
     "residual_ms": "Residual",

--- a/src/traceml_ai/reporting/primary_diagnosis.py
+++ b/src/traceml_ai/reporting/primary_diagnosis.py
@@ -230,27 +230,22 @@ def _phase_share_evidence(
     step_time_summary: Mapping[str, Any],
     system_summary: Mapping[str, Any],
 ) -> JsonDict:
-    """Build supporting average phase observations for a Step Time finding."""
+    """Build supporting observations from already-projected canonical values."""
     average = _global_average(step_time_summary)
-    total_ms = _float_or_none(average.get("total_step_ms"))
     step_time_ms = _float_or_none(average.get("step_time_ms"))
-    input_wait_ms = _float_or_none(average.get("input_wait_ms"))
-    iteration_time_ms = (
-        input_wait_ms + step_time_ms
-        if input_wait_ms is not None and step_time_ms is not None
-        else None
-    )
+    traced_step_time_ms = _float_or_none(average.get("traced_step_time_ms"))
     window = _global_window(step_time_summary)
     evidence: JsonDict = {
         "type": "phase_share",
         "basis": "average",
         "steps_analyzed": _steps_analyzed(step_time_summary),
-        "total_step_ms": _round(total_ms),
         "step_time_ms": _round(step_time_ms),
+        "traced_step_time_ms": _round(traced_step_time_ms),
         "diagnosis_clock": window.get("diagnosis_clock"),
-        "dataloader_ms": _round(_float_or_none(average.get("dataloader_ms"))),
+        "dataloader_fetch_cpu_ms": _round(
+            _float_or_none(average.get("dataloader_fetch_cpu_ms"))
+        ),
     }
-    evidence["iteration_time_ms"] = _round(iteration_time_ms)
 
     for metric in PHASE_METRICS:
         evidence[metric] = _round(_float_or_none(average.get(metric)))
@@ -360,7 +355,7 @@ def _rank_comparison_evidence(
 
     metric = _metric_for_primary_diagnosis(diagnosis)
     if metric is None:
-        metric = "total_step_ms"
+        metric = "step_time_ms"
     comparison = _comparison(
         step_time_summary=step_time_summary,
         metric=metric,
@@ -383,19 +378,19 @@ def _step_time_score_evidence(
     if kind in PHASE_SHARE_KINDS:
         return {
             "score": score,
-            "score_basis": "median_per_rank_iteration_share",
-            "score_denominator": "input_wait_ms + step_time_ms per rank",
+            "score_basis": "median_per_rank_step_time_share",
+            "score_denominator": "selected-clock Step Time per rank",
         }
 
     issue_evidence = _mapping(diagnosis.get("evidence"))
     return {
         "score": score,
-        "score_basis": "visible_cost_ms / victim_iteration_time_ms",
+        "score_basis": "visible_cost_ms / victim_step_time_ms",
         "score_numerator_ms": _float_or_none(
             issue_evidence.get("visible_cost_ms")
         ),
         "score_denominator_ms": _float_or_none(
-            issue_evidence.get("iteration_time_ms")
+            issue_evidence.get("step_time_ms")
         ),
     }
 

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -6,9 +6,9 @@
 
 """Pure final-summary projection for canonical Step Time analyses.
 
-The projector owns public JSON names, CPU compatibility fields, identities,
-and card text. Loading, alignment, statistics used by diagnosis, and diagnosis
-itself remain in the central Step Time pipeline.
+The projector owns the versioned public timing contract, identities, and card
+text. It consumes analyzer-owned values directly; loading, alignment,
+statistics, and diagnosis remain in the central Step Time pipeline.
 """
 
 from __future__ import annotations
@@ -39,10 +39,14 @@ if TYPE_CHECKING:
     from traceml_ai.step_time.pipeline import StepTimeAnalysis
 
 STEP_TIME_METRIC_NAMES = [
-    "total_step_ms",
-    "dataloader_ms",
     "input_wait_ms",
     "step_time_ms",
+    "traced_step_time_ms",
+    "step_time_cpu_ms",
+    "step_time_gpu_ms",
+    "traced_step_time_cpu_ms",
+    "traced_step_time_gpu_ms",
+    "dataloader_fetch_cpu_ms",
     "h2d_ms",
     "compute_ms",
     "residual_ms",
@@ -52,10 +56,26 @@ STEP_TIME_METRIC_NAMES = [
 ]
 
 _PUBLIC_METRICS = {
-    "total_step_ms": ("step_time_cpu_ms", "step_time_cpu"),
-    "dataloader_ms": ("dataloader_fetch_cpu_ms", "dataloader_fetch"),
     "input_wait_ms": ("input_wait_ms", "input_wait"),
-    "step_time_ms": ("traced_step_time_ms", "traced_step_time"),
+    "step_time_ms": ("step_time_ms", "step_time"),
+    "traced_step_time_ms": (
+        "traced_step_time_ms",
+        "traced_step_time",
+    ),
+    "step_time_cpu_ms": ("step_time_cpu_ms", "step_time_cpu"),
+    "step_time_gpu_ms": ("step_time_gpu_ms", "step_time_gpu"),
+    "traced_step_time_cpu_ms": (
+        "traced_step_time_cpu_ms",
+        "traced_step_time_cpu",
+    ),
+    "traced_step_time_gpu_ms": (
+        "traced_step_time_gpu_ms",
+        "traced_step_time_gpu",
+    ),
+    "dataloader_fetch_cpu_ms": (
+        "dataloader_fetch_cpu_ms",
+        "dataloader_fetch",
+    ),
     "h2d_ms": ("h2d_ms", "h2d"),
     "compute_ms": ("compute_ms", "compute"),
     "residual_ms": ("residual_ms", "residual_proxy"),
@@ -63,13 +83,7 @@ _PUBLIC_METRICS = {
     "backward_ms": ("backward_ms", "backward"),
     "optimizer_ms": ("optimizer_step_ms", "optimizer_step"),
 }
-"""Stable public fields projected from the canonical timing contract.
-
-The public summary schema predates the Step Time terminology migration:
-``step_time_ms`` still means the traced inner envelope and
-``total_step_ms`` still means CPU Step Time. Keep that compatibility at this
-projection boundary until the versioned public-schema migration.
-"""
+"""Stable schema-1.8 fields projected from the canonical timing contract."""
 
 
 class _MetricProjection(NamedTuple):
@@ -102,33 +116,6 @@ def _public_metric_values(
         metric: _optional_float(getattr(values, field_name))
         for metric, (field_name, _statistic) in _PUBLIC_METRICS.items()
     }
-
-
-def _legacy_issue_json(issue: Mapping[str, Any]) -> Dict[str, Any]:
-    """Project canonical diagnosis evidence to the stable summary schema."""
-    projected = dict(issue)
-    evidence = dict(projected.get("evidence") or {})
-    traced_step_time = evidence.pop("traced_step_time_ms", None)
-    step_time = evidence.pop("step_time_ms", None)
-
-    if traced_step_time is not None:
-        evidence["step_time_ms"] = traced_step_time
-    if step_time is not None:
-        evidence["iteration_time_ms"] = step_time
-
-    projected["evidence"] = evidence
-    return projected
-
-
-def _legacy_diagnosis_json(
-    diagnosis: Mapping[str, Any],
-    issues: list[Mapping[str, Any]],
-) -> tuple[Dict[str, Any], list[Dict[str, Any]]]:
-    """Return public diagnosis JSON without leaking new internal key names."""
-    projected_issues = [_legacy_issue_json(issue) for issue in issues]
-    if projected_issues:
-        return dict(projected_issues[0]), projected_issues
-    return _legacy_issue_json(diagnosis), projected_issues
 
 
 def _project_metric(
@@ -266,7 +253,7 @@ def _format_card_stats(
     if multi_rank:
         return (
             "- Stats: median/worst | "
-            f"total {_format_metric_pair(metrics['total_step_ms'])} | "
+            f"Step Time {_format_metric_pair(metrics['step_time_ms'])} | "
             f"input {_format_metric_pair(metrics['input_wait_ms'])} | "
             f"H2D {_format_metric_pair(metrics['h2d_ms'])} | "
             f"compute {_format_metric_pair(metrics['compute_ms'])}\n"
@@ -276,7 +263,7 @@ def _format_card_stats(
 
     return (
         "- Stats: "
-        f"total {format_ms(metrics['total_step_ms'].worst_value)} | "
+        f"Step Time {format_ms(metrics['step_time_ms'].worst_value)} | "
         f"input {format_ms(metrics['input_wait_ms'].worst_value)} | "
         f"H2D {format_ms(metrics['h2d_ms'].worst_value)} | "
         f"compute {format_ms(metrics['compute_ms'].worst_value)}\n"
@@ -288,7 +275,7 @@ def _format_card_ranks(metrics: Mapping[str, _MetricProjection]) -> str:
     """Render representative/worst global-rank lines."""
     return (
         "- Ranks: median/worst | "
-        f"total {_format_rank_pair(metrics['total_step_ms'])} | "
+        f"Step Time {_format_rank_pair(metrics['step_time_ms'])} | "
         f"input {_format_rank_pair(metrics['input_wait_ms'])} | "
         f"H2D {_format_rank_pair(metrics['h2d_ms'])} | "
         f"compute {_format_rank_pair(metrics['compute_ms'])}\n"
@@ -373,10 +360,6 @@ def project_step_time_summary(analysis: StepTimeAnalysis) -> Dict[str, Any]:
         {metric.metric: metric for metric in window.metrics},
     )
     diagnosis_json, issues_json = diagnostic_result_to_json(analysis.diagnosis)
-    diagnosis_json, issues_json = _legacy_diagnosis_json(
-        diagnosis_json,
-        issues_json,
-    )
     card = _build_card(
         analysis,
         metrics,

--- a/src/traceml_ai/sdk/summary_projection.py
+++ b/src/traceml_ai/sdk/summary_projection.py
@@ -14,10 +14,14 @@ TRACKER_PREFIX = "traceml"
 
 METRICS_BY_SECTION = {
     "step_time": (
-        "total_step_ms",
-        "dataloader_ms",
         "input_wait_ms",
         "step_time_ms",
+        "traced_step_time_ms",
+        "step_time_cpu_ms",
+        "step_time_gpu_ms",
+        "traced_step_time_cpu_ms",
+        "traced_step_time_gpu_ms",
+        "dataloader_fetch_cpu_ms",
         "h2d_ms",
         "compute_ms",
         "residual_ms",
@@ -87,6 +91,13 @@ def compact_summary(
         _set_scalar(out, f"{section}/severity", diagnosis.get("severity"))
 
         global_summary = _mapping(section_payload.get("global"))
+        window = _mapping(global_summary.get("window"))
+        if section == "step_time":
+            _set_scalar(
+                out,
+                "step_time/diagnosis_clock",
+                window.get("diagnosis_clock"),
+            )
         average = _mapping(global_summary.get("average"))
         for metric in METRICS_BY_SECTION.get(section, ()):
             _set_scalar(out, f"{section}/{metric}", average.get(metric))

--- a/tests/reporting/compare/test_compare.py
+++ b/tests/reporting/compare/test_compare.py
@@ -89,7 +89,35 @@ def _step_time_section(
             "reason": reason,
             "action": action,
         },
-        "global": {"average": average},
+        "global": {
+            "window": {"diagnosis_clock": "cpu"},
+            "average": average,
+        },
+    }
+
+
+def _canonical_step_time_section(
+    *,
+    step_time_ms: float,
+    diagnosis_clock: str,
+) -> dict:
+    """Build a minimal schema-1.8 Step Time section for compare coverage."""
+    return {
+        "diagnosis": {"status": "BALANCED"},
+        "global": {
+            "window": {"diagnosis_clock": diagnosis_clock},
+            "average": {
+                "step_time_ms": step_time_ms,
+                "traced_step_time_ms": step_time_ms - 10.0,
+                "input_wait_ms": 10.0,
+                "h2d_ms": 5.0,
+                "compute_ms": step_time_ms - 15.0,
+                "residual_ms": 0.0,
+                "forward_ms": step_time_ms - 15.0,
+                "backward_ms": 0.0,
+                "optimizer_ms": 0.0,
+            },
+        },
     }
 
 
@@ -232,7 +260,7 @@ def test_compare_render_shows_unavailable_in_a_for_missing_numeric_fields() -> (
     text = build_compare_text(compare_payload)
 
     assert "Verdict: INCONCLUSIVE" in text
-    assert "Total step" in text
+    assert "Step Time" in text
     assert "n/a" in text
     assert "296.5 ms" in text
     assert "Peak reserved" in text
@@ -466,7 +494,7 @@ def test_compare_payload_has_section_based_json_and_table_text() -> None:
         "system",
     }
     step_time_metrics = compare_payload["sections"]["step_time"]["metrics"]
-    assert step_time_metrics["total_step_ms"]["pct_change"] is not None
+    assert step_time_metrics["step_time_ms"]["pct_change"] is not None
     assert "forward_ms" in step_time_metrics
     assert "backward_ms" in step_time_metrics
     assert "optimizer_ms" in step_time_metrics
@@ -474,7 +502,7 @@ def test_compare_payload_has_section_based_json_and_table_text() -> None:
     assert compare_payload["verdict"]["primary_domain"] == "step_time"
     assert "Metric" in text
     assert "Step time diagnosis" in text
-    assert "Total step" in text
+    assert "Step Time" in text
     assert "Input" in text
     assert "H2D" in text
     assert "Compute" in text
@@ -503,9 +531,9 @@ def test_compare_warns_when_summary_schema_versions_differ() -> None:
     assert compare_payload["warnings"] == [
         (
             "Summary schema versions differ: A uses 1.5, B uses 1.6. "
-            "Step Time fields changed in schema 1.6 and became nullable "
-            "in schema 1.7, so Step Time deltas may not be directly "
-            "comparable."
+            "Step Time fields changed in schema 1.6, became nullable in "
+            "schema 1.7, and were renamed in schema 1.8; Step Time deltas "
+            "require matching selected clocks."
         )
     ]
     assert "Notes" in text
@@ -691,3 +719,85 @@ def test_compare_verdict_uses_priority_for_mixed_primary_signals() -> None:
     assert verdict["status"] == "MIXED"
     assert verdict["outcome"] == "mixed"
     assert verdict["findings"][0]["status"] == "MIXED"
+
+
+def test_compare_normalizes_legacy_and_schema_1_8_step_time() -> None:
+    lhs = _payload_with_sections(
+        step_time=_step_time_section(total_step_ms=155.0),
+    )
+    rhs = _payload_with_sections(
+        step_time=_canonical_step_time_section(
+            step_time_ms=100.0,
+            diagnosis_clock="cpu",
+        ),
+    )
+    rhs["schema_version"] = 1.8
+
+    step_time = _build_compare(lhs, rhs)["sections"]["step_time"]
+
+    assert step_time["metrics"]["step_time_ms"] == {
+        "label": "Step Time",
+        "unit": "ms",
+        "lhs": 155.0,
+        "rhs": 100.0,
+        "delta": -55.0,
+        "pct_change": pytest.approx(-35.4838709677),
+        "delta_unit": None,
+        "direction": "higher_is_worse",
+    }
+
+
+def test_compare_uses_canonical_step_time_for_schema_1_8_artifacts() -> None:
+    lhs = _payload_with_sections(
+        step_time=_canonical_step_time_section(
+            step_time_ms=155.0,
+            diagnosis_clock="gpu",
+        ),
+    )
+    rhs = _payload_with_sections(
+        step_time=_canonical_step_time_section(
+            step_time_ms=100.0,
+            diagnosis_clock="gpu",
+        ),
+    )
+    lhs["schema_version"] = 1.8
+    rhs["schema_version"] = 1.8
+
+    metric = _build_compare(lhs, rhs)["sections"]["step_time"]["metrics"][
+        "step_time_ms"
+    ]
+
+    assert metric["lhs"] == 155.0
+    assert metric["rhs"] == 100.0
+    assert metric["delta"] == -55.0
+    assert metric["pct_change"] == pytest.approx(-35.4838709677)
+
+
+def test_compare_rejects_selected_clock_mismatch() -> None:
+    lhs = _payload_with_sections(
+        step_time=_canonical_step_time_section(
+            step_time_ms=155.0,
+            diagnosis_clock="cpu",
+        ),
+    )
+    rhs = _payload_with_sections(
+        step_time=_canonical_step_time_section(
+            step_time_ms=100.0,
+            diagnosis_clock="gpu",
+        ),
+    )
+    lhs["schema_version"] = 1.8
+    rhs["schema_version"] = 1.8
+
+    step_time = _build_compare(lhs, rhs)["sections"]["step_time"]
+
+    assert step_time["metrics"]["step_time_ms"]["lhs"] is None
+    assert step_time["metrics"]["step_time_ms"]["rhs"] is None
+    assert step_time["metrics"]["compute_ms"]["lhs"] is None
+    assert step_time["metrics"]["compute_ms"]["rhs"] is None
+    assert step_time["notes"] == [
+        "Step Time metrics are unavailable because the selected clocks "
+        "differ or are missing (A: cpu, B: gpu).",
+        "Selected-clock phase metrics are unavailable because their clocks "
+        "differ or are missing (A: cpu, B: gpu).",
+    ]

--- a/tests/reporting/html/test_sections.py
+++ b/tests/reporting/html/test_sections.py
@@ -69,11 +69,11 @@ def test_friendly_metric_labels_and_raw_fallback(
     make_payload, make_section
 ) -> None:
     section = make_section(
-        metric_names=["total_step_ms", "weird_custom_metric"],
-        average={"total_step_ms": 100.0, "weird_custom_metric": 1.0},
+        metric_names=["step_time_ms", "weird_custom_metric"],
+        average={"step_time_ms": 100.0, "weird_custom_metric": 1.0},
     )
     out = render_sections(make_payload(step_time=section))
-    assert "Total step" in out  # mapped label
+    assert "Step Time" in out  # mapped label
     assert "weird_custom_metric" in out  # unknown key rendered raw
 
 

--- a/tests/reporting/html/test_svg.py
+++ b/tests/reporting/html/test_svg.py
@@ -10,18 +10,16 @@ def _widths(html: str):
 def test_phase_bar_emits_svg_rects_for_present_phases(make_section) -> None:
     section = make_section(
         metric_names=[
-            "total_step_ms",
-            "dataloader_ms",
             "input_wait_ms",
+            "step_time_ms",
             "forward_ms",
             "backward_ms",
         ],
         average={
-            "dataloader_ms": 20.0,
             "input_wait_ms": 20.0,
             "forward_ms": 30.0,
             "backward_ms": 50.0,
-            "total_step_ms": 100.0,
+            "step_time_ms": 100.0,
         },
     )
     out = phase_bar(section)
@@ -29,20 +27,20 @@ def test_phase_bar_emits_svg_rects_for_present_phases(make_section) -> None:
     assert out.count("<rect") == 3  # input wait + forward + backward
 
 
-def test_phase_bar_falls_back_to_dataloader_ms_for_pre_1_6(
+def test_phase_bar_adapts_legacy_inner_step_time_for_pre_1_8(
     make_section,
 ) -> None:
-    # Schema < 1.6 reports carry dataloader_ms but no input_wait_ms; the
-    # input phase must still render rather than silently dropping out.
+    # Schema < 1.8 used step_time_ms for the inner envelope. The private
+    # reader adapter reconstructs historical outer Step Time only here.
     section = make_section(
-        metric_names=["total_step_ms", "dataloader_ms", "forward_ms"],
+        metric_names=["dataloader_ms", "step_time_ms", "forward_ms"],
         average={
             "dataloader_ms": 60.0,
             "forward_ms": 40.0,
-            "total_step_ms": 100.0,
+            "step_time_ms": 40.0,
         },
     )
-    out = phase_bar(section)
+    out = phase_bar(section, schema_version=1.5)
     assert "input wait" in out
     assert out.count("<rect") == 2  # input (via dataloader_ms) + forward
 
@@ -60,17 +58,18 @@ def test_phase_bar_null_input_wait_is_not_borrowed_from_dataloader(
             "input_wait_ms": None,
             "dataloader_ms": 60.0,
             "forward_ms": 40.0,
-            "total_step_ms": 100.0,
+            "step_time_ms": 100.0,
         },
     )
     out = phase_bar(section)
     assert "input wait" not in out
     assert out.count("<rect") == 1  # forward only
+    assert 'width="40.00%"' in out
 
 
 def test_phase_bar_empty_when_no_timing(make_section) -> None:
     section = make_section(
-        metric_names=["total_step_ms"], average={"total_step_ms": 0.0}
+        metric_names=["step_time_ms"], average={"step_time_ms": 0.0}
     )
     assert phase_bar(section) == ""
 

--- a/tests/reporting/summary/test_final.py
+++ b/tests/reporting/summary/test_final.py
@@ -145,7 +145,7 @@ def test_final_summary_fixture_schema_contains_all_sections(tmp_path) -> None:
 
     payload = build_summary_payload(str(db_path))
 
-    assert payload["schema_version"] == 1.7
+    assert payload["schema_version"] == 1.8
     assert set(payload) == {
         "schema_version",
         "generated_at",
@@ -199,7 +199,7 @@ def test_final_report_generator_preserves_summary_schema_and_order():
         ),
     )
 
-    assert payload["schema_version"] == 1.7
+    assert payload["schema_version"] == 1.8
     assert payload["duration_s"] == 10.0
     assert list(payload.keys()) == [
         "schema_version",
@@ -261,7 +261,7 @@ def test_final_text_uses_single_process_average_layout():
         "INPUT_BOUND",
         "INPUT-BOUND",
         severity="crit",
-        summary="Input wait is 48.5% of the typical GPU iteration time.",
+        summary="Input wait is 48.5% of the typical GPU Step Time.",
         action="Increase workers, prefetch, or storage throughput.",
     )
     step_time = _payload(
@@ -270,10 +270,10 @@ def test_final_text_uses_single_process_average_layout():
         global_summary={
             "window": {"steps_analyzed": 60, "diagnosis_clock": "gpu"},
             "average": {
-                "total_step_ms": 139.1,
-                "dataloader_ms": 120.0,
+                "dataloader_fetch_cpu_ms": 120.0,
                 "input_wait_ms": 130.8,
-                "step_time_ms": 139.1,
+                "step_time_ms": 269.9,
+                "traced_step_time_ms": 139.1,
                 "compute_ms": 6.9,
                 "residual_ms": 1.3,
                 "h2d_ms": 0.2,
@@ -300,18 +300,22 @@ def test_final_text_uses_single_process_average_layout():
 
     text = payload["text"]
     assert "TraceML Verdict: INPUT-BOUND / CRITICAL" in text
-    assert (
-        "Why: Input wait is 48.5% of the typical GPU iteration time." in text
-    )
+    assert "Why: Input wait is 48.5% of the typical GPU Step Time." in text
     assert "Next: Increase workers, prefetch, or storage throughput." in text
     assert "System Evidence" in text
     assert "Metric            Average" in text
     assert "Step Time Evidence" in text
-    assert "Phase             Average           Share" in text
-    assert "Total             139.1ms           compat" in text
-    assert "Input Wait        130.8ms           48.5%" in text
-    assert "Dataloader        120.0ms           compat" in text
-    assert "Step Time         139.1ms           51.5%" in text
+    assert "Phase" in text
+    assert "Average" in text
+    assert "Share" in text
+    assert "Input Wait" in text
+    assert "130.8ms" in text
+    assert "48.5%" in text
+    assert "Step Time" in text
+    assert "Traced Step Time" in text
+    assert "DataLoader Fetch" in text
+    assert "supplemental" in text
+    assert "Total" not in text
     assert "Median" not in text
     assert "Worst" not in text
     assert "Skew" not in text
@@ -334,10 +338,10 @@ def test_final_text_renders_missing_step_metrics_as_na():
         global_summary={
             "window": {"steps_analyzed": 60, "diagnosis_clock": "cpu"},
             "average": {
-                "total_step_ms": 139.1,
-                "dataloader_ms": 120.0,
+                "dataloader_fetch_cpu_ms": 120.0,
                 "input_wait_ms": 130.8,
-                "step_time_ms": 139.1,
+                "step_time_ms": 269.9,
+                "traced_step_time_ms": 139.1,
                 "compute_ms": None,
                 "residual_ms": None,
                 "h2d_ms": None,
@@ -371,10 +375,10 @@ def test_final_text_uses_selected_step_time_for_phase_shares():
         global_summary={
             "window": {"steps_analyzed": 60, "diagnosis_clock": "gpu"},
             "average": {
-                "total_step_ms": 10.5,
-                "dataloader_ms": 0.5,
+                "dataloader_fetch_cpu_ms": 0.5,
                 "input_wait_ms": 2.0,
-                "step_time_ms": 50.0,
+                "step_time_ms": 52.0,
+                "traced_step_time_ms": 50.0,
                 "compute_ms": 48.0,
                 "residual_ms": 1.0,
                 "h2d_ms": 1.0,
@@ -385,12 +389,15 @@ def test_final_text_uses_selected_step_time_for_phase_shares():
     payload = _final_payload(step_time)
 
     text = payload["text"]
-    assert "Total             10.5ms            compat" in text
-    assert "Dataloader        0.5ms             compat" in text
-    assert "Step Time         50.0ms            96.2%" in text
-    assert "Compute           48.0ms            92.3%" in text
-    assert "457.1%" not in text
-    assert "476.2%" not in text
+    assert "DataLoader Fetch" in text
+    assert "supplemental" in text
+    assert "Traced Step Time" in text
+    assert "96.2%" in text
+    assert "Compute" in text
+    assert "48.0ms" in text
+    assert "92.3%" in text
+    assert "Step Time" in text
+    assert "Total" not in text
 
 
 def test_final_text_includes_h2d_bound_diagnosis():
@@ -400,16 +407,16 @@ def test_final_text_includes_h2d_bound_diagnosis():
             "H2D_BOUND",
             "H2D-BOUND",
             severity="crit",
-            summary="H2D transfer is 14.3% of the typical GPU iteration time.",
+            summary="H2D transfer is 14.3% of the typical GPU Step Time.",
             action="Inspect pinned memory and batch transfers.",
         ),
         global_summary={
             "window": {"steps_analyzed": 60, "diagnosis_clock": "gpu"},
             "average": {
-                "total_step_ms": 150.0,
-                "dataloader_ms": 40.0,
+                "dataloader_fetch_cpu_ms": 40.0,
                 "input_wait_ms": 40.0,
-                "step_time_ms": 100.0,
+                "step_time_ms": 140.0,
+                "traced_step_time_ms": 100.0,
                 "h2d_ms": 20.0,
                 "compute_ms": 70.0,
                 "residual_ms": 10.0,
@@ -420,7 +427,7 @@ def test_final_text_includes_h2d_bound_diagnosis():
     payload = _final_payload(step_time)
 
     assert "TraceML Verdict: H2D-BOUND / CRITICAL" in payload["text"]
-    assert "Why: H2D transfer is 14.3% of the typical GPU iteration time." in (
+    assert "Why: H2D transfer is 14.3% of the typical GPU Step Time." in (
         payload["text"]
     )
 
@@ -446,19 +453,19 @@ def test_final_text_uses_multi_process_comparison_layout():
         global_summary={
             "window": {"steps_analyzed": 60, "diagnosis_clock": "gpu"},
             "median": {
-                "total_step_ms": _point(303.7, 1),
-                "dataloader_ms": _point(3.8, 1),
+                "dataloader_fetch_cpu_ms": _point(3.8, 1),
                 "input_wait_ms": _point(13.8, 1),
-                "step_time_ms": _point(299.9, 1),
+                "step_time_ms": _point(303.7, 1),
+                "traced_step_time_ms": _point(299.9, 1),
                 "compute_ms": _point(259.5, 1),
                 "residual_ms": _point(40.5, 1),
                 "h2d_ms": _point(0.2, 1),
             },
             "worst": {
-                "total_step_ms": _point(304.1, 0),
-                "dataloader_ms": _point(254.5, 0),
+                "dataloader_fetch_cpu_ms": _point(254.5, 0),
                 "input_wait_ms": _point(264.5, 0),
-                "step_time_ms": _point(49.6, 0),
+                "step_time_ms": _point(304.1, 0),
+                "traced_step_time_ms": _point(49.6, 0),
                 "compute_ms": _point(261.0, 0),
                 "residual_ms": _point(42.1, 0),
                 "h2d_ms": _point(0.4, 0),

--- a/tests/reporting/summary/test_fixtures.py
+++ b/tests/reporting/summary/test_fixtures.py
@@ -300,7 +300,7 @@ def test_summary_sections_cover_single_rank_gpu_run(tmp_path: Path) -> None:
     assert process["metadata"]["global_ranks_seen"] == 1
     assert step_time["metadata"]["mode"] == "single_node"
     assert step_time["metadata"]["global_ranks_seen"] == 1
-    assert step_time["global"]["median"]["total_step_ms"]["value"] == 11.0
+    assert step_time["global"]["median"]["step_time_ms"]["value"] == 11.0
     assert step_time["units"] == {"time": "ms"}
     assert step_memory["metadata"]["global_ranks_seen"] == 1
     assert step_memory["metadata"]["global_ranks_used"] == 1

--- a/tests/reporting/summary/test_primary_diagnosis.py
+++ b/tests/reporting/summary/test_primary_diagnosis.py
@@ -58,16 +58,20 @@ def _step_time(
         "global": {
             "window": {"steps_analyzed": 256, "diagnosis_clock": "gpu"},
             "average": {
-                "total_step_ms": 200.0,
-                "dataloader_ms": 50.0,
+                "step_time_cpu_ms": 200.0,
+                "step_time_gpu_ms": 240.0,
+                "traced_step_time_cpu_ms": 120.0,
+                "traced_step_time_gpu_ms": 160.0,
+                "dataloader_fetch_cpu_ms": 50.0,
                 "input_wait_ms": 80.0,
-                "step_time_ms": 160.0,
+                "step_time_ms": 240.0,
+                "traced_step_time_ms": 160.0,
                 "h2d_ms": 10.0,
                 "compute_ms": 120.0,
                 "residual_ms": 20.0,
             },
             "median": {
-                "dataloader_ms": {"value": 5.0, "idx": "0"},
+                "dataloader_fetch_cpu_ms": {"value": 5.0, "idx": "0"},
                 "input_wait_ms": {"value": 8.0, "idx": "0"},
                 "h2d_ms": {"value": 10.0, "idx": "1"},
                 "compute_ms": {"value": 100.0, "idx": "1"},
@@ -75,7 +79,7 @@ def _step_time(
                 "residual_ms": {"value": 20.0, "idx": "0"},
             },
             "worst": {
-                "dataloader_ms": {"value": 80.0, "idx": "2"},
+                "dataloader_fetch_cpu_ms": {"value": 80.0, "idx": "2"},
                 "input_wait_ms": {"value": 120.0, "idx": "2"},
                 "h2d_ms": {"value": 40.0, "idx": "2"},
                 "compute_ms": {"value": 180.0, "idx": "2"},
@@ -100,7 +104,7 @@ def test_input_bound_uses_phase_share_evidence() -> None:
         _step_time(
             "INPUT_BOUND",
             status="INPUT-BOUND",
-            summary="Input wait is 33.3% of the typical GPU iteration time.",
+            summary="Input wait is 33.3% of the typical GPU Step Time.",
         ),
         _system(gpu_util=38.0),
     )
@@ -109,17 +113,16 @@ def test_input_bound_uses_phase_share_evidence() -> None:
     assert primary["section"] == "step_time"
     assert primary["scope"] == "performance"
     assert primary["summary"] == (
-        "Input wait is 33.3% of the typical GPU iteration time."
+        "Input wait is 33.3% of the typical GPU Step Time."
     )
     assert primary["evidence"] == {
         "type": "phase_share",
         "basis": "average",
         "steps_analyzed": 256,
-        "total_step_ms": 200.0,
-        "step_time_ms": 160.0,
-        "iteration_time_ms": 240.0,
+        "step_time_ms": 240.0,
+        "traced_step_time_ms": 160.0,
         "diagnosis_clock": "gpu",
-        "dataloader_ms": 50.0,
+        "dataloader_fetch_cpu_ms": 50.0,
         "input_wait_ms": 80.0,
         "h2d_ms": 10.0,
         "compute_ms": 120.0,
@@ -128,21 +131,21 @@ def test_input_bound_uses_phase_share_evidence() -> None:
     }
 
 
-def test_h2d_bound_uses_iteration_phase_share_evidence() -> None:
+def test_h2d_bound_uses_step_time_phase_share_evidence() -> None:
     primary = _primary(
         _step_time(
             "H2D_BOUND",
             status="H2D-BOUND",
-            summary="H2D transfer is 23.1% of the typical GPU iteration time.",
+            summary="H2D transfer is 23.1% of the typical GPU Step Time.",
         )
     )
 
     assert primary["kind"] == "H2D_BOUND"
     assert primary["summary"] == (
-        "H2D transfer is 23.1% of the typical GPU iteration time."
+        "H2D transfer is 23.1% of the typical GPU Step Time."
     )
     assert primary["evidence"]["type"] == "phase_share"
-    assert primary["evidence"]["iteration_time_ms"] == 240.0
+    assert primary["evidence"]["step_time_ms"] == 240.0
     assert "shares" not in primary["evidence"]
 
 
@@ -159,13 +162,13 @@ def test_phase_share_primary_keeps_the_diagnosis_impact_score() -> None:
 
     assert primary["evidence"]["score"] == 0.23125
     assert primary["evidence"]["h2d_ms"] == 10.0
-    assert primary["evidence"]["iteration_time_ms"] == 240.0
+    assert primary["evidence"]["step_time_ms"] == 240.0
     assert primary["evidence"]["score"] != pytest.approx(10.0 / 240.0)
     assert primary["evidence"]["score_basis"] == (
-        "median_per_rank_iteration_share"
+        "median_per_rank_step_time_share"
     )
     assert primary["evidence"]["score_denominator"] == (
-        "input_wait_ms + step_time_ms per rank"
+        "selected-clock Step Time per rank"
     )
     assert "shares" not in primary["evidence"]
 
@@ -177,7 +180,7 @@ def test_straggler_primary_keeps_the_diagnosis_impact_score() -> None:
             "score": 0.23,
             "evidence": {
                 "visible_cost_ms": 23.0,
-                "iteration_time_ms": 100.0,
+                "step_time_ms": 100.0,
             },
         }
     )
@@ -186,7 +189,7 @@ def test_straggler_primary_keeps_the_diagnosis_impact_score() -> None:
 
     assert primary["evidence"]["score"] == 0.23
     assert primary["evidence"]["score_basis"] == (
-        "visible_cost_ms / victim_iteration_time_ms"
+        "visible_cost_ms / victim_step_time_ms"
     )
     assert primary["evidence"]["score_numerator_ms"] == 23.0
     assert primary["evidence"]["score_denominator_ms"] == 100.0
@@ -197,15 +200,13 @@ def test_residual_heavy_uses_residual_phase_share() -> None:
         _step_time(
             "RESIDUAL_HEAVY",
             status="RESIDUAL-HEAVY",
-            summary=(
-                "Residual time is 21.0% of the typical GPU iteration time."
-            ),
+            summary=("Residual time is 21.0% of the typical GPU Step Time."),
         )
     )
 
     assert primary["kind"] == "RESIDUAL_HEAVY"
     assert primary["summary"] == (
-        "Residual time is 21.0% of the typical GPU iteration time."
+        "Residual time is 21.0% of the typical GPU Step Time."
     )
     assert primary["evidence"]["type"] == "phase_share"
     assert "shares" not in primary["evidence"]

--- a/tests/reporting/summary/test_step_time.py
+++ b/tests/reporting/summary/test_step_time.py
@@ -52,7 +52,7 @@ def test_step_time_summary_uses_persisted_events_json(tmp_path) -> None:
 
     assert summary["metadata"]["global_ranks_seen"] == 1
     assert summary["global"]["window"]["steps_analyzed"] == 2
-    assert summary["global"]["median"]["total_step_ms"]["value"] == 31.0
+    assert summary["global"]["median"]["step_time_ms"]["value"] == 31.0
     assert "Global: n/a" not in summary["card"]
 
 
@@ -130,7 +130,7 @@ def test_step_time_section_uses_summary_pipeline_and_sqlite_fixture(
     assert result.payload["metadata"]["training_total_steps"] == 3
     assert result.payload["metadata"]["training_latest_step"] == 2
     assert result.payload["metadata"]["global_ranks_seen"] == 1
-    assert result.payload["global"]["median"]["total_step_ms"]["value"] == 31.0
+    assert result.payload["global"]["median"]["step_time_ms"]["value"] == 31.0
     assert result.payload["groups"]["rows"]["0"]["identity"] == {
         "global_rank": 0,
         "local_rank": 0,

--- a/tests/reporting/summary/test_step_time_card.py
+++ b/tests/reporting/summary/test_step_time_card.py
@@ -76,17 +76,24 @@ def _assert_compact_card(card: str) -> None:
     assert "- Dominant:" not in card
 
 
-def _assert_public_step_metrics_keep_dataloader(payload) -> None:
+def _assert_public_step_metrics_are_canonical(payload) -> None:
     public_metric_keys = set(payload["global"]["median"])
-    assert "dataloader_ms" in public_metric_keys
-    assert "input_wait_ms" in public_metric_keys
-    assert "step_time_ms" in public_metric_keys
+    assert {
+        "input_wait_ms",
+        "step_time_ms",
+        "traced_step_time_ms",
+        "step_time_cpu_ms",
+        "step_time_gpu_ms",
+        "traced_step_time_cpu_ms",
+        "traced_step_time_gpu_ms",
+        "dataloader_fetch_cpu_ms",
+    } <= public_metric_keys
+    assert "total_step_ms" not in public_metric_keys
+    assert "dataloader_ms" not in public_metric_keys
 
     for row in payload["groups"]["rows"].values():
         row_metric_keys = set(row["metrics"])
-        assert "dataloader_ms" in row_metric_keys
-        assert "input_wait_ms" in row_metric_keys
-        assert "step_time_ms" in row_metric_keys
+        assert row_metric_keys == public_metric_keys
 
 
 def test_step_time_no_data_card_is_compact() -> None:
@@ -144,8 +151,8 @@ def test_card_median_and_json_representative_are_explicit() -> None:
         }
     )
 
-    assert "total 150.0/200.0ms" in payload["card"]
-    assert payload["global"]["median"]["total_step_ms"] == {
+    assert "Step Time 150.0/200.0ms" in payload["card"]
+    assert payload["global"]["median"]["step_time_ms"] == {
         "value": 100.0,
         "idx": "0",
     }
@@ -165,7 +172,7 @@ def test_card_median_and_json_representative_are_explicit() -> None:
                 ),
                 "status": "COMPUTE-BOUND",
                 "card": (
-                    "- Stats: total 97.0ms | input 2.0ms | H2D 0.0ms | "
+                    "- Stats: Step Time 97.0ms | input 2.0ms | H2D 0.0ms | "
                     "compute 90.0ms",
                     "- Residual: 5.0ms",
                     "- Why: Compute-bound; backward is the largest phase.",
@@ -191,17 +198,21 @@ def test_card_median_and_json_representative_are_explicit() -> None:
                 "diagnosis": {"metric": "input_wait", "phase": "input"},
                 "evidence": {
                     "input_wait_ms": 40.0,
-                    "step_time_ms": 100.0,
-                    "iteration_time_ms": 140.0,
+                    "step_time_ms": 140.0,
+                    "traced_step_time_ms": 100.0,
                     "diagnosis_clock": "gpu",
                 },
                 "average": {
-                    "dataloader_ms": 12.0,
+                    "dataloader_fetch_cpu_ms": 12.0,
                     "input_wait_ms": 40.0,
-                    "step_time_ms": 100.0,
-                    "total_step_ms": 102.0,
+                    "step_time_ms": 140.0,
+                    "traced_step_time_ms": 100.0,
+                    "step_time_cpu_ms": 102.0,
+                    "traced_step_time_cpu_ms": 90.0,
+                    "step_time_gpu_ms": 140.0,
+                    "traced_step_time_gpu_ms": 100.0,
                 },
-                "public_dataloader": True,
+                "public_metrics": True,
                 "card": (
                     "- Why: Input wait is 28.6% of the typical GPU Step "
                     "Time.",
@@ -270,9 +281,9 @@ def test_step_time_diagnosis_cards_use_short_reason(case: dict) -> None:
     for key, expected in case.get("average", {}).items():
         assert payload["global"]["average"][key] == expected
         assert payload["groups"]["rows"]["0"]["metrics"][key] == expected
-    if case.get("public_dataloader"):
+    if case.get("public_metrics"):
         assert payload["global"]["window"]["diagnosis_clock"] == "gpu"
-        _assert_public_step_metrics_keep_dataloader(payload)
+        _assert_public_step_metrics_are_canonical(payload)
     for expected in case["card"]:
         assert expected in payload["card"]
     _assert_compact_card(payload["card"])
@@ -357,7 +368,7 @@ def test_step_time_input_straggler_card_shows_rank_evidence() -> None:
     assert payload["diagnosis"]["status"] == "INPUT STRAGGLER"
     assert payload["diagnosis"]["metric"] == "input_wait"
     assert payload["diagnosis"]["phase"] == "input"
-    _assert_public_step_metrics_keep_dataloader(payload)
+    _assert_public_step_metrics_are_canonical(payload)
     assert "- Ranks: median/worst |" in payload["card"]
     assert (
         "- Why: r1 has excess input wait burden relative to victim r0 "

--- a/tests/reporting/summary/test_step_time_nullable.py
+++ b/tests/reporting/summary/test_step_time_nullable.py
@@ -202,6 +202,7 @@ def test_compare_treats_null_metric_as_unavailable(tmp_path) -> None:
                     "status": "INCOMPLETE DATA",
                 },
                 "global": {
+                    "window": {"diagnosis_clock": "cpu"},
                     "average": {
                         "total_step_ms": 31.0,
                         "input_wait_ms": 1.0,
@@ -211,7 +212,7 @@ def test_compare_treats_null_metric_as_unavailable(tmp_path) -> None:
                         "forward_ms": 5.0,
                         "backward_ms": 10.0,
                         "optimizer_ms": compute_ms,
-                    }
+                    },
                 },
             },
         }

--- a/tests/reporting/summary/test_step_time_nullable.py
+++ b/tests/reporting/summary/test_step_time_nullable.py
@@ -144,7 +144,15 @@ def test_missing_h2d_is_null_and_measured_zero_stays_zero(tmp_path) -> None:
     }
     assert missing["groups"]["rows"]["0"]["metrics"]["h2d_ms"] is None
     # Measured metrics on the same row stay plain floats.
-    assert missing["groups"]["rows"]["0"]["metrics"]["step_time_ms"] == 30.0
+    assert missing["groups"]["rows"]["0"]["metrics"]["step_time_ms"] == 31.0
+    assert (
+        missing["groups"]["rows"]["0"]["metrics"]["traced_step_time_ms"]
+        == 30.0
+    )
+    assert missing["global"]["average"]["step_time_cpu_ms"] == 31.0
+    assert missing["global"]["average"]["traced_step_time_cpu_ms"] == 30.0
+    assert missing["global"]["average"]["step_time_gpu_ms"] is None
+    assert missing["global"]["average"]["traced_step_time_gpu_ms"] is None
     assert "H2D n/a" in missing["card"]
 
     assert zero["global"]["average"]["h2d_ms"] == 0.0
@@ -170,13 +178,13 @@ def test_h2d_only_rank_keeps_row_and_stays_out_of_rank_selection(
     # The H2D-only rank keeps its H2D observation and nulls elsewhere.
     assert rows["1"]["metrics"]["h2d_ms"] == 6.0
     assert rows["1"]["metrics"]["step_time_ms"] is None
-    assert rows["1"]["metrics"]["total_step_ms"] is None
+    assert rows["1"]["metrics"]["traced_step_time_ms"] is None
 
     # Null metrics stay out of averages and rank picks: the H2D average
-    # spans both ranks, total-step rollups only the measured rank.
+    # spans both ranks, Step Time rollups only the measured rank.
     assert summary["global"]["average"]["h2d_ms"] == 4.0
-    assert summary["global"]["average"]["total_step_ms"] == 31.0
-    assert summary["global"]["worst"]["total_step_ms"]["idx"] == "0"
+    assert summary["global"]["average"]["step_time_ms"] == 31.0
+    assert summary["global"]["worst"]["step_time_ms"]["idx"] == "0"
     assert summary["global"]["worst"]["h2d_ms"]["idx"] == "1"
 
 
@@ -236,19 +244,19 @@ def test_single_rank_scope_wording_survives_null_total(tmp_path) -> None:
     assert "across 1 global ranks" not in summary["card"]
 
 
-def test_all_ranks_without_total_step_null_the_rank_picks(tmp_path) -> None:
+def test_all_ranks_without_step_time_null_the_rank_picks(tmp_path) -> None:
     db = tmp_path / "telemetry"
     _create_db(str(db), {0: {"h2d": 2.0}, 1: {"h2d": 6.0}})
     summary = StepTimeSummarySection().build(str(db)).payload
 
-    assert summary["global"]["worst"]["total_step_ms"] == {
+    assert summary["global"]["worst"]["step_time_ms"] == {
         "value": None,
         "idx": None,
     }
-    assert summary["global"]["average"]["total_step_ms"] is None
+    assert summary["global"]["average"]["step_time_ms"] is None
     assert summary["global"]["average"]["h2d_ms"] == 4.0
     assert summary["global"]["worst"]["h2d_ms"]["idx"] == "1"
-    assert "total n/a" in summary["card"]
+    assert "Step Time n/a" in summary["card"]
 
 
 def test_partial_compute_triplet_nulls_only_derived_metrics(
@@ -267,4 +275,4 @@ def test_partial_compute_triplet_nulls_only_derived_metrics(
     assert metrics["optimizer_ms"] is None
     assert metrics["compute_ms"] is None
     assert metrics["residual_ms"] is None
-    assert metrics["total_step_ms"] == 31.0
+    assert metrics["step_time_ms"] == 31.0

--- a/tests/sdk/test_summary_client.py
+++ b/tests/sdk/test_summary_client.py
@@ -114,6 +114,47 @@ def test_summary_projects_existing_final_payload(monkeypatch, tmp_path):
     }
 
 
+def test_summary_projects_canonical_step_time_metrics(monkeypatch, tmp_path):
+    session_root = _configure_session(monkeypatch, tmp_path)
+    session_root.mkdir(parents=True)
+    get_final_summary_json_path(session_root).write_text(
+        json.dumps(
+            {
+                "schema_version": 1.8,
+                "step_time": {
+                    "diagnosis": {"status": "BALANCED", "severity": "info"},
+                    "global": {
+                        "window": {"diagnosis_clock": "gpu"},
+                        "average": {
+                            "step_time_ms": 120.0,
+                            "traced_step_time_ms": 90.0,
+                            "step_time_cpu_ms": 140.0,
+                            "step_time_gpu_ms": 120.0,
+                            "traced_step_time_cpu_ms": 100.0,
+                            "traced_step_time_gpu_ms": 90.0,
+                            "dataloader_fetch_cpu_ms": 12.0,
+                        },
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = summary_client.summary()
+
+    assert result is not None
+    assert result["traceml/step_time/diagnosis_clock"] == "gpu"
+    assert result["traceml/step_time/step_time_ms"] == 120.0
+    assert result["traceml/step_time/traced_step_time_ms"] == 90.0
+    assert result["traceml/step_time/step_time_cpu_ms"] == 140.0
+    assert result["traceml/step_time/step_time_gpu_ms"] == 120.0
+    assert result["traceml/step_time/traced_step_time_cpu_ms"] == 100.0
+    assert result["traceml/step_time/traced_step_time_gpu_ms"] == 90.0
+    assert result["traceml/step_time/dataloader_fetch_cpu_ms"] == 12.0
+    assert "traceml/step_time/total_step_ms" not in result
+
+
 def test_final_summary_still_requests_generation_when_artifact_missing(
     monkeypatch,
     tmp_path,

--- a/tests/step_time/test_contract_baseline.py
+++ b/tests/step_time/test_contract_baseline.py
@@ -194,10 +194,14 @@ EXPECTED_METRIC_SUMMARIES: dict[
 EXPECTED_PUBLIC_ROWS: dict[str, dict[int, dict[str, float | None]]] = {
     "complete_gpu": {
         0: {
-            "total_step_ms": 200.0,
-            "dataloader_ms": 10.0,
+            "step_time_ms": 100.0,
+            "traced_step_time_ms": 95.0,
             "input_wait_ms": 5.0,
-            "step_time_ms": 95.0,
+            "step_time_cpu_ms": 200.0,
+            "step_time_gpu_ms": 100.0,
+            "traced_step_time_cpu_ms": 190.0,
+            "traced_step_time_gpu_ms": 95.0,
+            "dataloader_fetch_cpu_ms": 10.0,
             "compute_ms": 85.0,
             "residual_ms": 5.0,
         }
@@ -207,7 +211,12 @@ EXPECTED_PUBLIC_ROWS: dict[str, dict[int, dict[str, float | None]]] = {
             "forward_ms": None,
             "compute_ms": None,
             "residual_ms": None,
-            "step_time_ms": 95.0,
+            "step_time_ms": 100.0,
+            "traced_step_time_ms": 95.0,
+            "step_time_cpu_ms": 100.0,
+            "traced_step_time_cpu_ms": 95.0,
+            "step_time_gpu_ms": None,
+            "traced_step_time_gpu_ms": None,
         }
     },
     "measured_zero_forward": {
@@ -219,19 +228,47 @@ EXPECTED_PUBLIC_ROWS: dict[str, dict[int, dict[str, float | None]]] = {
     },
     "single_rank_cpu": {
         0: {
-            "total_step_ms": 100.0,
-            "dataloader_ms": 5.0,
             "input_wait_ms": 5.0,
-            "step_time_ms": 95.0,
+            "step_time_ms": 100.0,
+            "traced_step_time_ms": 95.0,
+            "step_time_cpu_ms": 100.0,
+            "traced_step_time_cpu_ms": 95.0,
+            "step_time_gpu_ms": None,
+            "traced_step_time_gpu_ms": None,
+            "dataloader_fetch_cpu_ms": 5.0,
         }
     },
     "ddp_rank_straggler": {
-        0: {"total_step_ms": 140.0, "input_wait_ms": 100.0},
-        1: {"total_step_ms": 140.0, "compute_ms": 140.0},
+        0: {
+            "step_time_ms": 140.0,
+            "traced_step_time_ms": 40.0,
+            "step_time_cpu_ms": 140.0,
+            "traced_step_time_cpu_ms": 40.0,
+            "input_wait_ms": 100.0,
+        },
+        1: {
+            "step_time_ms": 140.0,
+            "traced_step_time_ms": 140.0,
+            "step_time_cpu_ms": 140.0,
+            "traced_step_time_cpu_ms": 140.0,
+            "compute_ms": 140.0,
+        },
     },
     "fsdp_rank_straggler": {
-        0: {"total_step_ms": 140.0, "input_wait_ms": 100.0},
-        1: {"total_step_ms": 160.0, "compute_ms": 160.0},
+        0: {
+            "step_time_ms": 140.0,
+            "traced_step_time_ms": 40.0,
+            "step_time_cpu_ms": 140.0,
+            "traced_step_time_cpu_ms": 40.0,
+            "input_wait_ms": 100.0,
+        },
+        1: {
+            "step_time_ms": 160.0,
+            "traced_step_time_ms": 160.0,
+            "step_time_cpu_ms": 160.0,
+            "traced_step_time_cpu_ms": 160.0,
+            "compute_ms": 160.0,
+        },
     },
 }
 


### PR DESCRIPTION
## Summary

Publish schema `1.8` final summaries using the canonical timing vocabulary:

```text
Step Time = Input Wait + Traced Step Time
Residual = Traced Step Time − H2D − Compute
```

The final terminal report, JSON, tracker projection, HTML report, and compare
now use the same definitions. Existing summaries remain comparable through a
small versioned compatibility seam.

## What changed

- Bumped `final_summary.json` to schema `1.8`.
- Published selected-clock `step_time_ms` and `traced_step_time_ms`, plus all
  explicit clock aggregates:

  ```text
  step_time_cpu_ms                 step_time_gpu_ms
  traced_step_time_cpu_ms          traced_step_time_gpu_ms
  ```

- Published `diagnosis_clock` and supplemental `dataloader_fetch_cpu_ms`.
  DataLoader fetch is never added into Step Time or used as a phase-share
  denominator.
- Removed legacy `total_step_ms`, `iteration_time_ms`, and `dataloader_ms`
  from new summary, terminal, tracker, and HTML output.
- Final text and primary-diagnosis evidence consume canonical Step Time
  directly; no presentation-side reconstruction remains.
- HTML phase bars divide every visible phase by canonical selected-clock Step
  Time and do not rescale partial evidence to 100%. Pre-1.8 HTML input is
  handled by a private versioned adapter.
- Compare normalizes pre-1.8 CPU outer Step Time to canonical `step_time_ms`.
  New↔new and old↔new comparisons work; selected-clock timing deltas are
  withheld when the two summaries use different clocks.
- Updated the schema, timing-contract, and compare documentation.

## Non-goals

- No change to raw telemetry, `trace_step`, SDK/Lightning instrumentation,
  samplers, SQLite storage, or analyzer calculations.
- No synthetic zero is substituted for unavailable CPU or GPU timing.
- No CPU↔GPU duration comparison is reported as a regression or improvement.

## Tests

- Updated existing summary, HTML, tracker, contract-baseline, and compare
  tests.
- Added coverage for schema-1.8 comparison, old↔new compatibility, and
  CPU/GPU selected-clock mismatch handling.

```text
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/reporting tests/step_time tests/renderers \
  tests/sdk/test_summary_client.py -q

244 passed
```

`git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Summary mode is now the default for single-node and multi-node runs; live CLI and dashboard views can be selected explicitly.
  * Step Time reporting now uses unified timing metrics across live views, CLI output, dashboards, comparisons, and final reports.
  * Reports distinguish unavailable measurements from measured zero values and provide clearer `INCOMPLETE DATA` guidance.
  * Live views reuse recent valid analysis during temporary read failures and avoid unnecessary recalculation.
* **Bug Fixes**
  * Improved timing comparisons by preventing CPU/GPU clock mixing and validating measurement coverage.
  * Improved H2D and rank-straggler diagnosis accuracy when instrumentation is incomplete.
* **Documentation**
  * Updated quickstarts, FAQs, user guides, architecture guidance, and Step Time documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->