### PR TITLE
Make the Public API reference complete and behaviorally accurate

### DIFF
--- a/docs/user_guide/public-api.md
+++ b/docs/user_guide/public-api.md
@@ -1,198 +1,241 @@
 # Public API
 
-The stable surface that user code imports and calls. Everything in this page is covered by TraceML's compatibility contract across v0.x minor releases.
-
-## Core API
+Import the stable core API from `traceml_ai`:
 
 ```python
 import traceml_ai as traceml
-
-traceml.init(mode="auto")
-
-with traceml.trace_step(model):
-    ...
 ```
 
-The old `import traceml` path remains available for compatibility, but emits a
-`FutureWarning` and may be removed in a future release. Do not import from
-decorator compatibility paths.
+The reference below documents every symbol in `traceml_ai.__all__`. The old
+`import traceml` path remains a compatibility import and emits a
+`FutureWarning`; new code should use `traceml_ai`.
 
-## Hugging Face integration
+## Stable Core API
 
-::: traceml_ai.integrations.huggingface.init
+### `traceml.__version__`
+
+A string identifying the installed TraceML version. It is useful when recording
+the environment for a run or bug report.
+
+### Lifecycle
+
+::: traceml_ai.api.init
     options:
       show_root_heading: true
-      show_source: true
+      show_root_full_path: false
+      show_source: false
 
-::: traceml_ai.integrations.huggingface.TraceMLTrainerCallback
+::: traceml_ai.api.start
     options:
       show_root_heading: true
-      show_source: true
+      show_root_full_path: false
+      show_source: false
 
-::: traceml_ai.integrations.huggingface.TraceMLTrainer
+### Step boundary
+
+::: traceml_ai.api.trace_step
     options:
       show_root_heading: true
-      show_source: true
+      show_root_full_path: false
+      show_source: false
 
-## PyTorch Lightning integration
+### End-of-run summaries
 
-::: traceml_ai.integrations.lightning.init
+::: traceml_ai.api.summary
     options:
       show_root_heading: true
-      show_source: true
+      show_root_full_path: false
+      show_source: false
 
-::: traceml_ai.integrations.lightning.TraceMLCallback
+::: traceml_ai.api.final_summary
     options:
       show_root_heading: true
-      show_source: true
+      show_root_full_path: false
+      show_source: false
 
-## Ray Train integration
+### Manual instrumentation helpers
 
-::: traceml_ai.integrations.ray.TraceMLTorchTrainer
+Use these only for manual or selective instrumentation. Automatic mode already
+times the matching PyTorch paths, and manual wrappers reject duplicate automatic
+instrumentation where double-counting would be possible.
+
+::: traceml_ai.api.wrap_dataloader_fetch
     options:
       show_root_heading: true
-      show_source: true
+      show_root_full_path: false
+      show_source: false
 
-::: traceml_ai.integrations.ray.TraceMLRayConfig
+::: traceml_ai.api.wrap_forward
     options:
       show_root_heading: true
-      show_source: true
+      show_root_full_path: false
+      show_source: false
+
+::: traceml_ai.api.wrap_backward
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+      show_source: false
+
+::: traceml_ai.api.wrap_optimizer
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+      show_source: false
+
+::: traceml_ai.api.wrap_h2d
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+      show_source: false
 
 ## CLI
 
-TraceML ships with a CLI entry point installed as `traceml`.
+TraceML installs the `traceml` command-line entry point:
 
 ```bash
-traceml run <script>                 # default: final summary JSON/text
-traceml run <script> --mode=summary  # explicit form of the default
-traceml run <script> --mode=cli      # explicit live terminal view
+traceml run <script>                  # final summary JSON/text
+traceml run <script> --mode=summary   # explicit summary mode
+traceml run <script> --mode=cli       # live terminal view
 traceml run <script> --mode=dashboard # live browser view
-traceml watch <script>               # zero-code system/process summary
-traceml serve                        # standalone summary aggregator by default
+traceml watch <script>                # zero-code system/process summary
+traceml serve                         # standalone aggregator
 ```
 
 Summary mode is the default for every topology. Live `cli` and `dashboard`
