### PR TITLE
Compare canonical Step Time on a common clock

### DIFF
--- a/docs/user_guide/compare.md
+++ b/docs/user_guide/compare.md
@@ -191,14 +191,19 @@ That means:
 - if the two summaries use different schema versions, compare emits a warning because some fields may have changed meaning
 
 This helps keep compare useful across incremental TraceML releases.
-For Step Time input timing, schema 1.6 compares selected-clock `input_wait_ms`
-when present and falls back to legacy `dataloader_ms` for older summaries.
-Schema 1.8 normalizes historical outer Step Time to canonical `step_time_ms`
-at the compare boundary. It compares Step Time and selected-clock phases only
-when both summaries use the same diagnosis clock; CPU and GPU values are never
-mixed. Since schema 1.7, a Step Time metric can be `null` when its timing
-signal was never measured in the analyzed window; compare treats a null side as
-unavailable (no delta) instead of reading it as zero.
+Input Wait is compared only as selected-clock `input_wait_ms`; historical
+`dataloader_ms` is never substituted for it. Pre-1.7 `dataloader_ms` is
+instead adapted to the supplemental CPU `dataloader_fetch_cpu_ms` comparison
+field, which does not affect Step Time verdicts or phase shares.
+Schema 1.7 publishes explicit CPU and GPU outer Step Time aggregates. Compare
+uses GPU when both summaries have measured GPU Step Time; otherwise it uses CPU
+when both have measured CPU Step Time. If neither clock is shared, Step Time is
+inconclusive. Historical outer timing is interpreted only as CPU Step Time at
+the versioned compare boundary. Selected-clock phases still require matching
+diagnosis clocks, so CPU and GPU phase values are never mixed. Since schema
+1.7, a Step Time metric can be `null` when its timing signal was never measured
+in the analyzed window; compare treats a null side as unavailable (no delta)
+instead of reading it as zero.
 
 ---
 

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -1,10 +1,10 @@
 # Final Summary JSON
 
-TraceML writes one end-of-run JSON file. The current schema version is `1.8`.
+TraceML writes one end-of-run JSON file. The current schema version is `1.7`.
 Each section has the same outer shape so the output is easy to store, diff, and
 consume from tooling.
 
-Schema `1.8` publishes canonical Step Time vocabulary. Every public timing
+Schema `1.7` publishes canonical Step Time vocabulary. Every public timing
 metric is nullable: `null` means the
 underlying timing signal was never measured in the analyzed window (missing
 instrumentation), while a measured zero stays `0.0`. Null metrics are
@@ -24,7 +24,7 @@ Sections:
 
 ```json
 {
-  "schema_version": 1.8,
+  "schema_version": 1.7,
   "generated_at": "...",
   "duration_s": null,
   "meta": {
@@ -382,7 +382,7 @@ step_time_ms = complete selected-clock step duration
 diagnosis_clock = "cpu" | "gpu"
 ```
 
-Schema `1.8` does not publish historical timing aliases. Readers that support
+Schema `1.7` does not publish historical timing aliases. Readers that support
 older summary files must use an explicit schema-versioned compatibility adapter
 at their input boundary; new output remains canonical.
 

--- a/src/traceml_ai/reporting/compare/core.py
+++ b/src/traceml_ai/reporting/compare/core.py
@@ -62,9 +62,9 @@ def _schema_warnings(
         (
             "Summary schema versions differ: A uses "
             f"{lhs_version}, B uses {rhs_version}. Step Time fields changed "
-            "in schema 1.6, became nullable in schema 1.7, and were "
-            "renamed in schema 1.8; Step Time deltas require matching "
-            "selected clocks."
+            "in schema 1.6 and were made nullable and canonical in schema "
+            "1.7; compare uses a common measured GPU "
+            "clock when possible and otherwise a common CPU clock."
         )
     ]
 

