### PR TITLE
Smoke-test the Colab onboarding notebooks

### DIFF
--- a/.github/workflows/notebook-smoke.yml
+++ b/.github/workflows/notebook-smoke.yml
@@ -1,0 +1,72 @@
+name: Notebook Smoke
+
+on:
+  pull_request:
+    branches: [main, 'version_*']
+    paths:
+      - 'notebooks/**'
+      - 'src/traceml_ai/**'
+      - 'pyproject.toml'
+      - '.github/workflows/notebook-smoke.yml'
+  push:
+    branches: [main, 'version_*']
+    paths:
+      - 'notebooks/**'
+      - 'src/traceml_ai/**'
+      - 'pyproject.toml'
+      - '.github/workflows/notebook-smoke.yml'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: notebook-smoke-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: CPU notebook smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install TraceML and notebook runner
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[torch,hf]" nbconvert ipykernel
+      - name: Execute the PyTorch smoke notebook
+        env:
+          TRACEML_NOTEBOOK_MODE: smoke
+          TRACEML_NOTEBOOK_SKIP_INSTALL: '1'
+        run: |
+          set -euo pipefail
+          mkdir -p notebook-smoke/pytorch
+          cp notebooks/data_loading_bottleneck.ipynb notebook-smoke/pytorch/notebook.ipynb
+          cd notebook-smoke/pytorch
+          jupyter nbconvert --to notebook --execute notebook.ipynb \
+            --ExecutePreprocessor.timeout=180 \
+            --output=executed.ipynb
+          test -f logs/pytorch_smoke/final_summary.json
+          test -f logs/pytorch_smoke/final_summary.txt
+      - name: Execute the Hugging Face smoke notebook
+        env:
+          TRACEML_NOTEBOOK_MODE: smoke
+          TRACEML_NOTEBOOK_SKIP_INSTALL: '1'
+        run: |
+          set -euo pipefail
+          mkdir -p notebook-smoke/huggingface
+          cp notebooks/huggingface_dataloading_bottleneck.ipynb notebook-smoke/huggingface/notebook.ipynb
+          cd notebook-smoke/huggingface
+          jupyter nbconvert --to notebook --execute notebook.ipynb \
+            --ExecutePreprocessor.timeout=180 \
+            --output=executed.ipynb
+          test -f logs/hf_smoke/final_summary.json
+          test -f logs/hf_smoke/final_summary.txt

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -65,7 +65,8 @@ with traceml.trace_step(model):
 
 For supported integrations:
 
-- Hugging Face: use `TraceMLTrainer`
+- Hugging Face: call `traceml_ai.integrations.huggingface.init()` and add
+  `TraceMLTrainerCallback()` to the standard `Trainer` callbacks.
 - Lightning: call `traceml_ai.integrations.lightning.init()` and add `TraceMLCallback()`
 
 The preferred public API is the top-level `traceml.*` API from

--- a/notebooks/data_loading_bottleneck.ipynb
+++ b/notebooks/data_loading_bottleneck.ipynb
@@ -87,7 +87,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q traceml-ai\n",
+    "import os\n",
+    "\n",
+    "if os.environ.get(\"TRACEML_NOTEBOOK_SKIP_INSTALL\") == \"1\":\n",
+    "    print(\"Notebook smoke runner provided TraceML dependencies.\")\n",
+    "else:\n",
+    "    %pip install -q traceml-ai\n",
     "# Outside Colab or in a fresh CPU environment: %pip install -q \"traceml-ai[torch]\""
    ]
   },

--- a/notebooks/data_loading_bottleneck.ipynb
+++ b/notebooks/data_loading_bottleneck.ipynb
@@ -28,47 +28,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1. Check the GPU"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!nvidia-smi -L\n",
-    "import torch\n",
+    "## Choose a run mode\n",
     "\n",
