### PR TITLE
Redesign terminal run/watch summary cards (#342)

### DIFF
--- a/src/traceml_ai/aggregator/summary_service.py
+++ b/src/traceml_ai/aggregator/summary_service.py
@@ -38,6 +38,7 @@ class FinalSummaryService:
         settle_telemetry: Optional[Callable[[float], bool]] = None,
         summary_window_rows: int = DEFAULT_SUMMARY_WINDOW_ROWS,
         write_html: bool = False,
+        profile: str = "run",
     ) -> None:
         self._logger = logger
         self._session_root = Path(session_root).resolve()
@@ -46,6 +47,7 @@ class FinalSummaryService:
         self._settle_telemetry = settle_telemetry
         self._summary_window_rows = int(summary_window_rows)
         self._write_html = bool(write_html)
+        self._profile = str(profile)
         self._last_request_id: Optional[str] = None
 
     def poll(self) -> None:
@@ -87,6 +89,7 @@ class FinalSummaryService:
                 print_to_stdout=False,
                 summary_window_rows=self._summary_window_rows,
                 write_html=self._write_html,
+                profile=self._profile,
             )
 
             self._write_ok_response(response_path, request_id=request_id)

--- a/src/traceml_ai/aggregator/trace_aggregator.py
+++ b/src/traceml_ai/aggregator/trace_aggregator.py
@@ -141,6 +141,7 @@ class TraceMLAggregator:
             settle_telemetry=self._settle_telemetry,
             summary_window_rows=int(settings.summary_window_rows),
             write_html=bool(settings.html_report),
+            profile=str(settings.profile),
         )
 
         # Display driver owns renderer selection and layout mapping.
@@ -267,6 +268,7 @@ class TraceMLAggregator:
                             self._settings.summary_window_rows
                         ),
                         write_html=bool(self._settings.html_report),
+                        profile=str(self._settings.profile),
                     )
                 except Exception as summary_exc:
                     # A summary-generation error is only fatal if it left no

--- a/src/traceml_ai/reporting/SCHEMA.md
+++ b/src/traceml_ai/reporting/SCHEMA.md
@@ -53,11 +53,13 @@ Sections:
 section diagnoses. It answers "why was training slow?" and is intentionally
 narrower than section-level health/resource diagnoses.
 
-`text` is a compact human-readable verdict report. It is presentation text for
+`text` is a compact human-readable verdict card. It is presentation text for
 the CLI/TXT artifact, not a structured contract for downstream parsers. It
-starts with `TraceML Verdict`, `Why`, and `Next`, then shows compact section
-status plus System and Step Time evidence tables. Detailed section prose
-remains in each section-local `card` field.
+leads with `Verdict` and `Why`, then a hierarchical step-timing tree, `Next`,
+and bounded corroboration. It is profile-aware: `traceml watch` renders a
+host-and-process health card and never shows step timing, because watch does
+not collect it. Detailed section prose remains in each section-local `card`
+field.
 
 ## Primary Diagnosis Shape
 

--- a/src/traceml_ai/reporting/final.py
+++ b/src/traceml_ai/reporting/final.py
@@ -27,11 +27,12 @@ from traceml_ai.reporting.sections.process import ProcessSummarySection
 from traceml_ai.reporting.sections.step_memory import StepMemorySummarySection
 from traceml_ai.reporting.sections.step_time import StepTimeSummarySection
 from traceml_ai.reporting.sections.system import SystemSummarySection