--- a/src/traceml_ai/reporting/compare/formatters.py
+++ b/src/traceml_ai/reporting/compare/formatters.py
@@ -25,6 +25,7 @@ TEXT_METRIC_ORDER_BY_SECTION: Dict[str, tuple[str, ...]] = {
     "step_time": (
         "step_time_ms",
         "input_ms",
+        "dataloader_fetch_cpu_ms",
         "h2d_ms",
         "compute_ms",
         "residual_ms",
@@ -161,11 +162,17 @@ def _rows_for_section(
     return rows
 
 
-def _section_title(section_name: str) -> str:
-    return SECTION_TITLE_BY_SECTION.get(
+def _section_title(section_name: str, section: Dict[str, Any]) -> str:
+    title = SECTION_TITLE_BY_SECTION.get(
         section_name,
         section_name.replace("_", " ").title(),
     )
+    if section_name != "step_time":
+        return title
+    clock = section.get("comparison_clock")
+    if clock in {"cpu", "gpu"}:
+        return f"{title} ({str(clock).upper()} comparison clock)"
+    return f"{title} (no common comparison clock)"
 
 
 def _format_table_rows(rows: Iterable[tuple[str, str, str, str]]) -> list[str]:
@@ -254,7 +261,7 @@ class CompareTextFormatter(Formatter[Dict[str, Any], str]):
             section = sections.get(section_name)
             if isinstance(section, dict):
                 _append_card_line(lines)
-                _append_card_line(lines, _section_title(section_name))
+                _append_card_line(lines, _section_title(section_name, section))
                 for text in _format_table_rows(
                     _rows_for_section(section_name, section)
                 ):

--- a/src/traceml_ai/reporting/compare/model.py
+++ b/src/traceml_ai/reporting/compare/model.py
@@ -61,9 +61,10 @@ class CompareSection:
     diagnosis: CompareDiagnosis
     metrics: Dict[str, CompareMetric] = field(default_factory=dict)
     notes: tuple[str, ...] = ()
+    comparison_clock: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        payload = {
             "available": self.available,
             "diagnosis": self.diagnosis.to_dict(),
             "metrics": {
@@ -71,6 +72,9 @@ class CompareSection:
             },
             "notes": list(self.notes),
         }
+        if self.name == "step_time":
+            payload["comparison_clock"] = self.comparison_clock
+        return payload
 
 
 @dataclass(frozen=True)

--- a/src/traceml_ai/reporting/compare/sections/step_time.py
+++ b/src/traceml_ai/reporting/compare/sections/step_time.py
@@ -14,7 +14,6 @@ from traceml_ai.reporting.compare.model import CompareSection
 from traceml_ai.reporting.compare.sections.base import (
     as_float,
     global_average,
-    global_average_has_key,
     numeric_metric,
     section_available,
     section_diagnosis,
@@ -32,12 +31,13 @@ class StepTimeComparer:
     ) -> CompareSection:
         lhs = lhs_payload.get(self.name)
         rhs = rhs_payload.get(self.name)
-        lhs_step_clock = self._step_time_clock(lhs_payload, lhs)
-        rhs_step_clock = self._step_time_clock(rhs_payload, rhs)
-        step_clocks_match = (
-            lhs_step_clock is not None
-            and rhs_step_clock is not None
-            and lhs_step_clock == rhs_step_clock
+        comparison_clock, lhs_step_time, rhs_step_time = (
+            self._common_step_time_values(
+                lhs_payload,
+                lhs,
+                rhs_payload,
+                rhs,
+            )
         )
         lhs_selected_clock = self._selected_clock(lhs)
         rhs_selected_clock = self._selected_clock(rhs)
@@ -47,12 +47,10 @@ class StepTimeComparer:
             and lhs_selected_clock == rhs_selected_clock
         )
         notes: tuple[str, ...] = ()
-        if not step_clocks_match:
+        if comparison_clock is None:
             notes += (
-                "Step Time metrics are unavailable because the selected "
-                "clocks differ or are missing "
-                f"(A: {lhs_step_clock or 'n/a'}, "
-                f"B: {rhs_step_clock or 'n/a'}).",
+                "Step Time metrics are unavailable because the summaries "
+                "have no common measured GPU or CPU clock.",
             )
         if not selected_clocks_match:
             notes += (
@@ -84,18 +82,10 @@ class StepTimeComparer:
             metrics={
                 "step_time_ms": numeric_metric(
                     key="step_time_ms",
-                    label="Step Time",
+                    label=self._step_time_label(comparison_clock),
                     unit="ms",
-                    lhs=self._step_time_value(
-                        lhs_payload,
-                        lhs,
-                        clocks_match=step_clocks_match,
-                    ),
-                    rhs=self._step_time_value(
-                        rhs_payload,
-                        rhs,
-                        clocks_match=step_clocks_match,
-                    ),
+                    lhs=lhs_step_time,
+                    rhs=rhs_step_time,
                     direction="higher_is_worse",
                 ),
                 "input_ms": numeric_metric(
@@ -105,6 +95,14 @@ class StepTimeComparer:
                     lhs=selected_input(lhs),
                     rhs=selected_input(rhs),
                     direction="higher_is_worse",
+                ),
+                "dataloader_fetch_cpu_ms": numeric_metric(
+                    key="dataloader_fetch_cpu_ms",
+                    label="DataLoader Fetch (CPU)",
+                    unit="ms",
+                    lhs=self._dataloader_fetch_cpu_value(lhs_payload, lhs),
+                    rhs=self._dataloader_fetch_cpu_value(rhs_payload, rhs),
+                    direction="context",
                 ),
                 "h2d_ms": numeric_metric(
                     key="h2d_ms",
@@ -162,26 +160,40 @@ class StepTimeComparer:
                 ),
             },
             notes=notes,
+            comparison_clock=comparison_clock,
         )
 
     def _value(self, section: Any, key: str) -> Any:
         return global_average(section, key)
 
     def _input_value(self, section: Any) -> Any:
-        """Return selected-clock input wait.
+        """Return selected-clock Input Wait without legacy substitution.
 
-        Falls back to ``dataloader_ms`` only when ``input_wait_ms`` is
-        absent entirely (a pre-1.6 payload that never had the key). A
-        schema>=1.6 payload always carries the key; a present-but-null
-        value there means the signal was genuinely never measured this
-        window and must not be silently replaced by a different metric.
+        Historical ``dataloader_ms`` is CPU supplemental DataLoader-fetch
+        evidence, not selected-clock Input Wait. Compatibility for that field
+        is isolated in :meth:`_dataloader_fetch_cpu_value`.
         """
-        value = self._value(section, "input_wait_ms")
-        if value is not None:
-            return value
-        if global_average_has_key(section, "input_wait_ms"):
-            return None
-        return self._value(section, "dataloader_ms")
+        return self._value(section, "input_wait_ms")
+
+    def _dataloader_fetch_cpu_value(
+        self,
+        payload: Dict[str, Any],
+        section: Any,
+    ) -> Any:
+        """Read supplemental CPU fetch timing through the versioned seam.
+
+        Pre-1.7 summaries called this CPU-only field ``dataloader_ms``.
+        Schema 1.7 publishes the canonical ``dataloader_fetch_cpu_ms`` name.
+        This value is comparison context only; it never stands in for Input
+        Wait or contributes to a Step Time verdict.
+        """
+        schema = self._schema_version(payload)
+        key = (
+            "dataloader_fetch_cpu_ms"
+            if schema is not None and schema >= 1.7
+            else "dataloader_ms"
+        )
+        return global_average(section, key)
 
     def _dominant_phase(self, section: Any) -> Any:
         phases = {
@@ -208,23 +220,59 @@ class StepTimeComparer:
         except (TypeError, ValueError):
             return None
 
-    def _step_time_clock(
+    def _clock_step_time_values(
         self,
         payload: Dict[str, Any],
         section: Any,
-    ) -> Optional[str]:
-        """Return the clock represented by this payload's Step Time values."""
+    ) -> Dict[str, Any]:
+        """Read canonical clocks through the versioned summary seam.
+
+        Schema 1.7 publishes explicit CPU and GPU outer Step Time aggregates.
+        Historical summaries only expose ``total_step_ms``; it is compatibility
+        evidence for CPU Step Time and is never interpreted as GPU.
+        """
         schema = self._schema_version(payload)
-        if schema is None or schema < 1.8:
-            # Historical outer Step Time was explicitly CPU-clocked.
-            return "cpu"
-        window = (
-            section.get("global", {}).get("window", {})
-            if isinstance(section, dict)
-            else {}
-        )
-        clock = str(window.get("diagnosis_clock") or "").lower()
-        return clock if clock in {"cpu", "gpu"} else None
+        if schema is None or schema < 1.7:
+            return {
+                "cpu": global_average(section, "total_step_ms"),
+                "gpu": None,
+            }
+        return {
+            "cpu": global_average(section, "step_time_cpu_ms"),
+            "gpu": global_average(section, "step_time_gpu_ms"),
+        }
+
+    def _common_step_time_values(
+        self,
+        lhs_payload: Dict[str, Any],
+        lhs: Any,
+        rhs_payload: Dict[str, Any],
+        rhs: Any,
+    ) -> tuple[Optional[str], Any, Any]:
+        """Select one measured common clock without reconstructing Step Time.
+
+        GPU is preferred when both summaries publish it. CPU is the fallback
+        when both summaries publish CPU evidence. A numeric zero is measured;
+        only absent or null values make a clock unavailable.
+        """
+        lhs_values = self._clock_step_time_values(lhs_payload, lhs)
+        rhs_values = self._clock_step_time_values(rhs_payload, rhs)
+        for clock in ("gpu", "cpu"):
+            lhs_value = lhs_values[clock]
+            rhs_value = rhs_values[clock]
+            if (
+                as_float(lhs_value) is not None
+                and as_float(rhs_value) is not None
+            ):
+                return clock, lhs_value, rhs_value
+        return None, None, None
+
+    @staticmethod
+    def _step_time_label(comparison_clock: Optional[str]) -> str:
+        """Return the rendered outer Step Time label for the common clock."""
+        if comparison_clock in {"cpu", "gpu"}:
+            return f"{comparison_clock.upper()} Step Time"
+        return "Step Time"
 
     @staticmethod
     def _selected_clock(section: Any) -> Optional[str]:
@@ -236,24 +284,6 @@ class StepTimeComparer:
         )
         clock = str(window.get("diagnosis_clock") or "").lower()
         return clock if clock in {"cpu", "gpu"} else None
-
-    def _step_time_value(
-        self,
-        payload: Dict[str, Any],
-        section: Any,
-        *,
-        clocks_match: bool,
-    ) -> Any:
-        """Read outer Step Time through the schema-version compatibility seam."""
-        if not clocks_match:
-            return None
-        schema = self._schema_version(payload)
-        key = (
-            "step_time_ms"
-            if schema is not None and schema >= 1.8
-            else "total_step_ms"
-        )
-        return global_average(section, key)
 
 
 __all__ = ["StepTimeComparer"]

--- a/src/traceml_ai/reporting/compare/verdict.py
+++ b/src/traceml_ai/reporting/compare/verdict.py
@@ -113,6 +113,14 @@ def _status(section: Dict[str, Any], side: str) -> Optional[str]:
     return text or None
 
 
+def _step_time_label(context: CompareVerdictContext) -> str:
+    """Return the common-clock label selected by the compare adapter."""
+    clock = context.section("step_time").get("comparison_clock")
+    if clock in {"cpu", "gpu"}:
+        return f"{str(clock).upper()} Step Time"
+    return "Step Time"
+
+
 class MissingPrimarySignalsRule:
     def evaluate(
         self,
@@ -199,11 +207,12 @@ class MixedPrimarySignalsRule:
         step_good = step <= -context.policy.step_avg_pct_moderate
         mem_bad = memory >= 10.0
         mem_good = memory <= -10.0
+        step_time_label = _step_time_label(context)
 
         if step_good and mem_bad:
-            why = "Step time improved, but step memory worsened."
+            why = f"{step_time_label} improved, but step memory worsened."
         elif step_bad and mem_good:
-            why = "Step memory improved, but step time worsened."
+            why = f"Step memory improved, but {step_time_label} worsened."
         else:
             return None
 
@@ -232,7 +241,7 @@ class StepTimeRegressionRule:
             priority=VerdictPriority.STEP_TIME_REGRESSION,
             domain="step_time",
             metric="step_time_ms",
-            why=f"Step time increased by {pct:.1f}%.",
+            why=f"{_step_time_label(context)} increased by {pct:.1f}%.",
         )
 
 
@@ -251,7 +260,7 @@ class StepTimeImprovementRule:
             priority=VerdictPriority.STEP_TIME_IMPROVEMENT,
             domain="step_time",
             metric="step_time_ms",
-            why=f"Step time decreased by {abs(pct):.1f}%.",
+            why=(f"{_step_time_label(context)} decreased by {abs(pct):.1f}%."),
         )
 
 

--- a/src/traceml_ai/reporting/final.py
+++ b/src/traceml_ai/reporting/final.py
@@ -41,10 +41,10 @@ from traceml_ai.sdk.protocol import (
 )
 from traceml_ai.utils.atomic_io import write_json_atomic, write_text_atomic
 
-# Version of the final_summary.json contract. 1.8 publishes canonical Step
+# Version of the final_summary.json contract. 1.7 publishes canonical Step
 # Time and Traced Step Time values, including both explicit clock aggregates.
 # A timing signal that was never measured remains null; a measured zero is 0.0.
-SCHEMA_VERSION = 1.8
+SCHEMA_VERSION = 1.7
 
 SUMMARY_WIDTH = 78
 SUMMARY_INNER_TEXT_WIDTH = SUMMARY_WIDTH - 4

--- a/src/traceml_ai/reporting/html/svg.py
+++ b/src/traceml_ai/reporting/html/svg.py
@@ -37,13 +37,13 @@ def _phase_bar_denominator(
     *,
     schema_version: Any,
 ) -> Optional[float]:
-    """Return canonical Step Time, adapting only pre-1.8 report payloads."""
+    """Return canonical Step Time, adapting only pre-1.7 report payloads."""
     schema = _schema_number(schema_version)
-    if schema is not None and schema >= 1.8:
+    if schema is not None and schema >= 1.7:
         value = avg.get("step_time_ms")
         return float(value) if isinstance(value, (int, float)) else None
 
-    # Compatibility reader for historical final summaries only: before 1.8,
+    # Compatibility reader for historical final summaries only: before 1.7,
     # step_time_ms was the traced envelope and the outer duration was absent.
     traced = avg.get("step_time_ms")
     input_wait = avg.get("input_wait_ms")
@@ -59,7 +59,7 @@ def _phase_bar_denominator(
 def phase_bar(
     step_time_section: Dict[str, Any],
     *,
-    schema_version: Any = 1.8,
+    schema_version: Any = 1.7,
 ) -> str:
     """Render phase widths against canonical Step Time without rescaling."""
     avg = (step_time_section.get("global") or {}).get("average") or {}

--- a/src/traceml_ai/reporting/sections/step_time/builder.py
+++ b/src/traceml_ai/reporting/sections/step_time/builder.py
@@ -83,7 +83,7 @@ _PUBLIC_METRICS = {
     "backward_ms": ("backward_ms", "backward"),
     "optimizer_ms": ("optimizer_step_ms", "optimizer_step"),
 }
-"""Stable schema-1.8 fields projected from the canonical timing contract."""
+"""Stable schema-1.7 fields projected from the canonical timing contract."""
 
 
 class _MetricProjection(NamedTuple):

--- a/tests/reporting/compare/test_compare.py
+++ b/tests/reporting/compare/test_compare.py
@@ -100,8 +100,11 @@ def _canonical_step_time_section(
     *,
     step_time_ms: float,
     diagnosis_clock: str,
+    step_time_cpu_ms: Optional[float],
+    step_time_gpu_ms: Optional[float],
+    dataloader_fetch_cpu_ms: Optional[float] = None,
 ) -> dict:
-    """Build a minimal schema-1.8 Step Time section for compare coverage."""
+    """Build a minimal schema-1.7 Step Time section for compare coverage."""
     return {
         "diagnosis": {"status": "BALANCED"},
         "global": {
@@ -109,6 +112,9 @@ def _canonical_step_time_section(
             "average": {
                 "step_time_ms": step_time_ms,
                 "traced_step_time_ms": step_time_ms - 10.0,
+                "step_time_cpu_ms": step_time_cpu_ms,
+                "step_time_gpu_ms": step_time_gpu_ms,
+                "dataloader_fetch_cpu_ms": dataloader_fetch_cpu_ms,
                 "input_wait_ms": 10.0,
                 "h2d_ms": 5.0,
                 "compute_ms": step_time_ms - 15.0,
@@ -223,7 +229,7 @@ def test_compare_missing_both_primary_sections_on_lhs_is_unclear() -> None:
     assert verdict["outcome"] == "unclear"
     assert verdict["severity"] == "info"
     assert verdict["comparability"]["overall"]["state"] == "insufficient"
-    assert verdict["comparability"]["step_time"]["state"] == "missing_one_side"
+    assert verdict["comparability"]["step_time"]["state"] == "missing_both"
     assert (
         verdict["comparability"]["step_memory"]["state"] == "missing_one_side"
     )
@@ -262,7 +268,7 @@ def test_compare_render_shows_unavailable_in_a_for_missing_numeric_fields() -> (
     assert "Verdict: INCONCLUSIVE" in text
     assert "Step Time" in text
     assert "n/a" in text
-    assert "296.5 ms" in text
+    assert "no common comparison clock" in text
     assert "Peak reserved" in text
     assert "194 MB" in text
 
@@ -503,7 +509,8 @@ def test_compare_payload_has_section_based_json_and_table_text() -> None:
     assert "Metric" in text
     assert "Step time diagnosis" in text
     assert "Step Time" in text
-    assert "Input" in text
+    assert "Input" not in text
+    assert "DataLoader Fetch (CPU)" in text
     assert "H2D" in text
     assert "Compute" in text
     assert "Residual" in text
@@ -531,9 +538,10 @@ def test_compare_warns_when_summary_schema_versions_differ() -> None:
     assert compare_payload["warnings"] == [
         (
             "Summary schema versions differ: A uses 1.5, B uses 1.6. "
-            "Step Time fields changed in schema 1.6, became nullable in "
-            "schema 1.7, and were renamed in schema 1.8; Step Time deltas "
-            "require matching selected clocks."
+            "Step Time fields changed in schema 1.6 and were made nullable "
+            "and canonical in schema 1.7; compare uses a "
+            "common measured GPU clock when possible and otherwise a "
+            "common CPU clock."
         )
     ]
     assert "Notes" in text
@@ -592,18 +600,21 @@ def test_compare_step_time_null_input_wait_is_not_borrowed_from_dataloader() -> 
     assert step_time["metrics"]["input_ms"]["rhs"] is None
 
 
-def test_compare_step_time_absent_input_wait_still_falls_back_pre_1_6() -> (
-    None
-):
-    # True pre-1.6 shape: the key never existed at all. This case must
-    # keep falling back to dataloader_ms.
+def test_compare_legacy_dataloader_maps_to_cpu_fetch_not_input_wait() -> None:
+    # True pre-1.6 shape: Input Wait did not exist. Historical dataloader_ms
+    # is CPU supplemental DataLoader-fetch timing, not Input Wait.
     section = _step_time_section(total_step_ms=120.0)
     assert "input_wait_ms" not in section["global"]["average"]
 
     payload = _payload_with_sections(step_time=section)
     step_time = _build_compare(payload, payload)["sections"]["step_time"]
 
-    assert step_time["metrics"]["input_ms"]["lhs"] == (
+    assert step_time["metrics"]["input_ms"]["lhs"] is None
+    assert step_time["metrics"]["input_ms"]["rhs"] is None
+    assert step_time["metrics"]["dataloader_fetch_cpu_ms"]["lhs"] == (
+        section["global"]["average"]["dataloader_ms"]
+    )
+    assert step_time["metrics"]["dataloader_fetch_cpu_ms"]["rhs"] == (
         section["global"]["average"]["dataloader_ms"]
     )
 
@@ -721,7 +732,7 @@ def test_compare_verdict_uses_priority_for_mixed_primary_signals() -> None:
     assert verdict["findings"][0]["status"] == "MIXED"
 
 
-def test_compare_normalizes_legacy_and_schema_1_8_step_time() -> None:
+def test_compare_normalizes_legacy_and_schema_1_7_step_time() -> None:
     lhs = _payload_with_sections(
         step_time=_step_time_section(total_step_ms=155.0),
     )
@@ -729,14 +740,16 @@ def test_compare_normalizes_legacy_and_schema_1_8_step_time() -> None:
         step_time=_canonical_step_time_section(
             step_time_ms=100.0,
             diagnosis_clock="cpu",
+            step_time_cpu_ms=100.0,
+            step_time_gpu_ms=None,
         ),
     )
-    rhs["schema_version"] = 1.8
+    rhs["schema_version"] = 1.7
 
     step_time = _build_compare(lhs, rhs)["sections"]["step_time"]
 
     assert step_time["metrics"]["step_time_ms"] == {
-        "label": "Step Time",
+        "label": "CPU Step Time",
         "unit": "ms",
         "lhs": 155.0,
         "rhs": 100.0,
@@ -747,21 +760,25 @@ def test_compare_normalizes_legacy_and_schema_1_8_step_time() -> None:
     }
 
 
-def test_compare_uses_canonical_step_time_for_schema_1_8_artifacts() -> None:
+def test_compare_uses_canonical_step_time_for_schema_1_7_artifacts() -> None:
     lhs = _payload_with_sections(
         step_time=_canonical_step_time_section(
             step_time_ms=155.0,
             diagnosis_clock="gpu",
+            step_time_cpu_ms=165.0,
+            step_time_gpu_ms=155.0,
         ),
     )
     rhs = _payload_with_sections(
         step_time=_canonical_step_time_section(
             step_time_ms=100.0,
             diagnosis_clock="gpu",
+            step_time_cpu_ms=110.0,
+            step_time_gpu_ms=100.0,
         ),
     )
-    lhs["schema_version"] = 1.8
-    rhs["schema_version"] = 1.8
+    lhs["schema_version"] = 1.7
+    rhs["schema_version"] = 1.7
 
     metric = _build_compare(lhs, rhs)["sections"]["step_time"]["metrics"][
         "step_time_ms"
@@ -773,31 +790,158 @@ def test_compare_uses_canonical_step_time_for_schema_1_8_artifacts() -> None:
     assert metric["pct_change"] == pytest.approx(-35.4838709677)
 
 
-def test_compare_rejects_selected_clock_mismatch() -> None:
+def test_compare_prefers_gpu_despite_selected_clock_mismatch() -> None:
     lhs = _payload_with_sections(
         step_time=_canonical_step_time_section(
             step_time_ms=155.0,
             diagnosis_clock="cpu",
+            step_time_cpu_ms=155.0,
+            step_time_gpu_ms=140.0,
         ),
     )
     rhs = _payload_with_sections(
         step_time=_canonical_step_time_section(
             step_time_ms=100.0,
             diagnosis_clock="gpu",
+            step_time_cpu_ms=115.0,
+            step_time_gpu_ms=120.0,
         ),
     )
-    lhs["schema_version"] = 1.8
-    rhs["schema_version"] = 1.8
+    lhs["schema_version"] = 1.7
+    rhs["schema_version"] = 1.7
 
     step_time = _build_compare(lhs, rhs)["sections"]["step_time"]
 
-    assert step_time["metrics"]["step_time_ms"]["lhs"] is None
-    assert step_time["metrics"]["step_time_ms"]["rhs"] is None
+    assert step_time["comparison_clock"] == "gpu"
+    assert step_time["metrics"]["step_time_ms"]["label"] == "GPU Step Time"
+    assert step_time["metrics"]["step_time_ms"]["lhs"] == 140.0
+    assert step_time["metrics"]["step_time_ms"]["rhs"] == 120.0
     assert step_time["metrics"]["compute_ms"]["lhs"] is None
     assert step_time["metrics"]["compute_ms"]["rhs"] is None
     assert step_time["notes"] == [
-        "Step Time metrics are unavailable because the selected clocks "
-        "differ or are missing (A: cpu, B: gpu).",
         "Selected-clock phase metrics are unavailable because their clocks "
         "differ or are missing (A: cpu, B: gpu).",
     ]
+
+
+def test_compare_falls_back_to_common_cpu_clock() -> None:
+    lhs = _payload_with_sections(
+        step_time=_canonical_step_time_section(
+            step_time_ms=155.0,
+            diagnosis_clock="gpu",
+            step_time_cpu_ms=170.0,
+            step_time_gpu_ms=None,
+        ),
+    )
+    rhs = _payload_with_sections(
+        step_time=_canonical_step_time_section(
+            step_time_ms=100.0,
+            diagnosis_clock="cpu",
+            step_time_cpu_ms=130.0,
+            step_time_gpu_ms=100.0,
+        ),
+    )
+    lhs["schema_version"] = 1.7
+    rhs["schema_version"] = 1.7
+
+    compare_payload = _build_compare(lhs, rhs)
+    step_time = compare_payload["sections"]["step_time"]
+
+    assert step_time["comparison_clock"] == "cpu"
+    assert step_time["metrics"]["step_time_ms"]["label"] == "CPU Step Time"
+    assert step_time["metrics"]["step_time_ms"]["lhs"] == 170.0
+    assert step_time["metrics"]["step_time_ms"]["rhs"] == 130.0
+    assert step_time["metrics"]["input_ms"]["lhs"] is None
+    assert "CPU Step Time decreased" in compare_payload["verdict"]["why"]
+    text = build_compare_text(compare_payload)
+    assert "Step Time (CPU comparison clock)" in text
+    assert "CPU Step Time" in text
+    assert "Total step" not in text
+    assert "iteration" not in text.lower()
+
+
+def test_compare_legacy_step_time_is_cpu_compatibility_evidence() -> None:
+    lhs = _payload_with_sections(
+        step_time=_step_time_section(total_step_ms=155.0),
+    )
+    rhs = _payload_with_sections(
+        step_time=_canonical_step_time_section(
+            step_time_ms=100.0,
+            diagnosis_clock="gpu",
+            step_time_cpu_ms=120.0,
+            step_time_gpu_ms=100.0,
+            dataloader_fetch_cpu_ms=24.0,
+        ),
+    )
+    rhs["schema_version"] = 1.7
+
+    step_time = _build_compare(lhs, rhs)["sections"]["step_time"]
+
+    assert step_time["comparison_clock"] == "cpu"
+    assert step_time["metrics"]["step_time_ms"]["lhs"] == 155.0
+    assert step_time["metrics"]["step_time_ms"]["rhs"] == 120.0
+    assert step_time["metrics"]["dataloader_fetch_cpu_ms"]["lhs"] == 24.0
+    assert step_time["metrics"]["dataloader_fetch_cpu_ms"]["rhs"] == 24.0
+    assert "total_step_ms" not in json.dumps(step_time)
+
+
+def test_compare_reports_no_common_step_time_clock() -> None:
+    lhs = _payload_with_sections(
+        step_time=_canonical_step_time_section(
+            step_time_ms=155.0,
+            diagnosis_clock="gpu",
+            step_time_cpu_ms=None,
+            step_time_gpu_ms=155.0,
+        ),
+    )
+    rhs = _payload_with_sections(
+        step_time=_canonical_step_time_section(
+            step_time_ms=100.0,
+            diagnosis_clock="cpu",
+            step_time_cpu_ms=100.0,
+            step_time_gpu_ms=None,
+        ),
+    )
+    lhs["schema_version"] = 1.7
+    rhs["schema_version"] = 1.7
+
+    compare_payload = _build_compare(lhs, rhs)
+    step_time = compare_payload["sections"]["step_time"]
+
+    assert step_time["comparison_clock"] is None
+    assert step_time["metrics"]["step_time_ms"]["lhs"] is None
+    assert step_time["metrics"]["step_time_ms"]["rhs"] is None
+    assert step_time["notes"][0] == (
+        "Step Time metrics are unavailable because the summaries have no "
+        "common measured GPU or CPU clock."
+    )
+    assert compare_payload["verdict"]["status"] == "INCONCLUSIVE"
+
+
+def test_compare_accepts_measured_zero_for_common_gpu_clock() -> None:
+    lhs = _payload_with_sections(
+        step_time=_canonical_step_time_section(
+            step_time_ms=0.0,
+            diagnosis_clock="gpu",
+            step_time_cpu_ms=1.0,
+            step_time_gpu_ms=0.0,
+        ),
+    )
+    rhs = _payload_with_sections(
+        step_time=_canonical_step_time_section(
+            step_time_ms=5.0,
+            diagnosis_clock="gpu",
+            step_time_cpu_ms=6.0,
+            step_time_gpu_ms=5.0,
+        ),
+    )
+    lhs["schema_version"] = 1.7
+    rhs["schema_version"] = 1.7
+
+    metric = _build_compare(lhs, rhs)["sections"]["step_time"]["metrics"][
+        "step_time_ms"
+    ]
+
+    assert metric["lhs"] == 0.0
+    assert metric["rhs"] == 5.0
+    assert metric["pct_change"] is None

--- a/tests/reporting/html/test_svg.py
+++ b/tests/reporting/html/test_svg.py
@@ -27,10 +27,10 @@ def test_phase_bar_emits_svg_rects_for_present_phases(make_section) -> None:
     assert out.count("<rect") == 3  # input wait + forward + backward
 
 
-def test_phase_bar_adapts_legacy_inner_step_time_for_pre_1_8(
+def test_phase_bar_adapts_legacy_inner_step_time_for_pre_1_7(
     make_section,
 ) -> None:
-    # Schema < 1.8 used step_time_ms for the inner envelope. The private
+    # Schema < 1.7 used step_time_ms for the inner envelope. The private
     # reader adapter reconstructs historical outer Step Time only here.
     section = make_section(
         metric_names=["dataloader_ms", "step_time_ms", "forward_ms"],

--- a/tests/reporting/summary/test_final.py
+++ b/tests/reporting/summary/test_final.py
@@ -145,7 +145,7 @@ def test_final_summary_fixture_schema_contains_all_sections(tmp_path) -> None:
 
     payload = build_summary_payload(str(db_path))
 
-    assert payload["schema_version"] == 1.8
+    assert payload["schema_version"] == 1.7
     assert set(payload) == {
         "schema_version",
         "generated_at",
@@ -199,7 +199,7 @@ def test_final_report_generator_preserves_summary_schema_and_order():
         ),
     )
 
-    assert payload["schema_version"] == 1.8
+    assert payload["schema_version"] == 1.7
     assert payload["duration_s"] == 10.0
     assert list(payload.keys()) == [
         "schema_version",

--- a/tests/sdk/test_summary_client.py
+++ b/tests/sdk/test_summary_client.py
@@ -120,7 +120,7 @@ def test_summary_projects_canonical_step_time_metrics(monkeypatch, tmp_path):
     get_final_summary_json_path(session_root).write_text(
         json.dumps(
             {
-                "schema_version": 1.8,
+                "schema_version": 1.7,
                 "step_time": {
                     "diagnosis": {"status": "BALANCED", "severity": "info"},
                     "global": {


### PR DESCRIPTION

## Summary

Make `traceml compare` compare canonical outer Step Time on one common clock.
It prefers GPU when both summaries contain measured GPU Step Time, otherwise
uses CPU when both contain measured CPU Step Time, and reports an explicit
inconclusive result when neither clock is shared.

The change is strictly post-summary: raw telemetry, tracing, samplers, SQLite,
analyzer selection, and final-summary timing calculations are unchanged.

## What changed

- Added a private, schema-versioned compare adapter:
  - Schema 1.7 summaries provide explicit `step_time_gpu_ms` and
    `step_time_cpu_ms` evidence.
  - Older summaries map `total_step_ms` only to CPU Step Time. It is never
    reinterpreted as GPU timing.
- Added `comparison_clock` (`gpu`, `cpu`, or `null`) to the Step Time compare
  section. Terminal tables and Step Time verdicts clearly name the selected
  common clock, for example `GPU Step Time`.
- Kept selected-clock phase comparisons separate from outer Step Time:
  Input Wait, H2D, compute, residual, and subphases are compared only when
  both summaries have the same `diagnosis_clock`.
- Stopped treating legacy `dataloader_ms` as Input Wait. Input Wait now compares
  only `input_wait_ms` to `input_wait_ms`.
- Added a separate supplemental `DataLoader Fetch (CPU)` compare metric:
  historical `dataloader_ms` maps to schema-1.7
  `dataloader_fetch_cpu_ms`. It is context only and never affects Step Time,
  phase shares, or verdicts.
- Aligned the final-summary schema declaration and documentation to `1.7`, the
  next version after `main`'s `1.6`. The compare artifact schema remains `2`.
- Updated HTML version gates, schema documentation, compare documentation, and
  contributor-facing compatibility docstrings to use the same schema boundary.

## Compatibility and behavior

```text
Common Step Time clock:
GPU when both GPU aggregates are measured
CPU when GPU is not shared and both CPU aggregates are measured
inconclusive otherwise
```

- `null` means unavailable; measured `0.0` remains valid evidence.
- No Step Time is reconstructed from phases, Input Wait, or Traced Step Time.
- No CPU value is compared directly with a GPU value.
- New rendered output uses canonical Step Time vocabulary; historical names are
  confined to compatibility readers and legacy fixtures.

## Validation

Updated existing compare, summary, HTML, and SDK-summary tests for:

- GPU preference, CPU fallback, and no-common-clock handling.
- Legacy-to-new CPU Step Time and DataLoader Fetch compatibility.
- Selected-clock mismatch with safe phase suppression.
- Measured zero handling and canonical CPU/GPU labels in JSON, terminal output,
  and verdict text.

```text
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/reporting tests/step_time tests/renderers \
  tests/sdk/test_summary_client.py -q

248 passed
```

`git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified Step Time experience across CLI, dashboard, and final summaries.
  * Added clearer CPU/GPU timing metrics and improved live result freshness handling.
  * Added Hugging Face Accelerate integration guidance and example.
  * Added explicit `INCOMPLETE DATA` diagnoses for missing telemetry.

* **Bug Fixes**
  * Improved rank-straggler and H2D attribution by requiring sufficient measurements.
  * Improved comparisons with shared CPU/GPU clocks and nullable metrics.

* **Documentation**
  * Updated quickstarts, FAQs, architecture guidance, troubleshooting, and schema documentation.

* **Changes**
  * Summary mode is now the default for TraceML runs and services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->