### PR TITLE
Complete canonical Step Time documentation and contract guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ GPU waiting:
 +----------------------------------------------------------------------------+
 |                                                                            |
 |  TraceML Verdict: INPUT-BOUND / CRITICAL                                   |
-|  Why: Input wait is 64.0% of the typical GPU iteration time.               |
+|  Why: Input Wait is 64.0% of the typical GPU Step Time.                    |
 |  Next: Increase workers, prefetch, or storage throughput.                  |
 |                                                                            |
 |  Section Status                                                            |
@@ -57,10 +57,9 @@ GPU waiting:
 |  Step Time Evidence                                                        |
 |  Phase             Average           Share                                 |
 |  ------------------------------------------------                          |
-|  Total             200.4ms           compat                                |
-|  Dataloader        130.4ms           compat                                |
+|  Step Time         200.4ms           100.0%                                |
 |  Input Wait        128.0ms           64.0%                                 |
-|  Step Time         72.0ms            36.0%                                 |
+|  Traced Step Time  72.0ms            supplemental                          |
 |  Compute           68.0ms            34.0%                                 |
 |  Residual          3.6ms             1.8%                                  |
 |  H2D               0.4ms             0.2%                                  |
@@ -99,7 +98,7 @@ GPU waiting:
 |  Step Time Evidence                                                        |
 |  Phase           Median        Worst         Skew        Scope             |
 |  --------------------------------------------------------------------------|
-|  Total           303.7ms       304.1ms       0.1%        rank=r0 node=n0   |
+|  Step Time       303.7ms       304.1ms       0.1%        rank=r0 node=n0   |
 |  Input Wait      3.8ms         254.5ms       6597.4%     rank=r0 node=n0   |
 |  Compute         259.5ms       261.0ms       0.6%        rank=r2 node=n1   |
 +----------------------------------------------------------------------------+
@@ -191,7 +190,7 @@ diagnosis and cuts step time:
 |  Primary diagnosis: INPUT-BOUND -> COMPUTE-BOUND (changed)                           |
 |                                                                                      |
 |  Verdict: IMPROVEMENT                                                                |
-|  Why: Step time decreased by 59.9%.                                                  |
+|  Why: GPU Step Time decreased by 59.9%.                                              |
 +--------------------------------------------------------------------------------------+
 ```
 
@@ -209,12 +208,12 @@ diagnosis and cuts step time:
 |  Primary diagnosis: INPUT-BOUND -> COMPUTE-BOUND (changed)                           |
 |                                                                                      |
 |  Verdict: IMPROVEMENT                                                                |
-|  Why: Step time decreased by 59.9%.                                                  |
+|  Why: GPU Step Time decreased by 59.9%.                                              |
 |                                                                                      |
-|  Step Time                                                                           |
+|  Step Time (GPU comparison clock)                                                    |
 |  Metric                       A                 B                 Delta              |
 |  Step time diagnosis          INPUT-BOUND       COMPUTE-BOUND     changed            |
-|  Total step                   200.4 ms          80.4 ms           -120.0 ms (-59.9%) |
+|  GPU Step Time                200.4 ms          80.4 ms           -120.0 ms (-59.9%) |
 |  Input                        128.0 ms          8.0 ms            -120.0 ms (-93.8%) |
 |  H2D                          0.4 ms            0.4 ms            +0.0 ms (+0.0%)    |
 |  Compute                      68.0 ms           68.0 ms           +0.0 ms (+0.0%)    |
@@ -275,15 +274,11 @@ Use the live terminal view locally or over SSH:
 traceml run train.py --mode=cli
 ```
 
-![TraceML live terminal view](docs/assets/cli_demo.gif)
-
 Use the browser dashboard on a single node:
 
 ```bash
 traceml run train.py --mode=dashboard
 ```
-
-![TraceML live browser dashboard](docs/assets/dashboard_live.gif)
 
 For remote browser access and SSH tunneling, see the
 [full quickstart](docs/user_guide/quickstart.md).

--- a/docs/developer_guide/architecture.md
+++ b/docs/developer_guide/architecture.md
@@ -70,7 +70,7 @@ The load-bearing calls that shape the system, with the rationale and the main al
 | Length-prefixed msgpack frames, no version field, legacy flat shape still accepted | Keep the wire compact and simple while preserving existing v0.2.x senders (rejected: a versioned/handshaked protocol) | Wire evolution must stay additive and tolerant; there is no negotiated version to branch on |
 | Bounded in-memory deque tables for the live view, SQLite (WAL) for history | Cap per-rank memory yet keep a queryable history; renderers read from SQLite (rejected: unbounded in-memory retention) | Oldest in-memory rows evict at `maxlen`; SQLite retention is windowed and is the source of truth for renderers |
 | Rule-based diagnosis: stateless per-window thresholds, min-step damping, no hysteresis | Verdicts must be explainable, deterministic, and cheap, with no training data required (rejected: a learned/ML classifier) | Thresholds are hand-tuned and documented; verdicts are named (`INPUT_BOUND`, `COMPUTE_STRAGGLER`, `CREEP_CONFIRMED`, and so on) |
