### PR TITLE
 Fix Quickstart input timing with a real DataLoader

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import torch
 from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
 
 import traceml_ai as traceml
 
@@ -37,6 +38,25 @@ class TinyMLP(nn.Module):
         return self.net(x)
 
 
+def build_dataloader() -> DataLoader[tuple[torch.Tensor, torch.Tensor]]:
+    """Return one deterministic, CPU-friendly epoch of synthetic batches.
+
+    A real PyTorch DataLoader is intentional: TraceML's automatic mode records
+    its fetch timing, just as it would for a normal training script. Keep this
+    loader fast; the diagnosis demos are the place to inject artificial delay.
+    """
+    generator = torch.Generator().manual_seed(SEED)
+    dataset = TensorDataset(
+        torch.randn(NUM_STEPS * BATCH_SIZE, INPUT_DIM, generator=generator),
+        torch.randint(
+            NUM_CLASSES,
+            (NUM_STEPS * BATCH_SIZE,),
+            generator=generator,
+        ),
+    )
+    return DataLoader(dataset, batch_size=BATCH_SIZE, num_workers=0)
+
+
 def main() -> None:
     torch.manual_seed(SEED)
 
@@ -48,11 +68,12 @@ def main() -> None:
     model = TinyMLP().to(device)
     optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
     criterion = nn.CrossEntropyLoss()
+    dataloader = build_dataloader()
 
     model.train()
-    for step in range(1, NUM_STEPS + 1):
-        x = torch.randn(BATCH_SIZE, INPUT_DIM, device=device)
-        y = torch.randint(0, NUM_CLASSES, (BATCH_SIZE,), device=device)
+    for step, (x, y) in enumerate(dataloader, start=1):
+        x = x.to(device)
+        y = y.to(device)
 
         with traceml.trace_step(model):
             optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Summary

`examples/quickstart.py` generated its batches inline, so TraceML had no `DataLoader` fetch to measure. The example completed successfully but its first report ended with `INCOMPLETE DATA` because `input_wait` was absent.

This change makes the Quickstart use one deterministic, in-memory PyTorch `DataLoader`. The first run now produces measured input timing and a complete Step Time diagnosis on CPU, without adding synthetic delay or changing TraceML
instrumentation.

## What changed

- Added a `TensorDataset` containing one deterministic epoch of synthetic  classification data.
- Added `DataLoader(dataset, batch_size=BATCH_SIZE, num_workers=0)`.
- Iterated batches from that loader and moved them to the selected device  before the traced training step.
- Kept the original model, batch size, step count, optimizer, and CPU-friendly  execution time.

## Why no `sleep`

The Quickstart should show a normal, complete first run. Artificial input latency belongs in 'examples/diagnosis/dataloader_bottleneck_demo.py`, where a user intentionally wants to reproduce an input bottleneck.

On a very fast CPU, the small real loader can still be a meaningful share of a sub-millisecond synthetic step. The exact completed diagnosis is therefore hardware-sensitive; this PR guarantees measured input timing, not a fixed `BALANCED` or `INPUT-BOUND` label.

## Validation

```text
PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -c \
  'from traceml_ai.launcher.cli import main; main()' \
  run examples/quickstart.py --mode=summary \
  --logs-dir /tmp/traceml-doc-audit \
  --run-name quickstart_dataloader_cpu_20260804
```

CPU result:

```text
exit 0
Input Wait: 0.1 ms
DataLoader Fetch (CPU): 0.1 ms
No INCOMPLETE DATA verdict
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hugging Face Accelerate integration guidance and examples.
  * Introduced clearer Step Time and Traced Step Time metrics across summaries, dashboards, reports, and comparisons.
  * Added `INCOMPLETE_DATA` diagnostics when required timing signals are unavailable.

* **Improvements**
  * `traceml run` and `traceml serve` now default to summary mode; live CLI or dashboard views require explicit selection.
  * Live displays reuse recent analyses, handle expired data, and clearly show unavailable metrics.
  * Comparisons now select a common CPU or GPU clock and preserve null metrics accurately.

* **Documentation**
  * Updated quickstarts, architecture guidance, troubleshooting, integrations, and Step Time terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->