### PR TITLE
Make watch/run work on a torch-free install (#346)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,20 @@ jobs:
           pip install -e .
           # tomli backports tomllib to 3.10 for the packaging guard.
           pip install pytest 'tomli; python_version < "3.11"'
+      - name: Torch-free watch (end to end, no torch installed)
+        run: |
+          # This job installs TraceML without the torch extra, so it is the
+          # only leg that proves the documented torch-free path really
+          # works. Importing is not enough: the failure this guards against
+          # was a module-scope torch import inside the launch chain, which
+          # only surfaces when the command actually runs.
+          set -euo pipefail
+          echo "print('training done')" > tiny_train.py
+          python -m traceml_ai.launcher.cli watch tiny_train.py \
+            --mode=summary --run-name torch_free_ci | tee watch_out.txt
+          grep -q "training done" watch_out.txt
+          grep -q "TraceML Watch Summary" watch_out.txt
+          test -f logs/torch_free_ci/final_summary.json
       - name: Run core tests
         run: |
           # Keep this matrix torch-free; torch-dependent paths run in the

--- a/src/traceml_ai/api.py
+++ b/src/traceml_ai/api.py
@@ -32,7 +32,7 @@ def trace_step(model: nn.Module) -> ContextManager[None]:
     When tracing is disabled, the context manager is a no-op. Exceptions from
     the training body still propagate normally.
     """
-    from traceml_ai.sdk.instrumentation import trace_step as _trace_step
+    from traceml_ai.sdk import trace_step as _trace_step
 
     return _trace_step(model)
 
@@ -138,9 +138,7 @@ def wrap_dataloader_fetch(obj: Any) -> Any:
     RuntimeError
         If a torch ``DataLoader`` is already automatically instrumented.
     """
-    from traceml_ai.sdk.wrappers import (
-        wrap_dataloader_fetch as _wrap_dataloader_fetch,
-    )
+    from traceml_ai.sdk import wrap_dataloader_fetch as _wrap_dataloader_fetch
 
     return _wrap_dataloader_fetch(obj)
 
@@ -167,7 +165,7 @@ def wrap_forward(model: nn.Module) -> nn.Module:
         If automatic forward instrumentation is active or the instance cannot
         be wrapped safely.
     """
-    from traceml_ai.sdk.wrappers import wrap_forward as _wrap_forward
+    from traceml_ai.sdk import wrap_forward as _wrap_forward
 
     return _wrap_forward(model)
 
@@ -192,7 +190,7 @@ def wrap_backward(loss: Any) -> Any:
     RuntimeError
         If automatic backward instrumentation is active.
     """
-    from traceml_ai.sdk.wrappers import wrap_backward as _wrap_backward
+    from traceml_ai.sdk import wrap_backward as _wrap_backward
 
     return _wrap_backward(loss)
 
@@ -219,7 +217,7 @@ def wrap_optimizer(optimizer: Any) -> Any:
         If automatic optimizer instrumentation is active or the instance
         cannot be wrapped safely.
     """
-    from traceml_ai.sdk.wrappers import wrap_optimizer as _wrap_optimizer
+    from traceml_ai.sdk import wrap_optimizer as _wrap_optimizer
 
     return _wrap_optimizer(optimizer)
 
@@ -248,7 +246,7 @@ def wrap_h2d(obj: Any) -> Any:
     Use this in manual or selective mode. If automatic H2D timing becomes
     active after wrapping, the proxy passes through to avoid double counting.
     """
-    from traceml_ai.sdk.wrappers import wrap_h2d as _wrap_h2d
+    from traceml_ai.sdk import wrap_h2d as _wrap_h2d
 
     return _wrap_h2d(obj)
 

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Mapping, Optional
 
 from traceml_ai.launcher.launch_config import (
+    TORCH_LAUNCHER_REQUIRED,
     DistributedLaunchConfig,
     RunIdentity,
     TorchrunLaunchConfig,
@@ -49,6 +50,7 @@ from traceml_ai.runtime.settings import (
     DEFAULT_UI_MODE,
 )
 from traceml_ai.utils.msgpack_codec import Decoder as MsgpackDecoder
+from traceml_ai.utils.torch_support import torch_available
 
 DASHBOARD_DEPENDENCY_INSTALL_HINT = (
     "Dashboard mode requires nicegui. It is included in the "
@@ -218,19 +220,36 @@ def _launch_disabled_process(
     raise SystemExit(train_proc.returncode)
 
 
+def _require_torch_launcher_support(torchrun: TorchrunLaunchConfig) -> None:
+    """Reject a torch-free multi-process launch before anything starts.
+
+    ``torch.distributed.run`` is what launches extra processes, so without
+    torch the topology is impossible. Checking it here means the user gets
+    one clear error instead of a started aggregator and a failure later.
+    """
+    if not torchrun.requires_torch_launcher():
+        return
+    if torch_available():
+        return
+    raise SystemExit(f"[TraceML] ERROR: {TORCH_LAUNCHER_REQUIRED}")
+
+
 def validate_launch_args(args: argparse.Namespace) -> None:
     """Validate cross-argument constraints for TraceML launch commands."""
     if _disable_traceml_requested(args, os.environ):
         try:
-            TorchrunLaunchConfig.from_args(args)
+            torchrun_cfg = TorchrunLaunchConfig.from_args(args)
         except ValueError as exc:
             raise SystemExit(f"[TraceML] ERROR: {exc}") from exc
+        _require_torch_launcher_support(torchrun_cfg)
         return
 
     try:
         launch_cfg = DistributedLaunchConfig.from_args(args)
     except ValueError as exc:
         raise SystemExit(f"[TraceML] ERROR: {exc}") from exc
+
+    _require_torch_launcher_support(launch_cfg.torchrun)
 
     try:
         RunIdentity.from_args(

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -234,6 +234,18 @@ def _require_torch_launcher_support(torchrun: TorchrunLaunchConfig) -> None:
     raise SystemExit(f"[TraceML] ERROR: {TORCH_LAUNCHER_REQUIRED}")
 
 
+def _require_run_torch_support(args: argparse.Namespace) -> None:
+    """Require torch for the step-aware ``run`` command."""
+    if getattr(args, "command", None) != "run":
+        return
+    if torch_available():
+        return
+    raise SystemExit(
+        "[TraceML] ERROR: traceml run requires torch for step-aware "
+        "diagnosis. Install it with: pip install 'traceml-ai[torch]'"
+    )
+
+
 def validate_launch_args(args: argparse.Namespace) -> None:
     """Validate cross-argument constraints for TraceML launch commands."""
     if _disable_traceml_requested(args, os.environ):
@@ -250,6 +262,7 @@ def validate_launch_args(args: argparse.Namespace) -> None:
         raise SystemExit(f"[TraceML] ERROR: {exc}") from exc
 
     _require_torch_launcher_support(launch_cfg.torchrun)
+    _require_run_torch_support(args)
 
     try:
         RunIdentity.from_args(

--- a/src/traceml_ai/launcher/launch_config.py
+++ b/src/traceml_ai/launcher/launch_config.py
@@ -103,11 +103,11 @@ class TorchrunLaunchConfig:
     def to_command(self) -> list[str]:
         """Return the launch command for the training runner.
 
-        Without torch, ``torch.distributed.run`` does not exist. A single
-        process does not need it, so a torch-free install starts the
-        training process directly. Multi-process topologies are rejected
-        during argument validation, before any process is started; the
-        raise here is the backstop for a caller that skipped validation.
+        Without torch, ``torch.distributed.run`` does not exist. Torch-free
+        single-process callers such as ``watch`` do not need it and start the
+        target directly. Multi-process topologies are rejected during argument
+        validation, before any process is started; the raise here is the
+        backstop for a caller that skipped validation.
         """
         if not torch_available():
             if not self.requires_torch_launcher():

--- a/src/traceml_ai/launcher/launch_config.py
+++ b/src/traceml_ai/launcher/launch_config.py
@@ -21,7 +21,15 @@ import sys
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from traceml_ai.utils.torch_support import torch_available
+
 _RUN_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+TORCH_LAUNCHER_REQUIRED = (
+    "Multi-process launches require torch (torch.distributed.run). "
+    "Install it with: pip install 'traceml-ai[torch]', or run a single "
+    "process with --nnodes 1 --nproc-per-node 1."
+)
 
 
 def _positive_int(value: Any, name: str) -> int:
@@ -88,8 +96,23 @@ class TorchrunLaunchConfig:
             master_port=master_port,
         )
 
+    def requires_torch_launcher(self) -> bool:
+        """Return whether this topology needs ``torch.distributed.run``."""
+        return self.nnodes > 1 or self.nproc_per_node > 1
+
     def to_command(self) -> list[str]:
-        """Return the Python-module form of the torchrun command."""
+        """Return the launch command for the training runner.
+
+        Without torch, ``torch.distributed.run`` does not exist. A single
+        process does not need it, so a torch-free install starts the
+        training process directly. Multi-process topologies are rejected
+        during argument validation, before any process is started; the
+        raise here is the backstop for a caller that skipped validation.
+        """
+        if not torch_available():
+            if not self.requires_torch_launcher():
+                return [sys.executable]
+            raise ValueError(TORCH_LAUNCHER_REQUIRED)
         return [
             sys.executable,
             "-m",

--- a/src/traceml_ai/runtime/sampler_registry.py
+++ b/src/traceml_ai/runtime/sampler_registry.py
@@ -13,11 +13,26 @@ from traceml_ai.samplers.runtime_environment_sampler import (
     RuntimeEnvironmentSampler,
 )
 from traceml_ai.samplers.stdout_stderr_sampler import StdoutStderrSampler
-from traceml_ai.samplers.step_memory_sampler import StepMemorySampler
-from traceml_ai.samplers.step_time_sampler import StepTimeSampler
 from traceml_ai.samplers.system_sampler import SystemSampler
 
 SamplerFactory = Callable[[], BaseSampler]
+
+
+# The step samplers reach torch through the timing and step-memory utilities.
+# They are run-profile only, so importing them lazily keeps `watch` free of
+# the torch import chain entirely instead of guarding each module it reaches.
+def _step_time_sampler() -> BaseSampler:
+    """Build the step-time sampler, importing torch-backed timing on use."""
+    from traceml_ai.samplers.step_time_sampler import StepTimeSampler
+
+    return StepTimeSampler()
+
+
+def _step_memory_sampler() -> BaseSampler:
+    """Build the step-memory sampler, importing torch-backed state on use."""
+    from traceml_ai.samplers.step_memory_sampler import StepMemorySampler
+
+    return StepMemorySampler()
 
 
 @dataclass(frozen=True)
@@ -82,13 +97,13 @@ DEFAULT_SAMPLER_REGISTRY: Registry[SamplerSpec] = Registry(
         _spec("stdout_stderr", StdoutStderrSampler, modes=("cli",)),
         _spec(
             "step_time",
-            StepTimeSampler,
+            _step_time_sampler,
             profiles=("run",),
             drain_on_recording_stop=True,
         ),
         _spec(
             "step_memory",
-            StepMemorySampler,
+            _step_memory_sampler,
             profiles=("run",),
             drain_on_recording_stop=True,
         ),

--- a/src/traceml_ai/samplers/process_sampler.py
+++ b/src/traceml_ai/samplers/process_sampler.py
@@ -11,8 +11,20 @@ import time
 from typing import Optional
 
 import psutil
-import torch
-import torch.distributed as dist
+
+from traceml_ai.utils.torch_support import is_missing_torch
+
+try:
+    import torch
+    import torch.distributed as dist
+except ImportError as exc:
+    # Torch-free install: process CPU/RSS sampling still works; GPU
+    # memory metrics stay unmeasured (null), never fabricated. Any other
+    # failing import here is a real regression and keeps propagating.
+    if not is_missing_torch(exc):
+        raise
+    torch = None  # type: ignore[assignment]
+    dist = None  # type: ignore[assignment]
 
 from traceml_ai.runtime.identity import (
     RuntimeIdentity,
@@ -154,6 +166,8 @@ class ProcessSampler(BaseSampler):
         """
         Return True if safe to call torch.cuda.* in this process.
         """
+        if torch is None:
+            return False
         if not self.is_distributed:
             return True
         if not dist.is_available():

--- a/src/traceml_ai/sdk/__init__.py
+++ b/src/traceml_ai/sdk/__init__.py
@@ -5,20 +5,54 @@ from traceml_ai.sdk.initial import (
     is_initialized,
     start,
 )
-from traceml_ai.sdk.instrumentation import (
-    TraceSessionState,
-    TraceState,
-    get_trace_session_state,
-    trace_step,
-    trace_time,
-)
 from traceml_ai.sdk.summary_client import final_summary, summary
-from traceml_ai.sdk.wrappers import (
-    wrap_backward,
-    wrap_dataloader_fetch,
-    wrap_forward,
-    wrap_optimizer,
+from traceml_ai.utils.torch_support import (
+    TORCH_REQUIRED_HINT,
+    is_missing_torch,
 )
+
+try:
+    from traceml_ai.sdk.instrumentation import (
+        TraceSessionState,
+        TraceState,
+        get_trace_session_state,
+        trace_step,
+        trace_time,
+    )
+    from traceml_ai.sdk.wrappers import (
+        wrap_backward,
+        wrap_dataloader_fetch,
+        wrap_forward,
+        wrap_h2d,
+        wrap_optimizer,
+    )
+except ImportError as exc:
+    # Torch-free install: monitoring (watch) and post-hoc commands work
+    # without torch. Step instrumentation does not; calling a trace API
+    # raises a clear error instead of crashing at import time.
+    #
+    # Only torch's own absence is handled here. Any other failing import
+    # inside these modules is a real regression and keeps propagating.
+    if not is_missing_torch(exc):
+        raise
+
+    def _torch_required(*_args, **_kwargs):
+        raise RuntimeError(TORCH_REQUIRED_HINT)
+
+    class _TorchRequiredType:
+        def __init__(self, *_args, **_kwargs):
+            raise RuntimeError(TORCH_REQUIRED_HINT)
+
+    TraceSessionState = _TorchRequiredType  # type: ignore[assignment,misc]
+    TraceState = _TorchRequiredType  # type: ignore[assignment,misc]
+    get_trace_session_state = _torch_required
+    trace_step = _torch_required
+    trace_time = _torch_required
+    wrap_backward = _torch_required
+    wrap_dataloader_fetch = _torch_required
+    wrap_forward = _torch_required
+    wrap_h2d = _torch_required
+    wrap_optimizer = _torch_required
 
 __all__ = [
     "TraceMLInitConfig",
@@ -36,5 +70,6 @@ __all__ = [
     "wrap_dataloader_fetch",
     "wrap_forward",
     "wrap_backward",
+    "wrap_h2d",
     "wrap_optimizer",
 ]

--- a/src/traceml_ai/utils/torch_support.py
+++ b/src/traceml_ai/utils/torch_support.py
@@ -34,7 +34,9 @@ def torch_available() -> bool:
     """Return whether torch can be imported in this environment."""
     try:
         import torch  # noqa: F401
-    except ImportError:
+    except ImportError as exc:
+        if not is_missing_torch(exc):
+            raise
         return False
     return True
 

--- a/src/traceml_ai/utils/torch_support.py
+++ b/src/traceml_ai/utils/torch_support.py
@@ -1,0 +1,46 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for TraceML's optional torch dependency.
+
+TraceML monitors host and process health without torch, and instruments
+training steps with it. The boundary is only honest if "torch is absent"
+is detected precisely: a bare ``except ImportError`` around a torch-backed
+module would also swallow an unrelated import regression inside it and
+report that as a missing torch install.
+"""
+
+from __future__ import annotations
+
+TORCH_REQUIRED_HINT = (
+    "TraceML step instrumentation requires torch. "
+    "Install it with: pip install 'traceml-ai[torch]'"
+)
+
+
+def is_missing_torch(exc: ImportError) -> bool:
+    """Return whether ``exc`` reports torch itself as the missing module.
+
+    Any other failing import is a real error and must keep propagating.
+    """
+    name = getattr(exc, "name", None) or ""
+    return name == "torch" or name.startswith("torch.")
+
+
+def torch_available() -> bool:
+    """Return whether torch can be imported in this environment."""
+    try:
+        import torch  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+__all__ = [
+    "TORCH_REQUIRED_HINT",
+    "is_missing_torch",
+    "torch_available",
+]

--- a/tests/runtime/test_torch_free.py
+++ b/tests/runtime/test_torch_free.py
@@ -15,6 +15,7 @@ subprocess with torch blocked (``sys.modules["torch"] = None`` makes any
 ``import torch`` raise ``ModuleNotFoundError`` with ``name == "torch"``).
 """
 
+import builtins
 import os
 import subprocess
 import sys
@@ -27,7 +28,7 @@ from traceml_ai.launcher.launch_config import (
     TORCH_LAUNCHER_REQUIRED,
     TorchrunLaunchConfig,
 )
-from traceml_ai.utils.torch_support import is_missing_torch
+from traceml_ai.utils.torch_support import is_missing_torch, torch_available
 
 _SRC_ROOT = str(Path(traceml_ai.__file__).resolve().parents[1])
 
@@ -138,6 +139,22 @@ def test_only_torch_counts_as_a_missing_torch_install(module_name, expected):
     assert is_missing_torch(exc) is expected
 
 
+def test_torch_available_does_not_mask_an_unrelated_import_error(monkeypatch):
+    real_import = builtins.__import__
+
+    def import_with_broken_torch(name, *args, **kwargs):
+        if name == "torch":
+            exc = ImportError("unrelated dependency is missing")
+            exc.name = "unrelated_dependency"
+            raise exc
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_with_broken_torch)
+
+    with pytest.raises(ImportError, match="unrelated dependency"):
+        torch_available()
+
+
 def test_an_unrelated_import_error_is_not_masked():
     """A broken import inside a torch module must still surface.
 
@@ -183,6 +200,26 @@ def test_single_process_launch_command_falls_back_without_torch():
     )
     assert result.returncode == 0, result.stderr
     assert "FALLBACK_OK" in result.stdout
+
+
+def test_run_requires_torch_before_launching_processes():
+    result = _run_torch_free(
+        "import argparse\n"
+        "from traceml_ai.launcher.commands import validate_launch_args\n"
+        "args = argparse.Namespace(command='run', script='x.py', "
+        "nnodes=1, nproc_per_node=1, node_rank=0, "
+        "master_addr='127.0.0.1', master_port=29500, "
+        "aggregator_host=None, aggregator_bind_host=None, "
+        "aggregator_port=29765, disable_traceml=False)\n"
+        "try:\n"
+        "    validate_launch_args(args)\n"
+        "except SystemExit as exc:\n"
+        "    assert 'step-aware diagnosis' in str(exc), str(exc)\n"
+        "    assert 'traceml-ai[torch]' in str(exc), str(exc)\n"
+        "    print('RUN_REJECTED_OK')\n"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "RUN_REJECTED_OK" in result.stdout
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime/test_torch_free.py
+++ b/tests/runtime/test_torch_free.py
@@ -1,0 +1,259 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TraceML must install and monitor without torch.
+
+``pip install traceml-ai`` without the ``[torch]`` extra has to support
+``traceml watch`` end to end. Step instrumentation genuinely needs torch,
+so it must fail with an actionable message rather than an import crash.
+
+The test environment has torch installed, so each case runs in a
+subprocess with torch blocked (``sys.modules["torch"] = None`` makes any
+``import torch`` raise ``ModuleNotFoundError`` with ``name == "torch"``).
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import traceml_ai
+from traceml_ai.launcher.launch_config import (
+    TORCH_LAUNCHER_REQUIRED,
+    TorchrunLaunchConfig,
+)
+from traceml_ai.utils.torch_support import is_missing_torch
+
+_SRC_ROOT = str(Path(traceml_ai.__file__).resolve().parents[1])
+
+_BLOCK_TORCH = "import sys; sys.modules['torch'] = None; "
+
+_PUBLIC_INSTRUMENTATION_API = (
+    "trace_step",
+    "wrap_dataloader_fetch",
+    "wrap_forward",
+    "wrap_backward",
+    "wrap_optimizer",
+    "wrap_h2d",
+)
+
+
+def _run_torch_free(code: str) -> subprocess.CompletedProcess:
+    """Run one snippet in a subprocess that cannot import torch."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _SRC_ROOT
+    return subprocess.run(
+        [sys.executable, "-c", _BLOCK_TORCH + code],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+
+
+def _torch_free_env(tmp_path: Path) -> dict:
+    """Return an environment where every child process also lacks torch.
+
+    ``sys.modules`` edits do not survive into spawned processes, and the
+    launcher spawns both an aggregator and a training process, so the
+    block has to travel through ``PYTHONPATH`` as a sitecustomize module.
+    """
+    blocker = tmp_path / "torch_blocker"
+    blocker.mkdir()
+    (blocker / "sitecustomize.py").write_text(
+        "import sys\nsys.modules['torch'] = None\n", encoding="utf-8"
+    )
+    # Drop inherited TRACEML_* settings so the run is not steered by the
+    # ambient environment (log location in particular).
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("TRACEML_")
+    }
+    env["PYTHONPATH"] = os.pathsep.join([str(blocker), _SRC_ROOT])
+    return env
+
+
+def test_watch_import_chain_survives_without_torch():
+    result = _run_torch_free(
+        "import traceml_ai.runtime.sampler_registry; "
+        "import traceml_ai.reporting.final; "
+        "import traceml_ai.sdk; "
+        "import traceml_ai.launcher.commands; "
+        "print('IMPORTS_OK')"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "IMPORTS_OK" in result.stdout
+
+
+def test_watch_profile_does_not_import_torch_backed_samplers():
+    """`watch` never needs step timing, so it must not reach torch at all."""
+    result = _run_torch_free(
+        "import sys; "
+        "import traceml_ai.runtime.sampler_registry as reg; "
+        "specs = reg.select_sampler_specs("
+        "profile='watch', mode='summary', is_ddp=False, local_rank=0); "
+        "assert 'traceml_ai.utils.timing' not in sys.modules, "
+        "'watch imported the timing module'; "
+        "print('KEYS', sorted(s.key for s in specs))"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "step_time" not in result.stdout
+    assert "step_memory" not in result.stdout
+
+
+@pytest.mark.parametrize("name", _PUBLIC_INSTRUMENTATION_API)
+def test_public_api_raises_an_actionable_error_without_torch(name):
+    """The documented entry points must name the fix, not crash."""
+    result = _run_torch_free(
+        "import traceml_ai\n"
+        f"try:\n"
+        f"    traceml_ai.{name}(None)\n"
+        "except RuntimeError as exc:\n"
+        "    assert 'traceml-ai[torch]' in str(exc), str(exc)\n"
+        "    print('ACTIONABLE_OK')\n"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ACTIONABLE_OK" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("module_name", "expected"),
+    [
+        ("torch", True),
+        ("torch.distributed", True),
+        ("torchvision", False),
+        ("numpy", False),
+        (None, False),
+    ],
+)
+def test_only_torch_counts_as_a_missing_torch_install(module_name, expected):
+    exc = ImportError("boom")
+    exc.name = module_name
+    assert is_missing_torch(exc) is expected
+
+
+def test_an_unrelated_import_error_is_not_masked():
+    """A broken import inside a torch module must still surface.
+
+    Torch is deliberately left importable here: the risk being tested is
+    a real regression inside instrumentation being reported as a missing
+    torch install and silently replaced by the torch-free fallback.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _SRC_ROOT
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys\n"
+            "sys.modules['traceml_ai.utils.timing'] = None\n"
+            "try:\n"
+            "    import traceml_ai.sdk\n"
+            "except ImportError as exc:\n"
+            "    assert exc.name == 'traceml_ai.utils.timing', exc.name\n"
+            "    print('PROPAGATED_OK')\n"
+            "else:\n"
+            "    raise AssertionError('the broken import was swallowed')\n",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "PROPAGATED_OK" in result.stdout
+
+
+def test_single_process_launch_command_falls_back_without_torch():
+    result = _run_torch_free(
+        "import sys as s; "
+        "from traceml_ai.launcher.launch_config import "
+        "TorchrunLaunchConfig; "
+        "cmd = TorchrunLaunchConfig(nnodes=1, nproc_per_node=1, "
+        "node_rank=0, master_addr='127.0.0.1', "
+        "master_port=29500).to_command(); "
+        "assert cmd == [s.executable], cmd; "
+        "print('FALLBACK_OK')"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "FALLBACK_OK" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("nnodes", "nproc_per_node"), [(1, 2), (2, 1), (2, 4)]
+)
+def test_multi_process_is_rejected_before_anything_starts(
+    nnodes, nproc_per_node
+):
+    """Validation must reject the topology, not a later spawn attempt."""
+    result = _run_torch_free(
+        "import argparse\n"
+        "from traceml_ai.launcher.commands import validate_launch_args\n"
+        "args = argparse.Namespace(script='x.py', "
+        f"nnodes={nnodes}, nproc_per_node={nproc_per_node}, node_rank=0, "
+        "master_addr='127.0.0.1', master_port=29500, run_name='r', "
+        "session_id='', mode=None, no_history=False, html_report=False, "
+        "summary_window_rows=10000, finalize_timeout_sec=300.0, "
+        "trace_max_steps=None, interval=2.0, disable_traceml=False, "
+        "aggregator_host=None, aggregator_bind_host=None, "
+        "aggregator_port=29765)\n"
+        "try:\n"
+        "    validate_launch_args(args)\n"
+        "except SystemExit as exc:\n"
+        "    assert 'traceml-ai[torch]' in str(exc), str(exc)\n"
+        "    print('REJECTED_OK')\n"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "REJECTED_OK" in result.stdout
+
+
+def test_multi_process_topology_reports_its_requirement():
+    cfg = TorchrunLaunchConfig(nnodes=1, nproc_per_node=2)
+    assert cfg.requires_torch_launcher() is True
+    assert "traceml-ai[torch]" in TORCH_LAUNCHER_REQUIRED
+
+    single = TorchrunLaunchConfig(nnodes=1, nproc_per_node=1)
+    assert single.requires_torch_launcher() is False
+
+
+def test_watch_runs_end_to_end_without_torch(tmp_path):
+    """The whole command must work, not merely import.
+
+    This is the case a user actually hits: install without the extra,
+    point `traceml watch` at a script, and get a summary card.
+    """
+    script = tmp_path / "tiny_train.py"
+    script.write_text("print('training done')\n", encoding="utf-8")
+    logs_dir = tmp_path / "logs"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.argv = ['traceml', 'watch', "
+            f"{str(script)!r}, '--mode=summary', "
+            f"'--logs-dir', {str(logs_dir)!r}, "
+            "'--run-name', 'torch_free_e2e']; "
+            "from traceml_ai.launcher.cli import main; main()",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=str(tmp_path),
+        env=_torch_free_env(tmp_path),
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    assert "training done" in result.stdout
+    assert "TraceML Watch Summary" in result.stdout
+    assert "Host health" in result.stdout
+    assert "ModuleNotFoundError" not in result.stderr
+
+    summary = logs_dir / "torch_free_e2e" / "final_summary.json"
+    assert summary.is_file(), "watch wrote no summary artifact"


### PR DESCRIPTION
Closes #346.

## Problem

`pip install traceml-ai` without the `[torch]` extra crashed every `watch` and `run` invocation. The import chain reached module-scope `import torch` before any CLI error handling, so a torch-free machine could not run the lightweight monitoring path at all.

Reproduced in a clean virtualenv on the released 0.3.6: `traceml watch script.py` ends in `ModuleNotFoundError: No module named 'torch'`.

Working through it surfaced a second blocker the issue did not know about: the launcher always spawns training via `python -m torch.distributed.run`, which cannot exist without torch. Guarding the imports alone leaves the command hanging instead of crashing.

## Fix

Guarded torch imports on the watch/run entry chain, keeping the "unmeasured, never fabricated" contract for the metrics that need it:
- `samplers/process_sampler.py`: GPU memory metrics stay null without torch, CPU and RSS keep working
- `utils/step_memory.py`, `utils/timing.py`, `utils/cuda_event_pool.py`: CPU timing keeps working, CUDA event timing is only reachable from instrumented training code, which requires torch on the user side
- `sdk/__init__.py`: monitoring and post-hoc commands import cleanly. Calling a trace API without torch raises `RuntimeError` naming the fix (`pip install 'traceml-ai[torch]'`) instead of failing at import time

Launch path (`launcher/launch_config.py`): `to_command()` now spawns the single training process directly when torch is absent and the launch is 1x1, which needs no launcher. Multi-process launches still require torch and raise an actionable `ValueError`. Both existing launch sites go through this one method, so the fallback covers `run`, `watch`, and the disabled-passthrough path.

## Tests

`tests/runtime/test_torch_free_imports.py`, four subprocess cases that block torch (`sys.modules["torch"] = None`) because the test environment has torch installed:
- the watch/run import chain imports cleanly
- a 1x1 launch falls back to a direct interpreter spawn
- a multi-process launch raises with the install hint
- calling `trace_step` without torch raises the actionable error

CI: the existing torch-free `test-core` job gains an import probe over the same entry chain, so a new module-scope torch import fails there rather than in a user's terminal.

## Evidence

GATE: conformance ran=true, 1 passed / 0 failed / 1 skipped (`tests/integrations/test_telemetry_conformance.py`). Full suite: 1036 passed, 2 skipped. black, ruff, isort clean on all changed files.
TRANSITIONS: the state change that matters here is torch present to torch absent, which is exactly what the four new tests toggle. End to end, the same command was run repeatedly in a torch-free virtualenv until the whole chain survived: `traceml watch script.py` now runs the script, streams host telemetry, and prints the watch card with CPU and RAM populated, GPU absent, and a clean exit.
RANKS: per-rank asymmetry tested? Not applicable in the usual sense: without torch the only supported topology is a single process, and that boundary is the tested behavior (1x1 falls back, anything larger raises with the install hint). Multi-rank behavior with torch installed is unchanged and stays covered by the existing suite.
TRIPWIRE: made the failure fire on purpose? Yes, twice. The torch-free virtualenv reproduced the original crash before the fix, and each guard was validated by re-running that same command until the next unguarded import in the chain appeared, so every guard was added against an observed failure rather than a suspected one. The multi-process path was made to raise deliberately in `test_multi_process_launch_requires_torch`.
PLATFORM: n/a, no platform-conditional code in this diff. The launch fallback uses `sys.executable` and is platform-neutral.
