### PR TITLE
 Put Quickstart before example reports and synchronize summary documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,52 @@ storage read throughput.
 
 TraceML produces this diagnosis at the end of the instrumented training run.
 
+Want the complete evidence? Jump to the
+[single-run and distributed example reports](#example-reports).
+
+## Quickstart
+
+### 1. Install
+
+TraceML expects an existing PyTorch project. Install the TraceML package with:
+
+```bash
+pip install traceml-ai
+```
+
+Using [uv](https://docs.astral.sh/uv/) instead? Run `uv add traceml-ai`.
+
+### 2. Instrument the training step
+
+Add TraceML around the core step in your existing PyTorch training script:
+
+```diff
++   import traceml_ai as traceml
+
++   traceml.init(mode="auto")
+
+    for batch in dataloader:
++       with traceml.trace_step(model):
+            optimizer.zero_grad(set_to_none=True)
+            outputs = model(batch["x"])
+            loss = criterion(outputs, batch["y"])
+            loss.backward()
+            optimizer.step()
+```
+
+### 3. Run
+
+```bash
+traceml run train.py
+```
+
+Summary mode is the default. TraceML prints the final diagnosis and writes
+`final_summary.json` and `final_summary.txt` under `logs/<run_name>/`.
+
+No training script ready? [Try the Colab example](https://colab.research.google.com/github/traceopt-ai/traceml/blob/main/notebooks/data_loading_bottleneck.ipynb).
+
+## Example Reports
+
 <details>
 <summary><strong>See the complete single-run report</strong></summary>
 
@@ -105,47 +151,6 @@ TraceML produces this diagnosis at the end of the instrumented training run.
 ```
 
 </details>
-
-## Quickstart
-
-### 1. Install
-
-TraceML expects an existing PyTorch project. Install the TraceML package with:
-
-```bash
-pip install traceml-ai
-```
-
-Using [uv](https://docs.astral.sh/uv/) instead? Run `uv add traceml-ai`.
-
-### 2. Instrument the training step
-
-Add TraceML around the core step in your existing PyTorch training script:
-
-```diff
-+   import traceml_ai as traceml
-
-+   traceml.init(mode="auto")
-
-    for batch in dataloader:
-+       with traceml.trace_step(model):
-            optimizer.zero_grad(set_to_none=True)
-            outputs = model(batch["x"])
-            loss = criterion(outputs, batch["y"])
-            loss.backward()
-            optimizer.step()
-```
-
-### 3. Run
-
-```bash
-traceml run train.py
-```
-
-Summary mode is the default. TraceML prints the final diagnosis and writes
-`final_summary.json` and `final_summary.txt` under `logs/<run_name>/`.
-
-No training script ready? [Try the Colab example](https://colab.research.google.com/github/traceopt-ai/traceml/blob/main/notebooks/data_loading_bottleneck.ipynb).
 
 Read [How to Read TraceML Output](https://traceopt-ai.github.io/traceml/user_guide/reading-output/)
 for the complete field definitions, diagnosis rules, evidence, and recommended

--- a/docs/guides/low-gpu-utilization-pytorch.md
+++ b/docs/guides/low-gpu-utilization-pytorch.md
@@ -32,6 +32,7 @@ After confirming low or moderate GPU utilization, read the Step Time diagnosis.
 | Step Time diagnosis | What to do |
 |---|---|
 | `INPUT-BOUND` | Inspect input loading, preprocessing, collation, and storage. |
+| [`H2D-BOUND`](../user_guide/reading-output.md#h2d-bound) | Inspect pinned memory, batch transfer placement, and host-to-device copies. |
 | `INPUT STRAGGLER` | Inspect input loading on the culprit rank. |
 | `H2D STRAGGLER` | Inspect host-to-device transfer on the culprit rank. |
 | `RESIDUAL-HEAVY` | Inspect work outside traced phases, such as logging, checkpointing, validation, CPU stalls, framework orchestration, or unobserved transfers. |

--- a/docs/guides/pytorch-input-pipeline-bottleneck.md
+++ b/docs/guides/pytorch-input-pipeline-bottleneck.md
@@ -52,7 +52,7 @@ traceml view logs/<run_name>/final_summary.json
 
 ## What to look for
 
-Start with `TraceML Verdict`, then check the `Step Time Evidence` table.
+Start with `Verdict`, then check `Where a step goes`.
 
 For input pipeline problems, the most relevant diagnoses are:
 
@@ -64,16 +64,20 @@ For input pipeline problems, the most relevant diagnoses are:
 Example excerpt:
 
 ```text
-TraceML Verdict: INPUT STRAGGLER / CRITICAL
-Why: Rank r0 input wait was 254.5ms vs median rank r1 at 3.8ms.
-Next: Inspect input wait, collate_fn, preprocessing, and storage on the slow rank.
+Verdict: INPUT STRAGGLER  (CRITICAL)
+Why: rank 0 (node n0) waits 254.5 ms per step for input; the median rank
+waits 3.8 ms. All 4 ranks then advance at rank 0's pace.
 
-Step Time Evidence
-Phase           Median        Worst         Skew        Scope
---------------------------------------------------------------------------
-Step Time       303.7ms       304.1ms       0.1%        rank=r0 node=n0
-Input Wait      3.8ms         254.5ms       6597.4%     rank=r0 node=n0
-Compute         259.5ms       261.0ms       0.6%        rank=r2 node=n1
+Where a step goes (median rank, GPU clock)         worst rank
+Step Time           303.7 ms  100%                 304.1 ms (r0)
+├─ Input Wait         3.8 ms    1%                 254.5 ms (r0)  ◀  67x
+└─ Traced Step Time 299.9 ms   99%
+   ├─ Compute       259.5 ms   85%
+   ├─ H2D             1.1 ms   <1%
+   └─ Residual       39.3 ms   13%
+
+Next: inspect dataloader, collate_fn, preprocessing, and storage on rank 0
+(node n0).
 ```
 
 Read this as:

--- a/docs/guides/slow-pytorch-training.md
+++ b/docs/guides/slow-pytorch-training.md
@@ -33,6 +33,7 @@ diagnosis or symptom.
 | What you see | Start here |
 |---|---|
 | Step Time says `INPUT-BOUND` | [Find Input Pipeline Bottlenecks](pytorch-input-pipeline-bottleneck.md) |
+| Step Time says `H2D-BOUND` | [Read the H2D diagnosis](../user_guide/reading-output.md#h2d-bound) |
 | System says `LOW_GPU_UTILIZATION` or `MODERATE_GPU_UTILIZATION` | [Debug Low GPU Utilization](low-gpu-utilization-pytorch.md) |
 | Step Time says `INPUT STRAGGLER`, `COMPUTE STRAGGLER`, `H2D STRAGGLER`, or `STRAGGLER` | [Debug DDP Rank Stragglers](ddp-slow-training-rank-straggler.md) |
 | Step Memory says `MEMORY CREEP` or `MEMORY RISING` | [Find PyTorch Memory Creep](pytorch-memory-creep.md) |
@@ -44,6 +45,10 @@ diagnosis or symptom.
 `INPUT-BOUND` means Input Wait is taking a large share of selected-clock Step
 Time.
 Confirm the input path before tuning model compute.
+
+`H2D-BOUND` means host-to-device transfer is taking a large share of the
+selected-clock Step Time. Inspect pinned memory, batch transfer placement, and
+non-blocking copies before changing model compute.
 
 `LOW_GPU_UTILIZATION` and `MODERATE_GPU_UTILIZATION` are system-level symptoms.
 They say the GPU was not fully busy, not why it was not fully busy. Pair them

--- a/docs/user_guide/integrations/accelerate.md
+++ b/docs/user_guide/integrations/accelerate.md
@@ -96,7 +96,7 @@ see Limitations.
 
 ## Troubleshooting
 
-### The verdict says RESIDUAL-HEAVY / CRITICAL on the minimal example
+### The verdict says RESIDUAL-HEAVY (CRITICAL) on the minimal example
 
 This is expected on this specific example, not a sign of a problem. The
 synthetic `TinyMLP` finishes each step in roughly a millisecond, so ordinary

--- a/docs/user_guide/quickstart.md
+++ b/docs/user_guide/quickstart.md
@@ -183,29 +183,30 @@ the GPU waiting:
 
 ```text
 +----------------------------------------------------------------------------+
-|  TraceML Run Summary | duration 52.4s                                      |
+|  TraceML Run Summary                                                       |
+|  bert_finetune · 1 GPU · 256 steps analyzed · 52.4s                        |
 +----------------------------------------------------------------------------+
 |                                                                            |
-|  TraceML Verdict: INPUT-BOUND / CRITICAL                                   |
-|  Why: Input Wait is 64.0% of the typical GPU Step Time.                    |
-|  Next: Increase workers, prefetch, or storage throughput.                  |
+|  Verdict: INPUT-BOUND  (CRITICAL)                                          |
+|  Why: input wait is 64% of the typical step; the GPU sits idle while       |
+|  batches arrive.                                                           |
 |                                                                            |
-|  Section Status                                                            |
-|  Section       Status                  Severity                            |
-|  ------------------------------------------------                          |
-|  Step Time     INPUT-BOUND             CRITICAL                            |
-|  System        LOW GPU UTIL            INFO                                |
-|  Process       NORMAL                  INFO                                |
-|  Step Memory   BALANCED                INFO                                |
+|  Where a step goes (average, GPU clock)                                    |
+|  Step Time           200.4 ms  100%  ████████████████████████████          |
+|  ├─ Input Wait       128.0 ms   64%  ██████████████████░░░░░░░░░░  ◀  cause|
+|  └─ Traced Step Time  72.0 ms   36%  ██████████░░░░░░░░░░░░░░░░░░          |
+|     ├─ Compute        68.0 ms   34%                                        |
+|     ├─ H2D             0.4 ms   <1%                                        |
+|     └─ Residual        3.6 ms    2%                                        |
 |                                                                            |
-|  Step Time Evidence                                                        |
-|  Phase             Average           Share                                 |
-|  ------------------------------------------------                          |
-|  Step Time         200.4ms           100.0%                                |
-|  Input Wait        128.0ms           64.0%                                 |
-|  Compute           68.0ms            34.0%                                 |
-|  Residual          3.6ms             1.8%                                  |
-|  H2D               0.4ms             0.2%                                  |
+|  Peak step memory: 2.9 GB allocated · 3.2 GB reserved                      |
+|                                                                            |
+|  Next: raise DataLoader num_workers, enable pin_memory / prefetch, or check|
+|  storage read throughput.                                                  |
+|                                                                            |
+|  Supporting: GPU util 24% avg -- consistent with input starvation.         |
+|                                                                            |
+|  Full evidence: logs/bert_finetune/final_summary.json  (--html-report)     |
 +----------------------------------------------------------------------------+
 ```
 
@@ -221,36 +222,30 @@ regressions between saved summaries.
 
 ```text
 +----------------------------------------------------------------------------+
-|  TraceML Run Summary | duration 40.1s                                      |
+|  TraceML Run Summary                                                       |
+|  ddp_pretrain · 4 GPUs · 2 nodes · 250 steps analyzed · 40.1s              |
 +----------------------------------------------------------------------------+
 |                                                                            |
-|  TraceML Verdict: INPUT STRAGGLER / CRITICAL                               |
-|  Why: Rank r0 input wait was 254.5ms vs median rank r1 at 3.8ms.           |
-|  Next: Inspect dataloader, collate_fn, preprocessing, and storage on the   |
-|  slow rank.                                                                |
+|  Verdict: INPUT STRAGGLER  (CRITICAL)                                      |
+|  Why: rank 0 (node n0) waits 254.5 ms per step for input; the median rank  |
+|  waits 3.8 ms. All 4 ranks then advance at rank 0's pace.                  |
 |                                                                            |
-|  Section Status                                                            |
-|  Section       Status                  Severity                            |
-|  ------------------------------------------------                          |
-|  Step Time     INPUT STRAGGLER         CRITICAL                            |
-|  System        LOW GPU UTIL            INFO                                |
-|  Process       NORMAL                  INFO                                |
-|  Step Memory   BALANCED                INFO                                |
+|  Where a step goes (median rank, GPU clock)         worst rank             |
+|  Step Time           303.7 ms  100%                 304.1 ms (r0)          |
+|  ├─ Input Wait         3.8 ms    1%                 254.5 ms (r0)  ◀  67x  |
+|  └─ Traced Step Time 299.9 ms   99%                                        |
+|     ├─ Compute       259.5 ms   85%                                        |
+|     ├─ H2D             1.1 ms   <1%                                        |
+|     └─ Residual       39.3 ms   13%                                        |
 |                                                                            |
-|  System Evidence                                                           |
-|  Metric          Median        Worst         Skew        Scope             |
-|  --------------------------------------------------------------------------|
-|  CPU Util        18.4%         71.2%         52.8pp      node=n1           |
-|  GPU Util        14.0%         0.0%          14.0pp      node=n0           |
-|  GPU Memory      6.20GB        8.90GB        43.5%       node=n1           |
-|  GPU Temp        42C           58C           16C         node=n1           |
+|  Peak step memory: 9.8 GB reserved · worst rank r2                         |
 |                                                                            |
-|  Step Time Evidence                                                        |
-|  Phase           Median        Worst         Skew        Scope             |
-|  --------------------------------------------------------------------------|
-|  Total           303.7ms       304.1ms       0.1%        rank=r0 node=n0   |
-|  Input Wait      3.8ms         254.5ms       6597.4%     rank=r0 node=n0   |
-|  Compute         259.5ms       261.0ms       0.6%        rank=r2 node=n1   |
+|  Next: inspect dataloader, collate_fn, preprocessing, and storage on rank 0|
+|  (node n0).                                                                |
+|                                                                            |
+|  Supporting: GPU util median 14% -- ranks idle at the step barrier.        |
+|                                                                            |
+|  Full evidence: logs/ddp_pretrain/final_summary.json  (--html-report)      |
 +----------------------------------------------------------------------------+
 ```
 

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -16,7 +16,7 @@ The concepts are the same in both.
 
 ## Start with the diagnosis
 
-TraceML output has two layers:
+TraceML output has three layers:
 
 1. **Primary Diagnosis**
    - the first answer in the end-of-run summary
@@ -55,13 +55,18 @@ By default, `traceml run train.py` prints a compact final summary and writes
 
 The text summary is intentionally verdict-first:
 
-- `TraceML Verdict`: the promoted performance diagnosis and severity
+- the run context: run name, device and topology, analyzed steps, and duration
+- `Verdict`: the promoted performance diagnosis and severity
 - `Why`: the short evidence-backed reason
+- `Where a step goes`: the selected-clock step decomposition, with median and
+  worst-rank evidence on distributed runs
+- conditional context such as peak step memory, DataLoader fetch time, or
+  system, process, and memory health
 - `Next`: the first action to try or inspect
-- `Section Status`: compact health/status across System, Process, Step Time,
-  and Step Memory
-- `System Evidence` and `Step Time Evidence`: the core numbers behind the
-  verdict
+- `Supporting` and `Also`: relevant context and secondary findings when they
+  are present
+- `Full evidence`: the path to the structured JSON artifact and the optional
+  HTML-report hint
 
 Detailed section prose remains in the `system.card`, `process.card`,
 `step_time.card`, and `step_memory.card` fields inside `final_summary.json`.

--- a/notebooks/huggingface_dataloading_bottleneck.ipynb
+++ b/notebooks/huggingface_dataloading_bottleneck.ipynb
@@ -75,16 +75,7 @@
     "id": "3",
     "outputId": "865db77b-6007-4d91-c8a2-2a7cabd1b94c"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GPU 0: Tesla T4 (UUID: GPU-b3003e28-a103-405a-a1bb-a1d65557997c)\n",
-      "CUDA available: True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import torch\n",
     "\n",
@@ -123,17 +114,7 @@
     "id": "5",
     "outputId": "0ae2dddd-02a6-4f52-86ef-c9ab592364ad"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[?25l   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/550.1 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m550.1/550.1 kB\u001b[0m \u001b[31m19.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "\n",
@@ -167,16 +148,7 @@
     "id": "7",
     "outputId": "ebefcd4d-6541-483e-c69d-d35491424bbb"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU cores available: 2\n",
-      "Training images: 9469\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "\n",
@@ -222,15 +194,7 @@
     "id": "9",
     "outputId": "fca80db5-e612-433d-e6a2-2a3c9a3e9253"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Writing hf_train.py\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%writefile hf_train.py\n",
     "import argparse\n",
@@ -401,79 +365,7 @@
     "id": "11",
     "outputId": "b7ef917b-4686-4af4-fff5-6ccae50c1b7e"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[TraceML] Starting aggregator on 127.0.0.1:29765 (connect=127.0.0.1, ui=summary, profile=run)\n",
-      "[TraceML] Launching TraceML aggregator: /usr/bin/python3 /usr/local/lib/python3.12/dist-packages/traceml_ai/aggregator/aggregator_main.py\n",
-      "[TraceML] Aggregator PID: 1529\n",
-      "[TraceML] Aggregator ready on 127.0.0.1:29765 (workers connect to 127.0.0.1:29765, session=hf_baseline, ui=summary). Press Ctrl+C to stop.\n",
-      "[TraceML] Aggregator ready.\n",
-      "[TraceML] Launching training process: /usr/bin/python3 -m torch.distributed.run --nnodes=1 --nproc_per_node=1 --node_rank=0 --master_addr=127.0.0.1 --master_port=29500 /usr/local/lib/python3.12/dist-packages/traceml_ai/runtime/executor.py -- --profile baseline --data-dir imagenette2-320 --max-steps 200 --batch-size 32\n",
-      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n",
-      "preprocessor_config.json: 100% 266/266 [00:00<00:00, 1.30MB/s]\n",
-      "config.json: 100% 69.6k/69.6k [00:00<00:00, 19.6MB/s]\n",
-      "[transformers] You passed `num_labels=10` which is incompatible to the `id2label` map of length `1000`.\n",
-      "\n",
-      "model.safetensors: downloading bytes:  75% 77.3M/102M [00:01<00:00, 99.3MB/s, 4.93MB/s  ]\n",
-      "model.safetensors: downloading bytes: 100% 96.1M/96.1M [00:01<00:00, 61.0MB/s, 9.15MB/s  ]\n",
-      "model.safetensors: reconstructing file: 100% 102M/102M [00:01<00:00, 65.0MB/s, 9.87MB/s  ]\n",
-      "Loading weights: 100% 320/320 [00:00<00:00, 6337.60it/s]\n",
-      "[transformers] \u001b[1mResNetForImageClassification LOAD REPORT\u001b[0m from: microsoft/resnet-50\n",
-      "Key                 | Status   |                                                                                             \n",
-      "--------------------+----------+---------------------------------------------------------------------------------------------\n",
-      "classifier.1.weight | \u001b[33mMISMATCH\u001b[0m | Reinit due to size mismatch - ckpt: torch.Size([1000, 2048]) vs model:torch.Size([10, 2048])\n",
-      "classifier.1.bias   | \u001b[33mMISMATCH\u001b[0m | Reinit due to size mismatch - ckpt: torch.Size([1000]) vs model:torch.Size([10])            \n",
-      "\n",
-      "Notes:\n",
-      "- \u001b[33mMISMATCH:\u001b[0m\t\u001b[3mckpt weights were loaded, but they did not match the original empty weight shapes.\u001b[0m\n",
-      "[demo] profile=baseline workers=0 pin_memory=False persistent_workers=False batch_size=32 max_steps=200\n",
-      "{'train_runtime': '87.62', 'train_samples_per_second': '73.04', 'train_steps_per_second': '2.282', 'train_loss': '1.874', 'epoch': '0.6757'}\n",
-      "[rank0]:[W804 21:23:39.754270433 ProcessGroupNCCL.cpp:1575] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())\n",
-      "[TraceML] Training finished; stopping aggregator...\n",
-      "+----------------------------------------------------------------------------+\n",
-      "|  TraceML Run Summary | duration 122.3s                                     |\n",
-      "+----------------------------------------------------------------------------+\n",
-      "|                                                                            |\n",
-      "|  TraceML Verdict: INPUT-BOUND / CRITICAL                                   |\n",
-      "|  Why: Input wait is 28.1% of the typical gpu iteration time.               |\n",
-      "|  Next: Increase workers, prefetch, or storage throughput.                  |\n",
-      "|                                                                            |\n",
-      "|  Section Status                                                            |\n",
-      "|  Section       Status                  Severity                            |\n",
-      "|  ------------------------------------------------                          |\n",
-      "|  Step Time     INPUT-BOUND             CRITICAL                            |\n",
-      "|  System        MODERATE GPU UTIL       INFO                                |\n",
-      "|  Process       NORMAL                  INFO                                |\n",
-      "|  Step Memory   BALANCED                INFO                                |\n",
-      "|                                                                            |\n",
-      "|  System Evidence                                                           |\n",
-      "|  Metric            Average                                                 |\n",
-      "|  ----------------------------------                                        |\n",
-      "|  CPU Util          72.5%                                                   |\n",
-      "|  GPU Util          44.4%                                                   |\n",
-      "|  GPU Memory        2.98GB                                                  |\n",
-      "|  GPU Temp          66C                                                     |\n",
-      "|                                                                            |\n",
-      "|  Step Time Evidence                                                        |\n",
-      "|  Phase             Average           Share                                 |\n",
-      "|  ------------------------------------------------                          |\n",
-      "|  Total             431.4ms           compat                                |\n",
-      "|  Dataloader        121.5ms           compat                                |\n",
-      "|  Input Wait        121.5ms           28.1%                                 |\n",
-      "|  Step Time         311.1ms           71.9%                                 |\n",
-      "|  Compute           303.3ms           70.1%                                 |\n",
-      "|  Residual          7.8ms             1.8%                                  |\n",
-      "|  H2D               0.0ms             0.0%                                  |\n",
-      "+----------------------------------------------------------------------------+\n",
-      "[TraceML] Logs saved under: /content/logs/hf_baseline\n",
-      "\n",
-      "[TraceML] Aggregator stopped.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if RUN_MODE == \"smoke\":\n",
     "    !traceml run --mode summary --logs-dir logs --run-name hf_smoke hf_train.py --args --profile baseline --smoke --max-steps 8 --batch-size 4\n",
@@ -504,73 +396,7 @@
     "id": "13",
     "outputId": "40ae45ba-9a37-45da-9cc1-0682a87f2cc4"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[TraceML] Starting aggregator on 127.0.0.1:29765 (connect=127.0.0.1, ui=summary, profile=run)\n",
-      "[TraceML] Launching TraceML aggregator: /usr/bin/python3 /usr/local/lib/python3.12/dist-packages/traceml_ai/aggregator/aggregator_main.py\n",
-      "[TraceML] Aggregator PID: 2235\n",
-      "[TraceML] Aggregator ready on 127.0.0.1:29765 (workers connect to 127.0.0.1:29765, session=hf_optimized, ui=summary). Press Ctrl+C to stop.\n",
-      "[TraceML] Aggregator ready.\n",
-      "[TraceML] Launching training process: /usr/bin/python3 -m torch.distributed.run --nnodes=1 --nproc_per_node=1 --node_rank=0 --master_addr=127.0.0.1 --master_port=29500 /usr/local/lib/python3.12/dist-packages/traceml_ai/runtime/executor.py -- --profile optimized --data-dir imagenette2-320 --max-steps 200 --batch-size 32\n",
-      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n",
-      "[transformers] You passed `num_labels=10` which is incompatible to the `id2label` map of length `1000`.\n",
-      "Loading weights: 100% 320/320 [00:00<00:00, 6624.27it/s]\n",
-      "[transformers] \u001b[1mResNetForImageClassification LOAD REPORT\u001b[0m from: microsoft/resnet-50\n",
-      "Key                 | Status   |                                                                                             \n",
-      "--------------------+----------+---------------------------------------------------------------------------------------------\n",
-      "classifier.1.weight | \u001b[33mMISMATCH\u001b[0m | Reinit due to size mismatch - ckpt: torch.Size([1000, 2048]) vs model:torch.Size([10, 2048])\n",
-      "classifier.1.bias   | \u001b[33mMISMATCH\u001b[0m | Reinit due to size mismatch - ckpt: torch.Size([1000]) vs model:torch.Size([10])            \n",
-      "\n",
-      "Notes:\n",
-      "- \u001b[33mMISMATCH:\u001b[0m\t\u001b[3mckpt weights were loaded, but they did not match the original empty weight shapes.\u001b[0m\n",
-      "[demo] profile=optimized workers=2 pin_memory=True persistent_workers=True batch_size=32 max_steps=200\n",
-      "{'train_runtime': '66.07', 'train_samples_per_second': '96.87', 'train_steps_per_second': '3.027', 'train_loss': '1.846', 'epoch': '0.6757'}\n",
-      "[rank0]:[W804 21:25:14.057472507 ProcessGroupNCCL.cpp:1575] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())\n",
-      "[TraceML] Training finished; stopping aggregator...\n",
-      "+----------------------------------------------------------------------------+\n",
-      "|  TraceML Run Summary | duration 74.8s                                      |\n",
-      "+----------------------------------------------------------------------------+\n",
-      "|                                                                            |\n",
-      "|  TraceML Verdict: COMPUTE-BOUND / INFO                                     |\n",
-      "|  Why: Compute-bound; backward is the largest phase.                        |\n",
-      "|  Next: Optimize model compute or reduce step cost.                         |\n",
-      "|                                                                            |\n",
-      "|  Section Status                                                            |\n",
-      "|  Section       Status                  Severity                            |\n",
-      "|  ------------------------------------------------                          |\n",
-      "|  Step Time     COMPUTE-BOUND           INFO                                |\n",
-      "|  System        HIGH GPU PWR            WARNING                             |\n",
-      "|  Process       NORMAL                  INFO                                |\n",
-      "|  Step Memory   BALANCED                INFO                                |\n",
-      "|                                                                            |\n",
-      "|  System Evidence                                                           |\n",
-      "|  Metric            Average                                                 |\n",
-      "|  ----------------------------------                                        |\n",
-      "|  CPU Util          83.3%                                                   |\n",
-      "|  GPU Util          77.9%                                                   |\n",
-      "|  GPU Memory        3.54GB                                                  |\n",
-      "|  GPU Temp          77C                                                     |\n",
-      "|                                                                            |\n",
-      "|  Step Time Evidence                                                        |\n",
-      "|  Phase             Average           Share                                 |\n",
-      "|  ------------------------------------------------                          |\n",
-      "|  Total             325.5ms           compat                                |\n",
-      "|  Dataloader        2.5ms             compat                                |\n",
-      "|  Input Wait        2.5ms             0.8%                                  |\n",
-      "|  Step Time         324.2ms           99.2%                                 |\n",
-      "|  Compute           314.2ms           96.2%                                 |\n",
-      "|  Residual          9.9ms             3.0%                                  |\n",
-      "|  H2D               0.0ms             0.0%                                  |\n",
-      "+----------------------------------------------------------------------------+\n",
-      "[TraceML] Logs saved under: /content/logs/hf_optimized\n",
-      "\n",
-      "[TraceML] Aggregator stopped.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if RUN_MODE == \"extended\":\n",
     "    !traceml run --mode summary --logs-dir logs --run-name hf_optimized hf_train.py --args --profile optimized --data-dir imagenette2-320 --max-steps 200 --batch-size 32\n",
@@ -603,57 +429,7 @@
     "id": "15",
     "outputId": "a544073e-4836-483e-e143-f544d2f50e11"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+--------------------------------------------------------------------------------------+\n",
-      "|  TraceML Compare                                                                     |\n",
-      "+--------------------------------------------------------------------------------------+\n",
-      "|                                                                                      |\n",
-      "|  A: hf_baseline                                                                      |\n",
-      "|  B: hf_optimized                                                                     |\n",
-      "|  Delta: B - A                                                                        |\n",
-      "|  Primary diagnosis: INPUT-BOUND -> COMPUTE-BOUND (changed)                           |\n",
-      "|                                                                                      |\n",
-      "|  Verdict: IMPROVEMENT                                                                |\n",
-      "|  Why: Step time decreased by 24.5%.                                                  |\n",
-      "|                                                                                      |\n",
-      "|  Step Time                                                                           |\n",
-      "|  Metric                       A                 B                 Delta              |\n",
-      "|  Step time diagnosis          INPUT-BOUND       COMPUTE-BOUND     changed            |\n",
-      "|  Total step                   431.4 ms          325.5 ms          -105.8 ms (-24.5%) |\n",
-      "|  Input                        121.5 ms          2.5 ms            -119.1 ms (-98.0%) |\n",
-      "|  H2D                          0.0 ms            0.0 ms            +0.0 ms            |\n",
-      "|  Compute                      303.3 ms          314.2 ms          +11.0 ms (+3.6%)   |\n",
-      "|  Residual                     7.8 ms            9.9 ms            +2.1 ms (+26.8%)   |\n",
-      "|                                                                                      |\n",
-      "|  Step Memory                                                                         |\n",
-      "|  Metric                       A                 B                 Delta              |\n",
-      "|  Step memory diagnosis        BALANCED          BALANCED          same               |\n",
-      "|  Peak reserved                3.10 GB           3.10 GB           0 B (+0.0%)        |\n",
-      "|  Memory skew                  0.0%              0.0%              +0.0 pp            |\n",
-      "|                                                                                      |\n",
-      "|  Process                                                                             |\n",
-      "|  Metric                       A                 B                 Delta              |\n",
-      "|  Process diagnosis            NORMAL            NORMAL            same               |\n",
-      "|  Process CPU avg              85.6%             87.3%             +1.7 pp            |\n",
-      "|  Process RSS avg              1.4 GB            1.5 GB            +0.2 GB (+12.2%)   |\n",
-      "|                                                                                      |\n",
-      "|  System                                                                              |\n",
-      "|  Metric                       A                 B                 Delta              |\n",
-      "|  System diagnosis             MODERATE GPU UTIL HIGH GPU PWR      changed            |\n",
-      "|  System CPU avg               72.5%             83.3%             +10.8 pp           |\n",
-      "|  System RAM avg               4.1 GB            4.7 GB            +0.7 GB (+16.5%)   |\n",
-      "|  GPU util avg                 44.4%             77.9%             +33.5 pp           |\n",
-      "|  GPU memory avg               18.5%             22.0%             +3.5 pp            |\n",
-      "+--------------------------------------------------------------------------------------+\n",
-      "[TraceML] Compare JSON: /content/logs/hf_baseline_vs_optimized.json\n",
-      "[TraceML] Compare TXT:  /content/logs/hf_baseline_vs_optimized.txt\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if RUN_MODE == \"smoke\":\n",
     "    import json\n",


### PR DESCRIPTION
## Summary

Make the first copy-paste success path visible before the full terminal reports and synchronize the tracked documentation with TraceML's current summary-card formatter.

This keeps the existing product positioning and evidence-backed examples while making installation, minimal instrumentation, and the first run command easier to reach. It also removes stale saved GPU output from the Hugging Face notebook instead of publishing obsolete or manually reconstructed measurements.

## What changed

- Kept the compact verdict/why/next example near the top of the README and  added a direct link to the complete reports.
- Moved the existing single-run and distributed report disclosures below the  Quickstart install, instrumentation, and run steps.
- Replaced both outdated Quickstart reports with the exact current  `run_input_bound_critical` and `run_multi_input_straggler` formatter goldens.
- Updated the output guide to describe the current three-layer model and the  conditional summary-card structure: run context, verdict, reason, step  decomposition, memory/context, next action, supporting findings, and the  full-evidence path.
- Updated the input-pipeline guide and Accelerate troubleshooting heading to  use the current formatter terminology and severity syntax.
- Added `H2D-BOUND` routing to the slow-training and low-GPU-utilization guides,  linking to the existing canonical H2D explanation.
- Cleared stale saved T4 outputs from the Hugging Face notebook while  preserving its code, Markdown, metadata, extended mode, and CPU smoke path.

## Scope

- No runtime behavior or public API changes.
- No diagnosis thresholds or formatter behavior changes.
- No compare-output changes.
- No GPU measurements were regenerated or invented. The Hugging Face notebook  now generates current results when executed instead of displaying an old  saved baseline.

## Validation

- `pytest -p no:cacheprovider tests/docs/test_public_api_contract.py tests/reporting/summary -q`  — 178 passed.
- Executed both notebooks through their CPU smoke paths in isolated temporary  directories; both produced `final_summary.json` and `final_summary.txt`.
- Confirmed the Hugging Face notebook is schema-valid and that clearing output  did not change its code, Markdown, cell metadata, or notebook metadata.
- `python tools/integration_support_matrix.py --check`
- `mkdocs build --strict` on a tracked-only checkout.
- `codespell` on every affected tracked file.
- `git diff --check`
- Rendered the README through GitHub's Markdown API and `readme-renderer` for  PyPI; verified desktop and narrow ordering, collapsed disclosures, internal  anchors, and all external links.