-| Report residual time as a derived bucket: `residual = max(0, step - h2d - forward - backward - optimizer)` | No portable, in-process, cross-backend hook for collective/NCCL time exists today (rejected: backend-specific collective instrumentation) | Residual time can absorb legitimate non-collective gaps; explicit collective timing is on the roadmap and flagged in the user docs |
+| Report residual time as a derived bucket: `residual = max(0, Traced Step Time - h2d - forward - backward - optimizer)` | No portable, in-process, cross-backend hook for collective/NCCL time exists today (rejected: backend-specific collective instrumentation) | Residual time can absorb legitimate non-collective gaps; explicit collective timing is on the roadmap and flagged in the user docs |
 | Lazy imports for UI and integrations | `import traceml` should stay fast and avoid importing torch, NiceGUI, Plotly, or framework stacks until a feature needs them (rejected: eager imports of the UI/integration stack) | Summary is the default display mode. Dashboard dependencies currently ship with the default install, but UI/framework modules are imported lazily; torch, transformers, lightning, and ray stay behind extras or integration-specific installs |
 
 ## Quality requirements
@@ -109,12 +109,13 @@ Architectural risks and known structural debt. Day-to-day bugs live in the issue
 | Hook / patch / decorator | The mechanisms that capture phase boundaries: monkeypatches on torch internals plus the user-facing `trace_step`. |
 | H2D | Host-to-device copy (CPU to GPU), timed by patching `Tensor.to`. |
 | Phase | A timed part of a step: input wait, H2D, forward, backward, or optimizer. |
-| Step / trace_step | A training iteration; `with trace_step(model)` marks the boundary that phase timing is computed against. |
+| `trace_step` | Public API that brackets the instrumented inner duration. SQLite normalization publishes that duration as Traced Step Time. |
 | Step Time availability | `StepTimeWindow` carries the expected rank universe and sparse per-rank metrics. Measured-rank populations and multi-metric eligibility are derived from those facts; consumers do not maintain a second coverage model. |
-| Residual (residual_proxy) | Residual step time, `max(0, step - h2d - forward - backward - optimizer)`. |
-| INPUT_BOUND / COMPUTE_BOUND | Input wait is material, or compute reaches 90% of typical selected-clock iteration time. |
+| Step Time / Traced Step Time | Step Time is selected Input Wait plus selected Traced Step Time. Traced Step Time is the instrumented inner subtotal. |
+| Residual (residual_proxy) | `max(0, Traced Step Time - h2d - forward - backward - optimizer)`. |
+| INPUT_BOUND / COMPUTE_BOUND | Input Wait is material, or compute reaches 90% of typical selected-clock Step Time. |
 | INPUT_STRAGGLER / COMPUTE_STRAGGLER / H2D_STRAGGLER / STRAGGLER | Visible rank skew exists; the label names the culprit's material input, DDP-forward, or H2D excess, or `STRAGGLER` when the skew is sync-bound or unattributed. |
-| RESIDUAL_HEAVY | A large window-wide share of step time is unattributed residual time. |
+| RESIDUAL_HEAVY | A large window-wide share of Step Time is unattributed residual time. |
 | HIGH_PRESSURE / IMBALANCE | GPU memory is near capacity, or uneven across ranks. |
 | CREEP_EARLY / CREEP_CONFIRMED | Direction-confirmed GPU-memory growth across the run, early or confirmed. |
 | final_summary | The end-of-run `final_summary.{json,txt}`; the JSON carries `schema_version` (currently 1.7). |

--- a/docs/developer_guide/rank-straggler-policy.md
+++ b/docs/developer_guide/rank-straggler-policy.md
@@ -5,6 +5,8 @@ straggler, which rank it blames, and how confident it is. It is the developer
 reference behind the Step Time rank-straggler diagnoses. For the user-facing
 walkthrough of a slow rank, see
 [Diagnosing a slow rank in DDP](../guides/ddp-slow-training-rank-straggler.md).