-modes are intended for single-node runs.
-Dashboard mode is included in the default `traceml-ai` install.
+modes are intended for single-node runs. Use PyTorch Profiler or Nsight for
+operator- or kernel-level profiling.
 
-TraceML no longer ships layer-level/deep profiling. Use PyTorch Profiler,
-Nsight, or another operator-level profiler when you need that detail.
+## Direct Launch with `traceml serve`
 
-See `traceml --help` for the full set of options.
-
-## Direct launch with `traceml serve`
-
-`traceml run` starts the aggregator and your script together. If you would
-rather launch training yourself with `python` or `torchrun`, run the aggregator
-as a standalone process and call `traceml.init(...)` inside your script.
-
-`traceml serve` owns only the aggregator. It binds a host/port, prints the
-reachable endpoint, blocks until SIGINT/SIGTERM, shuts down cleanly, and writes
-the final summary on exit. It never launches or wraps your training script.
+`traceml run` starts the aggregator and your script together. For direct
+`python` or `torchrun` launches, start the aggregator yourself and call
+`traceml.init(...)` inside the training script:
 
 ```bash
-# terminal 1: start the aggregator
+# terminal 1
 traceml serve --aggregator-host 127.0.0.1 --aggregator-port 29765
 
-# terminal 2: run your script directly
+# terminal 2
 python train.py
 ```
 
-For torchrun and multi-node, bind the aggregator so workers on other nodes can
-connect:
+`traceml serve` owns only the aggregator. It binds the endpoint, waits for a
+shutdown signal, and writes the final summary; it never launches or wraps the
+training script.
+
+For multi-node workers, bind the aggregator on a reachable address and set the
+endpoint on every training node:
 
 ```bash
-# aggregator node: --nnodes x --nproc-per-node = total workers, so the
-# aggregator waits for every rank before finalizing (and warns about ranks
-# that never report)
 traceml serve --aggregator-bind-host 0.0.0.0 --aggregator-host <node0-ip> \
   --aggregator-port 29765 --nnodes <N> --nproc-per-node <M>
 
-# each training node: workers read the aggregator endpoint from the
-# environment, so set it before torchrun
 TRACEML_AGGREGATOR_HOST=<node0-ip> TRACEML_AGGREGATOR_PORT=29765 \
   torchrun ... train.py
 ```
 
-Workers resolve the aggregator host from `TRACEML_AGGREGATOR_HOST` (default
-`127.0.0.1`), so on multi-node it must be set on every non-aggregator node or
-those workers cannot reach node 0.
+Workers resolve `TRACEML_AGGREGATOR_HOST` as `127.0.0.1` by default, so every
+non-aggregator node needs the reachable node-0 address above.
 
 `traceml serve` flags:
 
 | Flag | Meaning |
 |---|---|
-| `--aggregator-host` | Address workers connect to. Default `127.0.0.1`. |
-| `--aggregator-bind-host` | Address the aggregator binds to. Use `0.0.0.0` for multi-node. Default `127.0.0.1`. |
-| `--aggregator-port` | Aggregator TCP port. Default `29765`. |
-| `--nnodes` / `--nproc-per-node` | Total ranks = product. The aggregator waits for all of them before finalizing and warns about missing ranks. Falls back to `TRACEML_EXPECTED_WORLD_SIZE`, else 1. |
-| `--mode` | Display mode: `summary` (default), `cli`, or `dashboard`. |
+| `--aggregator-host` | Address workers connect to; default `127.0.0.1`. |
+| `--aggregator-bind-host` | Bind address; use `0.0.0.0` for multi-node. |
+| `--aggregator-port` | Aggregator TCP port; default `29765`. |
+| `--nnodes` / `--nproc-per-node` | Expected world size; the aggregator waits for all ranks before finalizing. |
+| `--mode` | `summary` (default), `cli`, or `dashboard`. |
 | `--logs-dir` | Directory for session logs. |
