### PR TITLE
Run the CLI when invoked as a module (#351)

### DIFF
--- a/src/traceml_ai/launcher/cli.py
+++ b/src/traceml_ai/launcher/cli.py
@@ -420,3 +420,10 @@ def main() -> None:
     else:
         parser.print_help()
         raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    # Without this guard, `python -m traceml_ai.launcher.cli run train.py`
+    # imports the module and exits 0 without running anything, silently
+    # swallowing the user's command.
+    main()

--- a/tests/runtime/test_cli_module_entrypoint.py
+++ b/tests/runtime/test_cli_module_entrypoint.py
@@ -1,0 +1,49 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``python -m traceml_ai.launcher.cli`` must run the CLI.
+
+Regression test for the missing ``__main__`` guard, which made the module
+form import and exit 0 without running anything, silently swallowing the
+user's command.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import traceml_ai
+
+_SRC_ROOT = str(Path(traceml_ai.__file__).resolve().parents[1])
+
+
+def _run_module(*args: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _SRC_ROOT
+    return subprocess.run(
+        [sys.executable, "-m", "traceml_ai.launcher.cli", *args],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+
+
+def test_module_form_prints_usage():
+    result = _run_module("--help")
+
+    assert result.returncode == 0, result.stderr
+    assert "usage: " in result.stdout
+    for command in ("watch", "run", "compare", "view"):
+        assert command in result.stdout
+
+
+def test_module_form_reports_an_unknown_command():
+    result = _run_module("definitely-not-a-command")
+
+    assert result.returncode != 0
+    assert "invalid choice" in result.stderr


### PR DESCRIPTION
Closes #351.

## Problem

`launcher/cli.py` has no `__main__` guard, so the module form imports the module and exits 0 without running anything:

```
$ python -m traceml_ai.launcher.cli run train.py
$ echo $?
0
```

Nothing runs, nothing is printed, and the exit code says success. A user reaching for the module form (a common habit when a console script is not on PATH, for example inside a container or a notebook shell) loses their command silently.

## Fix

Add the guard so the module form calls `main()`, which is the same entry point the `traceml` console script uses. No behavior change for the console script.

## Tests

`tests/runtime/test_cli_module_entrypoint.py` runs the module form in a subprocess:
- `--help` exits 0 and prints usage listing the subcommands
- an unknown command exits non-zero and reports the invalid choice

## Evidence

GATE: conformance ran=true, 1 passed / 0 failed / 1 skipped (`tests/integrations/test_telemetry_conformance.py`). Full suite: 1034 passed, 2 skipped. black, ruff, isort clean on both changed files.
TRANSITIONS: not a stateful surface. The state change that exists is import versus execute, and that is precisely what the two subprocess tests separate: importing the module must now also run the CLI, while importing the package must not.
RANKS: per-rank asymmetry tested? Not applicable. This is argparse wiring in the launcher, which runs once per user command before any rank exists.
TRIPWIRE: made the failure fire on purpose? Yes. Removing the guard and re-running turns both tests red, including the `--help` case, which produces no output at all without it. So the tests fail for the reason the issue describes rather than passing by construction.
PLATFORM: n/a, no platform-conditional code in this diff.
