### PR TITLE
Fix error-log logger name so errors reach traceml_errors.log (#347)

### DIFF
--- a/src/traceml_ai/loggers/error_log.py
+++ b/src/traceml_ai/loggers/error_log.py
@@ -17,7 +17,7 @@ def setup_error_logger(is_aggregator=False) -> logging.Logger:
     """
     Configure and initialize the global TraceML error logger.
 
-    This function sets up a process-wide logger named ``"traceml"`` with:
+    This function sets up a process-wide logger named ``"traceml_ai"`` with:
       - WARNING and above logged to stderr (for visibility during runs)
       - ERROR and above logged to a rotating file on disk
 
@@ -43,7 +43,9 @@ def setup_error_logger(is_aggregator=False) -> logging.Logger:
     logging.Logger
         The configured TraceML root logger.
     """
-    logger = logging.getLogger("traceml")
+    # Parent of every ``get_error_logger`` child ("traceml_ai.<name>"), so
+    # child records propagate into the handlers attached here.
+    logger = logging.getLogger("traceml_ai")
 
     # If handlers are already attached, assume the logger
     # has been initialized and return it as-is.

--- a/tests/loggers/test_error_log.py
+++ b/tests/loggers/test_error_log.py
@@ -1,0 +1,77 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The error log must actually receive errors logged by TraceML code.
+
+Regression test for the logger-name mismatch where the rotating file
+handler lived on ``"traceml"`` while every call site logged under
+``"traceml_ai.*"``, leaving every ``traceml_errors.log`` empty.
+"""
+
+import logging
+
+import pytest
+
+from traceml_ai.loggers.error_log import get_error_logger, setup_error_logger
+
+
+@pytest.fixture
+def clean_error_logger():
+    """Detach handlers before and after so logger state cannot leak."""
+
+    def _reset():
+        logger = logging.getLogger("traceml_ai")
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            handler.close()
+        logger.propagate = True
+
+    _reset()
+    yield
+    _reset()
+
+
+def test_error_from_call_site_lands_in_file(
+    tmp_path, monkeypatch, clean_error_logger
+):
+    monkeypatch.setenv("TRACEML_LOGS_DIR", str(tmp_path))
+    monkeypatch.setenv("TRACEML_SESSION_ID", "session_test")
+
+    setup_error_logger(is_aggregator=True)
+    get_error_logger("Probe").error("[TraceML] probe-error-message")
+
+    log_file = tmp_path / "session_test" / "aggregator" / "traceml_errors.log"
+    assert log_file.is_file()
+    content = log_file.read_text(encoding="utf-8")
+    assert "probe-error-message" in content
+    assert "traceml_ai.Probe" in content
+
+
+def test_rank_process_writes_its_own_error_file(
+    tmp_path, monkeypatch, clean_error_logger
+):
+    """Each rank keeps its own file, so ranks cannot overwrite each other."""
+    monkeypatch.setenv("TRACEML_LOGS_DIR", str(tmp_path))
+    monkeypatch.setenv("TRACEML_SESSION_ID", "session_test")
+    monkeypatch.setenv("RANK", "3")
+
+    setup_error_logger(is_aggregator=False)
+    get_error_logger("Sampler").error("[TraceML] rank-scoped-error")
+
+    log_file = tmp_path / "session_test" / "rank_3" / "traceml_errors.log"
+    assert log_file.is_file()
+    assert "rank-scoped-error" in log_file.read_text(encoding="utf-8")
+
+
+def test_setup_is_idempotent(tmp_path, monkeypatch, clean_error_logger):
+    monkeypatch.setenv("TRACEML_LOGS_DIR", str(tmp_path))
+    monkeypatch.setenv("TRACEML_SESSION_ID", "session_test")
+
+    first = setup_error_logger(is_aggregator=True)
+    second = setup_error_logger(is_aggregator=True)
+
+    assert first is second
+    assert len(first.handlers) == 1


### PR DESCRIPTION
Closes #347.

## Problem

The rotating file handler was attached to logger `"traceml"` (`loggers/error_log.py:46`) while every call site logs through `get_error_logger`, which returns `"traceml_ai.<name>"` (`:115`). Those are unrelated branches of the logging tree, so no record ever reached the handler and every `traceml_errors.log` stayed 0 bytes.

## Fix

Attach the handler to `"traceml_ai"`, the parent of every call-site logger, so child records propagate into it. The handler configuration, levels, rotation, per-rank paths, and `propagate = False` are unchanged.

## Tests

`tests/loggers/test_error_log.py`, three cases:
- an error logged through `get_error_logger` lands in the aggregator's `traceml_errors.log`, with the logger name in the record
- a rank process writes to its own `rank_<global_rank>/traceml_errors.log`
- repeated `setup_error_logger()` calls stay idempotent (one handler)

## Evidence

GATE: conformance ran=true, 1 passed / 0 failed / 1 skipped (`tests/integrations/test_telemetry_conformance.py`). Full suite: 1035 passed, 2 skipped. black, ruff, isort clean on both changed files.
TRANSITIONS: the state changes this code has are unconfigured to configured, and configured to re-configured. Both are covered: the first setup creates exactly one handler and writes, and a second setup returns the same logger without adding a handler.
RANKS: per-rank asymmetry tested? Yes. `test_rank_process_writes_its_own_error_file` sets `RANK=3` and asserts the record lands in `rank_3/`, so ranks keep separate files and cannot overwrite each other. The aggregator path is covered by the first test.
TRIPWIRE: made the failure fire on purpose? Yes. Reverting the one-line fix to `getLogger("traceml")` and re-running turns both landing tests red (2 failed, 1 passed), so the tests fail for the reason the issue describes rather than passing by construction.
PLATFORM: n/a, no platform-conditional code in this diff (logger naming only).
