### PR TITLE
examples: add case studies with the resnet18 input-bound before/after

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ support and limitations.
 ## Learn More
 
 - [Complete quickstart](https://traceopt-ai.github.io/traceml/user_guide/quickstart/)
+- [Measured case studies](https://github.com/traceopt-ai/traceml/blob/main/examples/case_studies/README.md)
 - [Examples](https://github.com/traceopt-ai/traceml/blob/main/examples/README.md)
 - [Troubleshoot slow training](https://traceopt-ai.github.io/traceml/guides/slow-pytorch-training/)
 - [Public API](https://traceopt-ai.github.io/traceml/user_guide/public-api/)

--- a/examples/README.md
+++ b/examples/README.md
@@ -105,13 +105,13 @@ traceml run examples/advanced/bert_single_gpu_compare.py --mode=summary --summar
 
 ## Case studies
 
-Real before/after write-ups where TraceML diagnosed a bottleneck in an actual
-training run, one targeted fix was applied, and the improvement was verified
-against the wall clock. These are write-ups rather than runnable scripts.
+Measured before/after write-ups where TraceML diagnosed a bottleneck in a
+training run, a targeted intervention was applied, and the result was evaluated
+using wall-clock measurements. These are write-ups rather than runnable scripts.
 
 | Case study | Model | Bottleneck | Result |
 |---|---|---|---|
-| [`case_studies/resnet18_input_bound`](case_studies/resnet18_input_bound/) | ResNet-18, single T4 | Input-bound dataloader | 1.78x faster steps, GPU utilization 51% to 100% |
+| [`case_studies/resnet18_input_bound`](case_studies/resnet18_input_bound/) | ResNet-18, single T4 | Input-bound data loading | 43.8% lower step time; median GPU utilization 51% to 100% |
 
 See [`case_studies/README.md`](case_studies/README.md) for the index and for how
 to add a new one.

--- a/examples/README.md
+++ b/examples/README.md
@@ -103,6 +103,21 @@ traceml run examples/advanced/bert_single_gpu_compare.py --mode=summary --summar
 
 ---
 
+## Case studies
+
+Real before/after write-ups where TraceML diagnosed a bottleneck in an actual
+training run, one targeted fix was applied, and the improvement was verified
+against the wall clock. These are write-ups rather than runnable scripts.
+
+| Case study | Model | Bottleneck | Result |
+|---|---|---|---|
+| [`case_studies/resnet18_input_bound`](case_studies/resnet18_input_bound/) | ResNet-18, single T4 | Input-bound dataloader | 1.78x faster steps, GPU utilization 51% to 100% |
+
+See [`case_studies/README.md`](case_studies/README.md) for the index and for how
+to add a new one.
+
+---
+
 ## How to run examples
 
 Standard run with the default summary:

--- a/examples/case_studies/README.md
+++ b/examples/case_studies/README.md
@@ -1,0 +1,24 @@
+# Case studies
+
+Real-world before/after case studies where TraceML diagnosed a bottleneck in an
+actual training run, a targeted fix was applied, and the improvement was verified
+against the wall clock.
+
+Each case study is a subfolder with its own write-up: the setup, what TraceML
+found, the fix, and the measured before/after.
+
+## Index
+
+| Case study | Model | Bottleneck | Result |
+|---|---|---|---|
+| [resnet18_input_bound](resnet18_input_bound/) | ResNet-18 (single T4) | Input-bound dataloader | 1.78x faster steps, GPU util 51% to 100% |
+
+## Adding a case study
+
+1. Run a real training job under TraceML and confirm the bottleneck is genuine (a
+   large phase share, plus a fix that actually moves the wall clock).
+2. Apply one targeted fix, holding everything else constant so the before/after
+   isolates a single change.
+3. Write up the before/after using wall-clock metrics: step cadence, run duration,
+   GPU utilization, and TraceML's verdict.
+4. Keep raw telemetry out of git; commit the write-up and small summaries only.

--- a/examples/case_studies/README.md
+++ b/examples/case_studies/README.md
@@ -1,8 +1,8 @@
 # Case studies
 
-Real-world before/after case studies where TraceML diagnosed a bottleneck in an
-actual training run, a targeted fix was applied, and the improvement was verified
-against the wall clock.
+Measured before/after case studies where TraceML diagnosed a bottleneck in a
+training run, a targeted intervention was applied, and the result was evaluated
+using wall-clock measurements.
 
 Each case study is a subfolder with its own write-up: the setup, what TraceML
 found, the fix, and the measured before/after.
@@ -11,14 +11,13 @@ found, the fix, and the measured before/after.
 
 | Case study | Model | Bottleneck | Result |
 |---|---|---|---|
-| [resnet18_input_bound](resnet18_input_bound/) | ResNet-18 (single T4) | Input-bound dataloader | 1.78x faster steps, GPU util 51% to 100% |
+| [resnet18_input_bound](resnet18_input_bound/) | ResNet-18 (single T4) | Input-bound data loading | 43.8% lower step time; median GPU utilization 51% to 100% |
 
 ## Adding a case study
 
-1. Run a real training job under TraceML and confirm the bottleneck is genuine (a
-   large phase share, plus a fix that actually moves the wall clock).
-2. Apply one targeted fix, holding everything else constant so the before/after
-   isolates a single change.
+1. Run a training job under TraceML and identify the bottleneck from phase timing.
+2. Apply one targeted intervention, holding unrelated workload settings constant
+   so the before/after comparison isolates that intervention.
 3. Write up the before/after using wall-clock metrics: step cadence, run duration,
    GPU utilization, and TraceML's verdict.
 4. Keep raw telemetry out of git; commit the write-up and small summaries only.

--- a/examples/case_studies/resnet18_input_bound/README.md
+++ b/examples/case_studies/resnet18_input_bound/README.md
@@ -1,0 +1,60 @@
+# ResNet-18, input-bound dataloader (single T4)
+
+TraceML flagged a from-scratch ResNet-18 training run as input-bound: the GPU was
+starved waiting on data loading. Changing only the DataLoader (adding workers and
+pinned-memory transfers) made every step 1.78x faster and flipped the verdict to
+compute-bound.
+
+## Setup
+
+- Hardware: 1x NVIDIA Tesla T4, single GPU, no DDP.
+- Software: PyTorch 2.11, torchvision 0.26, CUDA 13, traceml-ai 0.3.2.
+- Model: torchvision ResNet-18 from scratch (`weights=None`).
+- Data: fast.ai Imagenette, full resolution, `ImageFolder` + `RandomResizedCrop(224)`.
+- Config: batch 64, 2,000 optimizer steps, seed 42, AMP off.
+
+Model, batch, steps, and AMP are held constant across both runs, so the only
+variable is data loading.
+
+## What TraceML found
+
+On the baseline run (`num_workers=0`), TraceML returned **INPUT-BOUND**. The GPU
+sat around 51% utilization (nvidia-smi median) while the training process decoded
+JPEGs synchronously, so the GPU waited on the CPU between steps.
+
+## The fix
+
+Change only the DataLoader:
+
+| Setting | Baseline | Optimized | What it does |
+|---|---|---|---|
+| `num_workers` | 0 | 4 | Background subprocesses decode upcoming batches in parallel with GPU compute. |
+| `pin_memory` | False | True | Page-locked host memory lets the host-to-GPU copy run as an async DMA. |
+| `persistent_workers` | False | True | Keeps workers alive across epochs instead of re-forking each one. |
+| H2D copy `non_blocking` | False | True | `.to(device)` returns immediately so the copy overlaps later work (needs pinned memory). |
+
+## Result (before to after)
+
+| Metric | Baseline | Optimized | Change |
+|---|---|---|---|
+| Step cadence (wall clock) | 315.5 ms | 177.2 ms | **1.78x faster** |
+| Run duration (2,000 steps) | 633.4 s | 358.2 s | **-43.4%** |
+| GPU utilization (nvidia-smi median) | 51% | 100% | no longer starving |
+| TraceML verdict | INPUT-BOUND | COMPUTE-BOUND | bottleneck moved |
+
+Numbers are wall-clock: step cadence is measured from telemetry receipt
+timestamps and cross-checked against the run duration and an independent
+nvidia-smi sample. The verdict flipping from input-bound to compute-bound is the
+point: once the data pipeline keeps up, the GPU becomes the limit, which is where
+you want to be.
+
+These numbers were measured on traceml-ai 0.3.2 and have not been re-run on
+later releases. The fix and the verdict flip are properties of the workload, not
+of the TraceML version.
+
+## Reproduce
+
+The [`data_loading_bottleneck.ipynb`](../../../notebooks/data_loading_bottleneck.ipynb)
+notebook runs the same before/after (an input-bound baseline versus the
+data-loading fix) on a free Colab T4 in a few minutes. This case study is the full
+2,000-step version of that experiment on a single T4.

--- a/examples/case_studies/resnet18_input_bound/README.md
+++ b/examples/case_studies/resnet18_input_bound/README.md
@@ -1,9 +1,8 @@
 # ResNet-18, input-bound dataloader (single T4)
 
-TraceML flagged a from-scratch ResNet-18 training run as input-bound: the GPU was
-starved waiting on data loading. Changing only the DataLoader (adding workers and
-pinned-memory transfers) made every step 1.78x faster and flipped the verdict to
-compute-bound.
+TraceML classified a from-scratch ResNet-18 training run as input-bound. After
+only the input pipeline was changed, wall-clock step time decreased by 43.8%,
+from 315.5 ms to 177.2 ms, and the verdict changed to compute-bound.
 
 ## Setup
 
@@ -13,48 +12,47 @@ compute-bound.
 - Data: fast.ai Imagenette, full resolution, `ImageFolder` + `RandomResizedCrop(224)`.
 - Config: batch 64, 2,000 optimizer steps, seed 42, AMP off.
 
-Model, batch, steps, and AMP are held constant across both runs, so the only
-variable is data loading.
+Model, batch size, step count, and AMP are held constant across both runs. The
+input-pipeline settings listed below are the only changes.
 
 ## What TraceML found
 
-On the baseline run (`num_workers=0`), TraceML returned **INPUT-BOUND**. The GPU
-sat around 51% utilization (nvidia-smi median) while the training process decoded
-JPEGs synchronously, so the GPU waited on the CPU between steps.
+On the baseline run (`num_workers=0`), TraceML returned **INPUT-BOUND**. Median
+GPU utilization reported by nvidia-smi was 51% while the training process decoded
+JPEGs synchronously, leaving the GPU idle between steps.
 
 ## The fix
 
-Change only the DataLoader:
+The optimized run changed these input-pipeline settings:
 
 | Setting | Baseline | Optimized | What it does |
 |---|---|---|---|
 | `num_workers` | 0 | 4 | Background subprocesses decode upcoming batches in parallel with GPU compute. |
-| `pin_memory` | False | True | Page-locked host memory lets the host-to-GPU copy run as an async DMA. |
+| `pin_memory` | False | True | Stores batches in page-locked host memory, enabling asynchronous H2D copies. |
 | `persistent_workers` | False | True | Keeps workers alive across epochs instead of re-forking each one. |
-| H2D copy `non_blocking` | False | True | `.to(device)` returns immediately so the copy overlaps later work (needs pinned memory). |
+| H2D copy `non_blocking` | False | True | Requests asynchronous H2D copies from pinned host memory. |
 
 ## Result (before to after)
 
 | Metric | Baseline | Optimized | Change |
 |---|---|---|---|
-| Step cadence (wall clock) | 315.5 ms | 177.2 ms | **1.78x faster** |
+| Step cadence (wall clock) | 315.5 ms | 177.2 ms | **-43.8%** |
 | Run duration (2,000 steps) | 633.4 s | 358.2 s | **-43.4%** |
-| GPU utilization (nvidia-smi median) | 51% | 100% | no longer starving |
-| TraceML verdict | INPUT-BOUND | COMPUTE-BOUND | bottleneck moved |
+| GPU utilization (nvidia-smi median) | 51% | 100% | +49 percentage points |
+| TraceML verdict | INPUT-BOUND | COMPUTE-BOUND | limiting phase changed |
 
-Numbers are wall-clock: step cadence is measured from telemetry receipt
-timestamps and cross-checked against the run duration and an independent
-nvidia-smi sample. The verdict flipping from input-bound to compute-bound is the
-point: once the data pipeline keeps up, the GPU becomes the limit, which is where
-you want to be.
+In the original measurement, step cadence was derived from telemetry receipt
+timestamps and cross-checked against run duration; GPU utilization came from an
+independent nvidia-smi sample. The lower wall-clock time and verdict change
+indicate that input was no longer the limiting phase.
 
 These numbers were measured on traceml-ai 0.3.2 and have not been re-run on
-later releases. The fix and the verdict flip are properties of the workload, not
-of the TraceML version.
+later releases. They apply to the hardware and software configuration recorded
+above.
 
 ## Reproduce
 
 The [`data_loading_bottleneck.ipynb`](../../../notebooks/data_loading_bottleneck.ipynb)
-notebook runs the same before/after (an input-bound baseline versus the
-data-loading fix) on a free Colab T4 in a few minutes. This case study is the full
-2,000-step version of that experiment on a single T4.
+notebook runs a 300-step version of the same comparison in Colab. Its result
+depends on the assigned CPU and GPU. This case study records the original
+2,000-step run on a single T4.


### PR DESCRIPTION
Adds `examples/case_studies/`, a place for real before/after write-ups where TraceML found a bottleneck in an actual training run, one targeted fix was applied, and the improvement was checked against the wall clock.

First entry: ResNet-18 on a single T4, input-bound dataloader. Changing only the DataLoader (workers, pinned memory, persistent workers, non-blocking H2D) made steps 1.78x faster and flipped the verdict from INPUT-BOUND to COMPUTE-BOUND.

Docs only, no code changes.

**Origin:** this sat on the `case-studies` branch since 2026-07-17, cut from `27bf082`, never opened as a PR. Rebased onto current `version_0.3.7` rather than merged, since the old base is 80+ commits behind. Two additions on top of the original commit:

- indexed the folder in `examples/README.md`, which otherwise left it unreachable from the examples index
- noted that the numbers were measured on traceml-ai 0.3.2 and have not been re-run since

**Verification:** pre-commit clean on all three files; every relative link in the new and changed files resolves. The measurements are quoted from the original write-up, not re-measured for this PR.