-| `--run-name` / `--session-id` | Run identity. Workers must use the same value for shared artifacts. |
+| `--run-name` / `--session-id` | Shared run identity for worker artifacts. |
 
-### Configuration in the direct-launch path
+### Missing-aggregator behavior
 
-In the direct `python` path you cannot pass `traceml run` flags, so runtime
-settings are resolved with this precedence:
+If the aggregator cannot be reached, `traceml.init(...)` retries for its
+bounded timeout, writes one stderr warning, and continues with tracing disabled
+as a no-op. This is the default `warn` policy; it does not stop training.
 
-1. explicit `traceml.init(...)` arguments
-2. `TRACEML_*` environment variables
-3. `traceml.yaml`
-4. built-in defaults
+Use strict behavior when telemetry is required, for example in CI:
 
 ```python
-traceml.init(
-    mode="auto",          # instrumentation mode
-    ui_mode="summary",    # display/telemetry mode
-    logs_dir="logs",
-    session_id="my_run",
-    aggregator_host="127.0.0.1",
-    aggregator_port=29765,
-)
+traceml.init(on_missing_aggregator="raise")
 ```
 
-The aggregator endpoint (`aggregator_host`, `aggregator_port`) is a launch
-setting, not read from `traceml.yaml`. If the aggregator is not reachable,
-`traceml.init(...)` retries for a short bounded period and then raises a clear
-error. Use `traceml.init(disabled=True)` (or `TRACEML_DISABLED=1`) to run with
-tracing fully disabled as a no-op.
+The policy resolves in this order: the explicit
+`on_missing_aggregator` argument, `TRACEML_ON_MISSING_AGGREGATOR`, then `warn`.
+It is not read from `traceml.yaml`.
+
+`aggregator_host` and `aggregator_port` are direct-launch settings, not
+`traceml.yaml` settings. Other runtime settings resolve as explicit
+`traceml.init(...)` arguments, then `TRACEML_*` environment variables, then
+`traceml.yaml`, then built-in defaults.
 
 ### Matching display modes across processes
 
-`traceml run` configures one display mode for the whole run. In the direct-launch
-path the aggregator and the worker are launched separately, so their display
-modes are set independently: `traceml serve --mode` for the aggregator, and
-`ui_mode` (via `traceml.init(ui_mode=...)` or `TRACEML_UI_MODE`) for the worker.
-
-For the live `cli` STDOUT/STDERR panel to show your script's output, set both to
-`cli` so the worker mirrors its stdout to the aggregator:
+In direct-launch mode, set the aggregator display with `traceml serve --mode`
+and the worker display with `traceml.init(ui_mode=...)` or `TRACEML_UI_MODE`.
+Use `cli` for both when the live terminal panel should include worker output:
 
 ```bash
 traceml serve --mode cli --run-name demo --aggregator-port 29765
 TRACEML_UI_MODE=cli TRACEML_SESSION_ID=demo python train.py
 ```
 
-If the modes differ (for example a `cli` aggregator with a worker left on the
-default `summary`), telemetry, diagnosis, and the final summary are unaffected;
+If the modes differ, telemetry, diagnosis, and final artifacts are unaffected;
 only worker stdout mirroring into the live panel is skipped.
 
-## Summary APIs
+## Framework Integrations
 
-### `traceml.summary()`
+Framework integrations are separate from the stable core API above. Use the
+matching integration guide for installation and runtime requirements.
 
-Returns a compact flat dict for experiment trackers such as W&B, MLflow, or
-internal dashboards. Call it near the end of training; it reuses the canonical
-`final_summary.json` if one already exists.
+### Hugging Face
 
-```python
-summary = traceml.summary(print_text=True)
-if summary is not None:
-    wandb.log(summary)
-```
+Preferred path: call the integration `init()` once and register
+`TraceMLTrainerCallback` with your existing `transformers.Trainer`.
 
-### `traceml.final_summary()`
+::: traceml_ai.integrations.huggingface.init
+    options:
+      show_root_heading: true
+      show_source: false
 