-from traceml_ai.reporting.summaries.summary_formatting import bytes_to_gb
-from traceml_ai.reporting.summaries.summary_layout import (
-    border,
-    row,
-    wrap_lines,
+from traceml_ai.reporting.summary_card import (
+    build_card_from_payload,
+    build_fallback_card,
+    card_hints,
+    card_to_plain,
+    colorize_stored_card,
 )
 from traceml_ai.sdk.protocol import (
     get_final_summary_html_path,
@@ -46,32 +47,7 @@ from traceml_ai.utils.atomic_io import write_json_atomic, write_text_atomic
 # A timing signal that was never measured remains null; a measured zero is 0.0.
 SCHEMA_VERSION = 1.7
 
-SUMMARY_WIDTH = 78
-SUMMARY_INNER_TEXT_WIDTH = SUMMARY_WIDTH - 4
-
-_SYSTEM_EVIDENCE_METRICS = (
-    ("CPU Util", "cpu_percent"),
-    ("GPU Util", "gpu_util_percent"),
-    ("GPU Memory", "gpu_mem_bytes"),
-    ("GPU Temp", "gpu_temp_c"),
-)
-_STEP_TIME_EVIDENCE_METRICS = (
-    ("Step Time", "step_time_ms"),
-    ("Traced Step Time", "traced_step_time_ms"),
-    ("Input Wait", "input_wait_ms"),
-    ("Compute", "compute_ms"),
-    ("Residual", "residual_ms"),
-    ("H2D", "h2d_ms"),
-    ("DataLoader Fetch (CPU)", "dataloader_fetch_cpu_ms"),
-)
-_STEP_TIME_SUPPLEMENTAL_METRICS = frozenset(("dataloader_fetch_cpu_ms",))
-_SEVERITY_LABELS = {
-    "crit": "CRITICAL",
-    "critical": "CRITICAL",
-    "warn": "WARNING",
-    "warning": "WARNING",
-    "info": "INFO",
-}
+DEFAULT_PROFILE = "run"
 
 
 def _log_final_report_error(message: str, exc: Exception) -> None:
@@ -294,460 +270,57 @@ def _build_final_meta(
     }
 
 
-def _diagnosis(section: Dict[str, Any]) -> Dict[str, Any]:
-    """Return a section diagnosis mapping, if present."""
-    diagnosis = section.get("diagnosis") if isinstance(section, dict) else None
-    return dict(diagnosis) if isinstance(diagnosis, dict) else {}
-
-
-def _global_block(section: Dict[str, Any], block: str) -> Dict[str, Any]:
-    """Return one global rollup block from a section payload."""
-    global_summary = (
-        section.get("global") if isinstance(section, dict) else None
-    )
-    if not isinstance(global_summary, dict):
-        return {}
-    value = global_summary.get(block)
-    return dict(value) if isinstance(value, dict) else {}
-
-
-def _point_value(point: Any) -> Optional[float]:
-    """Return a numeric `{value, idx}` point value, if available."""
-    if not isinstance(point, dict):
-        return None
-    value = point.get("value")
-    if value is None or isinstance(value, bool):
-        return None
-    try:
-        return float(value)
-    except Exception:
-        return None
-
-
-def _point_idx(point: Any) -> Optional[Any]:
-    """Return a `{value, idx}` point index, if available."""
-    if not isinstance(point, dict):
-        return None
-    return point.get("idx")
-
-
-def _average_value(section: Dict[str, Any], metric: str) -> Optional[float]:
-    """Return one average metric value from a section payload."""
-    value = _global_block(section, "average").get(metric)
-    if value is None or isinstance(value, bool):
-        return None
-    try:
-        return float(value)
-    except Exception:
-        return None
-
-
-def _point(section: Dict[str, Any], block: str, metric: str) -> Dict[str, Any]:
-    """Return one median/worst point from a section payload."""
-    point = _global_block(section, block).get(metric)
-    return dict(point) if isinstance(point, dict) else {}
-
-
-def _status_label(value: Any, default: str = "NO DATA") -> str:
-    """Return an uppercase status label for compact terminal output."""
-    text = str(value or default).replace("_", " ").strip()
-    return " ".join(text.upper().split()) or default
-
-
-def _severity_label(value: Any) -> str:
-    """Return a normalized severity label for compact terminal output."""
-    text = str(value or "info").strip().lower()
-    return _SEVERITY_LABELS.get(text, text.upper() if text else "INFO")
-
-
-def _format_value(metric: str, value: Optional[float]) -> str:
-    """Format final-summary evidence values using compact CLI units."""
-    if value is None:
-        return "n/a"
-    if metric.endswith("_ms"):
-        return f"{value:.1f}ms"
-    if metric.endswith("_bytes"):
-        gb = bytes_to_gb(value)
-        return "n/a" if gb is None else f"{gb:.2f}GB"
-    if metric.endswith("_percent"):
-        return f"{value:.1f}%"
-    if metric.endswith("_c"):
-        return f"{value:.0f}C"
-    return f"{value:.1f}"
-
-
-def _format_share(value: Optional[float], total: Optional[float]) -> str:
-    """Format a share as a percent of a selected denominator."""
-    if value is None or total is None or total <= 0.0:
-        return "n/a"
-    return f"{100.0 * value / total:.1f}%"
-
-
-def _format_skew(
-    metric: str,
-    median: Optional[float],
-    worst: Optional[float],
+def _build_final_summary_text(
+    payload: Dict[str, Any],
+    *,
+    profile: str = DEFAULT_PROFILE,
+    session_root: Optional[str] = None,
+    write_html: bool = False,
 ) -> str:
     """
-    Format worst-vs-median skew for compact evidence tables.
+    Build the printed end-of-run card from an already-built payload.
 
-    Percentage-valued utilization rows use percentage-point skew. Temperature
-    uses an absolute Celsius skew. Other metrics use relative percent skew
-    when the median is positive. The value is intentionally unsigned because
-    the ``worst`` point already encodes the bad direction for that metric.
+    Reporting runs during aggregator shutdown, so a rendering failure must
+    degrade to a minimal verdict card instead of raising.
     """
-    if median is None or worst is None:
-        return "n/a"
-    delta = abs(worst - median)
-    if metric.endswith("_percent"):
-        return f"{delta:.1f}pp"
-    if metric.endswith("_c"):
-        return f"{delta:.0f}C"
-    if median <= 0.0:
-        return "n/a"
-    return f"{100.0 * delta / median:.1f}%"
+    try:
+        return card_to_plain(
+            build_card_from_payload(
+                payload,
+                profile=profile,
+                session_root=session_root,
+                write_html=write_html,
+            )
+        )
+    except Exception as exc:
+        _log_final_report_error("Final summary card failed", exc)
+
+    try:
+        return card_to_plain(
+            build_fallback_card(
+                profile=profile,
+                primary_diagnosis=payload.get("primary_diagnosis") or {},
+                **card_hints(session_root, write_html=write_html),
+            )
+        )
+    except Exception as exc:
+        _log_final_report_error("Final summary fallback card failed", exc)
+        return ""
 
 
-def _clip(text: str, width: int) -> str:
-    """Clip text to a fixed table cell width without breaking layout."""
-    clean = str(text)
-    if len(clean) <= width:
-        return clean
-    if width <= 1:
-        return clean[:width]
-    return clean[: width - 1] + "."
-
-
-def _table_line(values: Sequence[Any], widths: Sequence[int]) -> str:
-    """Return one fixed-width table line for the compact text summary."""
-    cells = [
-        f"{_clip(str(value), width):<{width}}"
-        for value, width in zip(values, widths)
-    ]
-    return "  ".join(cells).rstrip()
-
-
-def _table_rule(widths: Sequence[int]) -> str:
-    """Return a separator matching a fixed-width table."""
-    return "-" * (sum(widths) + 2 * (len(widths) - 1))
-
-
-def _append_wrapped_text(lines: List[str], text: str) -> None:
-    """Append one potentially long logical line inside the summary border."""
-    for wrapped in wrap_lines(text, SUMMARY_INNER_TEXT_WIDTH):
-        lines.append(row(wrapped, width=SUMMARY_WIDTH))
-
-
-def _append_verdict_lines(
-    lines: List[str],
-    primary_diagnosis: Dict[str, Any],
-) -> None:
-    """Append the compact run-level verdict, why, and next-action lines."""
-    status = _status_label(primary_diagnosis.get("status"))
-    severity = _severity_label(primary_diagnosis.get("severity"))
-    summary = str(primary_diagnosis.get("summary") or "")
-    action = str(primary_diagnosis.get("action") or "")
-    _append_wrapped_text(lines, f"TraceML Verdict: {status} / {severity}")
-    if summary:
-        _append_wrapped_text(lines, f"Why: {summary}")
-    if action:
-        _append_wrapped_text(lines, f"Next: {action}")
-
-
-def _append_section_status(
-    lines: List[str],
+def _stdout_card_text(
+    payload: Dict[str, Any],
     *,
-    system_summary: Dict[str, Any],
-    process_summary: Dict[str, Any],
-    step_time_summary: Dict[str, Any],
-    step_memory_summary: Dict[str, Any],
-) -> None:
-    """Append a compact status table for all section-local diagnoses."""
-    rows = (
-        ("Step Time", _diagnosis(step_time_summary)),
-        ("System", _diagnosis(system_summary)),
-        ("Process", _diagnosis(process_summary)),
-        ("Step Memory", _diagnosis(step_memory_summary)),
-    )
-    widths = (12, 22, 10)
-    lines.append(row("Section Status", width=SUMMARY_WIDTH))
-    lines.append(
-        row(
-            _table_line(("Section", "Status", "Severity"), widths),
-            width=SUMMARY_WIDTH,
-        )
-    )
-    lines.append(row(_table_rule(widths), width=SUMMARY_WIDTH))
-    for label, diagnosis in rows:
-        lines.append(
-            row(
-                _table_line(
-                    (
-                        label,
-                        _status_label(diagnosis.get("status")),
-                        _severity_label(diagnosis.get("severity")),
-                    ),
-                    widths,
-                ),
-                width=SUMMARY_WIDTH,
-            )
-        )
-
-
-def _is_multi_process(step_time_summary: Dict[str, Any]) -> bool:
-    """Return whether Step Time observed more than one global rank/process."""
-    value = _section_metadata(step_time_summary).get("global_ranks_used")
-    parsed = _safe_int(value, allow_zero=True)
-    return bool(parsed is not None and parsed > 1)
-
-
-def _row_identity(section: Dict[str, Any], idx: Any) -> Dict[str, Any]:
-    """Return a grouped-row identity for a median/worst point index."""
-    if idx is None:
-        return {}
-    rows = _section_group_rows(section)
-    row_data = rows.get(str(idx), {})
-    identity = row_data.get("identity") if isinstance(row_data, dict) else None
-    return dict(identity) if isinstance(identity, dict) else {}
-
-
-def _system_scope(system_summary: Dict[str, Any], idx: Any) -> str:
-    """Return node-level scope text for System evidence rows."""
-    identity = _row_identity(system_summary, idx)
-    node_rank = _safe_int(identity.get("node_rank"), allow_zero=True)
-    if node_rank is not None:
-        return f"node=n{node_rank}"
-    parsed = _safe_int(idx, allow_zero=True)
-    if parsed is not None:
-        return f"node=n{parsed}"
-    return "n/a" if idx is None else f"node={idx}"
-
-
-def _step_scope(step_time_summary: Dict[str, Any], idx: Any) -> str:
-    """Return rank/node scope text for Step Time evidence rows."""
-    identity = _row_identity(step_time_summary, idx)
-    rank = _safe_int(identity.get("global_rank"), allow_zero=True)
-    if rank is None:
-        rank = _safe_int(idx, allow_zero=True)
-    parts = []
-    if rank is not None:
-        parts.append(f"rank=r{rank}")
-    node_rank = _safe_int(identity.get("node_rank"), allow_zero=True)
-    if node_rank is not None:
-        parts.append(f"node=n{node_rank}")
-    if parts:
-        return " ".join(parts)
-    return "n/a" if idx is None else f"rank={idx}"
-
-
-def _append_system_evidence_single(
-    lines: List[str],
-    system_summary: Dict[str, Any],
-) -> None:
-    """Append average-only System evidence for single-process runs."""
-    widths = (16, 16)
-    lines.append(row("System Evidence", width=SUMMARY_WIDTH))
-    lines.append(
-        row(_table_line(("Metric", "Average"), widths), width=SUMMARY_WIDTH)
-    )
-    lines.append(row(_table_rule(widths), width=SUMMARY_WIDTH))
-    for label, metric in _SYSTEM_EVIDENCE_METRICS:
-        value = _average_value(system_summary, metric)
-        lines.append(
-            row(
-                _table_line(
-                    (label, _format_value(metric, value)),
-                    widths,
-                ),
-                width=SUMMARY_WIDTH,
-            )
-        )
-
-
-def _append_system_evidence_multi(
-    lines: List[str],
-    system_summary: Dict[str, Any],
-) -> None:
-    """Append median/worst System evidence for multi-process runs."""
-    widths = (14, 12, 12, 10, 18)
-    lines.append(row("System Evidence", width=SUMMARY_WIDTH))
-    lines.append(
-        row(
-            _table_line(
-                ("Metric", "Median", "Worst", "Skew", "Scope"),
-                widths,
-            ),
-            width=SUMMARY_WIDTH,
-        )
-    )
-    lines.append(row(_table_rule(widths), width=SUMMARY_WIDTH))
-    for label, metric in _SYSTEM_EVIDENCE_METRICS:
-        median = _point_value(_point(system_summary, "median", metric))
-        worst_point = _point(system_summary, "worst", metric)
-        worst = _point_value(worst_point)
-        lines.append(
-            row(
-                _table_line(
-                    (
-                        label,
-                        _format_value(metric, median),
-                        _format_value(metric, worst),
-                        _format_skew(metric, median, worst),
-                        _system_scope(system_summary, _point_idx(worst_point)),
-                    ),
-                    widths,
-                ),
-                width=SUMMARY_WIDTH,
-            )
-        )
-
-
-def _append_step_time_evidence_single(
-    lines: List[str],
-    step_time_summary: Dict[str, Any],
-) -> None:
-    """Append canonical selected-clock average/share Step Time evidence."""
-    widths = (22, 16, 12)
-    step_time = _average_value(step_time_summary, "step_time_ms")
-    lines.append(row("Step Time Evidence", width=SUMMARY_WIDTH))
-    lines.append(
-        row(
-            _table_line(("Phase", "Average", "Share"), widths),
-            width=SUMMARY_WIDTH,
-        )
-    )
-    lines.append(row(_table_rule(widths), width=SUMMARY_WIDTH))
-    for label, metric in _STEP_TIME_EVIDENCE_METRICS:
-        value = _average_value(step_time_summary, metric)
-        if metric in _STEP_TIME_SUPPLEMENTAL_METRICS:
-            share = "supplemental"
-        else:
-            share = _format_share(value, step_time)
-        lines.append(
-            row(
-                _table_line(
-                    (label, _format_value(metric, value), share),
-                    widths,
-                ),
-                width=SUMMARY_WIDTH,
-            )
-        )
-
-
-def _append_step_time_evidence_multi(
-    lines: List[str],
-    step_time_summary: Dict[str, Any],
-) -> None:
-    """Append median/worst Step Time evidence for multi-process runs."""
-    widths = (14, 12, 12, 10, 18)
-    lines.append(row("Step Time Evidence", width=SUMMARY_WIDTH))
-    lines.append(
-        row(
-            _table_line(("Phase", "Median", "Worst", "Skew", "Scope"), widths),
-            width=SUMMARY_WIDTH,
-        )
-    )
-    lines.append(row(_table_rule(widths), width=SUMMARY_WIDTH))
-    for label, metric in _STEP_TIME_EVIDENCE_METRICS:
-        median = _point_value(_point(step_time_summary, "median", metric))
-        worst_point = _point(step_time_summary, "worst", metric)
-        worst = _point_value(worst_point)
-        lines.append(
-            row(
-                _table_line(
-                    (
-                        label,
-                        _format_value(metric, median),
-                        _format_value(metric, worst),
-                        _format_skew(metric, median, worst),
-                        _step_scope(
-                            step_time_summary,
-                            _point_idx(worst_point),
-                        ),
-                    ),
-                    widths,
-                ),
-                width=SUMMARY_WIDTH,
-            )
-        )
-
-
-def _build_final_summary_text_from_sections(
-    *,
-    primary_diagnosis: Dict[str, Any],
-    system_summary: Dict[str, Any],
-    process_summary: Dict[str, Any],
-    step_time_summary: Dict[str, Any],
-    step_memory_summary: Dict[str, Any],
+    session_root: Optional[str],
+    write_html: bool,
 ) -> str:
-    """
-    Build the compact printed end-of-run summary from per-domain sections.
-
-    Section-local ``card`` strings stay in the JSON payload for detailed
-    inspection. The top-level text is intentionally verdict-first and lossy:
-    it shows the primary finding plus the minimum evidence needed to orient
-    the next debugging step.
-    """
-    duration_s = _summary_duration_s(
-        step_time_summary,
-        process_summary,
-        system_summary,
+    """Return the stdout rendering: ANSI on a terminal, plain otherwise."""
+    return colorize_stored_card(
+        str(payload.get("text", "")),
+        payload,
+        session_root=session_root,
+        write_html=write_html,
     )
-
-    lines: List[str] = [
-        border(width=SUMMARY_WIDTH),
-        row(
-            "TraceML Run Summary"
-            + (
-                f" | duration {duration_s:.1f}s"
-                if duration_s is not None
-                else ""
-            ),
-            width=SUMMARY_WIDTH,
-        ),
-        border(width=SUMMARY_WIDTH),
-        row(width=SUMMARY_WIDTH),
-    ]
-
-    _append_verdict_lines(lines, primary_diagnosis)
-
-    lines.extend(
-        [
-            row(width=SUMMARY_WIDTH),
-        ]
-    )
-    _append_section_status(
-        lines,
-        system_summary=system_summary,
-        process_summary=process_summary,
-        step_time_summary=step_time_summary,
-        step_memory_summary=step_memory_summary,
-    )
-
-    multi_process = _is_multi_process(step_time_summary)
-
-    lines.extend(
-        [
-            row(width=SUMMARY_WIDTH),
-        ]
-    )
-    if multi_process:
-        _append_system_evidence_multi(lines, system_summary)
-    else:
-        _append_system_evidence_single(lines, system_summary)
-
-    lines.extend(
-        [
-            row(width=SUMMARY_WIDTH),
-        ]
-    )
-    if multi_process:
-        _append_step_time_evidence_multi(lines, step_time_summary)
-    else:
-        _append_step_time_evidence_single(lines, step_time_summary)
-
-    lines.append(border(width=SUMMARY_WIDTH))
-    return "\n".join(lines)
 
 
 def _fallback_section_result(section: SummarySection) -> SummaryResult:
@@ -778,6 +351,8 @@ class FinalReportGenerator:
         db_path: str,
         *,
         session_root: Optional[str] = None,
+        profile: str = DEFAULT_PROFILE,
+        write_html: bool = False,
     ) -> Dict[str, Any]:
         """
         Generate the structured final summary payload.
@@ -785,6 +360,9 @@ class FinalReportGenerator:
         Section failures are isolated and logged. A failed section contributes
         a schema-valid ``NO DATA`` payload so one broken report domain does
         not prevent artifact generation during aggregator shutdown.
+
+        ``profile`` and ``write_html`` are presentation inputs for the printed
+        card only; they do not change the JSON contract.
         """
         results: Dict[str, SummaryResult] = {}
         for section in self.sections:
@@ -819,15 +397,7 @@ class FinalReportGenerator:
             step_memory_summary=step_memory_summary,
         )
 
-        final_text = _build_final_summary_text_from_sections(
-            primary_diagnosis=primary_diagnosis,
-            system_summary=system_summary,
-            process_summary=process_summary,
-            step_time_summary=step_time_summary,
-            step_memory_summary=step_memory_summary,
-        )
-
-        return {
+        payload: Dict[str, Any] = {
             "schema_version": SCHEMA_VERSION,
             "generated_at": utc_now_iso(),
             "duration_s": _summary_duration_s(
@@ -847,8 +417,15 @@ class FinalReportGenerator:
             "process": process_summary,
             "step_time": step_time_summary,
             "step_memory": step_memory_summary,
-            "text": final_text,
+            "text": "",
         }
+        payload["text"] = _build_final_summary_text(
+            payload,
+            profile=profile,
+            session_root=session_root,
+            write_html=write_html,
+        )
+        return payload
 
 
 def build_final_report_generator(
@@ -876,6 +453,8 @@ def build_summary_payload(
     generator: Optional[FinalReportGenerator] = None,
     session_root: Optional[str] = None,
     summary_window_rows: int = DEFAULT_SUMMARY_WINDOW_ROWS,
+    profile: str = DEFAULT_PROFILE,
+    write_html: bool = False,
 ) -> Dict[str, Any]:
     """
     Build the structured final summary payload for one session database.
@@ -883,7 +462,12 @@ def build_summary_payload(
     active_generator = generator or build_final_report_generator(
         summary_window_rows=summary_window_rows,
     )
-    return active_generator.generate(db_path, session_root=session_root)
+    return active_generator.generate(
+        db_path,
+        session_root=session_root,
+        profile=profile,
+        write_html=write_html,
+    )
 
 
 def _write_html_artifact(payload: Dict[str, Any], session_root: Path) -> None:
@@ -953,14 +537,20 @@ def generate_summary(
     print_to_stdout: bool = True,
     summary_window_rows: int = DEFAULT_SUMMARY_WINDOW_ROWS,
     write_html: bool = False,
+    profile: str = DEFAULT_PROFILE,
 ) -> Dict[str, Any]:
     """
     Generate, write, and optionally print the final end-of-run summary.
+
+    ``payload["text"]`` and the ``.txt`` artifact always hold the plain
+    rendering. Severity-scoped ANSI is used only when printing to a terminal.
     """
     payload = build_summary_payload(
         db_path,
         session_root=session_root,
         summary_window_rows=summary_window_rows,
+        profile=profile,
+        write_html=write_html,
     )
     write_summary_artifacts(
         db_path=db_path,
@@ -970,7 +560,13 @@ def generate_summary(
     )
 
     if print_to_stdout:
-        print(payload["text"])
+        print(
+            _stdout_card_text(
+                payload,
+                session_root=session_root,
+                write_html=write_html,
+            )
+        )
 
     return payload
 

--- a/src/traceml_ai/reporting/summary_card.py
+++ b/src/traceml_ai/reporting/summary_card.py
@@ -54,6 +54,21 @@ FINAL_SUMMARY_HTML_NAME = "final_summary.html"
 RUN_TITLE = "TraceML Run Summary"
 WATCH_TITLE = "TraceML Watch Summary"
 
+# Terminal presentation contract
+# -----------------------------
+# - Chrome (borders, run metadata, section captions, and artifact hints) is
+#   dim neutral text.
+# - Titles and action text are bold in the terminal's default foreground.
+# - Measurements, explanations, and evidence rows use the terminal's default
+#   foreground; they are never colour-coded as a whole.
+# - The primary Verdict and Host health values are colour-coded by severity:
+#   normal is green, warning is amber, and critical is red. Secondary severity
+#   labels and culprit markers use the same colours, but their surrounding
+#   evidence stays neutral.
+#
+# Keep this contract when extending the card. The stored JSON/text artifacts
+# are deliberately plain; ANSI styling is an interactive-terminal enhancement
+# only and must not carry information that is absent from plain text.
 STYLE_PLAIN = "plain"
 STYLE_BORDER = "border"
 STYLE_DIM = "dim"
@@ -70,7 +85,7 @@ _ANSI_CODES = {
     STYLE_CRIT: "\x1b[1;31m",
     STYLE_WARN: "\x1b[1;33m",
     STYLE_OK: "\x1b[32m",
-    STYLE_NEXT: "\x1b[32m",
+    STYLE_NEXT: "\x1b[1m",
 }
 _ANSI_RESET = "\x1b[0m"
 
@@ -220,6 +235,25 @@ class CardDoc:
                 )
             else:
                 self.text(line, style)
+
+    def wrapped_with_severity(
+        self,
+        value: str,
+        *,
+        severity_label: str,
+        severity_style: str,
+    ) -> None:
+        """Append wrapped text with only its final severity word coloured."""
+        for line in wrap_lines(value, INNER_WIDTH):
+            before, marker, after = line.rpartition(severity_label)
+            if marker:
+                self.add(
+                    Span(before),
+                    Span(marker, severity_style),
+                    Span(after),
+                )
+            else:
+                self.text(line)
 
 
 def _visible_spans(line: CardLine) -> List[Span]:
@@ -932,6 +966,11 @@ def _append_timing_tree(
     for label, metric, depth in present:
         value = values[metric]
         glyph = _tree_glyph(depth, last_by_depth.get(depth) == metric)
+        suffix = (
+            _culprit_suffix(primary, kind=kind)
+            if metric == culprit_metric and metric != "step_time_ms"
+            else None
+        )
         text = _tree_row_text(
             f"{glyph}{label}",
             ms_text=_fmt_ms(float(value or 0.0)),
@@ -942,15 +981,14 @@ def _append_timing_tree(
                 else None
             ),
             worst=worst_cells.get(metric),
-            suffix=(
-                _culprit_suffix(primary, kind=kind)
-                if metric == culprit_metric and metric != "step_time_ms"
-                else None
-            ),
+            suffix=suffix,
             suffix_column=suffix_column,
         )
-        if metric == culprit_metric and metric != "step_time_ms":
-            doc.text(text, severity_style)
+        if suffix:
+            doc.add(
+                Span(text[: -len(suffix)]),
+                Span(suffix, severity_style),
+            )
         else:
             doc.text(text)
     return True
@@ -1039,11 +1077,12 @@ def _append_verdict(doc: CardDoc, primary: Mapping[str, Any]) -> None:
     """Append the verdict line."""
     status = _display_status(primary)
     severity = _severity(primary.get("severity"))
+    status_style = _severity_style(severity)
     if severity not in {"info", ""}:
         status = f"{status}  ({_severity_label(severity)})"
     doc.add(
         Span("Verdict: ", STYLE_BOLD),
-        Span(status, _severity_style(severity)),
+        Span(status, status_style),
     )
 
 
@@ -1305,11 +1344,14 @@ def _append_run_body(
                 after_next.append(
                     (
                         f"! {summary}  ({_severity_label(severity)})",
-                        _severity_style(severity),
+                        severity,
                     )
                 )
         if peak is not None:
-            after_next.append((peak, STYLE_DIM))
+            # Keep the measured memory evidence beside the timing evidence,
+            # before the recommended action.  This also keeps the ordering
+            # consistent with the all-normal path above.
+            before_next.append(peak)
 
     for line in before_next:
         doc.text(line, STYLE_DIM)
@@ -1322,7 +1364,14 @@ def _append_run_body(
     if after_next:
         doc.blank()
         for text, style in after_next:
-            doc.wrapped(text, style=style)
+            if style in _SEVERITY_RANK:
+                doc.wrapped_with_severity(
+                    text,
+                    severity_label=_severity_label(style),
+                    severity_style=_severity_style(style),
+                )
+            else:
+                doc.wrapped(text, style=style)
 
 
 def _watch_health_lines(

--- a/src/traceml_ai/reporting/summary_card.py
+++ b/src/traceml_ai/reporting/summary_card.py
@@ -1,0 +1,1780 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Terminal end-of-run summary card.
+
+This module owns the presentation of the final summary ``text`` field. It is
+presentation-only: every value it prints already exists in the final summary
+payload and no metric, threshold, or diagnosis is recomputed here.
+
+Two profiles are rendered from one skeleton:
+
+``run``
+    verdict, a hierarchical timing tree, the next action, and bounded
+    corroboration (supporting utilization, secondary findings, peak memory).
+
+``watch``
+    host and process health only. ``watch`` never collects step timing, so the
+    card never mentions Step Time, Step Memory, or steps analyzed.
+
+A card is built as a ``CardDoc`` (lines of styled spans) so the plain and the
+ANSI renderings share identical padding math. The plain rendering is the one
+stored in JSON and in the ``.txt`` artifact; ANSI is used only when printing
+to an interactive terminal.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from traceml_ai.reporting.summaries.summary_formatting import bytes_to_gb
+from traceml_ai.reporting.summaries.summary_layout import (
+    border,
+    row,
+    wrap_lines,
+)
+
+CARD_WIDTH = 78
+INNER_WIDTH = CARD_WIDTH - 4
+
+RUN_PROFILE = "run"
+WATCH_PROFILE = "watch"
+
+FINAL_SUMMARY_JSON_NAME = "final_summary.json"
+FINAL_SUMMARY_HTML_NAME = "final_summary.html"
+
+RUN_TITLE = "TraceML Run Summary"
+WATCH_TITLE = "TraceML Watch Summary"
+
+STYLE_PLAIN = "plain"
+STYLE_BORDER = "border"
+STYLE_DIM = "dim"
+STYLE_BOLD = "bold"
+STYLE_CRIT = "sev_crit"
+STYLE_WARN = "sev_warn"
+STYLE_OK = "sev_ok"
+STYLE_NEXT = "next"
+
+_ANSI_CODES = {
+    STYLE_BORDER: "\x1b[2m",
+    STYLE_DIM: "\x1b[2m",
+    STYLE_BOLD: "\x1b[1m",
+    STYLE_CRIT: "\x1b[1;31m",
+    STYLE_WARN: "\x1b[1;33m",
+    STYLE_OK: "\x1b[32m",
+    STYLE_NEXT: "\x1b[32m",
+}
+_ANSI_RESET = "\x1b[0m"
+
+_SEVERITY_LABELS = {
+    "crit": "CRITICAL",
+    "critical": "CRITICAL",
+    "warn": "WARNING",
+    "warning": "WARNING",
+    "info": "INFO",
+}
+_SEVERITY_STYLES = {
+    "crit": STYLE_CRIT,
+    "critical": STYLE_CRIT,
+    "warn": STYLE_WARN,
+    "warning": STYLE_WARN,
+}
+_SEVERITY_RANK = {"crit": 0, "critical": 0, "warn": 1, "warning": 1}
+
+PHASE_SHARE_KINDS = frozenset(
+    {"INPUT_BOUND", "H2D_BOUND", "RESIDUAL_HEAVY", "COMPUTE_BOUND"}
+)
+STRAGGLER_KINDS = frozenset(
+    {
+        "INPUT_STRAGGLER",
+        "COMPUTE_STRAGGLER",
+        "H2D_STRAGGLER",
+        "STRAGGLER",
+    }
+)
+LOW_GPU_UTIL_KINDS = frozenset(
+    {"LOW_GPU_UTILIZATION", "MODERATE_GPU_UTILIZATION"}
+)
+
+_DISPLAY_STATUS = {
+    "INPUT_BOUND": "INPUT-BOUND",
+    "H2D_BOUND": "H2D-BOUND",
+    "COMPUTE_BOUND": "COMPUTE-BOUND",
+    "RESIDUAL_HEAVY": "RESIDUAL-HEAVY",
+    "INPUT_STRAGGLER": "INPUT STRAGGLER",
+    "COMPUTE_STRAGGLER": "COMPUTE STRAGGLER",
+    "H2D_STRAGGLER": "H2D STRAGGLER",
+    "STRAGGLER": "RANK STRAGGLER",
+    "LOW_GPU_UTILIZATION_UNEXPLAINED": (
+        "LOW GPU UTILIZATION -- cause unclear"
+    ),
+    "NO_CLEAR_PERFORMANCE_BOTTLENECK": "NO CLEAR BOTTLENECK",
+}
+
+# Timing tree rows: (label, metric, depth). Depth drives the tree glyph.
+_TREE_ROWS: Tuple[Tuple[str, str, int], ...] = (
+    ("Step Time", "step_time_ms", 0),
+    ("Input Wait", "input_wait_ms", 1),
+    ("Traced Step Time", "traced_step_time_ms", 1),
+    ("Compute", "compute_ms", 2),
+    ("H2D", "h2d_ms", 2),
+    ("Residual", "residual_ms", 2),
+)
+_CULPRIT_METRIC_BY_KIND = {
+    "INPUT_BOUND": "input_wait_ms",
+    "H2D_BOUND": "h2d_ms",
+    "RESIDUAL_HEAVY": "residual_ms",
+    "COMPUTE_BOUND": "compute_ms",
+}
+
+_TREE_LABEL_WIDTH = 19
+_TREE_WORST_COLUMN = 50
+_BAR_COLUMN = 36
+_BAR_WIDTH = 28
+_BAR_FULL = "█"
+_BAR_EMPTY = "░"
+_MARKER = "◀"
+_DOT = "·"
+
+_WATCH_LEFT_LABEL_WIDTH = 11
+_WATCH_RIGHT_COLUMN = 28
+_WATCH_RIGHT_LABEL_WIDTH = 9
+_WATCH_MULTI_LABEL_WIDTH = 12
+_WATCH_MULTI_WORST_COLUMN = 26
+
+_SKEW_MATERIAL_RATIO = 0.20
+_SKEW_MATERIAL_DELTA_MS = 1.0
+_MEMORY_SKEW_EVEN_RATIO = 0.10
+_SUPPORTING_GPU_UTIL_MAX = 50.0
+
+_WATCH_BOUNDARY = (
+    "Watch monitors host and process health only; it does not measure "
+    "step time. To diagnose training speed: traceml run <your-script>.py"
+)
+_WATCH_RUN_ACTION = (
+    "traceml run <your-script>.py -- measures step time and finds the cause."
+)
+
+
+@dataclass(frozen=True)
+class Span:
+    """One styled run of visible text inside a card line."""
+
+    text: str
+    style: str = STYLE_PLAIN
+
+
+@dataclass(frozen=True)
+class CardLine:
+    """One card line: either a horizontal rule or a row of spans."""
+
+    spans: Tuple[Span, ...] = ()
+    rule: bool = False
+
+
+@dataclass
+class CardDoc:
+    """A rendered-independent card: an ordered list of card lines."""
+
+    lines: List[CardLine] = field(default_factory=list)
+
+    def rule(self) -> None:
+        """Append a horizontal border rule."""
+        self.lines.append(CardLine(rule=True))
+
+    def blank(self) -> None:
+        """Append an empty content row."""
+        self.lines.append(CardLine())
+
+    def add(self, *spans: Span) -> None:
+        """Append one content row built from styled spans."""
+        self.lines.append(CardLine(spans=tuple(spans)))
+
+    def text(self, value: str, style: str = STYLE_PLAIN) -> None:
+        """Append one single-style content row."""
+        self.add(Span(value, style))
+
+    def wrapped(
+        self,
+        value: str,
+        *,
+        label: str = "",
+        label_style: str = STYLE_BOLD,
+        style: str = STYLE_PLAIN,
+    ) -> None:
+        """Append a logical line wrapped inside the card, with a label."""
+        full = f"{label}{value}" if label else value
+        for index, line in enumerate(wrap_lines(full, INNER_WIDTH)):
+            if index == 0 and label and line.startswith(label):
+                self.add(
+                    Span(label, label_style),
+                    Span(line[len(label) :], style),
+                )
+            else:
+                self.text(line, style)
+
+
+def _visible_spans(line: CardLine) -> List[Span]:
+    """Return the spans of one row clipped to the card's inner width."""
+    out: List[Span] = []
+    used = 0
+    for span in line.spans:
+        if used >= INNER_WIDTH:
+            break
+        room = INNER_WIDTH - used
+        text = span.text[:room]
+        used += len(text)
+        if text:
+            out.append(Span(text, span.style))
+    return out
+
+
+def card_to_plain(doc: CardDoc) -> str:
+    """Render a card as plain text with no escape sequences."""
+    lines: List[str] = []
+    for line in doc.lines:
+        if line.rule:
+            lines.append(border(width=CARD_WIDTH))
+            continue
+        text = "".join(span.text for span in _visible_spans(line))
+        lines.append(row(text, width=CARD_WIDTH))
+    return "\n".join(lines)
+
+
+def _paint(text: str, style: str) -> str:
+    """Wrap one span in its ANSI code, if the style has one."""
+    code = _ANSI_CODES.get(style)
+    if not code or not text:
+        return text
+    return f"{code}{text}{_ANSI_RESET}"
+
+
+def card_to_ansi(doc: CardDoc) -> str:
+    """Render a card with severity-scoped ANSI, same geometry as plain."""
+    lines: List[str] = []
+    edge = _paint("|", STYLE_BORDER)
+    for line in doc.lines:
+        if line.rule:
+            lines.append(_paint(border(width=CARD_WIDTH), STYLE_BORDER))
+            continue
+        spans = _visible_spans(line)
+        visible = sum(len(span.text) for span in spans)
+        body = "".join(_paint(span.text, span.style) for span in spans)
+        padding = " " * max(0, INNER_WIDTH - visible)
+        lines.append(f"{edge}  {body}{padding}{edge}")
+    return "\n".join(lines)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    """Return a mapping, or an empty mapping for malformed blocks."""
+    return value if isinstance(value, Mapping) else {}
+
+
+def _sequence(value: Any) -> Sequence[Any]:
+    """Return a sequence, or an empty tuple for malformed blocks."""
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return value
+    return ()
+
+
+def _float(value: Any) -> Optional[float]:
+    """Return a float when a payload value is numeric."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def _int(value: Any) -> Optional[int]:
+    """Return an int when a payload value is numeric."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except Exception:
+        return None
+
+
+def _block(section: Mapping[str, Any], name: str) -> Mapping[str, Any]:
+    """Return one ``global`` rollup block from a section payload."""
+    return _mapping(_mapping(section.get("global")).get(name))
+
+
+def _window(section: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return a section's analysis window block."""
+    return _block(section, "window")
+
+
+def _average(section: Mapping[str, Any], metric: str) -> Optional[float]:
+    """Return one average metric value."""
+    return _float(_block(section, "average").get(metric))
+
+
+def _point(
+    section: Mapping[str, Any],
+    block: str,
+    metric: str,
+) -> Mapping[str, Any]:
+    """Return one median/worst point for a metric."""
+    return _mapping(_block(section, block).get(metric))
+
+
+def _point_value(
+    section: Mapping[str, Any],
+    block: str,
+    metric: str,
+) -> Optional[float]:
+    """Return one median/worst point value for a metric."""
+    return _float(_point(section, block, metric).get("value"))
+
+
+def _identity(section: Mapping[str, Any], idx: Any) -> Mapping[str, Any]:
+    """Return the grouped-row identity behind a median/worst index."""
+    if idx is None:
+        return {}
+    rows = _mapping(_mapping(section.get("groups")).get("rows"))
+    return _mapping(_mapping(rows.get(str(idx))).get("identity"))
+
+
+def _rank_of(section: Mapping[str, Any], idx: Any) -> Optional[int]:
+    """Return the global rank behind a median/worst index."""
+    rank = _int(_identity(section, idx).get("global_rank"))
+    return rank if rank is not None else _int(idx)
+
+
+def _node_of(section: Mapping[str, Any], idx: Any) -> Optional[int]:
+    """Return the node rank behind a median/worst index."""
+    node = _int(_identity(section, idx).get("node_rank"))
+    return node if node is not None else _int(idx)
+
+
+def _diagnosis(section: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return a section diagnosis block."""
+    return _mapping(section.get("diagnosis"))
+
+
+def _severity(value: Any) -> str:
+    """Return a normalized severity key."""
+    return str(value or "info").strip().lower()
+
+
+def _severity_label(value: Any) -> str:
+    """Return the uppercase display label for a severity."""
+    key = _severity(value)
+    return _SEVERITY_LABELS.get(key, key.upper() or "INFO")
+
+
+def _severity_style(value: Any) -> str:
+    """Return the span style for a severity."""
+    return _SEVERITY_STYLES.get(_severity(value), STYLE_OK)
+
+
+def _status_text(value: Any) -> str:
+    """Return an uppercase status label for an unknown diagnosis kind."""
+    text = str(value or "NO DATA").replace("_", " ").strip()
+    return " ".join(text.upper().split()) or "NO DATA"
+
+
+def fmt_duration(duration_s: Optional[float]) -> Optional[str]:
+    """Format a run duration as `52.4s`, `5m 12s`, or `1h 4m`."""
+    if duration_s is None:
+        return None
+    seconds = float(duration_s)
+    if seconds < 60.0:
+        return f"{seconds:.1f}s"
+    total = int(round(seconds))
+    if total < 3600:
+        minutes, rest = divmod(total, 60)
+        return f"{minutes}m {rest}s"
+    hours, rest = divmod(total, 3600)
+    return f"{hours}h {rest // 60}m"
+
+
+def _fmt_ms(value: float) -> str:
+    """Format one millisecond value for the timing tree column."""
+    return f"{value:>6.1f}"
+
+
+def _fmt_share(value: Optional[float], total: Optional[float]) -> str:
+    """Format a phase share as a 4-character right-aligned percentage."""
+    if value is None or total is None or total <= 0.0:
+        return ""
+    percent = 100.0 * value / total
+    text = f"{percent:.0f}%"
+    if text == "0%" and value > 0.0:
+        text = "<1%"
+    return f"{text:>4}"
+
+
+def _fmt_percent(value: Optional[float]) -> Optional[str]:
+    """Format a percentage with no decimals."""
+    return None if value is None else f"{value:.0f}"
+
+
+def _fmt_gb(value: Optional[float]) -> Optional[str]:
+    """Format a byte count as decimal gigabytes with one decimal."""
+    gb = bytes_to_gb(value)
+    return None if gb is None else f"{gb:.1f}"
+
+
+def _fmt_capacity(value: Optional[float]) -> Optional[str]:
+    """
+    Format a byte count with a unit that keeps one significant decimal.
+
+    Small training footprints round to `0.0 GB`, which reads as "nothing was
+    measured". Anything under 0.1 GB is reported in MB instead, on the same
+    decimal basis as ``bytes_to_gb``.
+    """
+    gb = bytes_to_gb(value)
+    if gb is None:
+        return None
+    if gb < 0.1:
+        return f"{float(value or 0.0) / 1e6:.1f} MB"
+    return f"{gb:.1f} GB"
+
+
+def _join_segments(segments: Sequence[Optional[str]]) -> str:
+    """Join header/observation segments, dropping missing ones."""
+    return f" {_DOT} ".join([text for text in segments if text])
+
+
+def _plural(count: int, singular: str) -> str:
+    """Return `1 GPU` / `2 GPUs` style text."""
+    return f"{count} {singular}" if count == 1 else f"{count} {singular}s"
+
+
+def is_multi_process(step_time_summary: Mapping[str, Any]) -> bool:
+    """Return whether Step Time observed more than one global rank."""
+    metadata = _mapping(step_time_summary.get("metadata"))
+    used = _int(metadata.get("global_ranks_used"))
+    return bool(used is not None and used > 1)
+
+
+def _is_multi_node(meta: Mapping[str, Any]) -> bool:
+    """Return whether more than one node was observed."""
+    nodes = _int(meta.get("nodes_observed"))
+    return bool(nodes is not None and nodes > 1)
+
+
+def _clock(step_time_summary: Mapping[str, Any]) -> str:
+    """Return the selected diagnosis clock label (`GPU` / `CPU`)."""
+    clock = str(_window(step_time_summary).get("diagnosis_clock") or "")
+    return "CPU" if clock.strip().lower() == "cpu" else "GPU"
+
+
+def _steps_analyzed(step_time_summary: Mapping[str, Any]) -> Optional[int]:
+    """Return the number of analyzed steps behind the Step Time window."""
+    return _int(_window(step_time_summary).get("steps_analyzed"))
+
+
+def _incomplete_timing(primary: Mapping[str, Any]) -> bool:
+    """Return whether the insufficient-data primary is a missing-signal one."""
+    evidence = _mapping(primary.get("evidence"))
+    status = str(evidence.get("step_time_status") or "")
+    return _status_text(status) == "INCOMPLETE DATA"
+
+
+def _display_status(primary: Mapping[str, Any]) -> str:
+    """Return the card's verdict status label for a primary diagnosis."""
+    kind = str(primary.get("kind") or "")
+    if kind == "INSUFFICIENT_STEP_TIME_DATA":
+        if _incomplete_timing(primary):
+            return "STEP TIMING INCOMPLETE"
+        return "NOT ENOUGH STEP DATA"
+    display = _DISPLAY_STATUS.get(kind)
+    return display if display else _status_text(primary.get("status"))
+
+
+def _score_percent(primary: Mapping[str, Any]) -> Optional[str]:
+    """Return the diagnosis score as an integer percentage string."""
+    score = _float(_mapping(primary.get("evidence")).get("score"))
+    return None if score is None else f"{score * 100:.0f}"
+
+
+def _rank_clause(rank: Optional[int], node: Optional[int]) -> str:
+    """Return `rank 0 (node n0)` style text for a straggler rank."""
+    if rank is None:
+        return "the slow rank"
+    if node is None:
+        return f"rank {rank}"
+    return f"rank {rank} (node n{node})"
+
+
+def _comparison(primary: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the rank comparison behind a straggler primary diagnosis."""
+    evidence = _mapping(primary.get("evidence"))
+    comparisons = _sequence(evidence.get("comparisons"))
+    if comparisons:
+        return _mapping(comparisons[0])
+    return evidence
+
+
+def _straggler_why(
+    primary: Mapping[str, Any],
+    *,
+    meta: Mapping[str, Any],
+    verb: str,
+    phrase: str,
+) -> str:
+    """Compose the straggler `Why` sentence from rank comparison evidence."""
+    comparison = _comparison(primary)
+    worst = _mapping(comparison.get("worst"))
+    median = _mapping(comparison.get("median"))
+    rank = _int(worst.get("rank"))
+    node = _int(meta.get("node_rank_of_worst"))
+    worst_ms = _float(worst.get("value_ms"))
+    median_ms = _float(median.get("value_ms"))
+    world_size = _int(meta.get("world_size"))
+
+    who = _rank_clause(rank, node)
+    parts = [f"{who} {verb} "]
+    parts.append("? ms" if worst_ms is None else f"{worst_ms:.1f} ms")
+    parts.append(f" per step {phrase}; the median rank {verb} ")
+    parts.append("? ms" if median_ms is None else f"{median_ms:.1f} ms")
+    parts.append(".")
+    if world_size is not None and rank is not None:
+        parts.append(
+            f" All {world_size} ranks then advance at rank {rank}'s pace."
+        )
+    return "".join(parts)
+
+
+def _phase_word(primary: Mapping[str, Any]) -> str:
+    """Return the phase word used in straggler wording."""
+    phase = str(_comparison(primary).get("phase") or "").strip()
+    return phase or "compute"
+
+
+def _why_next(
+    *,
+    primary: Mapping[str, Any],
+    step_time_summary: Mapping[str, Any],
+    meta: Mapping[str, Any],
+    multi: bool,
+) -> Tuple[str, str]:
+    """Compose the plain-language `Why` and `Next` text for a diagnosis."""
+    kind = str(primary.get("kind") or "")
+    score = _score_percent(primary)
+    evidence = _mapping(primary.get("evidence"))
+
+    if kind == "INPUT_BOUND" and score is not None:
+        if _clock(step_time_summary) == "CPU":
+            why = f"input wait is {score}% of the typical step (CPU clock)."
+        else:
+            why = (
+                f"input wait is {score}% of the typical step; the GPU sits "
+                "idle while batches arrive."
+            )
+        if _int(meta.get("gpus_observed")) == 0:
+            # pin_memory only helps host-to-device transfer, so it is not
+            # advice worth giving on a machine with no GPU.
+            return why, (
+                "raise DataLoader num_workers or prefetch, or check storage "
+                "read throughput."
+            )
+        return why, (
+            "raise DataLoader num_workers, enable pin_memory / prefetch, or "
+            "check storage read throughput."
+        )
+
+    if kind == "H2D_BOUND" and score is not None:
+        return (
+            f"host-to-device copies take {score}% of the typical step.",
+            "use pin_memory + non_blocking copies, batch transfers, or move "
+            "preprocessing to the GPU.",
+        )
+
+    if kind == "COMPUTE_BOUND" and score is not None:
+        return (
+            f"compute (forward/backward/optimizer) takes {score}% of the "
+            "typical step.",
+            "training is compute-dominated; for more speed profile kernels "
+            "(torch.profiler / Nsight).",
+        )
+
+    if kind == "RESIDUAL_HEAVY" and score is not None:
+        return (
+            f"{score}% of the typical step is time outside the traced "
+            "phases.",
+            "look for untraced work between steps -- validation, "
+            "checkpointing, logging.",
+        )
+
+    if kind in STRAGGLER_KINDS:
+        return _straggler_why_next(primary, meta=meta, kind=kind)
+
+    if kind == "LOW_GPU_UTILIZATION_UNEXPLAINED":
+        util = _fmt_percent(_float(evidence.get("gpu_util_avg_percent")))
+        if util is not None:
+            # Single-machine cards never use rank/node/skew vocabulary, so
+            # the cross-rank clause only appears on multi-rank runs.
+            unexplained = (
+                "input, transfer, or timing skew."
+                if multi
+                else "input or transfer."
+            )
+            why = (
+                "step timing is balanced, but GPU util averaged "
+                f"{util}%. The idle time is not explained by {unexplained}"
+            )
+            return why, (
+                "look for untraced work between steps -- validation, "
+                "checkpointing, logging -- or inefficient kernels "
+                "(torch.profiler)."
+            )
+
+    if kind == "NO_CLEAR_PERFORMANCE_BOTTLENECK":
+        skew = _step_time_skew_percent(step_time_summary) if multi else None
+        if multi and skew is not None:
+            why = (
+                "step timing is balanced and ranks are even (worst step "
+                f"time +{skew} vs median)."
+            )
+        else:
+            why = (
+                "step timing is balanced -- no input, transfer, or residual "
+                "issue."
+            )
+        return why, (
+            "training is compute-dominated; for more speed profile kernels "
+            "(torch.profiler / Nsight)."
+        )
+
+    if kind == "INSUFFICIENT_STEP_TIME_DATA":
+        if _incomplete_timing(primary):
+            names = _missing_signals(step_time_summary)
+            if names:
+                why = (
+                    "some timing signals were never measured (missing: "
+                    f"{names}), so phases don't add up to a reliable step "
+                    "time."
+                )
+            else:
+                why = (
+                    "some timing signals were never measured, so phases "
+                    "don't add up to a reliable step time."
+                )
+            return why, (
+                "check the integration wiring for the missing phases; "
+                "per-signal coverage is listed in the JSON step_time section."
+            )
+        steps = _steps_analyzed(step_time_summary)
+        if steps:
+            why = (
+                f"only {steps} completed steps were captured; a stable "
+                "diagnosis needs a larger sample."
+            )
+        else:
+            why = "no completed steps were captured."
+        return why, (
+            "run more steps, or check that traceml.trace_step(...) wraps "
+            "the training loop."
+        )
+
+    return (
+        str(primary.get("summary") or ""),
+        str(primary.get("action") or ""),
+    )
+
+
+def _straggler_why_next(
+    primary: Mapping[str, Any],
+    *,
+    meta: Mapping[str, Any],
+    kind: str,
+) -> Tuple[str, str]:
+    """Compose `Why` and `Next` for the rank-straggler diagnoses."""
+    comparison = _comparison(primary)
+    rank = _int(_mapping(comparison.get("worst")).get("rank"))
+    node = _int(meta.get("node_rank_of_worst"))
+    who = _rank_clause(rank, node)
+
+    if kind == "INPUT_STRAGGLER":
+        why = _straggler_why(
+            primary,
+            meta=meta,
+            verb="waits",
+            phrase="for input",
+        )
+        action = (
+            "inspect dataloader, collate_fn, preprocessing, and storage on "
+            f"{who}."
+        )
+        return why, action
+
+    if kind == "H2D_STRAGGLER":
+        why = _straggler_why(
+            primary,
+            meta=meta,
+            verb="spends",
+            phrase="in host-to-device copies",
+        )
+        target = "the slow rank" if rank is None else f"rank {rank}"
+        return why, f"inspect PCIe topology / transfer path on {target}."
+
+    if kind == "COMPUTE_STRAGGLER":
+        why = _straggler_why(
+            primary,
+            meta=meta,
+            verb="spends",
+            phrase=f"in {_phase_word(primary)}",
+        )
+        target = "the slow rank" if rank is None else f"rank {rank}"
+        return why, (
+            f"inspect {target}: thermal/clock throttling, imbalanced work, "
+            "or a slow device."
+        )
+
+    why = _straggler_why(
+        primary,
+        meta=meta,
+        verb="spends",
+        phrase=f"in {_phase_word(primary)}",
+    )
+    target = "the slow rank" if rank is None else f"rank {rank}"
+    return why, (
+        f"inspect {target} end-to-end; multiple phases are slow on it."
+    )
+
+
+def _missing_signals(step_time_summary: Mapping[str, Any]) -> str:
+    """Return the comma-joined missing Step Time signal names."""
+    evidence = _mapping(_diagnosis(step_time_summary).get("evidence"))
+    names = [str(name) for name in _sequence(evidence.get("missing_signals"))]
+    return ", ".join(names)
+
+
+def _step_time_skew_percent(
+    step_time_summary: Mapping[str, Any],
+) -> Optional[str]:
+    """Return the worst-vs-median Step Time skew as a percentage string."""
+    median = _point_value(step_time_summary, "median", "step_time_ms")
+    worst = _point_value(step_time_summary, "worst", "step_time_ms")
+    if median is None or worst is None or median <= 0.0:
+        return None
+    return f"{100.0 * (worst - median) / median:.1f}%"
+
+
+def _worst_node_rank(
+    step_time_summary: Mapping[str, Any],
+    primary: Mapping[str, Any],
+    meta: Mapping[str, Any],
+) -> Optional[int]:
+    """Return the node rank of the straggler rank, on multi-node runs."""
+    if not _is_multi_node(meta):
+        return None
+    metric = str(_comparison(primary).get("metric") or "step_time_ms")
+    idx = _point(step_time_summary, "worst", metric).get("idx")
+    return _node_of(step_time_summary, idx)
+
+
+def _tree_values(
+    step_time_summary: Mapping[str, Any],
+    *,
+    multi: bool,
+) -> Dict[str, Optional[float]]:
+    """Return the timing values used by the tree for this card variant."""
+    values: Dict[str, Optional[float]] = {}
+    for _, metric, _depth in _TREE_ROWS:
+        if multi:
+            values[metric] = _point_value(step_time_summary, "median", metric)
+        else:
+            values[metric] = _average(step_time_summary, metric)
+    return values
+
+
+def _tree_glyph(depth: int, last: bool) -> str:
+    """Return the tree glyph prefix for one row."""
+    if depth == 0:
+        return ""
+    branch = "└─ " if last else "├─ "
+    return branch if depth == 1 else f"   {branch}"
+
+
+def _bar(share: float) -> str:
+    """Return a 28-character share bar."""
+    filled = int(round(max(0.0, min(1.0, share)) * _BAR_WIDTH))
+    return _BAR_FULL * filled + _BAR_EMPTY * (_BAR_WIDTH - filled)
+
+
+def _worst_cell(
+    step_time_summary: Mapping[str, Any],
+    metric: str,
+) -> Optional[str]:
+    """Return the `worst rank` cell text for one tree row, when material."""
+    point = _point(step_time_summary, "worst", metric)
+    value = _float(point.get("value"))
+    if value is None:
+        return None
+    rank = _rank_of(step_time_summary, point.get("idx"))
+    if rank is None:
+        return None
+    return f"{_fmt_ms(value)} ms (r{rank})"
+
+
+def _is_material_skew(
+    step_time_summary: Mapping[str, Any],
+    metric: str,
+) -> bool:
+    """Return whether worst-vs-median skew is worth a `worst rank` cell."""
+    median = _point_value(step_time_summary, "median", metric)
+    worst = _point_value(step_time_summary, "worst", metric)
+    if median is None or worst is None or median <= 0.0:
+        return False
+    delta = abs(worst - median)
+    if delta < _SKEW_MATERIAL_DELTA_MS:
+        return False
+    return delta / median >= _SKEW_MATERIAL_RATIO
+
+
+def _culprit_suffix(primary: Mapping[str, Any], *, kind: str) -> str:
+    """Return the culprit-row marker text."""
+    if kind in STRAGGLER_KINDS:
+        ratio = _float(_comparison(primary).get("ratio"))
+        if ratio is not None and ratio >= 2.0:
+            return f"{_MARKER}  {ratio:.0f}x"
+    return f"{_MARKER}  cause"
+
+
+def _tree_row_text(
+    label: str,
+    *,
+    ms_text: str,
+    share: str,
+    bar: Optional[str],
+    worst: Optional[str],
+    suffix: Optional[str],
+    suffix_column: int = 0,
+) -> str:
+    """Assemble one fixed-column timing tree row."""
+    text = f"{label:<{_TREE_LABEL_WIDTH}}{ms_text} ms  {share:>4}"
+    if bar is not None:
+        text = f"{text}  {bar}"
+    if worst is not None:
+        text = f"{text:<{_TREE_WORST_COLUMN}}{worst}"
+    if suffix:
+        # Culprit markers line up in one column so a marker on a leaf row
+        # does not land inside the share-bar column of the rows above it.
+        text = f"{text:<{suffix_column}}  {suffix}"
+    return text
+
+
+def _append_timing_tree(
+    doc: CardDoc,
+    *,
+    primary: Mapping[str, Any],
+    step_time_summary: Mapping[str, Any],
+    multi: bool,
+) -> bool:
+    """Append the timing tree; return whether anything was drawn."""
+    values = _tree_values(step_time_summary, multi=multi)
+    total = values.get("step_time_ms")
+    if total is None or total <= 0.0:
+        return False
+
+    kind = str(primary.get("kind") or "")
+    present = [
+        (label, metric, depth)
+        for label, metric, depth in _TREE_ROWS
+        if values.get(metric) is not None
+    ]
+    last_by_depth: Dict[int, str] = {}
+    for _label, metric, depth in present:
+        last_by_depth[depth] = metric
+
+    culprit_metric = _CULPRIT_METRIC_BY_KIND.get(kind)
+    if culprit_metric is None and kind in STRAGGLER_KINDS:
+        culprit_metric = str(
+            _comparison(primary).get("metric") or "step_time_ms"
+        )
+
+    straggler_culprit = culprit_metric if kind in STRAGGLER_KINDS else None
+    worst_cells: Dict[str, str] = {}
+    if multi:
+        for _label, metric, _depth in present:
+            if metric == "step_time_ms":
+                continue
+            if metric == straggler_culprit or _is_material_skew(
+                step_time_summary, metric
+            ):
+                cell = _worst_cell(step_time_summary, metric)
+                if cell:
+                    worst_cells[metric] = cell
+        if worst_cells:
+            cell = _worst_cell(step_time_summary, "step_time_ms")
+            if cell:
+                worst_cells["step_time_ms"] = cell
+
+    draw_bars = bool(kind in PHASE_SHARE_KINDS and not multi)
+    suffix_column = _BAR_COLUMN + _BAR_WIDTH if draw_bars else 0
+    severity_style = _severity_style(primary.get("severity"))
+
+    caption = (
+        "Where a step goes (median rank, "
+        if multi
+        else "Where a step goes (average, "
+    ) + f"{_clock(step_time_summary)} clock)"
+    if worst_cells:
+        header_column = _TREE_WORST_COLUMN + 1
+        caption = f"{caption:<{header_column}}worst rank"
+    doc.text(caption, STYLE_DIM)
+
+    for label, metric, depth in present:
+        value = values[metric]
+        glyph = _tree_glyph(depth, last_by_depth.get(depth) == metric)
+        text = _tree_row_text(
+            f"{glyph}{label}",
+            ms_text=_fmt_ms(float(value or 0.0)),
+            share=_fmt_share(value, total),
+            bar=(
+                _bar(float(value or 0.0) / total)
+                if draw_bars and depth <= 1
+                else None
+            ),
+            worst=worst_cells.get(metric),
+            suffix=(
+                _culprit_suffix(primary, kind=kind)
+                if metric == culprit_metric and metric != "step_time_ms"
+                else None
+            ),
+            suffix_column=suffix_column,
+        )
+        if metric == culprit_metric and metric != "step_time_ms":
+            doc.text(text, severity_style)
+        else:
+            doc.text(text)
+    return True
+
+
+def _run_gpu_count(meta: Mapping[str, Any]) -> Optional[int]:
+    """
+    Return the GPU count a run card should report.
+
+    ``meta.gpus_observed`` counts the GPUs on the host, which overstates a
+    run that only used some of them (a one-process run on a four-GPU box).
+    The run card describes the run, so it is capped by the world size.
+    """
+    gpus = _int(meta.get("gpus_observed"))
+    world_size = _int(meta.get("world_size"))
+    if gpus is not None and gpus > 0 and world_size is not None:
+        if world_size > 0:
+            return min(gpus, world_size)
+    return gpus
+
+
+def _run_header_meta(
+    *,
+    meta: Mapping[str, Any],
+    step_time_summary: Mapping[str, Any],
+    duration_s: Optional[float],
+    multi: bool,
+) -> str:
+    """Compose the run card's identity and coverage line."""
+    gpus = _run_gpu_count(meta)
+    nodes = _int(meta.get("nodes_observed"))
+    steps = _steps_analyzed(step_time_summary)
+
+    segments: List[Optional[str]] = [
+        str(meta.get("run_name")) if meta.get("run_name") else None
+    ]
+    if gpus == 0:
+        segments.append("CPU only (no GPU detected)")
+    elif gpus is not None:
+        segments.append(_plural(gpus, "GPU"))
+    if multi and nodes is not None:
+        segments.append(_plural(nodes, "node"))
+    if steps is not None:
+        segments.append(f"{steps} steps analyzed")
+    segments.append(fmt_duration(duration_s))
+    return _join_segments(segments)
+
+
+def _watch_header_meta(
+    *,
+    meta: Mapping[str, Any],
+    duration_s: Optional[float],
+    multi: bool,
+) -> str:
+    """Compose the watch card's identity and coverage line."""
+    gpus = _int(meta.get("gpus_observed"))
+    nodes = _int(meta.get("nodes_observed"))
+
+    segments: List[Optional[str]] = []
+    if multi and nodes is not None:
+        segments.append(_plural(nodes, "node"))
+    else:
+        segments.append("1 machine")
+    if gpus == 0:
+        segments.append("no GPU detected")
+    elif gpus is not None:
+        segments.append(_plural(gpus, "GPU"))
+    duration = fmt_duration(duration_s)
+    if duration is not None:
+        segments.append(f"observed for {duration}")
+    return _join_segments(segments)
+
+
+def _append_header(doc: CardDoc, *, title: str, meta_line: str) -> None:
+    """Append the card header block."""
+    doc.rule()
+    doc.text(title, STYLE_BOLD)
+    if meta_line:
+        # Run names can be long session ids, so the coverage line wraps
+        # rather than losing identity or steps-analyzed to a clip.
+        doc.wrapped(meta_line, style=STYLE_DIM)
+    doc.rule()
+
+
+def _append_verdict(doc: CardDoc, primary: Mapping[str, Any]) -> None:
+    """Append the verdict line."""
+    status = _display_status(primary)
+    severity = _severity(primary.get("severity"))
+    if severity not in {"info", ""}:
+        status = f"{status}  ({_severity_label(severity)})"
+    doc.add(
+        Span("Verdict: ", STYLE_BOLD),
+        Span(status, _severity_style(severity)),
+    )
+
+
+def _supporting_line(
+    *,
+    primary: Mapping[str, Any],
+    multi: bool,
+) -> Optional[str]:
+    """Return the supporting GPU-utilization line, when it applies."""
+    kind = str(primary.get("kind") or "")
+    if kind not in PHASE_SHARE_KINDS and kind not in STRAGGLER_KINDS:
+        return None
+    evidence = _mapping(primary.get("evidence"))
+    util = _float(evidence.get("gpu_util_avg_percent"))
+    if util is None or util >= _SUPPORTING_GPU_UTIL_MAX:
+        return None
+    value = _fmt_percent(util)
+    if multi and kind in STRAGGLER_KINDS:
+        return (
+            f"Supporting: GPU util median {value}% -- ranks idle at the step "
+            "barrier."
+        )
+    if kind == "INPUT_BOUND":
+        return (
+            f"Supporting: GPU util {value}% avg -- consistent with input "
+            "starvation."
+        )
+    return f"Supporting: GPU util {value}% avg."
+
+
+def _peak_memory_line(
+    step_memory_summary: Mapping[str, Any],
+    *,
+    multi: bool,
+) -> Optional[str]:
+    """Return the one-line peak step-memory summary, when measured."""
+    reserved_point = _point(
+        step_memory_summary, "worst", "peak_reserved_bytes"
+    )
+    reserved = _float(reserved_point.get("value"))
+    allocated = _point_value(
+        step_memory_summary,
+        "worst",
+        "peak_allocated_bytes",
+    )
+    if reserved is None and allocated is None:
+        return None
+
+    if not multi:
+        alloc_text = _fmt_capacity(allocated)
+        reserved_text = _fmt_capacity(reserved)
+        parts = []
+        if alloc_text is not None:
+            parts.append(f"{alloc_text} allocated")
+        if reserved_text is not None:
+            parts.append(f"{reserved_text} reserved")
+        body = f" {_DOT} ".join(parts)
+        return f"Peak step memory: {body}"
+
+    if reserved is None:
+        return None
+    reserved_text = _fmt_capacity(reserved)
+    median = _point_value(
+        step_memory_summary,
+        "median",
+        "peak_reserved_bytes",
+    )
+    even = (
+        median is not None
+        and median > 0.0
+        and abs(reserved - median) / median < _MEMORY_SKEW_EVEN_RATIO
+    )
+    if even:
+        scope = "even across ranks"
+    else:
+        rank = _rank_of(step_memory_summary, reserved_point.get("idx"))
+        scope = "worst rank" if rank is None else f"worst rank r{rank}"
+    return f"Peak step memory: {reserved_text} reserved {_DOT} {scope}"
+
+
+def _all_normal_line(
+    *,
+    primary: Mapping[str, Any],
+    sections: Sequence[Mapping[str, Any]],
+    system_summary: Mapping[str, Any],
+    multi: bool,
+) -> Optional[str]:
+    """Return the collapsed all-healthy line, when every section is info."""
+    if str(primary.get("kind") or "") != "NO_CLEAR_PERFORMANCE_BOTTLENECK":
+        return None
+    for section in sections:
+        if _severity(_diagnosis(section).get("severity")) != "info":
+            return None
+    util = _float(
+        _mapping(primary.get("evidence")).get("gpu_util_avg_percent")
+    )
+    if util is None:
+        util = _average(system_summary, "gpu_util_percent")
+    scope = " on every rank" if multi else ""
+    line = f"System, process, and memory: all normal{scope}."
+    value = _fmt_percent(util)
+    if value is not None:
+        line = f"{line} GPU util {value}% avg."
+    return line
+
+
+def _also_findings(
+    *,
+    primary: Mapping[str, Any],
+    sections: Sequence[Tuple[str, Mapping[str, Any]]],
+) -> List[Tuple[str, str]]:
+    """
+    Return up to two secondary warn/crit findings as (summary, severity).
+
+    Only resource sections are eligible. A secondary Step Time finding may
+    well be a real cause of slow steps, so listing it under "not the cause of
+    slow steps" would be untrue; those stay in the JSON.
+    """
+    primary_kind = str(primary.get("kind") or "")
+    primary_section = str(primary.get("section") or "")
+    found: List[Tuple[int, str, str]] = []
+    for name, section in sections:
+        for raw_issue in _sequence(section.get("issues")):
+            issue = _mapping(raw_issue)
+            severity = _severity(issue.get("severity"))
+            if severity not in _SEVERITY_RANK:
+                continue
+            kind = str(issue.get("kind") or "")
+            if kind == primary_kind and name == primary_section:
+                continue
+            summary = str(issue.get("summary") or "").strip()
+            if not summary:
+                continue
+            found.append((_SEVERITY_RANK[severity], summary, severity))
+    found.sort(key=lambda item: item[0])
+    return [(summary, severity) for _rank, summary, severity in found[:2]]
+
+
+def _observed_anyway_line(
+    system_summary: Mapping[str, Any],
+    meta: Mapping[str, Any],
+) -> Optional[str]:
+    """Return the degraded-state observation line, when anything was seen."""
+    segments: List[Optional[str]] = []
+    if _int(meta.get("gpus_observed")) == 0:
+        segments.append("no GPU detected")
+    else:
+        gpu = _fmt_percent(_average(system_summary, "gpu_util_percent"))
+        if gpu is not None:
+            segments.append(f"GPU util {gpu}% avg")
+    cpu = _fmt_percent(_average(system_summary, "cpu_percent"))
+    if cpu is not None:
+        segments.append(f"CPU util {cpu}% avg")
+    body = _join_segments(segments)
+    return f"Observed anyway: {body}" if body else None
+
+
+def _footer_line(
+    artifact_hint: Optional[str],
+    html_hint: Optional[str],
+) -> str:
+    """Return the artifact footer line."""
+    path = artifact_hint or "final_summary.json"
+    if html_hint:
+        return f"Full evidence: {path} {_DOT} {html_hint}"
+    return f"Full evidence: {path}  (--html-report)"
+
+
+def _append_run_body(
+    doc: CardDoc,
+    *,
+    primary: Mapping[str, Any],
+    system_summary: Mapping[str, Any],
+    process_summary: Mapping[str, Any],
+    step_time_summary: Mapping[str, Any],
+    step_memory_summary: Mapping[str, Any],
+    meta: Mapping[str, Any],
+    multi: bool,
+) -> None:
+    """Append the run card body between the header and the footer."""
+    header_meta = dict(meta)
+    header_meta["node_rank_of_worst"] = _worst_node_rank(
+        step_time_summary,
+        primary,
+        meta,
+    )
+    why, action = _why_next(
+        primary=primary,
+        step_time_summary=step_time_summary,
+        meta=header_meta,
+        multi=multi,
+    )
+
+    degraded = str(primary.get("kind") or "") == "INSUFFICIENT_STEP_TIME_DATA"
+
+    doc.blank()
+    _append_verdict(doc, primary)
+    if why:
+        doc.wrapped(why, label="Why: ")
+    doc.blank()
+
+    if not degraded and _append_timing_tree(
+        doc,
+        primary=primary,
+        step_time_summary=step_time_summary,
+        multi=multi,
+    ):
+        doc.blank()
+
+    cpu_only = _int(meta.get("gpus_observed")) == 0
+    all_normal = _all_normal_line(
+        primary=primary,
+        sections=(
+            system_summary,
+            process_summary,
+            step_time_summary,
+            step_memory_summary,
+        ),
+        system_summary=system_summary,
+        multi=multi,
+    )
+    peak = _peak_memory_line(step_memory_summary, multi=multi)
+
+    before_next: List[str] = []
+    after_next: List[Tuple[str, str]] = []
+    also = _also_findings(
+        primary=primary,
+        sections=(
+            ("system", system_summary),
+            ("process", process_summary),
+            ("step_memory", step_memory_summary),
+        ),
+    )
+
+    if degraded:
+        observed = _observed_anyway_line(system_summary, meta)
+        if observed:
+            before_next.append(observed)
+    elif all_normal is not None:
+        before_next.append(all_normal)
+        if peak is not None:
+            before_next.append(peak)
+    elif cpu_only:
+        before_next.append("H2D and step memory not measured (no GPU).")
+        fetch = _average(step_time_summary, "dataloader_fetch_cpu_ms")
+        if fetch is not None:
+            before_next.append(
+                f"DataLoader fetch: {fetch:.1f} ms (supplemental)."
+            )
+    else:
+        supporting = _supporting_line(primary=primary, multi=multi)
+        if supporting:
+            after_next.append((supporting, STYLE_DIM))
+        if also:
+            after_next.append(
+                ("Also, not the cause of slow steps:", STYLE_DIM)
+            )
+            for summary, severity in also:
+                after_next.append(
+                    (
+                        f"! {summary}  ({_severity_label(severity)})",
+                        _severity_style(severity),
+                    )
+                )
+        if peak is not None:
+            after_next.append((peak, STYLE_DIM))
+
+    for line in before_next:
+        doc.text(line, STYLE_DIM)
+    if before_next:
+        doc.blank()
+
+    if action:
+        doc.wrapped(action, label="Next: ", style=STYLE_NEXT)
+
+    if after_next:
+        doc.blank()
+        for text, style in after_next:
+            doc.wrapped(text, style=style)
+
+
+def _watch_health_lines(
+    *,
+    system_summary: Mapping[str, Any],
+    process_summary: Mapping[str, Any],
+    meta: Mapping[str, Any],
+    multi: bool,
+) -> Tuple[List[Tuple[str, str]], Optional[str]]:
+    """Return the host-health lines and the finding action, when present."""
+    findings = []
+    for section in (system_summary, process_summary):
+        diagnosis = _diagnosis(section)
+        severity = _severity(diagnosis.get("severity"))
+        if severity in _SEVERITY_RANK:
+            findings.append((_SEVERITY_RANK[severity], diagnosis, severity))
+    findings.sort(key=lambda item: item[0])
+
+    if not findings:
+        nodes = _int(meta.get("nodes_observed"))
+        scope = f" on all {nodes} nodes" if multi and nodes else ""
+        return [(f"Host health: NORMAL{scope}", STYLE_OK)], None
+
+    _rank, diagnosis, severity = findings[0]
+    status = _status_text(diagnosis.get("status"))
+    label = _severity_label(severity)
+    lines = [(f"Host health: {status}  ({label})", _severity_style(severity))]
+    summary = str(diagnosis.get("summary") or "").strip()
+    if summary:
+        lines.append((summary, STYLE_PLAIN))
+    action = str(diagnosis.get("action") or "").strip()
+    return lines, (action or None)
+
+
+def _watch_total_gb(
+    used_bytes: Optional[float],
+    percent: Optional[float],
+) -> Optional[float]:
+    """Derive a capacity total from a used-bytes and percent pair."""
+    if used_bytes is None or percent is None or percent <= 0.0:
+        return None
+    return float(used_bytes) / (float(percent) / 100.0)
+
+
+def _watch_capacity_cell(
+    label: str,
+    used_bytes: Optional[float],
+    percent: Optional[float],
+) -> Optional[str]:
+    """Return a `RAM  6.2 / 32.0 GB  (19%)` style right-column cell."""
+    used = _fmt_gb(used_bytes)
+    if used is None:
+        return None
+    total = _fmt_gb(_watch_total_gb(used_bytes, percent))
+    head = f"{label:<{_WATCH_RIGHT_LABEL_WIDTH}}{used:>4}"
+    if total is None:
+        return f"{head} GB used"
+    return f"{head} / {total:>4} GB  ({_fmt_percent(percent)}%)"
+
+
+def _watch_single_metric_rows(
+    *,
+    system_summary: Mapping[str, Any],
+    process_summary: Mapping[str, Any],
+    show_gpu: bool,
+) -> List[str]:
+    """Return the two-column watch metric block for one machine."""
+    left: List[str] = []
+    cpu = _fmt_percent(_average(system_summary, "cpu_percent"))
+    if cpu is not None:
+        left.append(f"{'CPU Util':<{_WATCH_LEFT_LABEL_WIDTH}}{cpu}% avg")
+    if show_gpu:
+        util = _fmt_percent(_average(system_summary, "gpu_util_percent"))
+        if util is not None:
+            left.append(f"{'GPU Util':<{_WATCH_LEFT_LABEL_WIDTH}}{util}% avg")
+        temp = _point_value(system_summary, "worst", "gpu_temp_c")
+        if temp is None:
+            temp = _average(system_summary, "gpu_temp_c")
+        temp_text = _fmt_percent(temp)
+        if temp_text is not None:
+            left.append(
+                f"{'GPU Temp':<{_WATCH_LEFT_LABEL_WIDTH}}{temp_text}C max"
+            )
+
+    right: List[str] = []
+    ram = _watch_capacity_cell(
+        "RAM",
+        _average(system_summary, "ram_bytes"),
+        _average(system_summary, "ram_percent"),
+    )
+    if ram is not None:
+        right.append(ram)
+    if show_gpu:
+        gpu_mem = _watch_capacity_cell(
+            "GPU Mem",
+            _average(system_summary, "gpu_mem_bytes"),
+            _average(system_summary, "gpu_mem_percent"),
+        )
+        if gpu_mem is not None:
+            right.append(gpu_mem)
+    rss = _fmt_gb(_point_value(process_summary, "worst", "ram_bytes"))
+    if rss is None:
+        rss = _fmt_gb(_average(process_summary, "ram_bytes"))
+    if rss is not None:
+        right.append(f"{'Proc RSS':<{_WATCH_RIGHT_LABEL_WIDTH}}{rss:>4} GB")
+
+    rows: List[str] = []
+    for index in range(max(len(left), len(right))):
+        head = left[index] if index < len(left) else ""
+        tail = right[index] if index < len(right) else ""
+        if tail:
+            rows.append(f"{head:<{_WATCH_RIGHT_COLUMN}}{tail}")
+        else:
+            rows.append(head)
+    return rows
+
+
+_WATCH_MULTI_METRICS = (
+    ("CPU Util", "cpu_percent", "%", "avg"),
+    ("RAM", "ram_percent", "%", "used"),
+    ("GPU Util", "gpu_util_percent", "%", "avg"),
+    ("GPU Mem", "gpu_mem_percent", "%", "used"),
+    ("GPU Temp", "gpu_temp_c", "C", "max"),
+)
+
+
+def _watch_multi_metric_rows(
+    system_summary: Mapping[str, Any],
+    *,
+    show_gpu: bool,
+) -> List[str]:
+    """Return the median / worst-node watch metric table."""
+    rows: List[str] = []
+    for label, metric, unit, qualifier in _WATCH_MULTI_METRICS:
+        if not show_gpu and metric.startswith("gpu_"):
+            continue
+        median = _fmt_percent(_point_value(system_summary, "median", metric))
+        if median is None:
+            continue
+        cell = f"{label:<{_WATCH_MULTI_LABEL_WIDTH}}{median}{unit} {qualifier}"
+        worst_point = _point(system_summary, "worst", metric)
+        worst = _fmt_percent(_float(worst_point.get("value")))
+        node = _node_of(system_summary, worst_point.get("idx"))
+        if worst is not None and node is not None:
+            cell = (
+                f"{cell:<{_WATCH_MULTI_WORST_COLUMN}}{worst}{unit}  (n{node})"
+            )
+        rows.append(cell)
+    if rows:
+        header = (
+            f"{'':<{_WATCH_MULTI_LABEL_WIDTH}}median"
+            f"{'':<{_WATCH_MULTI_WORST_COLUMN - _WATCH_MULTI_LABEL_WIDTH - 6}}"
+            "worst node"
+        )
+        rows.insert(0, header)
+    return rows
+
+
+def _append_watch_body(
+    doc: CardDoc,
+    *,
+    system_summary: Mapping[str, Any],
+    process_summary: Mapping[str, Any],
+    meta: Mapping[str, Any],
+    multi: bool,
+) -> None:
+    """Append the watch card body between the header and the footer."""
+    show_gpu = _int(meta.get("gpus_observed")) != 0
+
+    doc.blank()
+    health_lines, health_action = _watch_health_lines(
+        system_summary=system_summary,
+        process_summary=process_summary,
+        meta=meta,
+        multi=multi,
+    )
+    for index, (text, style) in enumerate(health_lines):
+        if index == 0:
+            doc.add(Span("Host health: ", STYLE_BOLD), Span(text[13:], style))
+        else:
+            doc.wrapped(text, style=style)
+    doc.blank()
+
+    if multi:
+        rows = _watch_multi_metric_rows(system_summary, show_gpu=show_gpu)
+    else:
+        rows = _watch_single_metric_rows(
+            system_summary=system_summary,
+            process_summary=process_summary,
+            show_gpu=show_gpu,
+        )
+    for text in rows:
+        doc.text(text)
+    if rows:
+        doc.blank()
+
+    system_kind = str(_diagnosis(system_summary).get("kind") or "")
+    printed_next = False
+    if show_gpu and system_kind in LOW_GPU_UTIL_KINDS:
+        util = _fmt_percent(_average(system_summary, "gpu_util_percent"))
+        doc.wrapped(
+            f"GPU utilization stayed low ({util}% avg). Watch cannot tell "
+            "whether that is input, transfer, sync, or idle time.",
+            label="Observation: ",
+        )
+        doc.wrapped(_WATCH_RUN_ACTION, label="Next: ", style=STYLE_NEXT)
+        printed_next = True
+    elif health_action:
+        doc.wrapped(health_action, label="Next: ", style=STYLE_NEXT)
+        doc.blank()
+
+    if not printed_next:
+        doc.wrapped(_WATCH_BOUNDARY, style=STYLE_DIM)
+
+
+def build_summary_card(
+    *,
+    profile: str = RUN_PROFILE,
+    primary_diagnosis: Mapping[str, Any],
+    system_summary: Mapping[str, Any],
+    process_summary: Mapping[str, Any],
+    step_time_summary: Mapping[str, Any],
+    step_memory_summary: Mapping[str, Any],
+    duration_s: Optional[float] = None,
+    meta: Optional[Mapping[str, Any]] = None,
+    artifact_hint: Optional[str] = None,
+    html_hint: Optional[str] = None,
+) -> CardDoc:
+    """
+    Build the end-of-run terminal card for one already-built summary payload.
+
+    The card is presentation-only: values come from the section payloads and
+    the promoted ``primary_diagnosis`` exactly as they were computed.
+    """
+    primary = _mapping(primary_diagnosis)
+    system = _mapping(system_summary)
+    process = _mapping(process_summary)
+    step_time = _mapping(step_time_summary)
+    step_memory = _mapping(step_memory_summary)
+    run_meta = _mapping(meta)
+
+    doc = CardDoc()
+    watch = str(profile or RUN_PROFILE).strip().lower() == WATCH_PROFILE
+    if watch:
+        multi = _is_multi_node(run_meta)
+        _append_header(
+            doc,
+            title=WATCH_TITLE,
+            meta_line=_watch_header_meta(
+                meta=run_meta,
+                duration_s=duration_s,
+                multi=multi,
+            ),
+        )
+        _append_watch_body(
+            doc,
+            system_summary=system,
+            process_summary=process,
+            meta=run_meta,
+            multi=multi,
+        )
+    else:
+        multi = is_multi_process(step_time)
+        _append_header(
+            doc,
+            title=RUN_TITLE,
+            meta_line=_run_header_meta(
+                meta=run_meta,
+                step_time_summary=step_time,
+                duration_s=duration_s,
+                multi=multi,
+            ),
+        )
+        _append_run_body(
+            doc,
+            primary=primary,
+            system_summary=system,
+            process_summary=process,
+            step_time_summary=step_time,
+            step_memory_summary=step_memory,
+            meta=run_meta,
+            multi=multi,
+        )
+
+    doc.blank()
+    doc.wrapped(_footer_line(artifact_hint, html_hint), style=STYLE_DIM)
+    doc.rule()
+    return doc
+
+
+def build_fallback_card(
+    *,
+    profile: str = RUN_PROFILE,
+    primary_diagnosis: Optional[Mapping[str, Any]] = None,
+    artifact_hint: Optional[str] = None,
+    html_hint: Optional[str] = None,
+) -> CardDoc:
+    """
+    Build the minimal verdict-and-footer card used when rendering fails.
+
+    End-of-run reporting is best-effort: a card that cannot be composed must
+    still print something truthful instead of breaking shutdown.
+    """
+    primary = _mapping(primary_diagnosis)
+    watch = str(profile or RUN_PROFILE).strip().lower() == WATCH_PROFILE
+    doc = CardDoc()
+    _append_header(
+        doc,
+        title=(WATCH_TITLE if watch else RUN_TITLE),
+        meta_line="",
+    )
+    doc.blank()
+    _append_verdict(doc, primary)
+    doc.blank()
+    doc.wrapped(_footer_line(artifact_hint, html_hint), style=STYLE_DIM)
+    doc.rule()
+    return doc
+
+
+def stdout_supports_color() -> bool:
+    """
+    Return whether stdout can carry severity-scoped ANSI color.
+
+    Shared by every print path so the CLI and the SDK make the same call.
+    """
+    try:
+        if not sys.stdout.isatty():
+            return False
+    except Exception:
+        return False
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    return os.environ.get("TERM", "") != "dumb"
+
+
+def artifact_hint(session_root: Optional[str], name: str) -> str:
+    """Return a short session-relative artifact path for the card footer."""
+    if not session_root:
+        return name
+    root = Path(str(session_root))
+    parent = root.parent.name
+    if parent:
+        return f"{parent}/{root.name}/{name}"
+    return f"{root.name}/{name}"
+
+
+def card_hints(
+    session_root: Optional[str],
+    *,
+    write_html: bool = False,
+) -> Dict[str, Optional[str]]:
+    """Return the JSON and optional HTML artifact hints for the footer."""
+    return {
+        "artifact_hint": artifact_hint(session_root, FINAL_SUMMARY_JSON_NAME),
+        "html_hint": (
+            artifact_hint(session_root, FINAL_SUMMARY_HTML_NAME)
+            if write_html
+            else None
+        ),
+    }
+
+
+def card_profile_from_text(text: str) -> str:
+    """
+    Infer the profile a stored card was rendered with.
+
+    The title is written by this module, so the header line is a reliable
+    marker: only watch cards carry the watch title.
+    """
+    for line in str(text).splitlines()[:4]:
+        if WATCH_TITLE in line:
+            return WATCH_PROFILE
+    return RUN_PROFILE
+
+
+def build_card_from_payload(
+    payload: Mapping[str, Any],
+    *,
+    profile: str = RUN_PROFILE,
+    session_root: Optional[str] = None,
+    write_html: bool = False,
+) -> CardDoc:
+    """Build the card for an already-built final-summary payload."""
+    return build_summary_card(
+        profile=profile,
+        primary_diagnosis=payload.get("primary_diagnosis") or {},
+        system_summary=payload.get("system") or {},
+        process_summary=payload.get("process") or {},
+        step_time_summary=payload.get("step_time") or {},
+        step_memory_summary=payload.get("step_memory") or {},
+        duration_s=payload.get("duration_s"),
+        meta=payload.get("meta") or {},
+        **card_hints(session_root, write_html=write_html),
+    )
+
+
+def colorize_stored_card(
+    text: str,
+    payload: Mapping[str, Any],
+    *,
+    session_root: Optional[str] = None,
+    write_html: bool = False,
+) -> str:
+    """
+    Return an ANSI rendering of a stored card, or the stored text unchanged.
+
+    The colored output is only used when the card rebuilt from ``payload``
+    renders back to exactly the stored text, so colorizing can never change
+    what a reader sees beyond the escape codes. Anything unexpected -- a
+    non-terminal stdout, a payload that no longer reproduces the stored card,
+    or any exception -- falls back to the stored text.
+    """
+    if not text or not stdout_supports_color():
+        return text
+
+    body = text[:-1] if text.endswith("\n") else text
+    suffix = text[len(body) :]
+    try:
+        doc = build_card_from_payload(
+            payload,
+            profile=card_profile_from_text(body),
+            session_root=session_root,
+            write_html=write_html,
+        )
+        if card_to_plain(doc) != body:
+            return text
+        return card_to_ansi(doc) + suffix
+    except Exception:
+        return text
+
+
+__all__ = [
+    "CARD_WIDTH",
+    "FINAL_SUMMARY_HTML_NAME",
+    "FINAL_SUMMARY_JSON_NAME",
+    "CardDoc",
+    "CardLine",
+    "RUN_PROFILE",
+    "RUN_TITLE",
+    "Span",
+    "WATCH_PROFILE",
+    "WATCH_TITLE",
+    "artifact_hint",
+    "build_card_from_payload",
+    "build_fallback_card",
+    "build_summary_card",
+    "card_hints",
+    "card_profile_from_text",
+    "card_to_ansi",
+    "card_to_plain",
+    "colorize_stored_card",
+    "fmt_duration",
+    "is_multi_process",
+    "stdout_supports_color",
+]

--- a/src/traceml_ai/sdk/summary_client.py
+++ b/src/traceml_ai/sdk/summary_client.py
@@ -10,8 +10,10 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from traceml_ai.reporting.summary_card import colorize_stored_card
 from traceml_ai.sdk.protocol import (
     build_final_summary_request,
+    get_final_summary_html_path,
     get_final_summary_json_path,
     get_final_summary_request_path,
     get_final_summary_response_path,
@@ -35,6 +37,31 @@ def _read_text_or_empty(path: Path) -> str:
         return ""
 
 
+def _print_summary_text(
+    text: str,
+    summary: Dict[str, Any],
+    session_root: Path,
+) -> None:
+    """
+    Print the stored summary card, colorized when stdout is a terminal.
+
+    The stored text stays the source of truth: colorization only applies when
+    the card rebuilt from ``summary`` reproduces it exactly, so this can never
+    change what is printed beyond the escape codes.
+    """
+    try:
+        html_written = get_final_summary_html_path(session_root).is_file()
+        text = colorize_stored_card(
+            text,
+            summary,
+            session_root=str(session_root),
+            write_html=html_written,
+        )
+    except Exception:
+        pass
+    print(text)
+
+
 def _load_existing_final_summary(
     session_root: Path,
     *,
@@ -48,7 +75,7 @@ def _load_existing_final_summary(
     if print_text:
         text = _read_text_or_empty(get_final_summary_txt_path(session_root))
         if text:
-            print(text)
+            _print_summary_text(text, summary, session_root)
 
     return summary
 
@@ -139,7 +166,11 @@ def final_summary(
                 if summary_txt_path:
                     text = _read_text_or_empty(Path(summary_txt_path))
                     if text:
-                        print(text)
+                        _print_summary_text(
+                            text,
+                            summary,
+                            Path(summary_txt_path).parent,
+                        )
 
             return summary
 

--- a/tests/reporting/summary/test_card_golden.py
+++ b/tests/reporting/summary/test_card_golden.py
@@ -1,0 +1,1426 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Golden-output lock-down for the terminal run/watch summary card.
+
+Each case builds a final-summary shaped payload and asserts the full rendered
+card, byte for byte. Layout changes are intentional changes: update the golden
+in the same commit as the renderer.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from traceml_ai.reporting.primary_diagnosis import build_primary_diagnosis
+from traceml_ai.reporting.summary_card import (
+    CardDoc,
+    build_summary_card,
+    card_to_ansi,
+    card_to_plain,
+)
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _issue(
+    kind: str,
+    status: str,
+    *,
+    severity: str = "info",
+    summary: str = "",
+    action: str = "",
+    **extra: Any,
+) -> Dict[str, Any]:
+    """Build one section issue/diagnosis block."""
+    issue: Dict[str, Any] = {
+        "kind": kind,
+        "status": status,
+        "severity": severity,
+        "summary": summary,
+        "action": action,
+        "metric": None,
+        "phase": None,
+        "score": None,
+        "share_pct": None,
+        "skew_pct": None,
+        "ranks": [],
+        "evidence": {},
+    }
+    issue.update(extra)
+    return issue
+
+
+def _section(
+    *,
+    diagnosis: Dict[str, Any],
+    metadata: Optional[Dict[str, Any]] = None,
+    window: Optional[Dict[str, Any]] = None,
+    average: Optional[Dict[str, Any]] = None,
+    median: Optional[Dict[str, Any]] = None,
+    worst: Optional[Dict[str, Any]] = None,
+    rows: Optional[Dict[str, Any]] = None,
+    issues: Optional[List[Dict[str, Any]]] = None,
+    by: str = "global_rank",
+) -> Dict[str, Any]:
+    """Build one final-summary section payload."""
+    return {
+        "metadata": dict(metadata or {}),
+        "diagnosis": diagnosis,
+        "issues": list(issues if issues is not None else [diagnosis]),
+        "global": {
+            "index_by": by,
+            "window": dict(window or {}),
+            "average": dict(average or {}),
+            "median": dict(median or {}),
+            "worst": dict(worst or {}),
+        },
+        "groups": {"by": by, "rows": dict(rows or {})},
+        "units": {},
+        "card": "SECTION CARD",
+    }
+
+
+def _point(value: Optional[float], idx: str) -> Dict[str, Any]:
+    """Build one median/worst point."""
+    return {"value": value, "idx": idx}
+
+
+def _rank_rows(*ranks: int, node_rank: int = 0) -> Dict[str, Any]:
+    """Build grouped rows indexed by global rank."""
+    return {
+        str(rank): {
+            "identity": {
+                "global_rank": rank,
+                "local_rank": rank,
+                "node_rank": node_rank,
+                "hostname": None,
+                "local_world_size": None,
+                "world_size": None,
+            },
+            "metrics": {},
+        }
+        for rank in ranks
+    }
+
+
+def _node_rows(*nodes: int) -> Dict[str, Any]:
+    """Build grouped rows indexed by node rank."""
+    return {
+        str(node): {
+            "identity": {
+                "global_rank": None,
+                "local_rank": None,
+                "node_rank": node,
+                "hostname": None,
+                "local_world_size": None,
+                "world_size": None,
+            },
+            "metrics": {},
+        }
+        for node in nodes
+    }
+
+
+def _card(
+    *,
+    profile: str,
+    system: Dict[str, Any],
+    process: Dict[str, Any],
+    step_time: Dict[str, Any],
+    step_memory: Dict[str, Any],
+    meta: Dict[str, Any],
+    duration_s: Optional[float],
+    artifact_hint: str,
+    html_hint: Optional[str] = None,
+) -> CardDoc:
+    """Build one card document from already-built section payloads."""
+    primary = build_primary_diagnosis(
+        system_summary=system,
+        process_summary=process,
+        step_time_summary=step_time,
+        step_memory_summary=step_memory,
+    )
+    return build_summary_card(
+        profile=profile,
+        primary_diagnosis=primary,
+        system_summary=system,
+        process_summary=process,
+        step_time_summary=step_time,
+        step_memory_summary=step_memory,
+        duration_s=duration_s,
+        meta=meta,
+        artifact_hint=artifact_hint,
+        html_hint=html_hint,
+    )
+
+
+_NORMAL_PROCESS = _section(diagnosis=_issue("NORMAL", "NORMAL"))
+
+
+def _meta(
+    *,
+    run_name: Optional[str] = None,
+    mode: str = "single_node",
+    world_size: Optional[int] = 1,
+    nodes_observed: Optional[int] = 1,
+    gpus_observed: Optional[int] = 1,
+) -> Dict[str, Any]:
+    """Build the run-level meta block."""
+    return {
+        "run_name": run_name,
+        "mode": mode,
+        "world_size": world_size,
+        "nodes_observed": nodes_observed,
+        "gpus_observed": gpus_observed,
+    }
+
+
+def _system_single(
+    *,
+    diagnosis: Optional[Dict[str, Any]] = None,
+    cpu_percent: Optional[float] = None,
+    gpu_util_percent: Optional[float] = None,
+    ram_bytes: Optional[float] = None,
+    ram_percent: Optional[float] = None,
+    gpu_mem_bytes: Optional[float] = None,
+    gpu_mem_percent: Optional[float] = None,
+    gpu_temp_c: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Build a single-node System section payload."""
+    return _section(
+        diagnosis=diagnosis or _issue("NORMAL", "NORMAL"),
+        metadata={"mode": "single_node", "gpus_observed": 1},
+        average={
+            "cpu_percent": cpu_percent,
+            "ram_bytes": ram_bytes,
+            "ram_percent": ram_percent,
+            "gpu_util_percent": gpu_util_percent,
+            "gpu_mem_bytes": gpu_mem_bytes,
+            "gpu_mem_percent": gpu_mem_percent,
+            "gpu_temp_c": gpu_temp_c,
+        },
+        worst={"gpu_temp_c": _point(gpu_temp_c, "0")},
+        rows=_node_rows(0),
+        by="node_rank",
+    )
+
+
+def _step_memory_single(
+    allocated: Optional[float],
+    reserved: Optional[float],
+    *,
+    diagnosis: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a single-rank Step Memory section payload."""
+    return _section(
+        diagnosis=diagnosis or _issue("BALANCED", "BALANCED"),
+        metadata={"global_ranks_used": 1},
+        worst={
+            "peak_allocated_bytes": _point(allocated, "0"),
+            "peak_reserved_bytes": _point(reserved, "0"),
+        },
+        median={
+            "peak_allocated_bytes": _point(allocated, "0"),
+            "peak_reserved_bytes": _point(reserved, "0"),
+        },
+        rows=_rank_rows(0),
+    )
+
+
+def _step_time_single(
+    *,
+    diagnosis: Dict[str, Any],
+    steps_analyzed: Optional[int],
+    clock: str = "gpu",
+    step_time_ms: Optional[float] = None,
+    input_wait_ms: Optional[float] = None,
+    traced_step_time_ms: Optional[float] = None,
+    compute_ms: Optional[float] = None,
+    h2d_ms: Optional[float] = None,
+    residual_ms: Optional[float] = None,
+    dataloader_fetch_cpu_ms: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Build a single-rank Step Time section payload."""
+    return _section(
+        diagnosis=diagnosis,
+        metadata={"mode": "single_node", "global_ranks_used": 1},
+        window={"steps_analyzed": steps_analyzed, "diagnosis_clock": clock},
+        average={
+            "step_time_ms": step_time_ms,
+            "input_wait_ms": input_wait_ms,
+            "traced_step_time_ms": traced_step_time_ms,
+            "compute_ms": compute_ms,
+            "h2d_ms": h2d_ms,
+            "residual_ms": residual_ms,
+            "dataloader_fetch_cpu_ms": dataloader_fetch_cpu_ms,
+        },
+        rows=_rank_rows(0),
+    )
+
+
+def run_input_bound_critical() -> CardDoc:
+    """run x single GPU, INPUT-BOUND critical (the flagship card)."""
+    return _card(
+        profile="run",
+        system=_system_single(
+            diagnosis=_issue("LOW_GPU_UTILIZATION", "LOW GPU UTIL"),
+            cpu_percent=18.4,
+            gpu_util_percent=24.0,
+            gpu_mem_bytes=3.33e9,
+            gpu_temp_c=42.0,
+        ),
+        process=_NORMAL_PROCESS,
+        step_time=_step_time_single(
+            diagnosis=_issue(
+                "INPUT_BOUND",
+                "INPUT-BOUND",
+                severity="crit",
+                summary="Input Wait is 64.0% of the typical GPU Step Time.",
+                action="Increase workers, prefetch, or storage throughput.",
+                score=0.64,
+            ),
+            steps_analyzed=256,
+            step_time_ms=200.4,
+            input_wait_ms=128.0,
+            traced_step_time_ms=72.0,
+            compute_ms=68.0,
+            h2d_ms=0.4,
+            residual_ms=3.6,
+            dataloader_fetch_cpu_ms=120.0,
+        ),
+        step_memory=_step_memory_single(2.9e9, 3.2e9),
+        meta=_meta(run_name="bert_finetune"),
+        duration_s=52.4,
+        artifact_hint="logs/bert_finetune/final_summary.json",
+    )
+
+
+def run_healthy() -> CardDoc:
+    """run x single GPU, no clear bottleneck."""
+    return _card(
+        profile="run",
+        system=_system_single(
+            cpu_percent=42.0,
+            gpu_util_percent=92.0,
+            gpu_temp_c=61.0,
+        ),
+        process=_NORMAL_PROCESS,
+        step_time=_step_time_single(
+            diagnosis=_issue("BALANCED", "BALANCED"),
+            steps_analyzed=256,
+            step_time_ms=191.0,
+            input_wait_ms=2.1,
+            traced_step_time_ms=188.9,
+            compute_ms=185.0,
+            h2d_ms=1.9,
+            residual_ms=2.0,
+        ),
+        step_memory=_step_memory_single(2.9e9, 3.2e9),
+        meta=_meta(run_name="bert_finetune"),
+        duration_s=48.9,
+        artifact_hint="logs/bert_finetune/final_summary.json",
+    )
+
+
+def run_input_bound_with_also() -> CardDoc:
+    """run x single GPU, INPUT-BOUND critical plus a step-memory warning."""
+    creep = _issue(
+        "MEMORY_CREEP",
+        "MEMORY CREEP",
+        severity="warn",
+        summary="Step memory grew 1.2 GB over the run -- possible leak",
+        action="Check for retained tensors between steps.",
+    )
+    return _card(
+        profile="run",
+        system=_system_single(
+            cpu_percent=18.4,
+            gpu_util_percent=88.0,
+            gpu_temp_c=42.0,
+        ),
+        process=_NORMAL_PROCESS,
+        step_time=_step_time_single(
+            diagnosis=_issue(
+                "INPUT_BOUND",
+                "INPUT-BOUND",
+                severity="crit",
+                summary="Input Wait is 64.0% of the typical GPU Step Time.",
+                action="Increase workers, prefetch, or storage throughput.",
+                score=0.64,
+            ),
+            steps_analyzed=256,
+            step_time_ms=200.4,
+            input_wait_ms=128.0,
+            traced_step_time_ms=72.0,
+            compute_ms=68.0,
+            h2d_ms=0.4,
+            residual_ms=3.6,
+        ),
+        step_memory=_step_memory_single(3.9e9, 4.6e9, diagnosis=creep),
+        meta=_meta(run_name="bert_finetune"),
+        duration_s=52.4,
+        artifact_hint="logs/bert_finetune/final_summary.json",
+    )
+
+
+def run_low_gpu_utilization() -> CardDoc:
+    """run x single GPU, balanced timing with unexplained low GPU util."""
+    return _card(
+        profile="run",
+        system=_system_single(
+            diagnosis=_issue("LOW_GPU_UTILIZATION", "LOW GPU UTIL"),
+            cpu_percent=17.0,
+            gpu_util_percent=22.0,
+            gpu_temp_c=44.0,
+        ),
+        process=_NORMAL_PROCESS,
+        step_time=_step_time_single(
+            diagnosis=_issue("BALANCED", "BALANCED"),
+            steps_analyzed=256,
+            step_time_ms=240.0,
+            input_wait_ms=3.1,
+            traced_step_time_ms=236.9,
+            compute_ms=120.3,
+            h2d_ms=1.2,
+            residual_ms=115.4,
+        ),
+        step_memory=_step_memory_single(2.9e9, 3.2e9),
+        meta=_meta(run_name="bert_finetune"),
+        duration_s=61.2,
+        artifact_hint="logs/bert_finetune/final_summary.json",
+    )
+
+
+def run_cpu_only_input_bound() -> CardDoc:
+    """run x single CPU-only machine, INPUT-BOUND warning."""
+    return _card(
+        profile="run",
+        system=_system_single(cpu_percent=25.4),
+        process=_NORMAL_PROCESS,
+        step_time=_step_time_single(
+            diagnosis=_issue(
+                "INPUT_BOUND",
+                "INPUT-BOUND",
+                severity="warn",
+                summary="Input Wait is 14.0% of the typical CPU Step Time.",
+                action="Increase workers or prefetch.",
+                score=0.14,
+            ),
+            steps_analyzed=100,
+            clock="cpu",
+            step_time_ms=1.36,
+            input_wait_ms=0.19,
+            traced_step_time_ms=1.17,
+            compute_ms=1.02,
+            h2d_ms=None,
+            residual_ms=0.149,
+            dataloader_fetch_cpu_ms=0.19,
+        ),
+        step_memory=_step_memory_single(
+            None,
+            None,
+            diagnosis=_issue("NO_GPU", "NO GPU"),
+        ),
+        meta=_meta(run_name="quickstart", gpus_observed=0),
+        duration_s=2.0,
+        artifact_hint="logs/session_20260806_090618/final_summary.json",
+    )
+
+
+def run_not_enough_step_data() -> CardDoc:
+    """run x single GPU, not enough completed steps for a diagnosis."""
+    return _card(
+        profile="run",
+        system=_system_single(cpu_percent=17.0, gpu_util_percent=31.0),
+        process=_NORMAL_PROCESS,
+        step_time=_step_time_single(
+            diagnosis=_issue("NO_DATA", "NO DATA"),
+            steps_analyzed=12,
+        ),
+        step_memory=_step_memory_single(None, None),
+        meta=_meta(run_name="quickstart"),
+        duration_s=4.0,
+        artifact_hint="logs/quickstart/final_summary.json",
+    )
+
+
+def run_step_timing_incomplete() -> CardDoc:
+    """run x single GPU, step timing missing phase signals."""
+    incomplete = _issue(
+        "INCOMPLETE_DATA",
+        "INCOMPLETE DATA",
+        summary="Missing timing signals prevent a reliable diagnosis.",
+        action="Instrument the missing phases.",
+        evidence={"missing_signals": ["backward", "optimizer"]},
+    )
+    return _card(
+        profile="run",
+        system=_system_single(),
+        process=_NORMAL_PROCESS,
+        step_time=_step_time_single(
+            diagnosis=incomplete,
+            steps_analyzed=None,
+        ),
+        step_memory=_step_memory_single(None, None),
+        meta=_meta(run_name="quickstart"),
+        duration_s=4.0,
+        artifact_hint="logs/quickstart/final_summary.json",
+    )
+
+
+def run_multi_input_straggler() -> CardDoc:
+    """run x multi rank, input straggler on rank 0."""
+    system = _section(
+        diagnosis=_issue("LOW_GPU_UTILIZATION", "LOW GPU UTIL"),
+        metadata={"mode": "multi_node", "nodes_observed": 2},
+        average={"cpu_percent": 22.0, "gpu_util_percent": 14.0},
+        median={"gpu_util_percent": _point(14.0, "0")},
+        worst={"gpu_util_percent": _point(9.0, "1")},
+        rows=_node_rows(0, 1),
+        by="node_rank",
+    )
+    step_time = _section(
+        diagnosis=_issue(
+            "INPUT_STRAGGLER",
+            "INPUT STRAGGLER",
+            severity="crit",
+            summary="r0 has excess input wait burden relative to victim r1.",
+            action="Inspect input wait on the slow rank.",
+            phase="input",
+            score=0.83,
+        ),
+        metadata={"mode": "multi_node", "global_ranks_used": 4},
+        window={"steps_analyzed": 250, "diagnosis_clock": "gpu"},
+        median={
+            "step_time_ms": _point(303.7, "1"),
+            "input_wait_ms": _point(3.8, "1"),
+            "traced_step_time_ms": _point(299.9, "1"),
+            "compute_ms": _point(259.5, "1"),
+            "h2d_ms": _point(1.1, "1"),
+            "residual_ms": _point(39.3, "1"),
+        },
+        worst={
+            "step_time_ms": _point(304.1, "0"),
+            "input_wait_ms": _point(254.5, "0"),
+            "traced_step_time_ms": _point(300.5, "0"),
+            "compute_ms": _point(261.0, "0"),
+            "h2d_ms": _point(1.2, "0"),
+            "residual_ms": _point(39.5, "0"),
+        },
+        rows=_rank_rows(0, 1, 2, 3),
+    )
+    step_memory = _section(
+        diagnosis=_issue("BALANCED", "BALANCED"),
+        metadata={"global_ranks_used": 4},
+        median={"peak_reserved_bytes": _point(8.9e9, "1")},
+        worst={"peak_reserved_bytes": _point(9.8e9, "2")},
+        rows=_rank_rows(0, 1, 2, 3),
+    )
+    return _card(
+        profile="run",
+        system=system,
+        process=_NORMAL_PROCESS,
+        step_time=step_time,
+        step_memory=step_memory,
+        meta=_meta(
+            run_name="ddp_pretrain",
+            mode="multi_node",
+            world_size=4,
+            nodes_observed=2,
+            gpus_observed=4,
+        ),
+        duration_s=40.1,
+        artifact_hint="logs/ddp_pretrain/final_summary.json",
+    )
+
+
+def run_multi_healthy() -> CardDoc:
+    """run x multi rank, balanced and even across ranks."""
+    system = _section(
+        diagnosis=_issue("NORMAL", "NORMAL"),
+        metadata={"mode": "single_node", "nodes_observed": 1},
+        average={"cpu_percent": 38.0, "gpu_util_percent": 94.0},
+        rows=_node_rows(0),
+        by="node_rank",
+    )
+    step_time = _section(
+        diagnosis=_issue("BALANCED", "BALANCED"),
+        metadata={"mode": "single_node", "global_ranks_used": 4},
+        window={"steps_analyzed": 250, "diagnosis_clock": "gpu"},
+        median={
+            "step_time_ms": _point(152.1, "1"),
+            "input_wait_ms": _point(2.0, "1"),
+            "traced_step_time_ms": _point(150.1, "1"),
+            "compute_ms": _point(145.2, "1"),
+            "h2d_ms": _point(1.6, "1"),
+            "residual_ms": _point(3.3, "1"),
+        },
+        worst={
+            "step_time_ms": _point(152.7, "2"),
+            "input_wait_ms": _point(2.1, "2"),
+            "traced_step_time_ms": _point(150.6, "2"),
+            "compute_ms": _point(145.6, "2"),
+            "h2d_ms": _point(1.7, "2"),
+            "residual_ms": _point(3.4, "2"),
+        },
+        rows=_rank_rows(0, 1, 2, 3),
+    )
+    step_memory = _section(
+        diagnosis=_issue("BALANCED", "BALANCED"),
+        metadata={"global_ranks_used": 4},
+        median={"peak_reserved_bytes": _point(9.0e9, "1")},
+        worst={"peak_reserved_bytes": _point(9.1e9, "2")},
+        rows=_rank_rows(0, 1, 2, 3),
+    )
+    return _card(
+        profile="run",
+        system=system,
+        process=_NORMAL_PROCESS,
+        step_time=step_time,
+        step_memory=step_memory,
+        meta=_meta(
+            run_name="ddp_pretrain",
+            world_size=4,
+            nodes_observed=1,
+            gpus_observed=4,
+        ),
+        duration_s=38.7,
+        artifact_hint="logs/ddp_pretrain/final_summary.json",
+    )
+
+
+def run_single_gpu_on_shared_host() -> CardDoc:
+    """run x 1 process on a 4-GPU host (real 4xT4 capture)."""
+    return _card(
+        profile="run",
+        system=_system_single(
+            diagnosis=_issue("LOW_GPU_UTILIZATION", "LOW GPU UTIL"),
+            cpu_percent=0.2285714285714286,
+            gpu_util_percent=0.21428571428571427,
+            ram_bytes=3986740955.428571,
+            ram_percent=1.988849429010849,
+            gpu_mem_bytes=498930249.14285713,
+            gpu_mem_percent=3.0977666945684526,
+            gpu_temp_c=34.5,
+        ),
+        process=_NORMAL_PROCESS,
+        step_time=_step_time_single(
+            diagnosis=_issue(
+                "BALANCED",
+                "BALANCED",
+                summary="No dominant bottleneck is visible in this window.",
+                action="No action needed.",
+            ),
+            steps_analyzed=128,
+            step_time_ms=34.1507115913555,
+            input_wait_ms=2.4584102761000395,
+            traced_step_time_ms=31.692301315255463,
+            compute_ms=29.361732091289014,
+            h2d_ms=None,
+            residual_ms=2.3305692239664495,
+            dataloader_fetch_cpu_ms=2.4595465511083603,
+        ),
+        step_memory=_step_memory_single(18838528.0, 23068672.0),
+        meta=_meta(
+            run_name="session_20260806_101725_5580d3",
+            world_size=1,
+            nodes_observed=1,
+            gpus_observed=4,
+        ),
+        duration_s=12.133176565170288,
+        artifact_hint=(
+            "logs/session_20260806_101725_5580d3/final_summary.json"
+        ),
+    )
+
+
+def run_multi_residual_heavy() -> CardDoc:
+    """run x 4-rank DDP, residual-heavy with a competing step-time issue."""
+    system = _section(
+        diagnosis=_issue("LOW_GPU_UTILIZATION", "LOW GPU UTIL"),
+        metadata={"mode": "single_node", "nodes_observed": 1},
+        average={
+            "cpu_percent": 2.4,
+            "gpu_util_percent": 6.833333333333333,
+        },
+        rows=_node_rows(0),
+        by="node_rank",
+    )
+    residual_heavy = _issue(
+        "RESIDUAL_HEAVY",
+        "RESIDUAL-HEAVY",
+        severity="warn",
+        summary="Residual time is 14.0% of the typical GPU Step Time.",
+        action="Investigate untraced work between steps.",
+        score=0.13980705864843995,
+    )
+    # A competing Step Time finding: it must never reach the Also block,
+    # which is scoped to resource sections.
+    input_bound = _issue(
+        "INPUT_BOUND",
+        "INPUT-BOUND",
+        severity="warn",
+        summary="Input wait is 11.0% of the typical GPU Step Time.",
+        action="Increase workers, prefetch, or storage throughput.",
+        score=0.11,
+    )
+    step_time = _section(
+        diagnosis=residual_heavy,
+        issues=[residual_heavy, input_bound],
+        metadata={"mode": "single_node", "global_ranks_used": 4},
+        window={"steps_analyzed": 128, "diagnosis_clock": "gpu"},
+        median={
+            "step_time_ms": _point(5.203032052493654, "1"),
+            "input_wait_ms": _point(0.575069501879625, "1"),
+            "traced_step_time_ms": _point(4.6259870529174805, "1"),
+            "compute_ms": _point(3.83626828956767, "1"),
+            "h2d_ms": _point(0.08052700001280755, "1"),
+            "residual_ms": _point(0.7217999144340865, "1"),
+        },
+        worst={
+            "step_time_ms": _point(5.229208162869327, "2"),
+            "input_wait_ms": _point(0.5804139995016158, "1"),
+            "traced_step_time_ms": _point(4.6567043997347355, "0"),
+            "compute_ms": _point(3.8683359728602227, "3"),
+            "h2d_ms": _point(0.08191550013725646, "1"),
+            "residual_ms": _point(0.7465767902322114, "1"),
+        },
+        rows=_rank_rows(0, 1, 2, 3),
+    )
+    step_memory = _section(
+        diagnosis=_issue("BALANCED", "BALANCED"),
+        metadata={"global_ranks_used": 4},
+        median={"peak_reserved_bytes": _point(23068672.0, "1")},
+        worst={"peak_reserved_bytes": _point(25149440.0, "0")},
+        rows=_rank_rows(0, 1, 2, 3),
+    )
+    return _card(
+        profile="run",
+        system=system,
+        process=_NORMAL_PROCESS,
+        step_time=step_time,
+        step_memory=step_memory,
+        meta=_meta(
+            run_name="session_20260806_101837_1b81f7",
+            world_size=4,
+            nodes_observed=1,
+            gpus_observed=4,
+        ),
+        duration_s=2.744549512863159,
+        artifact_hint=(
+            "logs/session_20260806_101837_1b81f7/final_summary.json"
+        ),
+    )
+
+
+def _watch_system(
+    *,
+    diagnosis: Optional[Dict[str, Any]] = None,
+    cpu_percent: float,
+    ram_bytes: float,
+    ram_percent: float,
+    gpu_util_percent: Optional[float] = None,
+    gpu_mem_bytes: Optional[float] = None,
+    gpu_mem_percent: Optional[float] = None,
+    gpu_temp_c: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Build a single-node System payload for watch cards."""
+    return _section(
+        diagnosis=diagnosis or _issue("NORMAL", "NORMAL"),
+        metadata={"mode": "single_node", "gpus_observed": 1},
+        average={
+            "cpu_percent": cpu_percent,
+            "ram_bytes": ram_bytes,
+            "ram_percent": ram_percent,
+            "gpu_util_percent": gpu_util_percent,
+            "gpu_mem_bytes": gpu_mem_bytes,
+            "gpu_mem_percent": gpu_mem_percent,
+            "gpu_temp_c": gpu_temp_c,
+        },
+        worst={"gpu_temp_c": _point(gpu_temp_c, "0")},
+        rows=_node_rows(0),
+        by="node_rank",
+    )
+
+
+def _watch_process(rss_bytes: float) -> Dict[str, Any]:
+    """Build a Process payload for watch cards."""
+    return _section(
+        diagnosis=_issue("NORMAL", "NORMAL"),
+        metadata={"global_ranks_used": 1},
+        worst={"ram_bytes": _point(rss_bytes, "0")},
+        rows=_rank_rows(0),
+    )
+
+
+_WATCH_STEP_TIME = _section(
+    diagnosis=_issue("NO_DATA", "NO DATA"),
+    metadata={"global_ranks_used": 1},
+    window={"steps_analyzed": 0},
+)
+_WATCH_STEP_MEMORY = _section(diagnosis=_issue("NO_GPU", "NO GPU"))
+
+
+def watch_healthy() -> CardDoc:
+    """watch x single machine, healthy host."""
+    return _card(
+        profile="watch",
+        system=_watch_system(
+            cpu_percent=18.0,
+            ram_bytes=6.2e9,
+            ram_percent=19.375,
+            gpu_util_percent=76.0,
+            gpu_mem_bytes=10.3e9,
+            gpu_mem_percent=64.375,
+            gpu_temp_c=61.0,
+        ),
+        process=_watch_process(4.1e9),
+        step_time=_WATCH_STEP_TIME,
+        step_memory=_WATCH_STEP_MEMORY,
+        meta=_meta(),
+        duration_s=312.0,
+        artifact_hint="logs/watch_20260806/final_summary.json",
+    )
+
+
+def watch_low_gpu_utilization() -> CardDoc:
+    """watch x single machine, low GPU utilization observation."""
+    return _card(
+        profile="watch",
+        system=_watch_system(
+            diagnosis=_issue("LOW_GPU_UTILIZATION", "LOW GPU UTIL"),
+            cpu_percent=18.0,
+            ram_bytes=6.2e9,
+            ram_percent=19.375,
+            gpu_util_percent=14.0,
+            gpu_mem_bytes=3.3e9,
+            gpu_mem_percent=20.625,
+            gpu_temp_c=42.0,
+        ),
+        process=_watch_process(4.1e9),
+        step_time=_WATCH_STEP_TIME,
+        step_memory=_WATCH_STEP_MEMORY,
+        meta=_meta(),
+        duration_s=312.0,
+        artifact_hint="logs/watch_20260806/final_summary.json",
+    )
+
+
+def watch_memory_pressure() -> CardDoc:
+    """watch x single machine, host memory pressure."""
+    pressure = _issue(
+        "MEMORY_PRESSURE",
+        "MEMORY PRESSURE",
+        severity="warn",
+        summary=(
+            "RAM 30.1 / 32.0 GB (94%) -- the host is close to memory "
+            "exhaustion."
+        ),
+        action="reduce DataLoader workers or caching, or move work off "
+        "this host.",
+    )
+    return _card(
+        profile="watch",
+        system=_watch_system(
+            diagnosis=pressure,
+            cpu_percent=64.0,
+            ram_bytes=30.1e9,
+            ram_percent=94.0625,
+            gpu_util_percent=81.0,
+            gpu_mem_bytes=14.9e9,
+            gpu_mem_percent=93.125,
+            gpu_temp_c=79.0,
+        ),
+        process=_watch_process(28.6e9),
+        step_time=_WATCH_STEP_TIME,
+        step_memory=_WATCH_STEP_MEMORY,
+        meta=_meta(),
+        duration_s=312.0,
+        artifact_hint="logs/watch_20260806/final_summary.json",
+    )
+
+
+def watch_multi_node() -> CardDoc:
+    """watch x multi node, healthy hosts."""
+    system = _section(
+        diagnosis=_issue("NORMAL", "NORMAL"),
+        metadata={"mode": "multi_node", "nodes_observed": 3},
+        median={
+            "cpu_percent": _point(24.0, "0"),
+            "ram_percent": _point(31.0, "0"),
+            "gpu_util_percent": _point(88.0, "0"),
+            "gpu_mem_percent": _point(71.0, "0"),
+            "gpu_temp_c": _point(64.0, "0"),
+        },
+        worst={
+            "cpu_percent": _point(71.0, "1"),
+            "ram_percent": _point(64.0, "1"),
+            "gpu_util_percent": _point(62.0, "2"),
+            "gpu_mem_percent": _point(93.0, "0"),
+            "gpu_temp_c": _point(81.0, "0"),
+        },
+        rows=_node_rows(0, 1, 2),
+        by="node_rank",
+    )
+    return _card(
+        profile="watch",
+        system=system,
+        process=_watch_process(4.1e9),
+        step_time=_WATCH_STEP_TIME,
+        step_memory=_WATCH_STEP_MEMORY,
+        meta=_meta(
+            mode="multi_node",
+            world_size=12,
+            nodes_observed=3,
+            gpus_observed=12,
+        ),
+        duration_s=760.0,
+        artifact_hint="logs/watch_20260806/final_summary.json",
+    )
+
+
+CASES = {
+    "run_input_bound_critical": run_input_bound_critical,
+    "run_healthy": run_healthy,
+    "run_input_bound_with_also": run_input_bound_with_also,
+    "run_low_gpu_utilization": run_low_gpu_utilization,
+    "run_cpu_only_input_bound": run_cpu_only_input_bound,
+    "run_not_enough_step_data": run_not_enough_step_data,
+    "run_step_timing_incomplete": run_step_timing_incomplete,
+    "run_multi_input_straggler": run_multi_input_straggler,
+    "run_multi_healthy": run_multi_healthy,
+    "run_single_gpu_on_shared_host": run_single_gpu_on_shared_host,
+    "run_multi_residual_heavy": run_multi_residual_heavy,
+    "watch_healthy": watch_healthy,
+    "watch_low_gpu_utilization": watch_low_gpu_utilization,
+    "watch_memory_pressure": watch_memory_pressure,
+    "watch_multi_node": watch_multi_node,
+}
+
+WATCH_CASES = tuple(name for name in CASES if name.startswith("watch_"))
+SINGLE_MACHINE_CASES = (
+    "run_input_bound_critical",
+    "run_healthy",
+    "run_input_bound_with_also",
+    "run_low_gpu_utilization",
+    "run_cpu_only_input_bound",
+    "run_not_enough_step_data",
+    "run_step_timing_incomplete",
+    "run_single_gpu_on_shared_host",
+    "watch_healthy",
+    "watch_low_gpu_utilization",
+    "watch_memory_pressure",
+)
+
+
+GOLDENS = {
+    "run_input_bound_critical": """\
++----------------------------------------------------------------------------+
+|  TraceML Run Summary                                                       |
+|  bert_finetune · 1 GPU · 256 steps analyzed · 52.4s                        |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Verdict: INPUT-BOUND  (CRITICAL)                                          |
+|  Why: input wait is 64% of the typical step; the GPU sits idle while       |
+|  batches arrive.                                                           |
+|                                                                            |
+|  Where a step goes (average, GPU clock)                                    |
+|  Step Time           200.4 ms  100%  ████████████████████████████          |
+|  ├─ Input Wait       128.0 ms   64%  ██████████████████░░░░░░░░░░  ◀  cause|
+|  └─ Traced Step Time  72.0 ms   36%  ██████████░░░░░░░░░░░░░░░░░░          |
+|     ├─ Compute        68.0 ms   34%                                        |
+|     ├─ H2D             0.4 ms   <1%                                        |
+|     └─ Residual        3.6 ms    2%                                        |
+|                                                                            |
+|  Next: raise DataLoader num_workers, enable pin_memory / prefetch, or check|
+|  storage read throughput.                                                  |
+|                                                                            |
+|  Supporting: GPU util 24% avg -- consistent with input starvation.         |
+|  Peak step memory: 2.9 GB allocated · 3.2 GB reserved                      |
+|                                                                            |
+|  Full evidence: logs/bert_finetune/final_summary.json  (--html-report)     |
++----------------------------------------------------------------------------+""",
+    "run_healthy": """\
++----------------------------------------------------------------------------+
+|  TraceML Run Summary                                                       |
+|  bert_finetune · 1 GPU · 256 steps analyzed · 48.9s                        |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Verdict: NO CLEAR BOTTLENECK                                              |
+|  Why: step timing is balanced -- no input, transfer, or residual issue.    |
+|                                                                            |
+|  Where a step goes (average, GPU clock)                                    |
+|  Step Time           191.0 ms  100%                                        |
+|  ├─ Input Wait         2.1 ms    1%                                        |
+|  └─ Traced Step Time 188.9 ms   99%                                        |
+|     ├─ Compute       185.0 ms   97%                                        |
+|     ├─ H2D             1.9 ms    1%                                        |
+|     └─ Residual        2.0 ms    1%                                        |
+|                                                                            |
+|  System, process, and memory: all normal. GPU util 92% avg.                |
+|  Peak step memory: 2.9 GB allocated · 3.2 GB reserved                      |
+|                                                                            |
+|  Next: training is compute-dominated; for more speed profile kernels       |
+|  (torch.profiler / Nsight).                                                |
+|                                                                            |
+|  Full evidence: logs/bert_finetune/final_summary.json  (--html-report)     |
++----------------------------------------------------------------------------+""",
+    "run_input_bound_with_also": """\
++----------------------------------------------------------------------------+
+|  TraceML Run Summary                                                       |
+|  bert_finetune · 1 GPU · 256 steps analyzed · 52.4s                        |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Verdict: INPUT-BOUND  (CRITICAL)                                          |
+|  Why: input wait is 64% of the typical step; the GPU sits idle while       |
+|  batches arrive.                                                           |
+|                                                                            |
+|  Where a step goes (average, GPU clock)                                    |
+|  Step Time           200.4 ms  100%  ████████████████████████████          |
+|  ├─ Input Wait       128.0 ms   64%  ██████████████████░░░░░░░░░░  ◀  cause|
+|  └─ Traced Step Time  72.0 ms   36%  ██████████░░░░░░░░░░░░░░░░░░          |
+|     ├─ Compute        68.0 ms   34%                                        |
+|     ├─ H2D             0.4 ms   <1%                                        |
+|     └─ Residual        3.6 ms    2%                                        |
+|                                                                            |
+|  Next: raise DataLoader num_workers, enable pin_memory / prefetch, or check|
+|  storage read throughput.                                                  |
+|                                                                            |
+|  Also, not the cause of slow steps:                                        |
+|  ! Step memory grew 1.2 GB over the run -- possible leak  (WARNING)        |
+|  Peak step memory: 3.9 GB allocated · 4.6 GB reserved                      |
+|                                                                            |
+|  Full evidence: logs/bert_finetune/final_summary.json  (--html-report)     |
++----------------------------------------------------------------------------+""",
+    "run_low_gpu_utilization": """\
++----------------------------------------------------------------------------+
+|  TraceML Run Summary                                                       |
+|  bert_finetune · 1 GPU · 256 steps analyzed · 1m 1s                        |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Verdict: LOW GPU UTILIZATION -- cause unclear                             |
+|  Why: step timing is balanced, but GPU util averaged 22%. The idle time is |
+|  not explained by input or transfer.                                       |
+|                                                                            |
+|  Where a step goes (average, GPU clock)                                    |
+|  Step Time           240.0 ms  100%                                        |
+|  ├─ Input Wait         3.1 ms    1%                                        |
+|  └─ Traced Step Time 236.9 ms   99%                                        |
+|     ├─ Compute       120.3 ms   50%                                        |
+|     ├─ H2D             1.2 ms   <1%                                        |
+|     └─ Residual      115.4 ms   48%                                        |
+|                                                                            |
+|  Next: look for untraced work between steps -- validation, checkpointing,  |
+|  logging -- or inefficient kernels (torch.profiler).                       |
+|                                                                            |
+|  Peak step memory: 2.9 GB allocated · 3.2 GB reserved                      |
+|                                                                            |
+|  Full evidence: logs/bert_finetune/final_summary.json  (--html-report)     |
++----------------------------------------------------------------------------+""",
+    "run_cpu_only_input_bound": """\
++----------------------------------------------------------------------------+
+|  TraceML Run Summary                                                       |
+|  quickstart · CPU only (no GPU detected) · 100 steps analyzed · 2.0s       |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Verdict: INPUT-BOUND  (WARNING)                                           |
+|  Why: input wait is 14% of the typical step (CPU clock).                   |
+|                                                                            |
+|  Where a step goes (average, CPU clock)                                    |
+|  Step Time             1.4 ms  100%  ████████████████████████████          |
+|  ├─ Input Wait         0.2 ms   14%  ████░░░░░░░░░░░░░░░░░░░░░░░░  ◀  cause|
+|  └─ Traced Step Time   1.2 ms   86%  ████████████████████████░░░░          |
+|     ├─ Compute         1.0 ms   75%                                        |
+|     └─ Residual        0.1 ms   11%                                        |
+|                                                                            |
+|  H2D and step memory not measured (no GPU).                                |
+|  DataLoader fetch: 0.2 ms (supplemental).                                  |
+|                                                                            |
+|  Next: raise DataLoader num_workers or prefetch, or check storage read     |
+|  throughput.                                                               |
+|                                                                            |
+|  Full evidence: logs/session_20260806_090618/final_summary.json            |
+|  (--html-report)                                                           |
++----------------------------------------------------------------------------+""",
+    "run_not_enough_step_data": """\
++----------------------------------------------------------------------------+
+|  TraceML Run Summary                                                       |
+|  quickstart · 1 GPU · 12 steps analyzed · 4.0s                             |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Verdict: NOT ENOUGH STEP DATA                                             |
+|  Why: only 12 completed steps were captured; a stable diagnosis needs a    |
+|  larger sample.                                                            |
+|                                                                            |
+|  Observed anyway: GPU util 31% avg · CPU util 17% avg                      |
+|                                                                            |
+|  Next: run more steps, or check that traceml.trace_step(...) wraps the     |
+|  training loop.                                                            |
+|                                                                            |
+|  Full evidence: logs/quickstart/final_summary.json  (--html-report)        |
++----------------------------------------------------------------------------+""",
+    "run_step_timing_incomplete": """\
++----------------------------------------------------------------------------+
+|  TraceML Run Summary                                                       |
+|  quickstart · 1 GPU · 4.0s                                                 |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Verdict: STEP TIMING INCOMPLETE                                           |
+|  Why: some timing signals were never measured (missing: backward,          |
+|  optimizer), so phases don't add up to a reliable step time.               |
+|                                                                            |
+|  Next: check the integration wiring for the missing phases; per-signal     |
+|  coverage is listed in the JSON step_time section.                         |
+|                                                                            |
+|  Full evidence: logs/quickstart/final_summary.json  (--html-report)        |
++----------------------------------------------------------------------------+""",
+    "run_multi_input_straggler": """\
++----------------------------------------------------------------------------+
+|  TraceML Run Summary                                                       |
+|  ddp_pretrain · 4 GPUs · 2 nodes · 250 steps analyzed · 40.1s              |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Verdict: INPUT STRAGGLER  (CRITICAL)                                      |
+|  Why: rank 0 (node n0) waits 254.5 ms per step for input; the median rank  |
+|  waits 3.8 ms. All 4 ranks then advance at rank 0's pace.                  |
+|                                                                            |
+|  Where a step goes (median rank, GPU clock)         worst rank             |
+|  Step Time           303.7 ms  100%                 304.1 ms (r0)          |
+|  ├─ Input Wait         3.8 ms    1%                 254.5 ms (r0)  ◀  67x  |
+|  └─ Traced Step Time 299.9 ms   99%                                        |
+|     ├─ Compute       259.5 ms   85%                                        |
+|     ├─ H2D             1.1 ms   <1%                                        |
+|     └─ Residual       39.3 ms   13%                                        |
+|                                                                            |
+|  Next: inspect dataloader, collate_fn, preprocessing, and storage on rank 0|
+|  (node n0).                                                                |
+|                                                                            |
+|  Supporting: GPU util median 14% -- ranks idle at the step barrier.        |
+|  Peak step memory: 9.8 GB reserved · worst rank r2                         |
+|                                                                            |
+|  Full evidence: logs/ddp_pretrain/final_summary.json  (--html-report)      |
++----------------------------------------------------------------------------+""",
+    "run_multi_healthy": """\
++----------------------------------------------------------------------------+
+|  TraceML Run Summary                                                       |
+|  ddp_pretrain · 4 GPUs · 1 node · 250 steps analyzed · 38.7s               |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Verdict: NO CLEAR BOTTLENECK                                              |
+|  Why: step timing is balanced and ranks are even (worst step time +0.4% vs |
+|  median).                                                                  |
+|                                                                            |
+|  Where a step goes (median rank, GPU clock)                                |
+|  Step Time           152.1 ms  100%                                        |
+|  ├─ Input Wait         2.0 ms    1%                                        |
+|  └─ Traced Step Time 150.1 ms   99%                                        |
+|     ├─ Compute       145.2 ms   95%                                        |
+|     ├─ H2D             1.6 ms    1%                                        |
+|     └─ Residual        3.3 ms    2%                                        |
+|                                                                            |
+|  System, process, and memory: all normal on every rank. GPU util 94% avg.  |
+|  Peak step memory: 9.1 GB reserved · even across ranks                     |
+|                                                                            |
+|  Next: training is compute-dominated; for more speed profile kernels       |
+|  (torch.profiler / Nsight).                                                |
+|                                                                            |
+|  Full evidence: logs/ddp_pretrain/final_summary.json  (--html-report)      |
++----------------------------------------------------------------------------+""",
+    "run_single_gpu_on_shared_host": """\
++----------------------------------------------------------------------------+
+|  TraceML Run Summary                                                       |
+|  session_20260806_101725_5580d3 · 1 GPU · 128 steps analyzed · 12.1s       |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Verdict: LOW GPU UTILIZATION -- cause unclear                             |
+|  Why: step timing is balanced, but GPU util averaged 0%. The idle time is  |
+|  not explained by input or transfer.                                       |
+|                                                                            |
+|  Where a step goes (average, GPU clock)                                    |
+|  Step Time            34.2 ms  100%                                        |
+|  ├─ Input Wait         2.5 ms    7%                                        |
+|  └─ Traced Step Time  31.7 ms   93%                                        |
+|     ├─ Compute        29.4 ms   86%                                        |
+|     └─ Residual        2.3 ms    7%                                        |
+|                                                                            |
+|  Next: look for untraced work between steps -- validation, checkpointing,  |
+|  logging -- or inefficient kernels (torch.profiler).                       |
+|                                                                            |
+|  Peak step memory: 18.8 MB allocated · 23.1 MB reserved                    |
+|                                                                            |
+|  Full evidence: logs/session_20260806_101725_5580d3/final_summary.json     |
+|  (--html-report)                                                           |
++----------------------------------------------------------------------------+""",
+    "run_multi_residual_heavy": """\
++----------------------------------------------------------------------------+
+|  TraceML Run Summary                                                       |
+|  session_20260806_101837_1b81f7 · 4 GPUs · 1 node · 128 steps analyzed ·   |
+|  2.7s                                                                      |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Verdict: RESIDUAL-HEAVY  (WARNING)                                        |
+|  Why: 14% of the typical step is time outside the traced phases.           |
+|                                                                            |
+|  Where a step goes (median rank, GPU clock)                                |
+|  Step Time             5.2 ms  100%                                        |
+|  ├─ Input Wait         0.6 ms   11%                                        |
+|  └─ Traced Step Time   4.6 ms   89%                                        |
+|     ├─ Compute         3.8 ms   74%                                        |
+|     ├─ H2D             0.1 ms    2%                                        |
+|     └─ Residual        0.7 ms   14%  ◀  cause                              |
+|                                                                            |
+|  Next: look for untraced work between steps -- validation, checkpointing,  |
+|  logging.                                                                  |
+|                                                                            |
+|  Supporting: GPU util 7% avg.                                              |
+|  Peak step memory: 25.1 MB reserved · even across ranks                    |
+|                                                                            |
+|  Full evidence: logs/session_20260806_101837_1b81f7/final_summary.json     |
+|  (--html-report)                                                           |
++----------------------------------------------------------------------------+""",
+    "watch_healthy": """\
++----------------------------------------------------------------------------+
+|  TraceML Watch Summary                                                     |
+|  1 machine · 1 GPU · observed for 5m 12s                                   |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Host health: NORMAL                                                       |
+|                                                                            |
+|  CPU Util   18% avg          RAM       6.2 / 32.0 GB  (19%)                |
+|  GPU Util   76% avg          GPU Mem  10.3 / 16.0 GB  (64%)                |
+|  GPU Temp   61C max          Proc RSS  4.1 GB                              |
+|                                                                            |
+|  Watch monitors host and process health only; it does not measure step     |
+|  time. To diagnose training speed: traceml run <your-script>.py            |
+|                                                                            |
+|  Full evidence: logs/watch_20260806/final_summary.json  (--html-report)    |
++----------------------------------------------------------------------------+""",
+    "watch_low_gpu_utilization": """\
++----------------------------------------------------------------------------+
+|  TraceML Watch Summary                                                     |
+|  1 machine · 1 GPU · observed for 5m 12s                                   |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Host health: NORMAL                                                       |
+|                                                                            |
+|  CPU Util   18% avg          RAM       6.2 / 32.0 GB  (19%)                |
+|  GPU Util   14% avg          GPU Mem   3.3 / 16.0 GB  (21%)                |
+|  GPU Temp   42C max          Proc RSS  4.1 GB                              |
+|                                                                            |
+|  Observation: GPU utilization stayed low (14% avg). Watch cannot tell      |
+|  whether that is input, transfer, sync, or idle time.                      |
+|  Next: traceml run <your-script>.py -- measures step time and finds the    |
+|  cause.                                                                    |
+|                                                                            |
+|  Full evidence: logs/watch_20260806/final_summary.json  (--html-report)    |
++----------------------------------------------------------------------------+""",
+    "watch_memory_pressure": """\
++----------------------------------------------------------------------------+
+|  TraceML Watch Summary                                                     |
+|  1 machine · 1 GPU · observed for 5m 12s                                   |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Host health: MEMORY PRESSURE  (WARNING)                                   |
+|  RAM 30.1 / 32.0 GB (94%) -- the host is close to memory exhaustion.       |
+|                                                                            |
+|  CPU Util   64% avg          RAM      30.1 / 32.0 GB  (94%)                |
+|  GPU Util   81% avg          GPU Mem  14.9 / 16.0 GB  (93%)                |
+|  GPU Temp   79C max          Proc RSS 28.6 GB                              |
+|                                                                            |
+|  Next: reduce DataLoader workers or caching, or move work off this host.   |
+|                                                                            |
+|  Watch monitors host and process health only; it does not measure step     |
+|  time. To diagnose training speed: traceml run <your-script>.py            |
+|                                                                            |
+|  Full evidence: logs/watch_20260806/final_summary.json  (--html-report)    |
++----------------------------------------------------------------------------+""",
+    "watch_multi_node": """\
++----------------------------------------------------------------------------+
+|  TraceML Watch Summary                                                     |
+|  3 nodes · 12 GPUs · observed for 12m 40s                                  |
++----------------------------------------------------------------------------+
+|                                                                            |
+|  Host health: NORMAL on all 3 nodes                                        |
+|                                                                            |
+|              median        worst node                                      |
+|  CPU Util    24% avg       71%  (n1)                                       |
+|  RAM         31% used      64%  (n1)                                       |
+|  GPU Util    88% avg       62%  (n2)                                       |
+|  GPU Mem     71% used      93%  (n0)                                       |
+|  GPU Temp    64C max       81C  (n0)                                       |
+|                                                                            |
+|  Watch monitors host and process health only; it does not measure step     |
+|  time. To diagnose training speed: traceml run <your-script>.py            |
+|                                                                            |
+|  Full evidence: logs/watch_20260806/final_summary.json  (--html-report)    |
++----------------------------------------------------------------------------+""",
+}
+
+
+def plain(name: str) -> str:
+    """Render one named case as plain text."""
+    return card_to_plain(CASES[name]())
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_card_matches_golden(name: str) -> None:
+    assert plain(name) == GOLDENS[name]
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_card_lines_are_exactly_card_width(name: str) -> None:
+    for line in plain(name).splitlines():
+        assert len(line) == 78, (name, len(line), line)
+
+
+def test_run_header_gpu_count_is_capped_by_world_size() -> None:
+    # A one-process run on a four-GPU host describes the run, not the host.
+    assert " · 1 GPU · " in plain("run_single_gpu_on_shared_host")
+    # A four-rank run on the same host still reports every GPU it used.
+    assert " · 4 GPUs · " in plain("run_multi_residual_heavy")
+
+
+def test_watch_header_keeps_the_host_gpu_count() -> None:
+    # watch describes the host, so it is not capped by world size.
+    doc = _card(
+        profile="watch",
+        system=_watch_system(
+            cpu_percent=1.0,
+            ram_bytes=4.0e9,
+            ram_percent=25.0,
+            gpu_util_percent=0.2,
+            gpu_mem_bytes=0.5e9,
+            gpu_mem_percent=3.1,
+            gpu_temp_c=34.0,
+        ),
+        process=_watch_process(2.0e8),
+        step_time=_WATCH_STEP_TIME,
+        step_memory=_WATCH_STEP_MEMORY,
+        meta=_meta(world_size=1, nodes_observed=1, gpus_observed=4),
+        duration_s=2.0,
+        artifact_hint="logs/watch/final_summary.json",
+    )
+    assert "1 machine · 4 GPUs · observed for 2.0s" in card_to_plain(doc)
+
+
+def test_also_block_skips_step_time_and_keeps_resource_findings() -> None:
+    # A competing Step Time warning may well be a cause of slow steps, so it
+    # never appears under "not the cause of slow steps"; a resource finding
+    # from the same run still does.
+    creep = _issue(
+        "MEMORY_CREEP",
+        "MEMORY CREEP",
+        severity="warn",
+        summary="Step memory grew 1.2 GB over the run -- possible leak",
+        action="Check for retained tensors between steps.",
+    )
+    residual_heavy = _issue(
+        "RESIDUAL_HEAVY",
+        "RESIDUAL-HEAVY",
+        severity="warn",
+        summary="Residual time is 14.0% of the typical GPU Step Time.",
+        action="Investigate untraced work between steps.",
+        score=0.14,
+    )
+    input_bound = _issue(
+        "INPUT_BOUND",
+        "INPUT-BOUND",
+        severity="warn",
+        summary="Input wait is 11.0% of the typical GPU Step Time.",
+        action="Increase workers, prefetch, or storage throughput.",
+        score=0.11,
+    )
+    step_time = _step_time_single(
+        diagnosis=residual_heavy,
+        steps_analyzed=128,
+        step_time_ms=5.2,
+        input_wait_ms=0.6,
+        traced_step_time_ms=4.6,
+        compute_ms=3.8,
+        h2d_ms=0.1,
+        residual_ms=0.7,
+    )
+    step_time["issues"] = [residual_heavy, input_bound]
+
+    text = card_to_plain(
+        _card(
+            profile="run",
+            system=_system_single(gpu_util_percent=88.0),
+            process=_NORMAL_PROCESS,
+            step_time=step_time,
+            step_memory=_step_memory_single(3.9e9, 4.6e9, diagnosis=creep),
+            meta=_meta(run_name="ddp_balanced"),
+            duration_s=2.7,
+            artifact_hint="logs/ddp_balanced/final_summary.json",
+        )
+    )
+
+    assert "Also, not the cause of slow steps:" in text
+    assert "! Step memory grew 1.2 GB over the run" in text
+    assert "Input wait is 11.0%" not in text
+
+
+def test_peak_memory_falls_back_to_megabytes() -> None:
+    # A sub-0.1 GB footprint must not render as "0.0 GB".
+    text = plain("run_single_gpu_on_shared_host")
+    assert "Peak step memory: 18.8 MB allocated · 23.1 MB reserved" in text
+    assert "0.0 GB" not in text
+    multi = plain("run_multi_residual_heavy")
+    assert "Peak step memory: 25.1 MB reserved · even across ranks" in multi
+
+
+def test_peak_memory_keeps_gigabytes_above_the_threshold() -> None:
+    text = plain("run_healthy")
+    assert "Peak step memory: 2.9 GB allocated · 3.2 GB reserved" in text
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_card_never_prints_na(name: str) -> None:
+    assert "n/a" not in plain(name)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_ansi_rendering_has_the_same_visible_text(name: str) -> None:
+    doc = CASES[name]()
+    assert _ANSI_RE.sub("", card_to_ansi(doc)) == card_to_plain(doc)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_ansi_rendering_uses_only_the_allowed_codes(name: str) -> None:
+    codes = set(_ANSI_RE.findall(card_to_ansi(CASES[name]())))
+    assert codes <= {
+        "\x1b[0m",
+        "\x1b[1m",
+        "\x1b[2m",
+        "\x1b[32m",
+        "\x1b[1;31m",
+        "\x1b[1;33m",
+    }
+
+
+@pytest.mark.parametrize("name", WATCH_CASES)
+def test_watch_cards_never_mention_step_timing(name: str) -> None:
+    text = plain(name)
+    for banned in (
+        "Step Time",
+        "Step Memory",
+        "INSUFFICIENT",
+        "steps analyzed",
+    ):
+        assert banned not in text
+
+
+@pytest.mark.parametrize("name", SINGLE_MACHINE_CASES)
+def test_single_machine_cards_have_no_distributed_vocabulary(
+    name: str,
+) -> None:
+    text = plain(name)
+    for banned in ("rank", "node", "skew"):
+        assert not re.search(rf"\b{banned}", text, re.IGNORECASE), banned

--- a/tests/reporting/summary/test_card_golden.py
+++ b/tests/reporting/summary/test_card_golden.py
@@ -21,6 +21,13 @@ import pytest
 from traceml_ai.reporting.primary_diagnosis import build_primary_diagnosis
 from traceml_ai.reporting.summary_card import (
     CardDoc,
+    Span,
+    STYLE_BOLD,
+    STYLE_CRIT,
+    STYLE_NEXT,
+    STYLE_OK,
+    STYLE_PLAIN,
+    STYLE_WARN,
     build_summary_card,
     card_to_ansi,
     card_to_plain,
@@ -939,11 +946,12 @@ GOLDENS = {
 |     ├─ H2D             0.4 ms   <1%                                        |
 |     └─ Residual        3.6 ms    2%                                        |
 |                                                                            |
+|  Peak step memory: 2.9 GB allocated · 3.2 GB reserved                      |
+|                                                                            |
 |  Next: raise DataLoader num_workers, enable pin_memory / prefetch, or check|
 |  storage read throughput.                                                  |
 |                                                                            |
 |  Supporting: GPU util 24% avg -- consistent with input starvation.         |
-|  Peak step memory: 2.9 GB allocated · 3.2 GB reserved                      |
 |                                                                            |
 |  Full evidence: logs/bert_finetune/final_summary.json  (--html-report)     |
 +----------------------------------------------------------------------------+""",
@@ -990,12 +998,13 @@ GOLDENS = {
 |     ├─ H2D             0.4 ms   <1%                                        |
 |     └─ Residual        3.6 ms    2%                                        |
 |                                                                            |
+|  Peak step memory: 3.9 GB allocated · 4.6 GB reserved                      |
+|                                                                            |
 |  Next: raise DataLoader num_workers, enable pin_memory / prefetch, or check|
 |  storage read throughput.                                                  |
 |                                                                            |
 |  Also, not the cause of slow steps:                                        |
 |  ! Step memory grew 1.2 GB over the run -- possible leak  (WARNING)        |
-|  Peak step memory: 3.9 GB allocated · 4.6 GB reserved                      |
 |                                                                            |
 |  Full evidence: logs/bert_finetune/final_summary.json  (--html-report)     |
 +----------------------------------------------------------------------------+""",
@@ -1017,10 +1026,10 @@ GOLDENS = {
 |     ├─ H2D             1.2 ms   <1%                                        |
 |     └─ Residual      115.4 ms   48%                                        |
 |                                                                            |
+|  Peak step memory: 2.9 GB allocated · 3.2 GB reserved                      |
+|                                                                            |
 |  Next: look for untraced work between steps -- validation, checkpointing,  |
 |  logging -- or inefficient kernels (torch.profiler).                       |
-|                                                                            |
-|  Peak step memory: 2.9 GB allocated · 3.2 GB reserved                      |
 |                                                                            |
 |  Full evidence: logs/bert_finetune/final_summary.json  (--html-report)     |
 +----------------------------------------------------------------------------+""",
@@ -1099,11 +1108,12 @@ GOLDENS = {
 |     ├─ H2D             1.1 ms   <1%                                        |
 |     └─ Residual       39.3 ms   13%                                        |
 |                                                                            |
+|  Peak step memory: 9.8 GB reserved · worst rank r2                         |
+|                                                                            |
 |  Next: inspect dataloader, collate_fn, preprocessing, and storage on rank 0|
 |  (node n0).                                                                |
 |                                                                            |
 |  Supporting: GPU util median 14% -- ranks idle at the step barrier.        |
-|  Peak step memory: 9.8 GB reserved · worst rank r2                         |
 |                                                                            |
 |  Full evidence: logs/ddp_pretrain/final_summary.json  (--html-report)      |
 +----------------------------------------------------------------------------+""",
@@ -1150,10 +1160,10 @@ GOLDENS = {
 |     ├─ Compute        29.4 ms   86%                                        |
 |     └─ Residual        2.3 ms    7%                                        |
 |                                                                            |
+|  Peak step memory: 18.8 MB allocated · 23.1 MB reserved                    |
+|                                                                            |
 |  Next: look for untraced work between steps -- validation, checkpointing,  |
 |  logging -- or inefficient kernels (torch.profiler).                       |
-|                                                                            |
-|  Peak step memory: 18.8 MB allocated · 23.1 MB reserved                    |
 |                                                                            |
 |  Full evidence: logs/session_20260806_101725_5580d3/final_summary.json     |
 |  (--html-report)                                                           |
@@ -1176,11 +1186,12 @@ GOLDENS = {
 |     ├─ H2D             0.1 ms    2%                                        |
 |     └─ Residual        0.7 ms   14%  ◀  cause                              |
 |                                                                            |
+|  Peak step memory: 25.1 MB reserved · even across ranks                    |
+|                                                                            |
 |  Next: look for untraced work between steps -- validation, checkpointing,  |
 |  logging.                                                                  |
 |                                                                            |
 |  Supporting: GPU util 7% avg.                                              |
-|  Peak step memory: 25.1 MB reserved · even across ranks                    |
 |                                                                            |
 |  Full evidence: logs/session_20260806_101837_1b81f7/final_summary.json     |
 |  (--html-report)                                                           |
@@ -1403,6 +1414,72 @@ def test_ansi_rendering_uses_only_the_allowed_codes(name: str) -> None:
         "\x1b[1;31m",
         "\x1b[1;33m",
     }
+
+
+def _spans_for_line(doc: CardDoc, text: str):
+    """Return the styled spans in the first card row containing ``text``."""
+    for line in doc.lines:
+        if text in "".join(span.text for span in line.spans):
+            return line.spans
+    raise AssertionError(f"No card row contains {text!r}")
+
+
+def test_terminal_style_contract_keeps_evidence_neutral() -> None:
+    doc = CASES["run_input_bound_critical"]()
+
+    verdict = _spans_for_line(doc, "Verdict:")
+    assert [(span.text, span.style) for span in verdict] == [
+        ("Verdict: ", STYLE_BOLD),
+        ("INPUT-BOUND  (CRITICAL)", STYLE_CRIT),
+    ]
+
+    culprit = _spans_for_line(doc, "Input Wait")
+    assert len(culprit) == 2
+    assert culprit[0].style == STYLE_PLAIN
+    assert culprit[1] == Span("◀  cause", STYLE_CRIT)
+
+    next_line = _spans_for_line(doc, "Next:")
+    assert next_line[0] == Span("Next: ", STYLE_BOLD)
+    assert next_line[1].style == STYLE_NEXT
+
+
+def test_terminal_style_contract_colours_primary_status_values() -> None:
+    secondary = _spans_for_line(
+        CASES["run_input_bound_with_also"](),
+        "Step memory grew",
+    )
+    assert [(span.text, span.style) for span in secondary] == [
+        (
+            "! Step memory grew 1.2 GB over the run -- possible leak  (",
+            STYLE_PLAIN,
+        ),
+        ("WARNING", STYLE_WARN),
+        (")", STYLE_PLAIN),
+    ]
+
+    normal = _spans_for_line(CASES["watch_healthy"](), "Host health:")
+    assert [(span.text, span.style) for span in normal] == [
+        ("Host health: ", STYLE_BOLD),
+        ("NORMAL", STYLE_OK),
+    ]
+
+    warning = _spans_for_line(
+        CASES["watch_memory_pressure"](),
+        "Host health:",
+    )
+    assert [(span.text, span.style) for span in warning] == [
+        ("Host health: ", STYLE_BOLD),
+        ("MEMORY PRESSURE  (WARNING)", STYLE_WARN),
+    ]
+
+    multi_normal = _spans_for_line(
+        CASES["watch_multi_node"](),
+        "Host health:",
+    )
+    assert [(span.text, span.style) for span in multi_normal] == [
+        ("Host health: ", STYLE_BOLD),
+        ("NORMAL on all 3 nodes", STYLE_OK),
+    ]
 
 
 @pytest.mark.parametrize("name", WATCH_CASES)

--- a/tests/reporting/summary/test_card_plumbing.py
+++ b/tests/reporting/summary/test_card_plumbing.py
@@ -1,0 +1,285 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Plumbing tests for the terminal summary card.
+
+Covers the pieces that live outside the card renderer itself: profile
+threading, artifact/stdout parity, the TTY colour gate, and the best-effort
+fallback that keeps a rendering failure from breaking shutdown.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.sqlite_fixtures import (
+    insert_process_sample,
+    insert_step_time_sample,
+    insert_system_sample,
+    summary_database,
+)
+from traceml_ai.reporting import final as reporting_final
+from traceml_ai.reporting.final import generate_summary
+from traceml_ai.reporting.summary_card import card_profile_from_text
+from traceml_ai.sdk import summary_client
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+class _TTYBuffer(io.StringIO):
+    """A stdout stand-in that claims to be an interactive terminal."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+@pytest.fixture()
+def session(tmp_path: Path) -> Path:
+    """Build a small session database with system, process, and steps."""
+    db_path = tmp_path / "telemetry.db"
+    with summary_database(db_path) as conn:
+        insert_system_sample(
+            conn,
+            row_id=1,
+            rank=0,
+            ts=1.0,
+            gpu_available=False,
+            gpu_count=0,
+            gpu_util=None,
+        )
+        insert_process_sample(
+            conn,
+            row_id=1,
+            rank=0,
+            ts=1.0,
+            gpu_available=False,
+            gpu_count=0,
+        )
+        for step in range(1, 6):
+            insert_step_time_sample(
+                conn,
+                row_id=step,
+                rank=0,
+                step=step,
+                traced_step_time=10.0,
+            )
+    return db_path
+
+
+def _run(session: Path, tmp_path: Path, **kwargs) -> dict:
+    """Generate a summary into a session root under ``tmp_path``."""
+    session_root = tmp_path / "logs" / "session_test"
+    session_root.mkdir(parents=True, exist_ok=True)
+    return generate_summary(
+        str(session),
+        session_root=str(session_root),
+        print_to_stdout=False,
+        **kwargs,
+    )
+
+
+def test_text_matches_txt_artifact(session: Path, tmp_path: Path) -> None:
+    payload = _run(session, tmp_path)
+    txt = (tmp_path / "logs" / "session_test" / "final_summary.txt").read_text(
+        encoding="utf-8"
+    )
+    assert txt == payload["text"] + "\n"
+    assert "\x1b[" not in payload["text"]
+
+
+def test_run_profile_is_the_default(session: Path, tmp_path: Path) -> None:
+    text = _run(session, tmp_path)["text"]
+    assert "TraceML Run Summary" in text
+    assert "TraceML Watch Summary" not in text
+
+
+def test_watch_profile_renders_the_watch_card(
+    session: Path, tmp_path: Path
+) -> None:
+    text = _run(session, tmp_path, profile="watch")["text"]
+    assert "TraceML Watch Summary" in text
+    assert "Step Time" not in text
+    assert "Step Memory" not in text
+    assert "steps analyzed" not in text
+    assert "traceml run <your-script>.py" in text
+
+
+def test_footer_names_the_session_relative_artifact(
+    session: Path, tmp_path: Path
+) -> None:
+    text = _run(session, tmp_path)["text"]
+    assert "logs/session_test/final_summary.json" in text
+    assert "(--html-report)" in text
+
+
+def test_footer_names_the_html_artifact_when_written(
+    session: Path, tmp_path: Path
+) -> None:
+    text = _run(session, tmp_path, write_html=True)["text"]
+    assert "logs/session_test/final_summary.html" in text
+    assert "(--html-report)" not in text
+
+
+def _print_summary(session: Path, tmp_path: Path, monkeypatch) -> str:
+    """Run with printing enabled and capture what reached stdout."""
+    buffer = _TTYBuffer()
+    monkeypatch.setattr(sys, "stdout", buffer)
+    session_root = tmp_path / "logs" / "session_test"
+    session_root.mkdir(parents=True, exist_ok=True)
+    generate_summary(
+        str(session),
+        session_root=str(session_root),
+        print_to_stdout=True,
+    )
+    return buffer.getvalue()
+
+
+def test_tty_output_is_colorized(
+    session: Path, tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    printed = _print_summary(session, tmp_path, monkeypatch)
+    assert "\x1b[" in printed
+    payload_text = (
+        tmp_path / "logs" / "session_test" / "final_summary.txt"
+    ).read_text(encoding="utf-8")
+    assert _ANSI_RE.sub("", printed) == payload_text
+
+
+@pytest.mark.parametrize(
+    ("env_key", "env_value"),
+    [("NO_COLOR", "1"), ("TERM", "dumb")],
+)
+def test_color_is_disabled_by_environment(
+    session: Path,
+    tmp_path: Path,
+    monkeypatch,
+    env_key: str,
+    env_value: str,
+) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    monkeypatch.setenv(env_key, env_value)
+    assert "\x1b[" not in _print_summary(session, tmp_path, monkeypatch)
+
+
+def test_non_tty_output_is_plain(
+    session: Path, tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    session_root = tmp_path / "logs" / "session_test"
+    session_root.mkdir(parents=True, exist_ok=True)
+    payload = generate_summary(
+        str(session),
+        session_root=str(session_root),
+        print_to_stdout=True,
+    )
+    printed = capsys.readouterr().out
+    assert "\x1b[" not in printed
+    assert printed == payload["text"] + "\n"
+
+
+def _sdk_print(session_root: Path, monkeypatch) -> str:
+    """Print a stored summary through the SDK read path, capturing stdout."""
+    buffer = _TTYBuffer()
+    monkeypatch.setattr(sys, "stdout", buffer)
+    summary_client._load_existing_final_summary(session_root, print_text=True)
+    return buffer.getvalue()
+
+
+def _stored(session_root: Path) -> str:
+    return (session_root / "final_summary.txt").read_text(encoding="utf-8")
+
+
+def test_sdk_print_path_is_colorized_on_a_tty(
+    session: Path, tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    _run(session, tmp_path)
+    session_root = tmp_path / "logs" / "session_test"
+
+    printed = _sdk_print(session_root, monkeypatch)
+
+    assert "\x1b[" in printed
+    assert _ANSI_RE.sub("", printed) == _stored(session_root) + "\n"
+
+
+def test_sdk_print_path_infers_the_watch_profile(
+    session: Path, tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    _run(session, tmp_path, profile="watch")
+    session_root = tmp_path / "logs" / "session_test"
+    stored = _stored(session_root)
+    assert card_profile_from_text(stored) == "watch"
+
+    printed = _sdk_print(session_root, monkeypatch)
+
+    # A run-profile rebuild would not reproduce the watch card, so colour
+    # here also proves the profile was inferred correctly.
+    assert "\x1b[" in printed
+    assert "TraceML Watch Summary" in _ANSI_RE.sub("", printed)
+    assert _ANSI_RE.sub("", printed) == stored + "\n"
+
+
+def test_sdk_print_path_keeps_stored_text_when_rebuild_differs(
+    session: Path, tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    _run(session, tmp_path)
+    session_root = tmp_path / "logs" / "session_test"
+    txt_path = session_root / "final_summary.txt"
+    tampered = _stored(session_root).replace("Verdict:", "VERDICT!", 1)
+    txt_path.write_text(tampered, encoding="utf-8")
+
+    printed = _sdk_print(session_root, monkeypatch)
+
+    assert "\x1b[" not in printed
+    assert printed == tampered + "\n"
+
+
+def test_sdk_print_path_is_plain_without_a_tty(
+    session: Path, tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    _run(session, tmp_path)
+    session_root = tmp_path / "logs" / "session_test"
+
+    summary_client._load_existing_final_summary(session_root, print_text=True)
+
+    printed = capsys.readouterr().out
+    assert "\x1b[" not in printed
+    assert printed == _stored(session_root) + "\n"
+
+
+def test_card_failure_degrades_to_a_minimal_card(
+    session: Path, tmp_path: Path, monkeypatch
+) -> None:
+    def _boom(**kwargs):
+        raise RuntimeError("card exploded")
+
+    monkeypatch.setattr(reporting_final, "build_card_from_payload", _boom)
+
+    text = _run(session, tmp_path)["text"]
+
+    lines = text.splitlines()
+    assert lines[0].startswith("+---")
+    assert "TraceML Run Summary" in text
+    assert "Verdict:" in text
+    assert "final_summary.json" in text
+    for line in lines:
+        assert len(line) == 78

--- a/tests/reporting/summary/test_final.py
+++ b/tests/reporting/summary/test_final.py
@@ -184,7 +184,8 @@ def test_final_summary_fixture_schema_contains_all_sections(tmp_path) -> None:
         assert "- Next:" not in payload[key]["card"]
     assert payload["system"]["diagnosis"]["status"] == "NORMAL"
     assert "NO GPU" not in payload["system"]["card"]
-    assert "TraceML Verdict:" in payload["text"]
+    assert "TraceML Run Summary" in payload["text"]
+    assert "Verdict: NOT ENOUGH STEP DATA" in payload["text"]
     assert "Next:" in payload["text"]
 
 
@@ -223,11 +224,14 @@ def test_final_report_generator_preserves_summary_schema_and_order():
     assert payload["primary_diagnosis"]["kind"] == (
         "INSUFFICIENT_STEP_TIME_DATA"
     )
-    assert "TraceML Run Summary | duration 10.0s" in payload["text"]
-    assert "TraceML Verdict:" in payload["text"]
-    assert "Section Status" in payload["text"]
-    assert "System Evidence" in payload["text"]
-    assert "Step Time Evidence" in payload["text"]
+    text = payload["text"]
+    assert "TraceML Run Summary" in text
+    assert "10.0s" in text
+    assert "Verdict: NOT ENOUGH STEP DATA" in text
+    # The verdict card replaced the old section-status and evidence tables.
+    assert "Section Status" not in text
+    assert "System Evidence" not in text
+    assert "Step Time Evidence" not in text
 
 
 def test_final_report_generator_fails_open_for_one_section():
@@ -253,7 +257,8 @@ def test_final_report_generator_fails_open_for_one_section():
     assert payload["primary_diagnosis"]["kind"] == (
         "INSUFFICIENT_STEP_TIME_DATA"
     )
-    assert "Process" in payload["text"]
+    assert "TraceML Run Summary" in payload["text"]
+    assert "Verdict: NOT ENOUGH STEP DATA" in payload["text"]
 
 
 def test_final_text_uses_single_process_average_layout():
@@ -299,33 +304,31 @@ def test_final_text_uses_single_process_average_layout():
     payload = _final_payload(step_time, system=system)
 
     text = payload["text"]
-    assert "TraceML Verdict: INPUT-BOUND / CRITICAL" in text
+    assert "Verdict: INPUT-BOUND  (CRITICAL)" in text
+    # No composed score on this diagnosis, so the verbatim JSON summary and
+    # action are used (the F7 fallback path).
     assert "Why: Input wait is 48.5% of the typical GPU Step Time." in text
     assert "Next: Increase workers, prefetch, or storage throughput." in text
-    assert "System Evidence" in text
-    assert "Metric            Average" in text
-    assert "Step Time Evidence" in text
-    assert "Phase" in text
-    assert "Average" in text
-    assert "Share" in text
-    assert "Input Wait" in text
-    assert "130.8ms" in text
-    assert "48.5%" in text
-    assert "Step Time" in text
-    assert "Traced Step Time" in text
-    assert "DataLoader Fetch" in text
-    assert "supplemental" in text
-    assert "Total" not in text
+    assert "Where a step goes (average, GPU clock)" in text
+    assert "Step Time           269.9 ms  100%" in text
+    assert "├─ Input Wait       130.8 ms   48%" in text
+    assert "└─ Traced Step Time 139.1 ms   52%" in text
+    assert "Supporting: GPU util 0% avg" in text
+    # Single-machine cards carry no distributed vocabulary and no tables.
+    assert "Section Status" not in text
     assert "Median" not in text
     assert "Worst" not in text
     assert "Skew" not in text
-    assert "rank=r" not in text
-    assert "node=n" not in text
+    assert "rank" not in text
+    assert "node" not in text
+    # DataLoader Fetch is supplemental; it is never a timing-tree row.
+    assert "DataLoader Fetch" not in text
+    assert "supplemental" not in text
     assert payload["step_time"]["card"] == "STEP TIME ORIGINAL CARD"
     assert payload["system"]["card"] == "SYSTEM ORIGINAL CARD"
 
 
-def test_final_text_renders_missing_step_metrics_as_na():
+def test_final_text_omits_never_measured_step_metrics():
     step_diag = _diagnosis(
         "INCOMPLETE_DATA",
         "INCOMPLETE DATA",
@@ -353,19 +356,14 @@ def test_final_text_renders_missing_step_metrics_as_na():
     payload = _final_payload(step_time)
 
     text = payload["text"]
-    lines = text.splitlines()
 
-    def _evidence_row(label: str) -> str:
-        for line in lines:
-            if label in line:
-                return line
-        raise AssertionError(f"no evidence row for {label}")
-
-    # A never-measured metric renders n/a; measured metrics keep values.
-    assert "n/a" in _evidence_row("H2D")
-    assert "n/a" in _evidence_row("Compute")
-    assert "n/a" in _evidence_row("Residual")
-    assert "130.8ms" in _evidence_row("Input Wait")
+    # Never-measured signals are omitted and explained in words. The card
+    # never prints a placeholder value for a signal that was not measured.
+    assert "n/a" not in text
+    assert "H2D" not in text
+    assert "Compute" not in text
+    assert "Residual" not in text
+    assert "Verdict: STEP TIMING INCOMPLETE" in text
 
 
 def test_final_text_uses_selected_step_time_for_phase_shares():
@@ -389,14 +387,12 @@ def test_final_text_uses_selected_step_time_for_phase_shares():
     payload = _final_payload(step_time)
 
     text = payload["text"]
-    assert "DataLoader Fetch" in text
-    assert "supplemental" in text
-    assert "Traced Step Time" in text
-    assert "96.2%" in text
-    assert "Compute" in text
-    assert "48.0ms" in text
-    assert "92.3%" in text
-    assert "Step Time" in text
+    # Shares use the selected-clock step_time_ms denominator.
+    assert "Step Time            52.0 ms  100%" in text
+    assert "└─ Traced Step Time  50.0 ms   96%" in text
+    assert "├─ Compute        48.0 ms   92%" in text
+    assert "DataLoader Fetch" not in text
+    assert "supplemental" not in text
     assert "Total" not in text
 
 
@@ -426,10 +422,11 @@ def test_final_text_includes_h2d_bound_diagnosis():
 
     payload = _final_payload(step_time)
 
-    assert "TraceML Verdict: H2D-BOUND / CRITICAL" in payload["text"]
+    assert "Verdict: H2D-BOUND  (CRITICAL)" in payload["text"]
     assert "Why: H2D transfer is 14.3% of the typical GPU Step Time." in (
         payload["text"]
     )
+    assert "├─ H2D            20.0 ms   14%" in payload["text"]
 
 
 def test_final_text_uses_multi_process_comparison_layout():
@@ -514,23 +511,28 @@ def test_final_text_uses_multi_process_comparison_layout():
     payload = _final_payload(step_time, system=system)
 
     text = payload["text"]
-    assert "TraceML Verdict: INPUT STRAGGLER / CRITICAL" in text
+    assert "Verdict: INPUT STRAGGLER  (CRITICAL)" in text
     assert payload["primary_diagnosis"]["summary"] == (
         "r0 has excess input wait burden relative to victim r1 "
         "(~82.6% impact; ~100.0% of visible wait cost)."
     )
-    assert "Why: r0 has excess input wait burden relative to victim r1" in text
+    # The Why line is composed from rank-comparison evidence.
+    assert "Why: rank 0 (node n0) waits 264.5 ms per step for input" in text
+    assert "the median rank" in text
+    assert "Where a step goes (median rank, GPU clock)" in text
+    assert "worst rank" in text
     assert (
-        "Metric          Median        Worst         Skew        Scope" in text
+        "├─ Input Wait        13.8 ms    5%                 264.5 ms (r0)"
+        "  ◀  19x" in text
     )
-    assert "GPU Util        14.0%         0.0%          14.0pp" in text
-    assert "node=n1" in text
     assert (
-        "Phase           Median        Worst         Skew        Scope" in text
+        "Step Time           303.7 ms  100%                 304.1 ms (r0)"
+        in text
     )
-    assert "Input Wait      13.8ms        264.5ms       1816.7%" in text
-    assert "rank=r0 node=n0" in text
-    assert "Average" not in text
+    # The old wide median/worst/skew/scope table is gone.
+    assert "Skew" not in text
+    assert "rank=r" not in text
+    assert "node=n" not in text
 
 
 def test_reporting_final_is_the_summary_orchestration_owner():


### PR DESCRIPTION
Closes #342.

Presentation-only redesign of the end-of-run terminal summaries. The JSON schema is unchanged (still 1.7); only the `text` card and how it prints changed.

## What changed

- Verdict-first card: Verdict / Why / Next, then a hierarchical timing tree (Step Time = Input Wait + Traced Step Time; Compute, H2D, Residual indented beneath) with share bars when a phase-share finding fires and the culprit row marked.
- Four variants: run and watch, single-machine and multi-rank. Single-machine cards contain no rank/node/skew vocabulary. Multi cards show the median tree plus a worst-rank cell only where the skew is material.
- watch gets its own card: host and process health only, an explicit attribution boundary, and a pointer to `traceml run`. No step-time or step-memory placeholders.
- Missing is never zero: unmeasured signals are omitted and explained in one line ("H2D and step memory not measured (no GPU)"). No n/a floods.
- Header carries run name, topology, steps analyzed, and duration; the footer carries the artifact path.
- Severity-scoped ANSI color when stdout is a TTY (`NO_COLOR` and `TERM=dumb` respected; standard 16-color slots, so the user's terminal theme decides the palette). `final_summary.txt`, the JSON `text` field, CI logs, and piped output stay plain ASCII. The SDK print path (`traceml.summary()`) colorizes only when its rebuilt card matches the stored text byte-for-byte; otherwise it prints the stored text unchanged.
- Secondary warnings: at most two, warn/crit, resource findings only (system, process, step memory), under "Also, not the cause of slow steps". Competing step-time findings stay in JSON.

## Implementation

- New `src/traceml_ai/reporting/summary_card.py`: span-based renderer; the plain and ANSI renderings share identical visible geometry.
- `final.py` delegates to it; profile (run/watch) threaded from `TraceMLSettings` through the aggregator and the final-summary service. Rendering failures degrade to a minimal verdict card; shutdown never breaks on a card bug.
- 15 exact-text golden cards plus property tests: watch cards never mention step time; single-machine cards never contain rank/node/skew; every line is exactly 78 characters; ANSI stripped equals plain; no `n/a` on any card.

## Validation

- 1023 tests pass; black, ruff, and isort clean on all changed files.
- CPU end-to-end: quickstart, watch, 2-rank gloo DDP.
- GPU end-to-end (4x T4): single-GPU quickstart, 4-GPU input-straggler, 4-GPU balanced, watch. Every displayed value on the straggler card matches its own `final_summary.json` (median step 272.2 ms, worst input wait 201.2 ms on rank 0 vs 1.7 ms median, ratio 115x). Real GPU payload shapes are regression fixtures.

Example card from the 4-GPU straggler run:

```text
+----------------------------------------------------------------------------+
|  TraceML Run Summary                                                       |
|  session_20260806_101748_81187e · 4 GPUs · 1 node · 128 steps analyzed ·   |
|  39.4s                                                                     |
+----------------------------------------------------------------------------+
|                                                                            |
|  Verdict: INPUT STRAGGLER  (CRITICAL)                                      |
|  Why: rank 0 waits 201.2 ms per step for input; the median rank waits 1.7  |
|  ms. All 4 ranks then advance at rank 0's pace.                            |
|                                                                            |
|  Where a step goes (median rank, GPU clock)         worst rank             |
|  Step Time           272.2 ms  100%                 272.2 ms (r3)          |
|  ├─ Input Wait         1.7 ms    1%                 201.2 ms (r0)  ◀  115x |
|  └─ Traced Step Time 270.4 ms   99%                                        |
|     ├─ Compute       268.2 ms   99%                                        |
|     ├─ H2D             0.1 ms   <1%                                        |
|     └─ Residual        2.1 ms    1%                                        |
|                                                                            |
|  Next: inspect dataloader, collate_fn, preprocessing, and storage on rank  |
|  0.                                                                        |
|                                                                            |
|  Peak step memory: 1.1 GB reserved · even across ranks                     |
|                                                                            |
|  Full evidence: logs/session_20260806_101748_81187e/final_summary.json     |
|  (--html-report)                                                           |
+----------------------------------------------------------------------------+
```


The colored TTY rendering of the same card, captured live on the validation box:

![colored terminal card, input straggler](https://raw.githubusercontent.com/Pendu/traceml/assets/issue342-screenshot/issue342_card_color.png)

## Evidence

GATE: conformance ran=true, 1 passed / 0 failed / 1 skipped (tests/integrations/test_telemetry_conformance.py; this diff is renderer-only and does not touch telemetry emission). Card lock-down gate: 15 golden cards plus invariants, 1023 tests total passed.
TRANSITIONS: the renderer consumes one finished payload, so there is no live-view state machine in this diff. Failure transitions tested on purpose: card build raising falls back to a minimal verdict card; an SDK colorize rebuild mismatch prints the stored plain text unchanged.
RANKS: per-rank asymmetry tested? yes. A real 4-rank straggler payload is a fixture (rank 0 input wait 201.2 ms vs 1.7 ms median; worst-rank cells and the ratio marker on the card), alongside single-rank and 4-rank balanced fixtures.
TRIPWIRE: made the failure paths fire on purpose? yes. Forced build_card_from_payload to raise (fallback card observed) and tampered final_summary.txt (colorization refused, stored text printed verbatim).
PLATFORM: EVIDENCE: n/a (no platform-specific branch added; rendering is pure string assembly).