-    "print(\"CUDA available:\", torch.cuda.is_available())\n",
-    "assert (\n",
-    "    torch.cuda.is_available()\n",
-    "), \"No GPU. Runtime -> Change runtime type -> GPU, then rerun.\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 2. Install TraceML\n",
-    "torch and torchvision come preinstalled on Colab; we only add TraceML. We pass `--no-deps` so pip does not try to downgrade Colab's numpy (TraceML's runtime deps are already present on Colab). On a fresh environment that lacks them, drop `--no-deps`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install -q traceml-ai --no-deps"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3. Get the data (full-resolution Imagenette, ~1.5 GB)\n",
-    "Full-resolution JPEGs are the point: decoding them is the heavy CPU cost that a single-worker loader cannot hide. (~1-2 min to download and extract.)"
+    "`extended` is the default GPU/Imagenette demonstration. `smoke` is a small CPU-only verification mode for contributors and CI: it uses synthetic data, downloads nothing, and checks that TraceML produces a complete input-bound diagnosis.\n"
    ]
   },
   {
@@ -79,12 +41,85 @@
    "source": [
     "import os\n",
     "\n",
-    "if not os.path.isdir(\"imagenette2/train\"):\n",
-    "    !wget -q https://s3.amazonaws.com/fast-ai-imageclas/imagenette2.tgz\n",
-    "    !tar -xzf imagenette2.tgz\n",
-    "print(\"CPU cores:\", os.cpu_count())\n",
-    "print(\"train classes:\", len(os.listdir(\"imagenette2/train\")))\n",
-    "print(\"train images:\", sum(len(f) for _, _, f in os.walk(\"imagenette2/train\")))"
+    "# Change the default to \"smoke\" to run the small CPU-only path manually.\n",
+    "RUN_MODE = os.environ.get(\"TRACEML_NOTEBOOK_MODE\", \"extended\")\n",
+    "if RUN_MODE not in {\"extended\", \"smoke\"}:\n",
+    "    raise ValueError(\"TRACEML_NOTEBOOK_MODE must be 'extended' or 'smoke'\")\n",
+    "print(f\"TraceML notebook mode: {RUN_MODE}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Check the GPU (extended mode only)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "if RUN_MODE == \"extended\":\n",
+    "    !nvidia-smi -L\n",
+    "    print(\"CUDA available:\", torch.cuda.is_available())\n",
+    "    assert (\n",
+    "        torch.cuda.is_available()\n",
+    "    ), \"No GPU. Runtime -> Change runtime type -> GPU, then rerun.\"\n",
+    "else:\n",
+    "    print(\"Smoke mode uses CPU; no GPU is required.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Install TraceML\n",
+    "Colab supplies a CUDA-matched PyTorch and torchvision build, so this cell installs TraceML and its runtime dependencies without replacing them. Outside Colab, install the Torch extra shown in the comment below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q traceml-ai\n",
+    "# Outside Colab or in a fresh CPU environment: %pip install -q \"traceml-ai[torch]\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Get the data (extended mode only)\n",
+    "\n",
+    "The extended GPU demonstration uses full-resolution Imagenette (~1.5 GB) because JPEG decoding is the CPU cost it investigates. Smoke mode skips this download and creates its data in memory.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if RUN_MODE == \"extended\":\n",
+    "    if not os.path.isdir(\"imagenette2/train\"):\n",
+    "        !wget -q https://s3.amazonaws.com/fast-ai-imageclas/imagenette2.tgz\n",
+    "        !tar -xzf imagenette2.tgz\n",
+    "    print(\"CPU cores:\", os.cpu_count())\n",
+    "    print(\"train classes:\", len(os.listdir(\"imagenette2/train\")))\n",
+    "    print(\n",
+    "        \"train images:\",\n",
+    "        sum(len(f) for _, _, f in os.walk(\"imagenette2/train\")),\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"Smoke mode uses a small in-memory synthetic dataset.\")"
    ]
   },
   {
@@ -102,15 +137,38 @@
    "outputs": [],
    "source": [
     "%%writefile train.py\n",
-    "import argparse, os\n",
-    "import torch, torch.nn as nn\n",
+    "import argparse\n",
+    "import os\n",
+    "import time\n",
+    "\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
     "import torchvision\n",
     "import torchvision.transforms as T\n",
-    "from torch.utils.data import DataLoader\n",
+    "from torch.utils.data import DataLoader, Dataset\n",
+    "\n",
     "import traceml_ai as traceml\n",
     "\n",
     "MEAN = (0.485, 0.456, 0.406)\n",
     "STD = (0.229, 0.224, 0.225)\n",
+    "\n",
+    "\n",
+    "class SlowSyntheticImages(Dataset):\n",
+    "    # Small CPU-only dataset with deliberate fetch latency for smoke mode.\n",
+    "\n",
+    "    classes = (\"zero\", \"one\")\n",
+    "\n",
+    "    def __init__(self, samples=32, delay_s=0.05):\n",
+    "        self.images = torch.zeros(samples, 3, 32, 32)\n",
+    "        self.labels = torch.arange(samples) % len(self.classes)\n",
+    "        self.delay_s = delay_s\n",
+    "\n",
+    "    def __len__(self):\n",
+    "        return len(self.labels)\n",
+    "\n",
+    "    def __getitem__(self, index):\n",
+    "        time.sleep(self.delay_s)\n",
+    "        return self.images[index], self.labels[index]\n",
     "\n",
     "\n",
     "def main():\n",
@@ -120,29 +178,38 @@
     "    ap.add_argument(\"--data-dir\", default=\"imagenette2\")\n",
     "    ap.add_argument(\"--batch-size\", type=int, default=64)\n",
     "    ap.add_argument(\"--max-steps\", type=int, default=300)\n",
+    "    ap.add_argument(\"--smoke\", action=\"store_true\",\n",
+    "                    help=\"Run the small CPU-only synthetic verification path.\")\n",
     "    args = ap.parse_args()\n",
     "\n",
     "    optimized = args.profile == \"optimized\"\n",
-    "    device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
+    "    device = torch.device(\"cpu\" if args.smoke else\n",
+    "                          (\"cuda\" if torch.cuda.is_available() else \"cpu\"))\n",
     "\n",
-    "    # ---- The ONLY thing that changes between the two profiles: data loading ----\n",
-    "    # Match workers to CPU cores so we do not oversubscribe (Colab free tier\n",
-    "    # has ~2 cores; more workers than cores thrash instead of overlapping).\n",
-    "    num_workers = min(4, os.cpu_count() or 2) if optimized else 0\n",
-    "    transform = T.Compose([\n",
-    "        T.RandomResizedCrop(224),\n",
-    "        T.RandomHorizontalFlip(),\n",
-    "        T.ToTensor(),\n",
-    "        T.Normalize(MEAN, STD),\n",
-    "    ])\n",
-    "    dataset = torchvision.datasets.ImageFolder(\n",
-    "        os.path.join(args.data_dir, \"train\"), transform=transform)\n",
+    "    # ---- The ONLY thing that changes between the two extended profiles: data loading ----\n",
+    "    if args.smoke:\n",
+    "        # The short, intentional fetch delay makes the CPU smoke diagnosis\n",
+    "        # stable while exercising the same DataLoader and trace_step path.\n",
+    "        num_workers = 0\n",
+    "        dataset = SlowSyntheticImages()\n",
+    "    else:\n",
+    "        # Match workers to CPU cores so we do not oversubscribe (Colab free tier\n",
+    "        # has ~2 cores; more workers than cores thrash instead of overlapping).\n",
+    "        num_workers = min(4, os.cpu_count() or 2) if optimized else 0\n",
+    "        transform = T.Compose([\n",
+    "            T.RandomResizedCrop(224),\n",
+    "            T.RandomHorizontalFlip(),\n",
+    "            T.ToTensor(),\n",
+    "            T.Normalize(MEAN, STD),\n",
+    "        ])\n",
+    "        dataset = torchvision.datasets.ImageFolder(\n",
+    "            os.path.join(args.data_dir, \"train\"), transform=transform)\n",
     "    loader = DataLoader(\n",
     "        dataset,\n",
     "        batch_size=args.batch_size,\n",
     "        shuffle=True,\n",
     "        num_workers=num_workers,\n",
-    "        pin_memory=optimized,                              # async H2D staging\n",
+    "        pin_memory=optimized and not args.smoke,             # async H2D staging\n",
     "        persistent_workers=(optimized and num_workers > 0),\n",
     "        drop_last=True,\n",
     "    )\n",
@@ -154,7 +221,7 @@
     "    criterion = nn.CrossEntropyLoss()\n",
     "    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)\n",
     "\n",
-    "    print(f\"[demo] profile={args.profile} device={device} \"\n",
+    "    print(f\"[demo] profile={args.profile} smoke={args.smoke} device={device} \"\n",
     "          f\"num_workers={num_workers} batch={args.batch_size} \"\n",
     "          f\"max_steps={args.max_steps} amp=off\", flush=True)\n",
     "\n",
@@ -165,8 +232,8 @@
     "    while step < args.max_steps:\n",
     "        for images, labels in loader:\n",
     "            with traceml.trace_step(model):   # <-- TraceML line 2\n",
-    "                images = images.to(device, non_blocking=optimized)\n",
-    "                labels = labels.to(device, non_blocking=optimized)\n",
+    "                images = images.to(device, non_blocking=optimized and not args.smoke)\n",
+    "                labels = labels.to(device, non_blocking=optimized and not args.smoke)\n",
     "                optimizer.zero_grad(set_to_none=True)\n",
     "                loss = criterion(model(images), labels)\n",
     "                loss.backward()\n",
@@ -184,8 +251,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 5. Run 1 - baseline (`num_workers=0`)\n",
-    "The default, single-process data loading. 300 steps (the verdict needs at least ~50; use more for steadier numbers). Watch the end-of-run summary: it should say **INPUT-BOUND**."
+    "## 5. Run the baseline\n",
+    "\n",
+    "Extended mode runs the original GPU/Imagenette baseline. Smoke mode runs eight CPU-only synthetic steps with deliberate input delay, which should produce a complete `INPUT-BOUND` diagnosis.\n"
    ]
   },
   {
@@ -194,15 +262,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!traceml run --mode summary --logs-dir logs --run-name baseline train.py --args --profile baseline --data-dir imagenette2 --max-steps 300 --batch-size 64"
+    "if RUN_MODE == \"smoke\":\n",
+    "    !traceml run --mode summary --logs-dir logs --run-name pytorch_smoke train.py --args --profile baseline --smoke --max-steps 8 --batch-size 4\n",
+    "else:\n",
+    "    !traceml run --mode summary --logs-dir logs --run-name baseline train.py --args --profile baseline --data-dir imagenette2 --max-steps 300 --batch-size 64"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6. Run 2 - optimized (workers matched to CPU cores + pinned + persistent)\n",
-    "Same model, same data, same steps. Only the data loading changes (workers on, `pin_memory`, `persistent_workers`, non-blocking H2D). The GPU utilization should rise and the run should finish faster; if your machine has enough cores to fully hide the decode, the verdict flips to **COMPUTE-BOUND**."
+    "## 6. Run the optimized loader (extended mode only)\n",
+    "\n",
+    "Same images, model, batch size, and steps. Only the data loading changes (workers on, `pin_memory`, `persistent_workers`, non-blocking H2D). The GPU utilization should rise and the run should finish faster; if your machine has enough cores to fully hide the decode, the verdict flips to **COMPUTE-BOUND**.\n"
    ]
   },
   {
@@ -211,7 +283,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!traceml run --mode summary --logs-dir logs --run-name optimized train.py --args --profile optimized --data-dir imagenette2 --max-steps 300 --batch-size 64"
+    "if RUN_MODE == \"extended\":\n",
+    "    !traceml run --mode summary --logs-dir logs --run-name optimized train.py --args --profile optimized --data-dir imagenette2 --max-steps 300 --batch-size 64\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Smoke mode runs one intentional input-bound case, not a comparison.\"\n",
+    "    )"
    ]
   },
   {
@@ -229,52 +306,71 @@
    "outputs": [],
    "source": [
     "import json\n",
+    "from pathlib import Path\n",
     "\n",
-    "\n",
-    "def load(run):\n",
-    "    d = json.load(open(f\"logs/{run}/final_summary.json\"))\n",
-    "    g = d[\"system\"][\"global\"][\"average\"]\n",
-    "    return {\n",
-    "        \"wall_s\": round(d[\"duration_s\"], 1),\n",
-    "        \"verdict\": d[\"primary_diagnosis\"][\"status\"],\n",
-    "        \"gpu_util\": round(g[\"gpu_util_percent\"], 1),\n",
-    "        \"cpu_util\": round(g[\"cpu_percent\"], 1),\n",
-    "    }\n",
-    "\n",
-    "\n",
-    "b, o = load(\"baseline\"), load(\"optimized\")\n",
-    "speedup = b[\"wall_s\"] / o[\"wall_s\"]\n",
-    "saved = (1 - o[\"wall_s\"] / b[\"wall_s\"]) * 100\n",
-    "\n",
-    "print(f\"{'metric':<20}{'baseline':>15}{'optimized':>15}\")\n",
-    "print(\"-\" * 50)\n",
-    "print(f\"{'wall clock (s)':<20}{b['wall_s']:>15}{o['wall_s']:>15}\")\n",
-    "print(f\"{'GPU util (%)':<20}{b['gpu_util']:>15}{o['gpu_util']:>15}\")\n",
-    "print(f\"{'CPU util (%)':<20}{b['cpu_util']:>15}{o['cpu_util']:>15}\")\n",
-    "print(f\"{'TraceML verdict':<20}{b['verdict']:>15}{o['verdict']:>15}\")\n",
-    "print(\"-\" * 50)\n",
-    "print(\n",
-    "    f\"\\nSpeedup (wall clock): {speedup:.2f}x  \"\n",
-    "    f\"({saved:.0f}% less GPU time for identical training)\\n\"\n",
-    ")\n",
-    "\n",
-    "if o[\"verdict\"] != \"INPUT-BOUND\":\n",
-    "    print(\n",
-    "        \"The fix flipped the bottleneck: your machine had enough CPU to hide\"\n",
-    "    )\n",
-    "    print(\"the decode, so the GPU is now the limit (COMPUTE-BOUND).\")\n",
+    "if RUN_MODE == \"smoke\":\n",
+    "    summary_dir = Path(\"logs/pytorch_smoke\")\n",
+    "    summary_json = summary_dir / \"final_summary.json\"\n",
+    "    summary_text = summary_dir / \"final_summary.txt\"\n",
+    "    assert summary_json.is_file(), f\"Missing {summary_json}\"\n",
+    "    assert summary_text.is_file(), f\"Missing {summary_text}\"\n",
+    "    summary = json.loads(summary_json.read_text())\n",
+    "    diagnosis = summary[\"primary_diagnosis\"][\"status\"]\n",
+    "    assert (\n",
+    "        diagnosis == \"INPUT-BOUND\"\n",
+    "    ), f\"Expected the intentional input-bound smoke diagnosis, got {diagnosis!r}\"\n",
+    "    print(f\"Smoke check passed: {diagnosis}; artifacts are in {summary_dir}\")\n",
     "else:\n",
+    "\n",
+    "    def load(run):\n",
+    "        d = json.load(open(f\"logs/{run}/final_summary.json\"))\n",
+    "        g = d[\"system\"][\"global\"][\"average\"]\n",
+    "        return {\n",
+    "            \"wall_s\": round(d[\"duration_s\"], 1),\n",
+    "            \"verdict\": d[\"primary_diagnosis\"][\"status\"],\n",
+    "            \"gpu_util\": round(g[\"gpu_util_percent\"], 1),\n",
+    "            \"cpu_util\": round(g[\"cpu_percent\"], 1),\n",
+    "        }\n",
+    "\n",
+    "    b, o = load(\"baseline\"), load(\"optimized\")\n",
+    "    speedup = b[\"wall_s\"] / o[\"wall_s\"]\n",
+    "    saved = (1 - o[\"wall_s\"] / b[\"wall_s\"]) * 100\n",
+    "\n",
+    "    print(f\"{'metric':<20}{'baseline':>15}{'optimized':>15}\")\n",
+    "    print(\"-\" * 50)\n",
+    "    print(f\"{'wall clock (s)':<20}{b['wall_s']:>15}{o['wall_s']:>15}\")\n",
+    "    print(f\"{'GPU util (%)':<20}{b['gpu_util']:>15}{o['gpu_util']:>15}\")\n",
+    "    print(f\"{'CPU util (%)':<20}{b['cpu_util']:>15}{o['cpu_util']:>15}\")\n",
+    "    print(f\"{'TraceML verdict':<20}{b['verdict']:>15}{o['verdict']:>15}\")\n",
+    "    print(\"-\" * 50)\n",
     "    print(\n",
-    "        f\"Workers helped: GPU util {b['gpu_util']}% -> {o['gpu_util']}%, \"\n",
-    "        f\"{speedup:.2f}x faster.\"\n",
+    "        f\"\\nSpeedup (wall clock): {speedup:.2f}x  \"\n",
+    "        f\"({saved:.0f}% less GPU time for identical training)\\n\"\n",
     "    )\n",
-    "    print(f\"But the CPU is now the ceiling ({o['cpu_util']}% used) and still\")\n",
-    "    print(\"cannot fully feed the GPU, so it stays input-bound. With more CPU\")\n",
-    "    print(\"cores this flips to COMPUTE-BOUND (the case study ran on a 4-core\")\n",
-    "    print(\n",
-    "        \"box: 1.8x, fully compute-bound). That is the machine-dependence the\"\n",
-    "    )\n",
-    "    print(\"post is about, showing up live on your hardware.\")"
+    "\n",
+    "    if o[\"verdict\"] != \"INPUT-BOUND\":\n",
+    "        print(\n",
+    "            \"The fix flipped the bottleneck: your machine had enough CPU to hide\"\n",
+    "        )\n",
+    "        print(\"the decode, so the GPU is now the limit (COMPUTE-BOUND).\")\n",
+    "    else:\n",
+    "        print(\n",
+    "            f\"Workers helped: GPU util {b['gpu_util']}% -> {o['gpu_util']}%, \"\n",
+    "            f\"{speedup:.2f}x faster.\"\n",
+    "        )\n",
+    "        print(\n",
+    "            f\"But the CPU is now the ceiling ({o['cpu_util']}% used) and still\"\n",
+    "        )\n",
+    "        print(\n",
+    "            \"cannot fully feed the GPU, so it stays input-bound. With more CPU\"\n",
+    "        )\n",
+    "        print(\n",
+    "            \"cores this flips to COMPUTE-BOUND (the case study ran on a 4-core\"\n",
+    "        )\n",
+    "        print(\n",
+    "            \"box: 1.8x, fully compute-bound). That is the machine-dependence the\"\n",
+    "        )\n",
+    "        print(\"post is about, showing up live on your hardware.\")"
    ]
   },
   {

--- a/notebooks/huggingface_dataloading_bottleneck.ipynb
+++ b/notebooks/huggingface_dataloading_bottleneck.ipynb
@@ -135,7 +135,12 @@
     }
    ],
    "source": [
-    "%pip install -q \"traceml-ai[hf]\"\n",
+    "import os\n",
+    "\n",
+    "if os.environ.get(\"TRACEML_NOTEBOOK_SKIP_INSTALL\") == \"1\":\n",
+    "    print(\"Notebook smoke runner provided TraceML dependencies.\")\n",
+    "else:\n",
+    "    %pip install -q \"traceml-ai[hf]\"\n",
     "# Outside Colab or in a fresh CPU environment: %pip install -q \"traceml-ai[torch,hf]\""
    ]
   },