-Returns the full `final_summary.json` payload. Use this when you need the
-complete structured report or want to store the artifact for `traceml compare`.
-TraceML generates this canonical artifact once per run and reuses it on later
-calls.
+::: traceml_ai.integrations.huggingface.TraceMLTrainerCallback
+    options:
+      show_root_heading: true
+      show_source: false
+
+#### Legacy compatibility: `TraceMLTrainer`
+
+`TraceMLTrainer` remains supported for existing users. New code should prefer
+`TraceMLTrainerCallback`; see the [Hugging Face guide](integrations/huggingface.md)
+for its trade-offs.
+
+::: traceml_ai.integrations.huggingface.TraceMLTrainer
+    options:
+      show_root_heading: true
+      show_source: false
+
+### PyTorch Lightning
+
+::: traceml_ai.integrations.lightning.init
+    options:
+      show_root_heading: true
+      show_source: false
+
+::: traceml_ai.integrations.lightning.TraceMLCallback
+    options:
+      show_root_heading: true
+      show_source: false
+
+### Ray Train
+
+::: traceml_ai.integrations.ray.TraceMLTorchTrainer
+    options:
+      show_root_heading: true
+      show_source: false
+
+::: traceml_ai.integrations.ray.TraceMLRayConfig
+    options:
+      show_root_heading: true
+      show_source: false

--- a/src/traceml_ai/api.py
+++ b/src/traceml_ai/api.py
@@ -2,18 +2,39 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, ContextManager, Dict, Optional
 
 from traceml_ai.sdk.initial import TraceMLInitConfig
 from traceml_ai.sdk.summary_client import final_summary as _final_summary
 from traceml_ai.sdk.summary_client import summary as _summary
 
+if TYPE_CHECKING:
+    import torch.nn as nn
 
-def trace_step(*args: Any, **kwargs: Any) -> Any:
-    """Return the TraceML step tracing context manager."""
+
+def trace_step(model: nn.Module) -> ContextManager[None]:
+    """Return the context manager that defines one training-step boundary.
+
+    Parameters
+    ----------
+    model:
+        The PyTorch model being trained. TraceML uses it to collect step-memory
+        measurements and associate automatic phase timing with the step.
+
+    Returns
+    -------
+    ContextManager[None]
+        Use around the work from ``optimizer.zero_grad(...)`` through
+        ``optimizer.step()``.
+
+    Notes
+    -----
+    When tracing is disabled, the context manager is a no-op. Exceptions from
+    the training body still propagate normally.
+    """
     from traceml_ai.sdk.instrumentation import trace_step as _trace_step
 