+For the shared timing definitions, see the
+[Step Time glossary](../user_guide/reading-output.md#step-time-glossary).
 
 The implementation lives in `src/traceml_ai/diagnostics/` (rule evaluation and
 culprit/victim context) and `src/traceml_ai/reporting/primary_diagnosis.py`
@@ -28,8 +30,8 @@ window, as opposed to the single-rank bottleneck kinds (`INPUT_BOUND`,
 ## Selected clock and eligibility
 
 Step Time diagnosis analyzes one *selected clock* for the window. It uses GPU
-event timing when every rank and step has GPU timing for the step envelope,
-input wait, and traced phase events; otherwise it falls back to explicit
+event timing when every rank and step has GPU timing for Traced Step Time,
+Input Wait, and traced phase events; otherwise it falls back to explicit
 `cpu_ms` timing. All rank-straggler comparisons below are in that selected
 clock.
 
@@ -40,8 +42,8 @@ visible_r = backward_r              # DDP / default
 visible_r = forward_r + backward_r  # FSDP
 ```
 
-Only ranks with a measured visible-phase anchor, a measured step envelope,
-and a measured input wait are eligible:
+Only ranks with a measured visible-phase anchor, measured Traced Step Time,
+and measured Input Wait are eligible:
 
 ```text
 DDP / default: input_wait measured and backward_r > 0 and step_time_r > 0

--- a/docs/developer_guide/step-time-pipeline-contract.md
+++ b/docs/developer_guide/step-time-pipeline-contract.md
@@ -7,6 +7,8 @@ For diagnosis thresholds and issue semantics, see
 [`diagnostics/DIAGNOSIS.md`](https://github.com/traceopt-ai/traceml/blob/main/src/traceml_ai/diagnostics/DIAGNOSIS.md).
 For the public final-summary shape, see
 [`reporting/SCHEMA.md`](https://github.com/traceopt-ai/traceml/blob/main/src/traceml_ai/reporting/SCHEMA.md).
+For user-facing timing definitions, see the
+[Step Time glossary](../user_guide/reading-output.md#step-time-glossary).
 
 ## Current flow
 
@@ -137,8 +139,8 @@ contract does not load the analyzer or NumPy.
 | `StepTimeSourceCursor` | The single stored latest-row/latest-step position used by live-session reuse. |
 | `StepTimeWindow.training_strategy` | Run strategy analyzed with the window; diagnosis does not need a parallel source of truth. |
 | `representative_rank` | A real rank closest to the mathematical median; it is not the median itself. |
-| `*_cpu_ms` | CPU-clock values used by the public summary. |
-| Other `*_ms` fields | Values from the single clock selected for the complete analysis window. |
+| `*_cpu_ms` / `*_gpu_ms` | Explicit clock aggregates preserved independently for public summary and compare compatibility. |
+| Selected `*_ms` fields | Values from the one clock selected for the complete analysis window. |
 
 ## Canonical window invariants
 
@@ -147,19 +149,28 @@ contract does not load the analyzer or NumPy.
 | Common window | Only the latest bounded set of completed step ids shared across the participating ranks is analyzed. |
 | Expected ranks | The window retains the persisted global-rank universe even when a rank lacks a metric. |
 | Selected clock | One clock, CPU or GPU, is selected for the entire window. Phase values are never mixed across clocks. |
-| Required metrics | Input wait, forward, backward, and step envelope must be measured on every aligned step for a rank. Partial presence makes that metric unavailable for the rank. |
+| Required metrics | Input Wait, forward, backward, and Traced Step Time must be measured on every aligned step for a rank. Partial presence makes that metric unavailable for the rank. |
 | Occurrence-driven metrics | H2D and optimizer may legitimately occur on only some steps. Once observed, absent steps contribute zero work. An entirely absent H2D means no observed transfers, not incomplete instrumentation. |
 | Missing versus zero | An unavailable metric is absent from the sparse rank row and projects to `null`. A measured `0.0` remains present and projects to `0.0`. |
-| Derived metrics | Compute needs forward, backward, and optimizer. Residual needs the traced envelope and every compute phase; absent H2D contributes zero. Step Time needs input wait and the traced envelope. |
+| Derived metrics | Compute needs forward, backward, and optimizer. Residual needs Traced Step Time and every compute phase; absent H2D contributes zero. Step Time needs Input Wait and Traced Step Time. |
 | Rank cohorts | A diagnosis uses only ranks carrying all metrics required by that rule. Consumers must not reconstruct another availability policy. |
 | Metric statistics | Median, worst value, worst rank, and skew are computed from ranks that measured that metric. The worst value and rank must describe the same rank. |
 | Representative rank | Choose the real rank nearest the mathematical median, then the lower value, then the lower rank id. |
-| Residual meaning | `max(0, step - h2d - forward - backward - optimizer)` is unattributed time, not proof of communication or NCCL overhead. |
+| Residual meaning | `max(0, Traced Step Time - h2d - forward - backward - optimizer)` is unattributed time, not proof of communication or NCCL overhead. |
 
 In `final_summary.json`, `step_time_ms`, `traced_step_time_ms`, and phase
 metrics use the selected diagnosis clock. The explicit CPU/GPU Step Time and
 Traced Step Time fields preserve both clocks, while `dataloader_fetch_cpu_ms`
-is supplemental CPU evidence.
+is supplemental CPU evidence. It is not part of Step Time and is never added
+to selected-clock Input Wait.
+
+## Naming boundary
+
+`traceml.trace_step(...)` remains the public API name. It records the inner
+instrumented duration that becomes canonical Traced Step Time only after
+SQLite normalization. `_traceml_internal:step_time` is intentionally stable
+raw telemetry and storage vocabulary below that normalization boundary; it is
+not a public metric name or presentation label.
 
 ## Surface responsibilities
 
@@ -246,8 +257,8 @@ PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider tests/step_time -q
 
 | Term | Meaning |
 |---|---|
-| Step envelope | Instrumented time inside one traced training step. |
-| Iteration | Selected input wait plus the selected step envelope. |
+| Traced Step Time | Instrumented inner duration inside one traced training step. |
+| Step Time | Selected Input Wait plus selected Traced Step Time. |
 | Common window | Aligned completed step suffix shared by participating ranks. |
 | Rank universe | Expected global ranks retained by the canonical window. |
 | Measured rank | A rank carrying a particular sparse metric. |

--- a/docs/guides/ddp-slow-training-rank-straggler.md
+++ b/docs/guides/ddp-slow-training-rank-straggler.md
@@ -72,12 +72,12 @@ These fingerprints came from the DDP demo on two nodes with one GPU per node.
 
 | Scenario | Diagnosis | Key signal |
 |---|---|---|
-| Balanced | `COMPUTE-BOUND` | total `124.6/124.6ms`, input `1.4/1.4ms`, compute `122.4/122.4ms` |
+| Balanced | `COMPUTE-BOUND` | Step Time `124.6/124.6ms`, Input Wait `1.4/1.4ms`, compute `122.4/122.4ms` |
 | Input straggler | `INPUT STRAGGLER` | r0 input wait `201.6ms` vs r1 `1.4ms` |
 | Compute straggler | `COMPUTE STRAGGLER` | r0 optimizer `33.1ms` vs r1 `14.5ms` |
 
-Read the balanced run as the control: both ranks have similar total step time,
-input time is small, and the run is mostly compute.
+Read the balanced run as the control: both ranks have similar Step Time, Input
+Wait is small, and the run is mostly compute.
 
 Read the input-straggler run as a rank-local input issue: rank 0 reaches compute
 late because its input path is slower.
@@ -169,8 +169,8 @@ the old and new summaries:
 traceml compare old_run/final_summary.json new_run/final_summary.json
 ```
 
-Look for changes in total step time, visible rank skew, input time, compute
-time, residual time, and diagnosis.
+Look for changes in common-clock Step Time, visible rank skew, Input Wait,
+compute time, residual time, and diagnosis.
 
 ## Related
 

--- a/docs/guides/low-gpu-utilization-pytorch.md
+++ b/docs/guides/low-gpu-utilization-pytorch.md
@@ -77,8 +77,8 @@ After changing the suspected cause, compare the before and after summaries:
 traceml compare old_run/final_summary.json new_run/final_summary.json
 ```
 
-Check whether GPU utilization, total step time, input time, residual time, or the
-primary diagnosis changed.
+Check whether GPU utilization, common-clock Step Time, Input Wait, residual
+time, or the primary diagnosis changed.
 
 ## Related
 

--- a/docs/guides/pytorch-input-pipeline-bottleneck.md
+++ b/docs/guides/pytorch-input-pipeline-bottleneck.md
@@ -56,7 +56,8 @@ Start with `TraceML Verdict`, then check the `Step Time Evidence` table.
 
 For input pipeline problems, the most relevant diagnoses are:
 
-- `INPUT-BOUND`: input wait is taking a large share of iteration time
+- `INPUT-BOUND`: Input Wait is taking a large share of selected-clock Step
+  Time
 - `INPUT STRAGGLER`: one rank has meaningfully more input-wait burden than a
   typical rank
 
@@ -70,7 +71,7 @@ Next: Inspect input wait, collate_fn, preprocessing, and storage on the slow ran
 Step Time Evidence
 Phase           Median        Worst         Skew        Scope
 --------------------------------------------------------------------------
-Total           303.7ms       304.1ms       0.1%        rank=r0 node=n0
+Step Time       303.7ms       304.1ms       0.1%        rank=r0 node=n0
 Input Wait      3.8ms         254.5ms       6597.4%     rank=r0 node=n0
 Compute         259.5ms       261.0ms       0.6%        rank=r2 node=n1
 ```
@@ -112,8 +113,8 @@ After changing the input path, compare the old and new final summaries:
 traceml compare old_run/final_summary.json new_run/final_summary.json
 ```
 
-Use the compare output to check whether total step time, input time, residual
-time, or the diagnosis changed.
+Use the compare output to check whether common-clock Step Time, Input Wait,
+residual time, or the diagnosis changed.
 
 ## When this is not the right guide
 

--- a/docs/guides/slow-pytorch-training.md
+++ b/docs/guides/slow-pytorch-training.md
@@ -41,7 +41,8 @@ diagnosis or symptom.
 
 ## Quick interpretation
 
-`INPUT-BOUND` means input wait is taking a large share of iteration time.
+`INPUT-BOUND` means Input Wait is taking a large share of selected-clock Step
+Time.
 Confirm the input path before tuning model compute.
 
 `LOW_GPU_UTILIZATION` and `MODERATE_GPU_UTILIZATION` are system-level symptoms.

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -141,6 +141,44 @@ The local UI is best for:
 
 ---
 
+## Step Time glossary
+
+TraceML uses one selected clock for an aligned analysis window. It selects GPU
+only when every required timing signal is complete on GPU for every included
+rank and step; otherwise it uses CPU. The selected clock is shown as
+`diagnosis_clock` in JSON and in the live-output footer.
+
+```text
+Step Time = Input Wait + Traced Step Time
+Residual = Traced Step Time − H2D − Forward − Backward − Optimizer
+```
+
+- **Step Time** is the complete selected-clock duration used for diagnosis,
+  displayed shares, and run comparison.
+- **Traced Step Time** is the inner duration instrumented by
+  `traceml.trace_step(...)`; it is a subtotal, not an end-to-end replacement
+  for Step Time.
+- **Input Wait** is selected-clock time spent waiting for the next batch.
+- **DataLoader Fetch (CPU)** is supplemental CPU evidence. When GPU is
+  selected it can differ from Input Wait; it is never added into Step Time or
+  counted twice.
+- `null` / `n/a` means a signal was not measured in the window. A measured
+  `0.0 ms` remains a real zero.
+
+Examples:
+
+| Window | Selected values | Interpretation |
+|---|---|---|
+| GPU complete | GPU Step Time and GPU Traced Step Time | GPU timing is used consistently for phases and shares. |
+| GPU incomplete | CPU Step Time and CPU Traced Step Time | CPU is selected; unavailable GPU aggregates remain `null`. |
+| Partial GPU evidence | CPU selected values plus optional GPU aggregates | Do not replace missing GPU values with zero or mix clocks. |
+
+The raw `_traceml_internal:step_time` event is an internal persisted telemetry
+key. After SQLite normalization, user-facing output calls that inner metric
+Traced Step Time.
+
+---
+
 ## Step-time diagnoses
 
 The step-time diagnosis explains where training time is going.
@@ -204,7 +242,7 @@ What to do next:
 
 Meaning:
 
-- input wait is taking a large share of iteration time
+- Input Wait is taking a large share of selected-clock Step Time
 - TraceML uses the median per-rank input share, so one unusually slow rank
   does not hide a broad input bottleneck
 
@@ -218,7 +256,7 @@ Common causes:
 What to look at:
 
 - `Input Wait`
-- its share of iteration time
+- its share of selected-clock Step Time
 - whether the issue is broad or rank-specific
 
 What to do next:
@@ -234,13 +272,14 @@ What to do next:
 
 Meaning:
 
-- host-to-device transfer is taking a large share of typical iteration time
+- host-to-device transfer is taking a large share of typical selected-clock
+  Step Time
 - TraceML uses the median per-rank H2D share, so one unusually slow rank does
   not hide a broad transfer bottleneck
 - this diagnosis requires GPU-selected timing; CPU host-call duration is not
   treated as transfer cost
 
-TraceML reports a warning at 10% of iteration time and critical severity at
+TraceML reports a warning at 10% of Step Time and critical severity at
 20%.
 
 What to do next:
@@ -427,21 +466,21 @@ What to do next:
 
 Meaning:
 
-- a meaningful part of the traced step is not attributed to H2D, forward,
+- a meaningful part of Traced Step Time is not attributed to H2D, forward,
   backward, or optimizer work
 
 In TraceML:
 
 - `compute = forward + backward + optimizer`
-- `residual = step_time - h2d - compute`
-- `total_step = input_wait + step_time`
+- `residual = traced_step_time - h2d - compute`
+- `step_time = input_wait + traced_step_time`
 
-TraceML evaluates residual as the median per-rank share of selected-clock
-iteration time (`input_wait + step_time`). Input and residual findings warn at
+TraceML evaluates residual as the median per-rank share of selected-clock Step
+Time. Input and residual findings warn at
 10% and are critical at 20%; rank skew is supporting evidence rather than a
 gate that hides a typical bottleneck.
 
-This is residual unattributed time inside the traced step, not direct
+This is residual unattributed time inside Traced Step Time, not direct
 collective, NCCL, or all-reduce timing.
 
 Common causes:
@@ -492,7 +531,8 @@ In the CLI step summary, the important columns are:
 - `Forward`
 - `Backward`
 - `Optimizer`
-- `STEP` / `Traced Step`
+- `Step Time`
+- `Traced Step Time`
 - `Residual`
 
 Important rows:
@@ -515,7 +555,7 @@ Important rows:
 
 ### `Residual`
 
-- how much of the traced step is unattributed to H2D, forward, backward, or
+- how much of Traced Step Time is unattributed to H2D, forward, backward, or
   optimizer work
 
 A good reading pattern is:

--- a/src/traceml_ai/diagnostics/DIAGNOSIS.md
+++ b/src/traceml_ai/diagnostics/DIAGNOSIS.md
@@ -102,9 +102,8 @@ availability instead of synthesizing zeros that would leak the missing work
 into the residual. An absent H2D means "no observed transfers", contributes
 zero to derived metrics, and is never reported as a missing signal. Derived
 metrics exist only when their inputs are available: `compute` needs forward,
-backward, and optimizer; outer `step_time` needs input wait plus the traced
-step envelope; `residual_proxy` needs the traced step envelope plus every compute
-phase.
+backward, and optimizer; outer `step_time` needs Input Wait plus Traced Step
+Time; `residual_proxy` needs Traced Step Time plus every compute phase.
 
 The canonical `StepTimeWindow` carries the expected rank universe and sparse
 per-rank metrics. A metric's measured-rank population and any multi-metric
@@ -124,8 +123,8 @@ for missing signals, Step Time reports `INCOMPLETE_DATA` instead of
 `BALANCED`.
 
 Step-time diagnosis uses one selected clock for the analyzed window. It uses
-GPU event timing when every rank/step has GPU timing for the traced envelope,
-input wait, and traced phase events present in the window. Otherwise it uses
+GPU event timing when every rank/step has GPU timing for Traced Step Time,
+Input Wait, and traced phase events present in the window. Otherwise it uses
 explicit `cpu_ms` timing. The live CLI Step Time table, dashboard, and final
 summary use the same global-rank SQLite loader and selected-clock window
 builder for diagnosis-facing timing; they differ only by row window sizing.
@@ -133,7 +132,7 @@ The canonical model exposes selected-clock `input_wait_ms`, outer
 `step_time_ms`, and inner `traced_step_time_ms`. Summary JSON also publishes
 explicit CPU and GPU Step Time and Traced Step Time aggregates.
 `dataloader_fetch_cpu_ms` remains supplemental CPU fetch evidence and is not a
-selected-clock phase-share denominator.
+selected-clock phase-share denominator or a second Step Time component.
 `duration_ms` stays stored compatibility timing and is not used for Step Time
 display or diagnosis. In the final text report, selected-clock phase shares
 are divided directly by public `step_time_ms`. These report-table shares are
@@ -193,7 +192,7 @@ unattributed step time averaged from per-step clamped residuals:
 ```text
 compute_ms = forward_ms + backward_ms + optimizer_ms
 known_step_ms = h2d_ms + compute_ms
-traced_step_time_ms = selected traced envelope timing
+traced_step_time_ms = selected Traced Step Time
 step_time_ms = selected input_wait_ms + selected traced_step_time_ms
 residual_ms = average(max(0, traced_step_time_ms - known_step_ms))
 ```

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -12,6 +12,9 @@ excluded from `global.average`, `global.median`, and `global.worst` and from
 rank median/worst selection; a rank with only some metrics measured (for
 example an H2D-only rank) keeps its row with `null` for the others.
 
+For user-facing definitions and examples, see the
+[Step Time glossary](../../../docs/user_guide/reading-output.md#step-time-glossary).
+
 Sections:
 
 - `system`: node-level CPU, RAM, GPU utilization, GPU memory, temperature,
@@ -362,6 +365,11 @@ Every displayed phase share uses the selected `step_time_ms` denominator.
 Those table shares are observational averages and may differ from the
 authoritative median per-rank diagnosis `score`.
 
+When GPU is selected, `input_wait_ms` is GPU-clocked while
+`dataloader_fetch_cpu_ms` remains CPU evidence, so they can differ. When CPU
+is selected they describe the same CPU input-wait interval; neither is counted
+twice.
+
 `residual_ms` is residual unattributed step time. It is averaged from
 per-step clamped residuals, not recomputed from already-averaged phase totals:
 
@@ -377,7 +385,7 @@ The selected-clock diagnosis contract is:
 
 ```text
 input_wait_ms = selected-clock input wait
-traced_step_time_ms = selected-clock traced step envelope
+traced_step_time_ms = selected-clock Traced Step Time
 step_time_ms = complete selected-clock step duration
 diagnosis_clock = "cpu" | "gpu"
 ```

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -359,6 +359,17 @@ traced_step_time_cpu_ms
 traced_step_time_gpu_ms
 ```
 
+The clock-qualified relationships are:
+
+```text
+CPU Step Time = CPU Input Wait + CPU Traced Step Time
+GPU Step Time = GPU Input Wait + GPU Traced Step Time
+```
+
+The summary publishes the selected Input Wait as `input_wait_ms`; CPU and GPU
+Input Wait are not additional summary fields. The explicit Step Time and Traced
+Step Time aggregates above retain the corresponding clock-qualified values.
+
 `dataloader_fetch_cpu_ms` is supplemental CPU DataLoader-fetch evidence. It
 is never added into Input Wait or Step Time and has no phase-share percentage.
 Every displayed phase share uses the selected `step_time_ms` denominator.

--- a/src/traceml_ai/samplers/schema/step_time_schema.py
+++ b/src/traceml_ai/samplers/schema/step_time_schema.py
@@ -35,7 +35,7 @@ Clocks
 - GPU events use CUDA event (stream) time and are stored in nullable `gpu_ms`.
 - `duration_ms` preserves the legacy effective clock: GPU time when available,
   otherwise CPU wall time. `is_gpu` identifies which clock backs `duration_ms`.
-- Dataloader fetch and full step envelope events preserve CPU-wall
+- Input Wait and the raw traced-step event preserve CPU-wall
   `duration_ms` for compatibility even when `gpu_ms` is recorded.
 
 Schema (per DB row)

--- a/src/traceml_ai/samplers/step_time_sampler.py
+++ b/src/traceml_ai/samplers/step_time_sampler.py
@@ -62,7 +62,7 @@ class StepTimeSampler(BaseSampler):
         """
         Return whether `duration_ms` should use the recorded GPU clock.
 
-        Dataloader fetch and full step envelope events keep CPU-wall
+        Input Wait and the raw traced-step event keep CPU-wall
         `duration_ms` for compatibility while still carrying nullable
         `gpu_ms` evidence for later analysis.
         """

--- a/tests/step_time/test_contract_baseline.py
+++ b/tests/step_time/test_contract_baseline.py
@@ -16,9 +16,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+import subprocess
 from typing import Any, Mapping
 
 import pytest
+from rich.console import Console
 
 from tests.step_time.scenarios import (
     SCENARIOS,
@@ -34,6 +36,8 @@ from traceml_ai.renderers.model_diagnostics.renderer import (
 from traceml_ai.renderers.step_memory.schema import StepMemoryCombinedResult
 from traceml_ai.renderers.step_time import renderer as cli_renderer_module
 from traceml_ai.renderers.step_time.renderer import StepTimeRenderer
+from traceml_ai.reporting.compare import build_compare_payload
+from traceml_ai.reporting.html.svg import phase_bar
 from traceml_ai.reporting.sections.step_time import (
     STEP_TIME_METRIC_NAMES,
     StepTimeSummarySection,
@@ -51,6 +55,8 @@ _WINDOW_KEYS = {
     "step_time",
     "residual_proxy",
 }
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 @dataclass(frozen=True)
@@ -481,3 +487,167 @@ def test_final_summary_projection_matches_golden(
 
     # The same diagnosis object is projected as the first ordered issue.
     assert payload["diagnosis"] == payload["issues"][0]
+
+
+def test_canonical_surface_values_share_one_step_time_contract(
+    scenario_db: tuple[StepTimeScenario, Path],
+    tmp_path: Path,
+) -> None:
+    """Keep CLI, summary, HTML, and compare on canonical outer Step Time."""
+    scenario, db_path = scenario_db
+    request = StepTimeLoadRequest(
+        window_size=len(scenario.steps),
+        lookback_factor=4,
+    )
+    live = LiveStepTimeSession(str(db_path), request=request).refresh()
+    window = live.analysis.window
+    summary = (
+        StepTimeSummarySection(max_rows=len(scenario.steps))
+        .build(str(db_path))
+        .payload
+    )
+    average = summary["global"]["average"]
+
+    def rank_average(field: str) -> float | None:
+        values = [
+            getattr(facts.average, field)
+            for facts in window.rank_facts
+            if getattr(facts.average, field) is not None
+        ]
+        return None if not values else sum(values) / len(values)
+
+    assert average["step_time_ms"] == pytest.approx(
+        rank_average("step_time_ms")
+    )
+    assert average["traced_step_time_ms"] == pytest.approx(
+        rank_average("traced_step_time_ms")
+    )
+
+    console = Console(record=True, width=140)
+    renderer = StepTimeRenderer(
+        LiveStepTimeSession(str(db_path), request=request)
+    )
+    console.print(renderer.get_panel_renderable())
+    cli_text = console.export_text()
+    assert "Step Time" in cli_text
+    assert "Traced Step Time" in cli_text
+    assert "STEP=traced" not in cli_text
+
+    pytest.importorskip("nicegui")
+    from traceml_ai.aggregator.display_drivers.nicegui_sections import theme
+    from traceml_ai.aggregator.display_drivers.nicegui_sections import (
+        model_combined_section,
+    )
+
+    class _Element:
+        def __init__(self) -> None:
+            self.content = ""
+            self.text = ""
+
+        def style(self, _value: str) -> "_Element":
+            return self
+
+    dashboard = {
+        "seg_divs": [_Element() for _ in theme.PHASES],
+        "seg_labs": [_Element() for _ in theme.PHASES],
+        "win": _Element(),
+        "verdict": _Element(),
+        "kpis": {
+            key: _Element()
+            for key in ("median", "worst", "gap", "residual", "rank")
+        },
+        "_last_sig": None,
+    }
+    model_combined_section.update_model_combined_section(dashboard, live)
+    step_metric = next(
+        metric for metric in window.metrics if metric.metric == "step_time"
+    )
+    assert (
+        f"{step_metric.median_total:.0f}"
+        in dashboard["kpis"]["median"].content
+    )
+    assert f"{window.clock.upper()} selected" in dashboard["win"].text
+
+    html = phase_bar({"global": {"average": average}}, schema_version=1.7)
+    if average["step_time_ms"] in (None, 0.0):
+        assert html == ""
+    else:
+        assert "<svg" in html
+
+    direct_denominator = phase_bar(
+        {
+            "global": {
+                "average": {
+                    "step_time_ms": 200.0,
+                    "input_wait_ms": 10.0,
+                    "forward_ms": 10.0,
+                }
+            }
+        },
+        schema_version=1.7,
+    )
+    assert direct_denominator.count('width="5.00%"') == 2
+
+    compare = build_compare_payload(
+        lhs_payload={"schema_version": 1.7, "step_time": summary},
+        rhs_payload={"schema_version": 1.7, "step_time": summary},
+        lhs_path=tmp_path / "before.json",
+        rhs_path=tmp_path / "after.json",
+    )
+    expected_clock = (
+        "gpu" if average.get("step_time_gpu_ms") is not None else "cpu"
+    )
+    assert compare["sections"]["step_time"]["comparison_clock"] == (
+        expected_clock
+    )
+    expected_key = f"step_time_{expected_clock}_ms"
+    assert compare["sections"]["step_time"]["metrics"]["step_time_ms"][
+        "lhs"
+    ] == pytest.approx(average[expected_key])
+
+
+def test_public_step_time_vocabulary_excludes_obsolete_terms() -> None:
+    """Keep legacy timing names below explicit compatibility boundaries."""
+    tracked = subprocess.run(
+        ["git", "ls-files"],
+        cwd=_PROJECT_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.splitlines()
+    public_paths = [
+        _PROJECT_ROOT / path
+        for path in tracked
+        if path == "README.md"
+        or (path.startswith("docs/") and path.endswith(".md"))
+        or path
+        in {
+            "src/traceml_ai/renderers/step_time/renderer.py",
+            (
+                "src/traceml_ai/aggregator/display_drivers/"
+                "nicegui_sections/model_combined_section.py"
+            ),
+            "src/traceml_ai/reporting/final.py",
+            "src/traceml_ai/reporting/primary_diagnosis.py",
+            "src/traceml_ai/reporting/sections/step_time/builder.py",
+            "src/traceml_ai/reporting/html/textutils.py",
+            "src/traceml_ai/reporting/compare/formatters.py",
+            "src/traceml_ai/reporting/compare/verdict.py",
+        }
+    ]
+    forbidden = (
+        "total_step_ms",
+        "iteration_time_ms",
+        "Total step",
+        "total step time",
+        "iteration time",
+        "STEP=traced",
+        "STEP / Traced Step",
+    )
+    offenders = {
+        path.relative_to(_PROJECT_ROOT).as_posix(): token
+        for path in public_paths
+        for token in forbidden
+        if token.lower() in path.read_text(encoding="utf-8").lower()
+    }
+    assert offenders == {}

--- a/tests/step_time/test_contract_baseline.py
+++ b/tests/step_time/test_contract_baseline.py
@@ -584,6 +584,9 @@ def test_canonical_surface_values_share_one_step_time_contract(
                 }
             }
         },
+        # 1.7 takes the canonical branch. A pre-1.7 reader would interpret
+        # step_time_ms as traced time and produce a different denominator;
+        # dedicated legacy-adapter coverage lives in test_svg.py.
         schema_version=1.7,
     )
     assert direct_denominator.count('width="5.00%"') == 2


### PR DESCRIPTION
## Summary

Finish the Step Time naming migration as documentation and regression-test
cleanup. This PR makes the public explanation consistent across the README,
guides, schema reference, diagnostics documentation, and output examples.

It does **not** change telemetry, `traceml.trace_step`, samplers, Lightning,
SQLite, analyzer calculations, diagnosis policy, CLI/dashboard behavior, or
the final-summary / compare artifact schemas.

## What changed

- Added a single user-facing Step Time glossary in
  `docs/user_guide/reading-output.md`, covering:
  - selected CPU/GPU clock rules;
  - `Step Time = Input Wait + Traced Step Time`;
  - `Residual = Traced Step Time - H2D - Forward - Backward - Optimizer`;
  - `null` versus measured `0.0`; and
  - GPU-selected, CPU-fallback, and partial-GPU examples.
- Linked developer and schema documentation to that glossary instead of
  maintaining duplicate definitions.
- Replaced public-facing Total Step, Iteration Time, and ambiguous traced
  `STEP` terminology with **Step Time** and **Traced Step Time** throughout
  the README, architecture, pipeline contract, rank-straggler policy,
  troubleshooting guides, diagnostics reference, schema reference, and tracked
  output examples.
- Documented the naming boundary: `traceml.trace_step(...)` remains the public
  API; `_traceml_internal:step_time` remains the stable raw SQLite key; after
  SQLite normalization its public meaning is **Traced Step Time**.
- Clarified that `dataloader_fetch_cpu_ms` is supplemental CPU evidence. It is
  never added to Step Time, never substituted for selected Input Wait, and
  never used as a percentage denominator.
- Added explicit clock-qualified documentation:

  ```text
  CPU Step Time = CPU Input Wait + CPU Traced Step Time
  GPU Step Time = GPU Input Wait + GPU Traced Step Time
  ```

- Removed stale README embeds that visibly used obsolete timing vocabulary;
  the original GIF assets themselves are unchanged.
- Updated concise sampler/schema docstrings so internal terminology matches the
  documented normalization boundary.

## Contract coverage

Extended the existing SQLite-backed Step Time contract baseline to verify that
the same canonical outer Step Time is consumed by:

- the live CLI;
- the existing NiceGUI model card;
- final-summary projection;
- HTML phase bars; and
- compare output.

The test covers CPU-only, GPU-complete, GPU-partial, and measured-zero scenarios
already present in the shared scenario fixture. It asserts that:

- displayed Step Time is the selected-clock outer value;
- Traced Step Time remains the inner value;
- phase shares use only `step_time_ms` and are not rescaled to fill missing
  evidence; and
- comparison uses the applicable explicit common-clock Step Time aggregate.

Added a tracked-file vocabulary guard over public documentation and
presentation/reporting sources. It rejects obsolete semantic labels while
leaving raw-event modules, versioned compatibility readers, and legacy fixtures
outside the check.

## Compatibility and scope

- Final-summary schema remains **1.7**.
- Compare artifact schema remains **2**.
- Existing backward-compatible readers remain intact.
- No compatibility aliases are reintroduced into new public output.

## Validation

```text
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/step_time tests/reporting tests/renderers tests/display \
  tests/sdk/test_summary_client.py -q

323 passed, 1 warning
```

```text
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider \
  tests/step_time/test_contract_baseline.py tests/reporting/html/test_svg.py -q

32 passed
```

`git diff --check` passes, and the scoped vocabulary scan is clean.