--- a/notebooks/huggingface_dataloading_bottleneck.ipynb
+++ b/notebooks/huggingface_dataloading_bottleneck.ipynb
@@ -31,17 +31,43 @@
   {
    "cell_type": "markdown",
    "id": "2",
-   "metadata": {
-    "id": "2"
-   },
+   "metadata": {},
    "source": [
-    "## 1. Check that a GPU is available"
+    "## Choose a run mode\n",
+    "\n",
+    "`extended` is the default GPU/Imagenette demonstration. `smoke` is a small CPU-only verification mode for contributors and CI: it uses synthetic data, downloads nothing, and checks that TraceML produces a complete input-bound diagnosis.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Change the default to \"smoke\" to run the small CPU-only path manually.\n",
+    "RUN_MODE = os.environ.get(\"TRACEML_NOTEBOOK_MODE\", \"extended\")\n",
+    "if RUN_MODE not in {\"extended\", \"smoke\"}:\n",
+    "    raise ValueError(\"TRACEML_NOTEBOOK_MODE must be 'extended' or 'smoke'\")\n",
+    "print(f\"TraceML notebook mode: {RUN_MODE}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {
+    "id": "2"
+   },
+   "source": [
+    "## 1. Check that a GPU is available (extended mode only)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -60,19 +86,21 @@
     }
    ],
    "source": [
-    "!nvidia-smi -L\n",
-    "\n",
     "import torch\n",
     "\n",
-    "print(\"CUDA available:\", torch.cuda.is_available())\n",
-    "assert (\n",
-    "    torch.cuda.is_available()\n",
-    "), \"No GPU found. In Colab: Runtime → Change runtime type → GPU, then rerun.\""
+    "if RUN_MODE == \"extended\":\n",
+    "    !nvidia-smi -L\n",
+    "    print(\"CUDA available:\", torch.cuda.is_available())\n",
+    "    assert (\n",
+    "        torch.cuda.is_available()\n",
+    "    ), \"No GPU found. In Colab: Runtime → Change runtime type → GPU, then rerun.\"\n",
+    "else:\n",
+    "    print(\"Smoke mode uses CPU; no GPU is required.\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "6",
    "metadata": {
     "id": "4"
    },
@@ -81,13 +109,13 @@
     "\n",
     "TraceML adds `TraceMLTrainerCallback` to the standard Hugging Face `Trainer`. The notebook uses ordinary `TrainingArguments` and `Trainer`; there is no custom training loop to learn.\n",
     "\n",
-    "TraceML is installed with `--no-deps` so it does not replace Colab's NumPy version. Hugging Face packages are installed separately."
+    "Colab supplies a CUDA-matched PyTorch and torchvision build, so this cell installs TraceML and the Hugging Face integration dependencies without replacing them. Outside Colab, install the Torch extra shown in the comment below."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "7",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -107,26 +135,26 @@
     }
    ],
    "source": [
-    "!pip install -q \"traceml-ai[hf]\" --no-deps\n",
-    "!pip install -q transformers datasets accelerate"
+    "%pip install -q \"traceml-ai[hf]\"\n",
+    "# Outside Colab or in a fresh CPU environment: %pip install -q \"traceml-ai[torch,hf]\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "8",
    "metadata": {
     "id": "6"
    },
    "source": [
-    "## 3. Download a compact dataset where image decoding still matters\n",
+    "## 3. Download a compact dataset where image decoding still matters (extended mode only)\n",
     "\n",
-    "The official 320px Imagenette variant contains real JPEGs but is much smaller than the full-resolution archive. `num_workers=0` still makes data loading a realistic source of GPU idle time."
+    "The extended GPU demonstration uses the official 320px Imagenette variant. Smoke mode skips this download and creates its data and model in memory.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "9",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -147,20 +175,23 @@
    "source": [
     "import os\n",
     "\n",
-    "if not os.path.isdir(\"imagenette2-320/train\"):\n",
-    "    !wget -q https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz\n",
-    "    !tar -xzf imagenette2-320.tgz\n",
+    "if RUN_MODE == \"extended\":\n",
+    "    if not os.path.isdir(\"imagenette2-320/train\"):\n",
+    "        !wget -q https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz\n",
+    "        !tar -xzf imagenette2-320.tgz\n",
     "\n",
-    "print(\"CPU cores available:\", os.cpu_count())\n",
-    "print(\n",
-    "    \"Training images:\",\n",
-    "    sum(len(files) for _, _, files in os.walk(\"imagenette2-320/train\")),\n",
-    ")"
+    "    print(\"CPU cores available:\", os.cpu_count())\n",
+    "    print(\n",
+    "        \"Training images:\",\n",
+    "        sum(len(files) for _, _, files in os.walk(\"imagenette2-320/train\")),\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"Smoke mode uses a small in-memory synthetic dataset and model.\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "10",
    "metadata": {
     "id": "8"
    },
@@ -178,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -199,12 +230,21 @@
     "%%writefile hf_train.py\n",
     "import argparse\n",
     "import os\n",
+    "import time\n",
     "\n",
     "import torch\n",
     "from torch.utils.data import Dataset\n",
     "from torchvision.datasets import ImageFolder\n",
     "from torchvision.transforms import Compose, Normalize, RandomHorizontalFlip, RandomResizedCrop, ToTensor\n",
-    "from transformers import AutoImageProcessor, AutoModelForImageClassification, DefaultDataCollator, Trainer, TrainingArguments\n",
+    "from transformers import (\n",
+    "    AutoImageProcessor,\n",
+    "    AutoModelForImageClassification,\n",
+    "    DefaultDataCollator,\n",
+    "    ResNetConfig,\n",
+    "    ResNetForImageClassification,\n",
+    "    Trainer,\n",
+    "    TrainingArguments,\n",
+    ")\n",
     "\n",
     "from traceml_ai.integrations import huggingface as traceml_hf\n",
     "\n",
@@ -212,7 +252,7 @@
     "\n",
     "\n",
     "class ImagenetteForTrainer(Dataset):\n",
-    "    \"\"\"Return the field names expected by AutoModelForImageClassification.\"\"\"\n",
+    "    # Return the field names expected by AutoModelForImageClassification.\n",
     "\n",
     "    def __init__(self, root, transform):\n",
     "        self.images = ImageFolder(root, transform=transform)\n",
@@ -226,40 +266,74 @@
     "        return {\"pixel_values\": pixel_values, \"labels\": label}\n",
     "\n",
     "\n",
+    "class SlowSyntheticImages(Dataset):\n",
+    "    # Small CPU-only dataset with deliberate fetch latency for smoke mode.\n",
+    "\n",
+    "    def __init__(self, samples=32, delay_s=0.05):\n",
+    "        self.pixel_values = torch.zeros(samples, 3, 32, 32)\n",
+    "        self.labels = torch.arange(samples) % 2\n",
+    "        self.delay_s = delay_s\n",
+    "\n",
+    "    def __len__(self):\n",
+    "        return len(self.labels)\n",
+    "\n",
+    "    def __getitem__(self, index):\n",
+    "        time.sleep(self.delay_s)\n",
+    "        return {\n",
+    "            \"pixel_values\": self.pixel_values[index],\n",
+    "            \"labels\": self.labels[index],\n",
+    "        }\n",
+    "\n",
+    "\n",
     "def main():\n",
     "    parser = argparse.ArgumentParser()\n",
     "    parser.add_argument(\"--profile\", choices=[\"baseline\", \"optimized\"], required=True)\n",
     "    parser.add_argument(\"--data-dir\", default=\"imagenette2-320\")\n",
     "    parser.add_argument(\"--batch-size\", type=int, default=32)\n",
     "    parser.add_argument(\"--max-steps\", type=int, default=200)\n",
+    "    parser.add_argument(\"--smoke\", action=\"store_true\",\n",
+    "                        help=\"Run the small CPU-only synthetic verification path.\")\n",
     "    args = parser.parse_args()\n",
     "\n",
     "    torch.manual_seed(42)\n",
     "    optimized = args.profile == \"optimized\"\n",
-    "    # The only experimental change: DataLoader settings exposed by TrainingArguments.\n",
-    "    num_workers = min(4, os.cpu_count() or 2) if optimized else 0\n",
+    "    # The only experimental change in the extended demo: DataLoader settings.\n",
+    "    num_workers = 0 if args.smoke else (min(4, os.cpu_count() or 2) if optimized else 0)\n",
     "\n",
-    "    image_processor = AutoImageProcessor.from_pretrained(MODEL_NAME)\n",
-    "    crop_size = image_processor.size.get(\"height\", image_processor.size.get(\"shortest_edge\", 224))\n",
-    "    transform = Compose([\n",
-    "        RandomResizedCrop(crop_size),\n",
-    "        RandomHorizontalFlip(),\n",
-    "        ToTensor(),\n",
-    "        Normalize(mean=image_processor.image_mean, std=image_processor.image_std),\n",
-    "    ])\n",
-    "    train_dataset = ImagenetteForTrainer(\n",
-    "        os.path.join(args.data_dir, \"train\"), transform=transform\n",
-    "    )\n",
-    "\n",
-    "    id2label = {index: name for index, name in enumerate(train_dataset.classes)}\n",
-    "    label2id = {name: index for index, name in id2label.items()}\n",
-    "    model = AutoModelForImageClassification.from_pretrained(\n",
-    "        MODEL_NAME,\n",
-    "        num_labels=len(train_dataset.classes),\n",
-    "        id2label=id2label,\n",
-    "        label2id=label2id,\n",
-    "        ignore_mismatched_sizes=True,\n",
-    "    )\n",
+    "    if args.smoke:\n",
+    "        # The short, intentional fetch delay makes the CPU smoke diagnosis\n",
+    "        # stable while exercising the standard Trainer callback integration.\n",
+    "        train_dataset = SlowSyntheticImages()\n",
+    "        model = ResNetForImageClassification(ResNetConfig(\n",
+    "            num_labels=2,\n",
+    "            id2label={0: \"zero\", 1: \"one\"},\n",
+    "            label2id={\"zero\": 0, \"one\": 1},\n",
+    "            embedding_size=8,\n",
+    "            hidden_sizes=[8, 16, 32, 64],\n",
+    "            depths=[1, 1, 1, 1],\n",
+    "            layer_type=\"basic\",\n",
+    "        ))\n",
+    "    else:\n",
+    "        image_processor = AutoImageProcessor.from_pretrained(MODEL_NAME)\n",
+    "        crop_size = image_processor.size.get(\"height\", image_processor.size.get(\"shortest_edge\", 224))\n",
+    "        transform = Compose([\n",
+    "            RandomResizedCrop(crop_size),\n",
+    "            RandomHorizontalFlip(),\n",
+    "            ToTensor(),\n",
+    "            Normalize(mean=image_processor.image_mean, std=image_processor.image_std),\n",
+    "        ])\n",
+    "        train_dataset = ImagenetteForTrainer(\n",
+    "            os.path.join(args.data_dir, \"train\"), transform=transform\n",
+    "        )\n",
+    "        id2label = {index: name for index, name in enumerate(train_dataset.classes)}\n",
+    "        label2id = {name: index for index, name in id2label.items()}\n",
+    "        model = AutoModelForImageClassification.from_pretrained(\n",
+    "            MODEL_NAME,\n",
+    "            num_labels=len(train_dataset.classes),\n",
+    "            id2label=id2label,\n",
+    "            label2id=label2id,\n",
+    "            ignore_mismatched_sizes=True,\n",
+    "        )\n",
     "\n",
     "    training_args = TrainingArguments(\n",
     "        output_dir=f\"outputs/{args.profile}\",\n",
@@ -271,13 +345,15 @@
     "        disable_tqdm=True,\n",
     "        remove_unused_columns=False,\n",
     "        dataloader_num_workers=num_workers,\n",
-    "        dataloader_pin_memory=optimized,\n",
+    "        dataloader_pin_memory=optimized and not args.smoke,\n",
     "        dataloader_persistent_workers=optimized and num_workers > 0,\n",
+    "        use_cpu=args.smoke,\n",
     "    )\n",
     "\n",
     "    print(\n",
-    "        f\"[demo] profile={args.profile} workers={num_workers} \"\n",
-    "        f\"pin_memory={optimized} persistent_workers={optimized and num_workers > 0} \"\n",
+    "        f\"[demo] profile={args.profile} smoke={args.smoke} workers={num_workers} \"\n",
+    "        f\"pin_memory={optimized and not args.smoke} \"\n",
+    "        f\"persistent_workers={optimized and num_workers > 0} \"\n",
     "        f\"batch_size={args.batch_size} max_steps={args.max_steps}\",\n",
     "        flush=True,\n",
     "    )\n",
@@ -294,25 +370,25 @@
     "\n",
     "\n",
     "if __name__ == \"__main__\":\n",
-    "    main()"
+    "    main()\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "12",
    "metadata": {
     "id": "10"
    },
    "source": [
-    "## 5. Run the baseline: one process loads every image\n",
+    "## 5. Run the baseline\n",
     "\n",
-    "With `dataloader_num_workers=0`, the main training process decodes and augments each batch itself. TraceML should report `INPUT-BOUND` when that work leaves the GPU waiting. The run uses 200 steps—enough for a stable diagnosis without turning this into a long training job."
+    "Extended mode runs the original GPU/Imagenette baseline. Smoke mode runs eight CPU-only synthetic steps with deliberate input delay, using the standard `Trainer` and `TraceMLTrainerCallback`; it should produce a complete `INPUT-BOUND` diagnosis.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -394,25 +470,28 @@
     }
    ],
    "source": [
-    "!traceml run --mode summary --logs-dir logs --run-name hf_baseline hf_train.py --args --profile baseline --data-dir imagenette2-320 --max-steps 200 --batch-size 32"
+    "if RUN_MODE == \"smoke\":\n",
+    "    !traceml run --mode summary --logs-dir logs --run-name hf_smoke hf_train.py --args --profile baseline --smoke --max-steps 8 --batch-size 4\n",
+    "else:\n",
+    "    !traceml run --mode summary --logs-dir logs --run-name hf_baseline hf_train.py --args --profile baseline --data-dir imagenette2-320 --max-steps 200 --batch-size 32"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "14",
    "metadata": {
     "id": "12"
    },
    "source": [
-    "## 6. Run the optimized loader\n",
+    "## 6. Run the optimized loader (extended mode only)\n",
     "\n",
-    "Same images, model, batch size, and steps. This profile lets up to four CPU workers decode ahead, pins batches for faster transfer, and keeps workers alive after the loader is created. If your CPU can hide the decode work, the verdict can flip to `COMPUTE-BOUND`."
+    "Same images, model, batch size, and steps. This profile lets up to four CPU workers decode ahead, pins batches for faster transfer, and keeps workers alive after the loader is created. If your CPU can hide the decode work, the verdict can flip to `COMPUTE-BOUND`.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "15",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -488,12 +567,17 @@
     }
    ],
    "source": [
-    "!traceml run --mode summary --logs-dir logs --run-name hf_optimized hf_train.py --args --profile optimized --data-dir imagenette2-320 --max-steps 200 --batch-size 32"
+    "if RUN_MODE == \"extended\":\n",
+    "    !traceml run --mode summary --logs-dir logs --run-name hf_optimized hf_train.py --args --profile optimized --data-dir imagenette2-320 --max-steps 200 --batch-size 32\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Smoke mode runs one intentional input-bound case, not a comparison.\"\n",
+    "    )"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "16",
    "metadata": {
     "id": "14"
    },
@@ -506,7 +590,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "17",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -566,12 +650,28 @@
     }
    ],
    "source": [
-    "!traceml compare logs/hf_baseline/final_summary.json logs/hf_optimized/final_summary.json --output=logs/hf_baseline_vs_optimized"
+    "if RUN_MODE == \"smoke\":\n",
+    "    import json\n",
+    "    from pathlib import Path\n",
+    "\n",
+    "    summary_dir = Path(\"logs/hf_smoke\")\n",
+    "    summary_json = summary_dir / \"final_summary.json\"\n",
+    "    summary_text = summary_dir / \"final_summary.txt\"\n",
+    "    assert summary_json.is_file(), f\"Missing {summary_json}\"\n",
+    "    assert summary_text.is_file(), f\"Missing {summary_text}\"\n",
+    "    summary = json.loads(summary_json.read_text())\n",
+    "    diagnosis = summary[\"primary_diagnosis\"][\"status\"]\n",
+    "    assert (\n",
+    "        diagnosis == \"INPUT-BOUND\"\n",
+    "    ), f\"Expected the intentional input-bound smoke diagnosis, got {diagnosis!r}\"\n",
+    "    print(f\"Smoke check passed: {diagnosis}; artifacts are in {summary_dir}\")\n",
+    "else:\n",
+    "    !traceml compare logs/hf_baseline/final_summary.json logs/hf_optimized/final_summary.json --output=logs/hf_baseline_vs_optimized"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "18",
    "metadata": {
     "id": "16"
    },
@@ -586,7 +686,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "19",
    "metadata": {
     "id": "17"
    },


### PR DESCRIPTION
## Summary

Make the two public Colab notebooks reliable onboarding paths while preserving their existing GPU/Imagenette demonstrations. The Hugging Face path teaches the supported callback integration, and both notebooks now have a small,
deterministic CPU smoke mode for automated verification.

## What changed

- Updated the FAQ to recommend `TraceMLTrainerCallback`; the legacy  `TraceMLTrainer` remains documented only in the integration guide.
- Replaced `--no-deps` notebook installs with normal dependency-resolving  installs while preserving Colab's CUDA-matched PyTorch installation. Each  notebook also shows the complete fresh CPU-environment install command.
- Added an explicit `extended`/`smoke` run mode to both notebooks. `extended`  remains the default GPU/Imagenette demo.
- Added a CPU-only smoke path with a small in-memory dataset, deliberate input  delay, eight training steps, and assertions for `final_summary.json`,  `final_summary.txt`, and an `INPUT-BOUND` diagnosis.
- Kept Hugging Face smoke coverage on standard `Trainer` plus   `TraceMLTrainerCallback`; it does not introduce or promote the legacy  subclass.
- Added a CPU-only GitHub Actions notebook-smoke workflow. It runs weekly,   manually, and when notebooks, TraceML source, packaging, or the workflow   change. It executes isolated copies of both notebooks from top to bottom.

## Scope

The full GPU/Imagenette comparisons remain available for Colab users and are not CI prerequisites. This PR does not change Hugging Face H2D timing semantics; #276 continues to own that coverage limitation. It also does not deprecate or remove `TraceMLTrainer`.

## Validation

- Ran both smoke notebooks top-to-bottom through Jupyter in isolated temporary  directories.
- Confirmed both runs create `final_summary.json` and `final_summary.txt` and   report `INPUT-BOUND`.
- Confirmed both notebook files pass `nbformat` validation.
- `git diff --check version_0.3.7...HEAD` passes.