-    return _trace_step(*args, **kwargs)
+    return _trace_step(model)
 
 
 def final_summary(
@@ -23,8 +44,30 @@ def final_summary(
     print_text: bool = False,
     rank0_only: bool = True,
 ) -> Optional[Dict[str, Any]]:
-    """
-    Return the full final_summary.json payload for the active session.
+    """Return the full final-summary payload for the active session.
+
+    Parameters
+    ----------
+    timeout_sec:
+        Maximum time to wait for the aggregator to publish the summary.
+    poll_interval_sec:
+        Delay between checks for the aggregator response.
+    print_text:
+        Print the matching ``final_summary.txt`` artifact when available.
+    rank0_only:
+        Return ``None`` on non-primary ranks when true.
+
+    Returns
+    -------
+    dict or None
+        The parsed ``final_summary.json`` payload, or ``None`` for a non-primary
+        rank when ``rank0_only=True``.
+
+    Raises
+    ------
+    RuntimeError
+        If session history is unavailable, the aggregator returns an error, or
+        the request times out.
     """
     return _final_summary(
         timeout_sec=timeout_sec,
@@ -41,8 +84,30 @@ def summary(
     print_text: bool = False,
     rank0_only: bool = True,
 ) -> Optional[Dict[str, Any]]:
-    """
-    Return a compact tracker-friendly TraceML summary for the active session.
+    """Return a compact tracker-friendly summary for the active session.
+
+    Parameters
+    ----------
+    timeout_sec:
+        Maximum time to wait for the aggregator to publish the summary.
+    poll_interval_sec:
+        Delay between checks for the aggregator response.
+    print_text:
+        Print the matching ``final_summary.txt`` artifact when available.
+    rank0_only:
+        Return ``None`` on non-primary ranks when true.
+
+    Returns
+    -------
+    dict or None
+        A flat projection of the final summary for experiment trackers, or
+        ``None`` for a non-primary rank when ``rank0_only=True``.
+
+    Raises
+    ------
+    RuntimeError
+        If session history is unavailable, the aggregator returns an error, or
+        the request times out.
     """
     return _summary(
         timeout_sec=timeout_sec,
@@ -52,43 +117,140 @@ def summary(
     )
 
 
-def wrap_dataloader_fetch(*args: Any, **kwargs: Any) -> Any:
-    """Wrap dataloader fetch timing."""
+def wrap_dataloader_fetch(obj: Any) -> Any:
+    """Wrap a loader or iterator to time step-scoped batch fetches.
+
+    Parameters
+    ----------
+    obj:
+        A loader implementing ``__iter__`` or an iterator implementing
+        ``__next__``.
+
+    Returns
+    -------
+    Any
+        A loader or iterator proxy that records fetch time.
+
+    Raises
+    ------
+    TypeError
+        If ``obj`` is neither a loader nor an iterator.
+    RuntimeError
+        If a torch ``DataLoader`` is already automatically instrumented.
+    """
     from traceml_ai.sdk.wrappers import (
         wrap_dataloader_fetch as _wrap_dataloader_fetch,
     )
 
-    return _wrap_dataloader_fetch(*args, **kwargs)
+    return _wrap_dataloader_fetch(obj)
 
 
-def wrap_forward(*args: Any, **kwargs: Any) -> Any:
-    """Wrap forward-pass timing."""
+def wrap_forward(model: nn.Module) -> nn.Module:
+    """Wrap one model instance's ``forward(...)`` for step-scoped timing.
+
+    Parameters
+    ----------
+    model:
+        The PyTorch module to instrument.
+
+    Returns
+    -------
+    torch.nn.Module
+        The same model instance after its ``forward`` method is wrapped in
+        place.
+
+    Raises
+    ------
+    TypeError
+        If ``model`` is not a PyTorch module with a callable ``forward``.
+    RuntimeError
+        If automatic forward instrumentation is active or the instance cannot
+        be wrapped safely.
+    """
     from traceml_ai.sdk.wrappers import wrap_forward as _wrap_forward
 
-    return _wrap_forward(*args, **kwargs)
+    return _wrap_forward(model)
 
 
-def wrap_backward(*args: Any, **kwargs: Any) -> Any:
-    """Wrap backward-pass timing."""
+def wrap_backward(loss: Any) -> Any:
+    """Wrap a loss-like object so ``.backward(...)`` records timing.
+
+    Parameters
+    ----------
+    loss:
+        An object with a callable ``backward`` method, normally a loss tensor.
+
+    Returns
+    -------
+    Any
+        A proxy that forwards attributes and times its ``backward`` call.
+
+    Raises
+    ------
+    TypeError
+        If ``loss`` has no callable ``backward`` method.
+    RuntimeError
+        If automatic backward instrumentation is active.
+    """
     from traceml_ai.sdk.wrappers import wrap_backward as _wrap_backward
 
-    return _wrap_backward(*args, **kwargs)
+    return _wrap_backward(loss)
 
 
-def wrap_optimizer(*args: Any, **kwargs: Any) -> Any:
-    """Wrap optimizer-step timing."""
+def wrap_optimizer(optimizer: Any) -> Any:
+    """Wrap one optimizer instance's ``.step(...)`` for timing.
+
+    Parameters
+    ----------
+    optimizer:
+        An optimizer with a callable ``step`` method.
+
+    Returns
+    -------
+    Any
+        The same optimizer instance after its ``step`` method is wrapped in
+        place.
+
+    Raises
+    ------
+    TypeError
+        If ``optimizer`` has no callable ``step`` method.
+    RuntimeError
+        If automatic optimizer instrumentation is active or the instance
+        cannot be wrapped safely.
+    """
     from traceml_ai.sdk.wrappers import wrap_optimizer as _wrap_optimizer
 
-    return _wrap_optimizer(*args, **kwargs)
+    return _wrap_optimizer(optimizer)
 
 
-def wrap_h2d(*args: Any, **kwargs: Any) -> Any:
-    """
-    Lazily resolve and apply TraceML H2D transfer wrapping.
+def wrap_h2d(obj: Any) -> Any:
+    """Wrap an object so qualifying CPU-to-CUDA ``.to(...)`` calls are timed.
+
+    Parameters
+    ----------
+    obj:
+        A tensor or batch object with a callable ``.to(...)`` method.
+
+    Returns
+    -------
+    Any
+        A proxy that forwards attributes and returns the transferred object on
+        its first ``.to(...)`` call.
+
+    Raises
+    ------
+    TypeError
+        If ``obj`` has no callable ``.to(...)`` method.
+
+    Notes
+    -----
+    Use this in manual or selective mode. If automatic H2D timing becomes
+    active after wrapping, the proxy passes through to avoid double counting.
     """
     from traceml_ai.sdk.wrappers import wrap_h2d as _wrap_h2d
 
-    return _wrap_h2d(*args, **kwargs)
+    return _wrap_h2d(obj)
 
 
 def init(
@@ -112,11 +274,51 @@ def init(
 ) -> TraceMLInitConfig:
     """Initialize TraceML and start its runtime for this process.
 
-    ``on_missing_aggregator`` controls what happens when the aggregator is
-    unreachable (or the runtime fails to start): ``'warn'`` (default) emits one
-    stderr warning and continues as a no-op so tracing never crashes training;
-    ``'raise'`` fails hard. Defaults to ``TRACEML_ON_MISSING_AGGREGATOR`` then
-    ``'warn'``.
+    Parameters
+    ----------
+    mode:
+        Instrumentation policy: ``"auto"`` (default), ``"manual"``, or
+        ``"selective"``. ``"custom"`` is accepted as an alias for selective.
+    patch_dataloader, patch_forward, patch_backward, patch_h2d:
+        Per-feature automatic-instrumentation settings. They may be supplied
+        only with ``mode="selective"``.
+    disabled:
+        Disable TraceML entirely for this process.
+    ui_mode:
+        Display mode: ``"summary"``, ``"cli"``, or ``"dashboard"``.
+    interval:
+        Sampling interval in seconds for runtime telemetry.
+    logs_dir:
+        Directory for session artifacts.
+    enable_logging:
+        Enable TraceML file logging.
+    session_id:
+        Identifier shared by workers that write one run's artifacts.
+    aggregator_host, aggregator_port:
+        Aggregator endpoint for direct launches. ``traceml run`` configures it
+        automatically.
+    connect_timeout_sec, connect_retry_interval_sec:
+        Bounded connection wait and retry interval for the aggregator.
+    on_missing_aggregator:
+        Missing-aggregator policy: ``"warn"`` prints one stderr warning and
+        continues with tracing disabled; ``"raise"`` fails the call. Resolution
+        is explicit argument, then ``TRACEML_ON_MISSING_AGGREGATOR``, then
+        ``"warn"``.
+
+    Returns
+    -------
+    TraceMLInitConfig
+        The effective instrumentation configuration. Fail-open initialization
+        returns a disabled configuration.
+
+    Raises
+    ------
+    ValueError
+        If mode or selective patch settings are invalid.
+    RuntimeError
+        If initialization conflicts with an existing configuration, or when
+        ``on_missing_aggregator="raise"`` is selected and setup fails.
+
     """
     from traceml_ai.sdk.initial import init as _init
 
@@ -157,8 +359,14 @@ def start(
     aggregator_port: Optional[int] = None,
     connect_timeout_sec: float = 10.0,
     connect_retry_interval_sec: float = 0.25,
+    on_missing_aggregator: Optional[str] = None,
 ) -> TraceMLInitConfig:
-    """Alias for `traceml.init(...)`."""
+    """Backward-compatible alias for :func:`init`.
+
+    This function accepts the same parameters and has the same missing-
+    aggregator behavior as :func:`init`. New code may use either name; prefer
+    ``init`` for consistency with framework integration entry points.
+    """
     from traceml_ai.sdk.initial import start as _start
 
     return _start(
@@ -177,6 +385,7 @@ def start(
         aggregator_port=aggregator_port,
         connect_timeout_sec=connect_timeout_sec,
         connect_retry_interval_sec=connect_retry_interval_sec,
+        on_missing_aggregator=on_missing_aggregator,
     )
 
 

--- a/src/traceml_ai/sdk/initial.py
+++ b/src/traceml_ai/sdk/initial.py
@@ -660,12 +660,14 @@ def start(
     aggregator_port: Optional[int] = None,
     connect_timeout_sec: float = 10.0,
     connect_retry_interval_sec: float = 0.25,
+    on_missing_aggregator: Optional[str] = None,
 ) -> TraceMLInitConfig:
     """
     Alias for `init()` for the current transition period.
 
     This keeps the already-exposed public surface usable while the TraceML
-    is being formalized. Today, `start()` and `init()` are equivalent.
+    is being formalized. It forwards every public ``init()`` option, including
+    the missing-aggregator policy.
     """
     return init(
         mode=mode,
@@ -683,6 +685,7 @@ def start(
         aggregator_port=aggregator_port,
         connect_timeout_sec=connect_timeout_sec,
         connect_retry_interval_sec=connect_retry_interval_sec,
+        on_missing_aggregator=on_missing_aggregator,
         _source="user",
     )
 

--- a/tests/sdk/test_init_and_wrappers.py
+++ b/tests/sdk/test_init_and_wrappers.py
@@ -1,4 +1,5 @@
 import importlib
+import inspect
 import sys
 from contextlib import contextmanager
 from pathlib import Path
@@ -191,6 +192,45 @@ def test_start_is_alias_for_init():
     assert cfg.patch_dataloader is False
     assert cfg.patch_forward is False
     assert cfg.patch_backward is False
+
+
+def test_start_forwards_missing_aggregator_policy(monkeypatch):
+    initialization = _reload_initialization_module()
+    captured = {}
+    expected = object()
+
+    def fake_init(**kwargs):
+        captured.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(initialization, "init", fake_init)
+
+    assert (
+        initialization.start(mode="manual", on_missing_aggregator="raise")
+        is expected
+    )
+    assert captured["mode"] == "manual"
+    assert captured["on_missing_aggregator"] == "raise"
+
+
+def test_public_start_matches_init_and_forwards_missing_aggregator_policy(
+    monkeypatch,
+):
+    import traceml_ai.api as api
+    import traceml_ai.sdk.initial as initialization
+
+    captured = {}
+    expected = object()
+
+    def fake_start(**kwargs):
+        captured.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(initialization, "start", fake_start)
+
+    assert inspect.signature(api.start) == inspect.signature(api.init)
+    assert api.start(on_missing_aggregator="raise") is expected
+    assert captured["on_missing_aggregator"] == "raise"
 
 
 def test_api_import_does_not_initialize_implicitly():

--- a/tests/sdk/test_init_and_wrappers.py
+++ b/tests/sdk/test_init_and_wrappers.py
@@ -1,5 +1,6 @@
 import importlib
 import inspect
+import re
 import sys
 from contextlib import contextmanager
 from pathlib import Path
@@ -769,3 +770,36 @@ def test_wrap_optimizer_preserves_identity_and_times_step(monkeypatch):
     assert result == "ok"
     assert optimizer.called is True
     assert calls == [("_traceml_internal:optimizer_step", "step", True)]
+
+
+def test_public_api_page_documents_every_public_symbol():
+    """The Public API page and ``__all__`` must not drift (issue #334).
+
+    public-api.md renders the api-module docstrings through mkdocstrings
+    directives. Every symbol in ``traceml_ai.__all__`` needs one (plus the
+    ``__version__`` prose entry), and no directive may document a symbol
+    that is not public.
+    """
+    import traceml_ai
+
+    page = (ROOT / "docs" / "user_guide" / "public-api.md").read_text(
+        encoding="utf-8"
+    )
+    directives = set(
+        re.findall(r"^::: traceml_ai\.api\.(\w+)", page, flags=re.MULTILINE)
+    )
+    documented = set(directives)
+    if "`traceml.__version__`" in page:
+        documented.add("__version__")
+
+    missing = sorted(set(traceml_ai.__all__) - documented)
+    unexpected = sorted(directives - set(traceml_ai.__all__))
+
+    assert not missing, (
+        "symbols in traceml_ai.__all__ without a public-api.md entry: "
+        f"{missing}"
+    )
+    assert not unexpected, (
+        "public-api.md documents symbols missing from traceml_ai.__all__: "
+        f"{unexpected}"
+    )

--- a/tests/sdk/test_init_runtime.py
+++ b/tests/sdk/test_init_runtime.py
@@ -325,6 +325,28 @@ def test_init_raises_when_aggregator_unreachable_and_strict(
     assert initialization.get_init_config() is None  # config not stored
 
 
+@pytest.mark.parametrize(
+    ("env_value", "explicit_value", "expected"),
+    [
+        (None, None, "warn"),
+        ("raise", None, "raise"),
+        ("raise", "warn", "warn"),
+        ("warn", "raise", "raise"),
+    ],
+)
+def test_missing_aggregator_policy_precedence(
+    initialization, monkeypatch, env_value, explicit_value, expected
+):
+    monkeypatch.delenv("TRACEML_ON_MISSING_AGGREGATOR", raising=False)
+    if env_value is not None:
+        monkeypatch.setenv("TRACEML_ON_MISSING_AGGREGATOR", env_value)
+
+    assert (
+        initialization._resolve_on_missing_aggregator(explicit_value)
+        == expected
+    )
+
+
 def test_init_skips_runtime_when_already_active(initialization, monkeypatch):
     import traceml_ai.runtime.lifecycle as lifecycle
 


### PR DESCRIPTION
## Summary

This PR makes the documented `traceml_ai` API match the runtime contract.
It documents every public export, corrects missing-aggregator behavior, and
adds tests that keep the API reference synchronized as the package evolves.

## What changed

- Rebuilt the Public API page around the top-level `traceml_ai` import path,
  covering all callable exports and `__version__`.
- Added complete public signatures and concise docstrings for the façade API:
  parameters, return values, side effects, duplicate-instrumentation errors,
  and no-op behavior.
- Corrected direct-launch behavior: an unreachable aggregator warns once and
  makes tracing a no-op by default; `raise` is opt-in through
  `on_missing_aggregator="raise"` or `TRACEML_ON_MISSING_AGGREGATOR=raise`.
- Made `traceml.start()` forward every `traceml.init()` option, including the
  missing-aggregator policy, so the existing alias has the same behavior.
- Separated stable core APIs from framework integrations and labelled
  `TraceMLTrainer` as legacy compatibility; `TraceMLTrainerCallback` remains
  the recommended Hugging Face integration.
- Added a docs-contract test derived from `traceml_ai.__all__`, plus focused
  runtime tests for missing-aggregator policy precedence and `start()` parity.

## Scope

This does not change instrumentation semantics, CLI behavior, aggregation, or
framework integrations. The only runtime API correction is that the existing
`traceml.start()` alias now accepts and forwards the same
`on_missing_aggregator` option as `traceml.init()`.

## Validation

```text
PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider -q tests/sdk tests/docs/test_public_api_contract.py
```

Result: `52 passed`.

`git diff --check` also passes.

`python -m mkdocs build --strict` is currently blocked in this worktree by an
untracked `docs/README.md` that conflicts with `docs/index.md`; that file is
outside this PR's changes. Re-run the strict build in a clean checkout (or
after resolving that unrelated conflict) before merge.
