### PR TITLE
Run the strict docs build on documentation-only PRs and fail on broken anchors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,10 +9,14 @@ on:
       - 'mkdocs.yml'
       - 'pyproject.toml'
   pull_request:
-    branches: [main]
+    # PRs in this repo target release branches (version_*) day to day and
+    # main only for the batch merge; the docs check must run on both.
+    branches: [main, 'version_*']
     paths:
+      - 'docs/**'
+      - '*.md'
       - 'mkdocs.yml'
-      - 'pyproject.toml' # Skips PR builds entirely for pure .md text files!
+      - 'pyproject.toml'
 
 concurrency:
   group: docs-${{ github.ref }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,12 @@ repo_url: https://github.com/traceopt-ai/traceml
 repo_name: traceopt-ai/traceml
 edit_uri: edit/main/docs/
 
+validation:
+  links:
+    # Broken anchors are only INFO by default, which `mkdocs build --strict`
+    # does not fail on. Warn so strict mode rejects them in CI.
+    anchors: warn
+
 theme:
   name: material
   # logo: assets/logo.png        # uncomment when traceopt.ai logo is available


### PR DESCRIPTION
Closes #333.

## Problem

Docs-only pull requests ran no documentation check: core CI ignores
`docs/**` and `*.md`, and the docs workflow's `pull_request` trigger listed
only `mkdocs.yml` and `pyproject.toml`. Two additional gaps surfaced while
fixing it:

1. Both docs triggers were filtered to `branches: [main]`, but day-to-day
   PRs in this repo target `version_*` release branches, so the docs check
   never ran on any of them regardless of paths.
2. `mkdocs build --strict` does not reject broken anchors: a broken link
   target is a WARNING (strict fails), but a broken `#anchor` in an
   otherwise-valid link is only INFO and passes strict silently
   (verified below).

## What changed

- `.github/workflows/docs.yml`: `pull_request` now triggers on
  `[main, version_*]` and on `docs/**` + root `*.md` paths (plus the
  existing `mkdocs.yml` / `pyproject.toml`).
- `mkdocs.yml`: `validation.links.anchors: warn` (mkdocs >= 1.6 built-in),
  so strict mode fails on broken anchors too. No new dependency; the
  existing `mkdocs build --strict` step is unchanged.

## Verification (local, on this branch)

1. Clean tree: `mkdocs build --strict` exit 0 (no pre-existing anchor
   violations, so this change does not break the current docs).
2. Added `[test](../index.md#no-such-anchor-xyz)` to a page:
   exit 1, `Aborted with 1 warnings in strict mode!` (INFO-and-pass
   before this change).
3. Added `[test](does-not-exist-xyz.md)`: exit 1, as before.
4. Reverted both: exit 0 again.

The issue's PR-level verification (docs-only PR triggers the job) is
demonstrated by this PR itself once the workflow change is on the base
branch; until then the run can be confirmed on a follow-up docs-only PR.

One acceptance criterion needs a repo setting rather than code: marking
the docs job as a required status check is branch protection
configuration, which an admin has to toggle once the job has run on a PR.

GATE: mkdocs build --strict exit codes verified locally for all four cases above; no runtime code touched
TRANSITIONS: n/a (CI trigger + docs-validation config only, no state machines touched)
RANKS: n/a (no telemetry or multi-rank code touched)
PLATFORM: n/a (no platform-conditional code; workflow runs on ubuntu-latest as before)
TRIPWIRE: if the first docs-only PR after merge does not show the Docs check, the paths filter needs a second look; watch the first such PR
