### PR TITLE
fix(dashboard): hold last-known diagnosis on empty refresh (#353)

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_diagnostics_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_diagnostics_section.py
@@ -74,7 +74,7 @@ def build_model_diagnostics_section(
             "font-family:var(--mono); font-size:11px; color:var(--muted); "
             "font-style:italic; padding-top:6px;"
         )
-    return {"overall": overall, "body": body, "hint": hint}
+    return {"overall": overall, "body": body, "hint": hint, "_last": None}
 
 
 def update_model_diagnostics_section(
@@ -82,6 +82,16 @@ def update_model_diagnostics_section(
 ) -> None:
     try:
         items = _items(payload)
+        held = False
+        if items:
+            panel["_last"] = payload
+        else:
+            # A transiently empty read (ranks settling, end of run, a rank
+            # dying) is not a new verdict, so re-render the last one the
+            # engine produced instead of blanking the rail (#353).
+            payload = panel.get("_last")
+            items = _items(payload)
+            held = bool(items)
         if not items:
             panel["overall"].text = "NO DATA"
             panel["body"].content = ""
@@ -92,7 +102,13 @@ def update_model_diagnostics_section(
                 f"border:1px solid {_tint(neutral, 0.28)};"
             )
             return
-        panel["hint"].text = ""
+        # States what this view itself observed. It classifies nothing: no
+        # threshold, no staleness age, no severity of its own.
+        panel["hint"].text = (
+            "Holding last diagnosis - no update in the latest refresh"
+            if held
+            else ""
+        )
 
         sev = _overall_sev(_overall(payload))
         col = theme.SEV.get(sev, theme.SEV["neutral"])

--- a/tests/display/test_model_diagnostics_section.py
+++ b/tests/display/test_model_diagnostics_section.py
@@ -1,0 +1,134 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Diagnostics rail last-known-state tests (issue #353)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from traceml_ai.aggregator.display_drivers.nicegui_sections import theme
+from traceml_ai.aggregator.display_drivers.nicegui_sections.model_diagnostics_section import (
+    build_model_diagnostics_section,
+    update_model_diagnostics_section,
+)
+
+_HOLDING = "Holding last diagnosis - no update in the latest refresh"
+
+
+class _FakeText:
+    def __init__(self) -> None:
+        self.text = ""
+        self.styles: list[str] = []
+
+    def style(self, value: str) -> "_FakeText":
+        self.styles.append(value)
+        return self
+
+
+class _FakeHtml:
+    def __init__(self) -> None:
+        self.content = ""
+
+
+def _panel() -> dict:
+    return {
+        "overall": _FakeText(),
+        "body": _FakeHtml(),
+        "hint": _FakeText(),
+        "_last": None,
+    }
+
+
+def _payload(status: str = "INPUT-BOUND") -> dict:
+    return {
+        "overall_severity": "crit",
+        "items": [
+            {
+                "source": "step_time",
+                "status": status,
+                "severity": "crit",
+                "kind": "INPUT_BOUND",
+                "reason": "dataloader starves the step",
+                "confidence_label": "high",
+                "evidence": {"window": "30 steps"},
+            }
+        ],
+    }
+
+
+def test_build_starts_with_an_empty_cache() -> None:
+    panel = build_model_diagnostics_section()
+
+    assert "_last" in panel
+    assert panel["_last"] is None
+
+
+def test_diagnosis_renders_and_is_cached() -> None:
+    panel = _panel()
+
+    update_model_diagnostics_section(panel, _payload())
+
+    assert panel["overall"].text == "CRIT"
+    assert "INPUT-BOUND" in panel["body"].content
+    assert "dataloader starves the step" in panel["body"].content
+    assert panel["hint"].text == ""
+    assert panel["_last"] == _payload()
+
+
+def test_empty_refresh_holds_the_last_diagnosis() -> None:
+    # #353 regression: ranks settling, end of run, or a dying rank produce a
+    # transiently empty read. That is not a new verdict, so the rail must
+    # keep the last one instead of blanking to NO DATA.
+    panel = _panel()
+    update_model_diagnostics_section(panel, _payload())
+    rendered = panel["body"].content
+
+    update_model_diagnostics_section(panel, {"items": []})
+
+    assert panel["overall"].text == "CRIT"
+    assert panel["body"].content == rendered
+    assert panel["hint"].text == _HOLDING
+
+
+def test_empty_refresh_without_a_cache_shows_no_data() -> None:
+    panel = _panel()
+
+    update_model_diagnostics_section(panel, {"items": []})
+
+    assert panel["overall"].text == "NO DATA"
+    assert panel["body"].content == ""
+    assert panel["hint"].text == "Waiting for diagnostics"
+    assert theme.SEV["neutral"] in panel["overall"].styles[-1]
+
+
+def test_repeated_empty_refresh_does_not_evict_the_cache() -> None:
+    panel = _panel()
+    update_model_diagnostics_section(panel, _payload())
+    rendered = panel["body"].content
+
+    update_model_diagnostics_section(panel, {"items": []})
+    update_model_diagnostics_section(panel, {"items": []})
+
+    assert panel["overall"].text == "CRIT"
+    assert panel["body"].content == rendered
+    assert panel["hint"].text == _HOLDING
+    assert panel["_last"] == _payload()
+
+
+def test_recovered_diagnosis_replaces_the_held_one() -> None:
+    panel = _panel()
+    update_model_diagnostics_section(panel, _payload())
+    update_model_diagnostics_section(panel, {"items": []})
+    assert panel["hint"].text == _HOLDING
+
+    update_model_diagnostics_section(panel, _payload("COMPUTE-BOUND"))
+
+    assert "COMPUTE-BOUND" in panel["body"].content
+    assert "INPUT-BOUND" not in panel["body"].content
+    assert panel["hint"].text == ""


### PR DESCRIPTION
Closes #353.

**Problem.** #301 dropped the `_last` payload cache from the dashboard
diagnostics rail. Any transiently empty diagnostics read (ranks settling,
end of run, a rank dying) now blanks the panel to "NO DATA / Waiting for
diagnostics" instead of re-rendering the last finding the engine produced.

**Fix.** Reinstate the cache. A non-empty payload is stored; an empty read
re-renders the cached one and sets the hint to "Holding last diagnosis - no
update in the latest refresh". With no cached payload the NO DATA path is
byte-identical to today. The card adds no threshold, no staleness age, and no
severity of its own; it states only what the view itself observed.

**Testing.** New `tests/display/test_model_diagnostics_section.py` (6 tests):
render+cache, empty-after-cached holds with the hint, empty-with-no-cache
still shows NO DATA, a second empty refresh does not evict the cache, and a
recovered diagnosis replaces the held one. `tests/display/` 74 passed;
full suite 1048 passed, 2 skipped.

GATE: tests listed above run with exit codes shown (tests/display 74 passed
EXIT=0; full suite 1048 passed / 2 skipped EXIT=0; black/ruff/isort exit 0).
TRANSITIONS: empty→NO DATA covered by test_empty_refresh_without_a_cache_shows_no_data;
populated→held by test_empty_refresh_holds_the_last_diagnosis; held→held by
test_repeated_empty_refresh_does_not_evict_the_cache; held→recovered by
test_recovered_diagnosis_replaces_the_held_one.
RANKS: rank-agnostic. This is view code over the already-aggregated
model-diagnostics payload; it reads no rank field and changes no per-rank
behavior.
TRIPWIRE: with the fix reverted, test_empty_refresh_holds_the_last_diagnosis
fails with `assert 'NO DATA' == 'CRIT'` (5 of 6 red); restored, all green.
