### PR TITLE
Always show GPU utilization beside a step-time finding (#349)

### DIFF
--- a/src/traceml_ai/reporting/summary_card.py
+++ b/src/traceml_ai/reporting/summary_card.py
@@ -168,7 +168,9 @@ _WATCH_MULTI_WORST_COLUMN = 26
 _SKEW_MATERIAL_RATIO = 0.20
 _SKEW_MATERIAL_DELTA_MS = 1.0
 _MEMORY_SKEW_EVEN_RATIO = 0.10
-_SUPPORTING_GPU_UTIL_MAX = 50.0
+# Below this, GPU utilization corroborates a step-time finding and the card
+# says so. At or above it the number is still shown, but without a claim.
+_LOW_GPU_UTIL_MAX = 50.0
 
 _WATCH_BOUNDARY = (
     "Watch monitors host and process health only; it does not measure "
@@ -1091,15 +1093,25 @@ def _supporting_line(
     primary: Mapping[str, Any],
     multi: bool,
 ) -> Optional[str]:
-    """Return the supporting GPU-utilization line, when it applies."""
+    """Return the GPU-utilization line shown beside a performance finding.
+
+    GPU utilization is the number most readers reach for first, so it is
+    shown whenever it was measured. Only the explanation is conditional:
+    low utilization is consistent with the finding above it, while high
+    utilization is reported without interpreting it.
+    """
     kind = str(primary.get("kind") or "")
     if kind not in PHASE_SHARE_KINDS and kind not in STRAGGLER_KINDS:
         return None
     evidence = _mapping(primary.get("evidence"))
     util = _float(evidence.get("gpu_util_avg_percent"))
-    if util is None or util >= _SUPPORTING_GPU_UTIL_MAX:
-        return None
     value = _fmt_percent(util)
+    if util is None or value is None:
+        return None
+    if util >= _LOW_GPU_UTIL_MAX:
+        if multi and kind in STRAGGLER_KINDS:
+            return f"Supporting: GPU util median {value}%."
+        return f"Supporting: GPU util {value}% avg."
     if multi and kind in STRAGGLER_KINDS:
         return (
             f"Supporting: GPU util median {value}% -- ranks idle at the step "

--- a/tests/reporting/summary/test_card_golden.py
+++ b/tests/reporting/summary/test_card_golden.py
@@ -1003,6 +1003,7 @@ GOLDENS = {
 |  Next: raise DataLoader num_workers, enable pin_memory / prefetch, or check|
 |  storage read throughput.                                                  |
 |                                                                            |
+|  Supporting: GPU util 88% avg.                                             |
 |  Also, not the cause of slow steps:                                        |
 |  ! Step memory grew 1.2 GB over the run -- possible leak  (WARNING)        |
 |                                                                            |
@@ -1289,6 +1290,21 @@ def test_card_matches_golden(name: str) -> None:
 def test_card_lines_are_exactly_card_width(name: str) -> None:
     for line in plain(name).splitlines():
         assert len(line) == 78, (name, len(line), line)
+
+
+def test_gpu_utilization_is_shown_for_a_finding_at_any_level() -> None:
+    """The number readers look for first is not hidden by its own value."""
+    # Low utilization corroborates the finding, so the card says so.
+    assert (
+        "Supporting: GPU util 24% avg -- consistent with input starvation."
+        in plain("run_input_bound_critical")
+    )
+
+    # High utilization does not corroborate it. The number is still shown,
+    # without a claim attached to it.
+    high = plain("run_input_bound_with_also")
+    assert "Supporting: GPU util 88% avg." in high
+    assert "88% avg -- consistent" not in high
 
 
 def test_run_header_gpu_count_is_capped_by_world_size() -> None:


### PR DESCRIPTION
Closes #349.

## Problem

The run card hid GPU utilization on exactly the cards where a reader most wants it. The supporting line was suppressed whenever utilization was at or above 50%, so a card reporting a step-time finding on a busy GPU showed no utilization figure at all.

That is backwards. GPU utilization is the number most engineers reach for first, and its absence reads as missing data rather than as a deliberate omission. The healthy card already prints utilization, which made the gap inconsistent as well.

## Fix

Show the utilization figure for every step-time finding on a GPU run. Only the explanation stays conditional:

- below 50%, the line keeps its existing wording, because low utilization corroborates the finding above it (`GPU util 24% avg -- consistent with input starvation.`)
- at or above 50%, the number is reported without a claim attached (`GPU util 88% avg.`), since a busy GPU does not corroborate the finding and the card must not imply that it does

The threshold constant is renamed to say what it now gates, which is the explanation rather than the line. Behavior is unchanged for CPU-only runs (no utilization to report), for healthy runs, and for degraded states, which already print utilization through their own lines.

## Tests

- `test_gpu_utilization_is_shown_for_a_finding_at_any_level` asserts both halves: the explanatory wording at low utilization, and the bare figure with no claim at high utilization
- the `run_input_bound_with_also` golden gains the line it was previously suppressing (that fixture runs at 88% utilization)

## Evidence

GATE: conformance ran=true, 1 passed / 0 failed / 1 skipped (`tests/integrations/test_telemetry_conformance.py`). Full suite: 1033 passed, 2 skipped. black and ruff clean on both changed files.
TRANSITIONS: the transition this diff owns is low to high utilization across the explanation threshold, and both sides are asserted on real fixtures rather than one side being assumed. The card's other states (healthy, CPU-only, degraded, watch) are unchanged and stay locked by their existing goldens.
RANKS: per-rank asymmetry tested? Yes, through the existing multi-rank goldens: the straggler card keeps its median-phrased line (`GPU util median 14% -- ranks idle at the step barrier.`) and the multi residual-heavy card keeps its plain line, so the single and multi wordings are both pinned.
TRIPWIRE: made the failure fire on purpose? Yes. Restoring the old suppression and re-running turns both the new test and the updated golden red, so they fail for the reason the issue describes rather than passing by construction.
PLATFORM: n/a, no platform-conditional code in this diff.
