### PR TITLE
Add traceml view --re-render to rebuild older cards (#350)

### DIFF
--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -87,6 +87,16 @@ traceml view logs/<run_name>/final_summary.json --html out.html
 The HTML report is optional and additive: the JSON and TXT artifacts are
 unchanged whether or not you pass `--html-report`.
 
+`traceml view` prints the card that was stored with the run, so an artifact
+always reads back exactly as it was written. To read an older artifact in the
+current card layout, rebuild it from the same JSON:
+
+```bash
+traceml view logs/<run_name>/final_summary.json --re-render
+```
+
+This only changes what is printed. The stored artifact is not modified.
+
 ### Live CLI
 
 When launched with `--mode=cli`, the terminal shows live:

--- a/src/traceml_ai/launcher/cli.py
+++ b/src/traceml_ai/launcher/cli.py
@@ -377,6 +377,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to a TraceML summary JSON file.",
     )
     view_parser.add_argument(
+        "--re-render",
+        action="store_true",
+        help=(
+            "Rebuild the card from the summary JSON with the current "
+            "renderer instead of printing the stored text. Use this to read "
+            "an older artifact in the current card layout. The stored "
+            "artifact is not modified."
+        ),
+    )
+    view_parser.add_argument(
         "--html",
         nargs="?",
         const="",

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -810,7 +810,11 @@ def run_view(args: argparse.Namespace) -> None:
 
         from traceml_ai.reporting.view import view_summary
 
-        view_summary(args.summary, print_to_stdout=True)
+        view_summary(
+            args.summary,
+            print_to_stdout=True,
+            re_render=bool(getattr(args, "re_render", False)),
+        )
     except RuntimeError as exc:
         print(f"[TraceML] ERROR: {exc}", file=sys.stderr)
         raise SystemExit(1)

--- a/src/traceml_ai/reporting/view/command.py
+++ b/src/traceml_ai/reporting/view/command.py
@@ -20,22 +20,60 @@ def view_summary(
     summary_path: str | Path,
     *,
     print_to_stdout: bool = True,
+    re_render: bool = False,
 ) -> str:
     """
-    Print and return the stored terminal summary from a summary JSON artifact.
+    Print and return the terminal summary for a summary JSON artifact.
 
-    This is read-only: it does not regenerate diagnostics or read telemetry
-    databases. Rendering a derived HTML report is opt-in and handled
-    separately by ``traceml view <summary.json> --html`` (see
+    By default this prints the stored card verbatim, so an artifact always
+    reads back exactly as it was written.
+
+    With ``re_render=True`` the card is rebuilt from the payload with the
+    current renderer, which is how an artifact written before a card change
+    can be read in the current layout. The stored text is never modified.
+    The profile is inferred from the stored card's own title; artifacts
+    written before watch had its own card therefore re-render as run cards,
+    which is what they already stated.
+
+    Either way this is read-only: it does not regenerate diagnostics or read
+    telemetry databases. Rendering a derived HTML report is opt-in and
+    handled separately by ``traceml view <summary.json> --html`` (see
     ``reporting.html.render_html_report_from_file``).
     """
     payload = load_summary_artifact(summary_path)
     text = extract_summary_text(payload, path=summary_path)
 
+    if re_render:
+        text = _re_rendered_card(payload, stored_text=text)
+
     if print_to_stdout:
         print(text)
 
     return text
+
+
+def _re_rendered_card(payload: dict, *, stored_text: str) -> str:
+    """Rebuild the card from the payload, falling back to the stored text.
+
+    A payload old or partial enough to defeat the current renderer must not
+    turn a read-only command into an error, so any failure degrades to the
+    text the artifact already carries.
+    """
+    try:
+        from traceml_ai.reporting.summary_card import (
+            build_card_from_payload,
+            card_profile_from_text,
+            card_to_plain,
+        )
+
+        return card_to_plain(
+            build_card_from_payload(
+                payload,
+                profile=card_profile_from_text(stored_text),
+            )
+        )
+    except Exception:
+        return stored_text
 
 
 __all__ = ["view_summary"]

--- a/tests/reporting/test_view.py
+++ b/tests/reporting/test_view.py
@@ -69,3 +69,113 @@ def test_view_summary_rejects_missing_file(tmp_path) -> None:
 def test_view_summary_rejects_directory_path(tmp_path) -> None:
     with pytest.raises(RuntimeError, match="Summary path is not a file"):
         view_summary(tmp_path, print_to_stdout=False)
+
+
+_OLD_CARD = (
+    "+------------------------+\n"
+    "|  TraceML Run Summary   |\n"
+    "|  Section Status        |\n"
+    "+------------------------+"
+)
+
+
+def _payload_with_stored_card(stored_card: str) -> dict:
+    """An artifact whose stored card predates the current renderer."""
+    return {
+        "schema_version": 1.7,
+        "duration_s": 52.4,
+        "meta": {
+            "run_name": "old_run",
+            "mode": "single_node",
+            "world_size": 1,
+            "nodes_observed": 1,
+            "gpus_observed": 1,
+        },
+        "primary_diagnosis": {
+            "kind": "INPUT_BOUND",
+            "status": "INPUT-BOUND",
+            "severity": "crit",
+            "section": "step_time",
+            "summary": "Input Wait is 64.0% of the typical Step Time.",
+            "action": "Increase workers, prefetch, or storage throughput.",
+            "evidence": {"type": "phase_share", "score": 0.64},
+        },
+        "system": {"global": {"average": {"cpu_percent": 18.4}}},
+        "process": {},
+        "step_memory": {},
+        "step_time": {
+            "global": {
+                "window": {"steps_analyzed": 256, "diagnosis_clock": "gpu"},
+                "average": {
+                    "step_time_ms": 200.4,
+                    "input_wait_ms": 128.0,
+                    "traced_step_time_ms": 72.0,
+                    "compute_ms": 68.0,
+                    "residual_ms": 3.6,
+                },
+            }
+        },
+        "text": stored_card,
+    }
+
+
+def test_view_summary_re_renders_an_older_card(tmp_path) -> None:
+    summary_path = tmp_path / "summary.json"
+    _write_json(summary_path, _payload_with_stored_card(_OLD_CARD))
+
+    text = view_summary(summary_path, print_to_stdout=False, re_render=True)
+
+    assert "Section Status" not in text
+    assert "Verdict: INPUT-BOUND" in text
+    assert "├─ Input Wait" in text
+    assert "256 steps analyzed" in text
+
+
+def test_view_summary_default_still_prints_the_stored_card(tmp_path) -> None:
+    summary_path = tmp_path / "summary.json"
+    _write_json(summary_path, _payload_with_stored_card(_OLD_CARD))
+
+    text = view_summary(summary_path, print_to_stdout=False)
+
+    assert text == _OLD_CARD
+
+
+def test_view_summary_re_render_infers_the_watch_profile(tmp_path) -> None:
+    stored = "+---+\n|  TraceML Watch Summary  |\n+---+"
+    summary_path = tmp_path / "summary.json"
+    _write_json(summary_path, _payload_with_stored_card(stored))
+
+    text = view_summary(summary_path, print_to_stdout=False, re_render=True)
+
+    assert "TraceML Watch Summary" in text
+    assert "Step Time" not in text
+
+
+def test_view_summary_re_render_survives_a_bare_payload(tmp_path) -> None:
+    """A payload with no sections still renders, it does not raise."""
+    summary_path = tmp_path / "summary.json"
+    _write_json(summary_path, {"text": _OLD_CARD})
+
+    text = view_summary(summary_path, print_to_stdout=False, re_render=True)
+
+    assert "TraceML Run Summary" in text
+    assert "Section Status" not in text
+
+
+def test_view_summary_re_render_falls_back_when_rendering_fails(
+    tmp_path, monkeypatch
+) -> None:
+    """A read-only command must never fail because a rebuild failed."""
+    import traceml_ai.reporting.summary_card as summary_card
+
+    def _boom(*_args, **_kwargs):
+        raise ValueError("renderer exploded")
+
+    monkeypatch.setattr(summary_card, "build_card_from_payload", _boom)
+
+    summary_path = tmp_path / "summary.json"
+    _write_json(summary_path, _payload_with_stored_card(_OLD_CARD))
+
+    text = view_summary(summary_path, print_to_stdout=False, re_render=True)
+
+    assert text == _OLD_CARD


### PR DESCRIPTION
Closes #350.

## Problem

`traceml view` prints the `text` field stored in the artifact, so a summary written before a card change always reads back in the old layout even though the payload holds everything needed to render the current one. Saved runs drift away from what the tool prints today, which makes older artifacts harder to compare against new ones.

## Fix

`traceml view <summary.json> --re-render` rebuilds the card from the payload with the current renderer instead of printing the stored text:
- the profile comes from the stored card's own title, so watch artifacts stay watch cards
- any failure to rebuild falls back to the stored text, because a read-only command must not start failing on an old or partial payload
- the default path is untouched, so an artifact still reads back exactly as written unless the flag is passed
- the stored artifact is never modified

## Tests

Six cases in `tests/reporting/test_view.py`:
- an artifact carrying an older card re-renders into the current layout (verdict line, timing tree, coverage in the header) and no longer shows the old section-status block
- without the flag, the stored card is returned verbatim
- a stored watch card re-renders as a watch card and stays free of step-time content
- a payload with no sections still renders rather than raising
- when the rebuild raises, the stored text is returned unchanged

Also verified end to end against a real artifact written before the card redesign: `view` prints its original card, `view --re-render` prints the current card, and the JSON on disk is unchanged.

Docs: a short block in `docs/user_guide/reading-output.md` next to the existing `--html` examples.

## Evidence

GATE: conformance ran=true, 1 passed / 0 failed / 1 skipped (`tests/integrations/test_telemetry_conformance.py`). Full suite: 1037 passed, 2 skipped. black, ruff, isort clean on all changed files.
TRANSITIONS: the transitions that matter are stored to re-rendered and success to failure. Both are covered: default versus `--re-render` on the same artifact are asserted separately, and the rebuild is forced to raise so the fallback to stored text is exercised rather than assumed.
RANKS: per-rank asymmetry tested? Not directly, and it does not apply here: this command reads one finished artifact and renders it, so rank-shaped data is whatever the payload already contains. Multi-rank rendering itself is covered by the existing card goldens.
TRIPWIRE: made the failure fire on purpose? Yes. `build_card_from_payload` is monkeypatched to raise, and the command still returns the stored card instead of propagating the error, which is the behavior the fallback exists for.
PLATFORM: n/a, no platform-conditional code in this diff.
