### PR TITLE
fix(dashboard): render the engine's action and note in the diagnosis rail (#357)

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_diagnostics_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/model_diagnostics_section.py
@@ -1,7 +1,9 @@
 """Model diagnostics rail — overall verdict + per-source severity rows (PR2).
 
-Renderer payload {overall_severity, items:[{source,status,reason,
-confidence_label,evidence}]} is unchanged; only the presentation changes.
+Renderer payload {overall_severity, items:[{source,status,reason,action,
+note,confidence_label,evidence}]} is unchanged; only the presentation
+changes. The row shows the engine's own ``action`` under the same "Next:"
+label the terminal uses, so one verdict reads the same on both surfaces.
 """
 
 from __future__ import annotations
@@ -23,6 +25,9 @@ _SOURCE_NAMES = {
 # present in the payload — never re-parsed from the status text. New diagnosis
 # kinds therefore color correctly with no change here (single source of truth).
 _NEUTRAL_KINDS = ("NO_DATA", "WARMUP", "NO_GPU", "INCOMPLETE_DATA")
+# One length budget for every text line of a row (reason, action, note), so
+# the rail cannot truncate the same engine sentence differently per field.
+_MAX_LINE_CHARS = 130
 
 
 def _row_sev(item: Dict[str, Any]) -> str:
@@ -127,14 +132,42 @@ def _tint(hex_color: str, alpha: float = 0.12) -> str:
     return f"rgba({r},{g},{b},{alpha})"
 
 
+def _line_text(value: Any) -> str:
+    """Escaped, length-capped text for one line of a diagnosis row.
+
+    Truncate first, escape second. Cutting escaped text can slice through an
+    entity (``&amp;`` becomes ``&a``), which renders as broken literal markup;
+    the cap is also meant to bound what the reader sees, not how long the
+    escaped form happens to be.
+    """
+    text = str(value or "").strip()
+    if len(text) > _MAX_LINE_CHARS:
+        text = text[: _MAX_LINE_CHARS - 3] + "…"
+    return html.escape(text)
+
+
 def _row_html(item: Dict[str, Any]) -> str:
     source = _SOURCE_NAMES.get(
         str(item.get("source")), str(item.get("source", "")).title()
     )
     status = str(item.get("status", "NO DATA"))
-    reason = html.escape(str(item.get("reason", "")).strip())
-    if len(reason) > 130:
-        reason = reason[:127] + "…"
+    reason = _line_text(item.get("reason"))
+    # Verbatim engine text: the rail must not reword, shorten or re-derive
+    # the next step it prints (issue #357).
+    action = _line_text(item.get("action"))
+    note = _line_text(item.get("note"))
+    action_html = (
+        f"<div style='font-family:var(--sans); font-size:12px; font-weight:500; "
+        f"color:{theme.INK}; line-height:1.4; margin-top:4px;'>Next: {action}</div>"
+        if action
+        else ""
+    )
+    note_html = (
+        f"<div style='font-family:var(--sans); font-size:11px; "
+        f"color:{theme.MUTED}; line-height:1.4; margin-top:3px;'>{note}</div>"
+        if note
+        else ""
+    )
     sev = _row_sev(item)
     col = theme.SEV.get(sev, theme.SEV["neutral"])
     conf = str(item.get("confidence_label", "") or "").strip()
@@ -154,6 +187,7 @@ def _row_html(item: Dict[str, Any]) -> str:
         f"{conf_html}</div>"
         f"<div style='font-family:var(--mono); font-size:10px; font-weight:600; letter-spacing:.05em; color:{col}; margin-top:2px;'>{html.escape(status)}</div>"
         f"<div style='font-family:var(--sans); font-size:12px; color:#4b5563; line-height:1.4; margin-top:3px;'>{reason}</div>"
+        f"{action_html}{note_html}"
         f"{ev}</div></div>"
     )
 

--- a/tests/display/test_model_combined_section.py
+++ b/tests/display/test_model_combined_section.py
@@ -5,6 +5,7 @@ import sqlite3
 
 import pytest
 from rich.console import Console
+
 from tests.step_time.factories import (
     live_result_from_window,
     rank_average,
@@ -21,7 +22,10 @@ from traceml_ai.aggregator.display_drivers.nicegui_sections.model_combined_secti
 from traceml_ai.diagnostics.model_diagnostics import (
     build_model_diagnostics_payload,
 )
-from traceml_ai.renderers.step_time.renderer import StepTimeRenderer
+from traceml_ai.renderers.step_time.renderer import (
+    StepTimeRenderer,
+    format_cli_diagnosis,
+)
 from traceml_ai.reporting.sections.step_time import StepTimeSummarySection
 from traceml_ai.step_time.model import (
     StepTimeLoadRequest,
@@ -774,6 +778,146 @@ def test_diagnostics_rail_incomplete_data_is_neutral() -> None:
         == "neutral"
     )
     assert mds._row_sev({"severity": "info", "kind": "BALANCED"}) == "healthy"
+
+
+def test_diagnostics_rail_row_renders_engine_action() -> None:
+    # Issue #357: the rail dropped the engine's action, so the dashboard
+    # showed a verdict with no next step while the terminal printed one.
+    from traceml_ai.aggregator.display_drivers.nicegui_sections import (
+        model_diagnostics_section as mds,
+    )
+
+    row = mds._row_html(
+        {
+            "source": "step_time",
+            "status": "INPUT-BOUND",
+            "reason": "Input wait is 80.0% of the typical CPU Step Time.",
+            "action": "Increase workers, prefetch, or storage throughput.",
+        }
+    )
+
+    assert "Next: Increase workers, prefetch, or storage throughput." in row
+
+
+def test_diagnostics_rail_row_renders_action_and_note() -> None:
+    from traceml_ai.aggregator.display_drivers.nicegui_sections import (
+        model_diagnostics_section as mds,
+    )
+
+    row = mds._row_html(
+        {
+            "source": "step_memory",
+            "status": "MEMORY-CREEP",
+            "reason": "Allocated memory grows across the window.",
+            "action": "Check for retained tensors between steps.",
+            "note": "peak 12.4 GB on rank 3",
+        }
+    )
+
+    assert "Next: Check for retained tensors between steps." in row
+    assert "peak 12.4 GB on rank 3" in row
+
+
+@pytest.mark.parametrize("action", (None, "", "   "))
+def test_diagnostics_rail_row_omits_next_without_action(
+    action: str | None,
+) -> None:
+    from traceml_ai.aggregator.display_drivers.nicegui_sections import (
+        model_diagnostics_section as mds,
+    )
+
+    item = {
+        "source": "step_time",
+        "status": "NO DATA",
+        "reason": "Waiting for the first complete window.",
+    }
+    if action is not None:
+        item["action"] = action
+
+    row = mds._row_html(item)
+
+    assert "Next:" not in row
+    assert "Waiting for the first complete window." in row
+
+
+def test_diagnostics_rail_row_truncates_action_like_reason() -> None:
+    from traceml_ai.aggregator.display_drivers.nicegui_sections import (
+        model_diagnostics_section as mds,
+    )
+
+    row = mds._row_html(
+        {
+            "source": "step_time",
+            "status": "INPUT-BOUND",
+            "reason": "R" * 300,
+            "action": "A" * 300,
+            "note": "N" * 300,
+        }
+    )
+
+    for char in ("R", "A", "N"):
+        assert char * 127 + "…" in row
+        assert char * 128 not in row
+
+
+def test_diagnostics_rail_row_never_truncates_inside_an_html_entity() -> None:
+    """Cutting escaped text can split ``&amp;`` into literal ``&a``."""
+    from traceml_ai.aggregator.display_drivers.nicegui_sections import (
+        model_diagnostics_section as mds,
+    )
+
+    # Places the '&' where its 5-character entity would straddle the cut.
+    long_text = "x" * 125 + "& more text that runs past the cap" + "z" * 40
+
+    row = mds._row_html(
+        {
+            "source": "step_time",
+            "status": "INPUT-BOUND",
+            "reason": long_text,
+            "action": long_text,
+            "note": long_text,
+        }
+    )
+
+    assert "&amp;" in row
+    for broken in ("&a…", "&am…", "&amp…"):
+        assert broken not in row
+
+
+def test_diagnostics_rail_next_line_matches_cli_diagnosis() -> None:
+    """One engine verdict reads the same on the terminal and the rail."""
+    from traceml_ai.aggregator.display_drivers.nicegui_sections import (
+        model_diagnostics_section as mds,
+    )
+
+    result = _payload(
+        _metrics(
+            overrides={
+                "input_wait": 80.0,
+                "h2d": 0.0,
+                "forward": 5.0,
+                "backward": 10.0,
+                "optimizer_step": 4.0,
+                "residual_proxy": 1.0,
+                "traced_step_time": 20.0,
+            }
+        )
+    )
+    diagnosis = result.analysis.diagnosis.primary
+    assert diagnosis.kind == "INPUT_BOUND"
+    assert diagnosis.action
+
+    payload = build_model_diagnostics_payload(
+        step_time_window=result.analysis.window,
+        step_time_diagnosis=diagnosis,
+        step_memory_metrics=(),
+    ).to_dict()
+    item = next(
+        entry for entry in payload["items"] if entry["source"] == "step_time"
+    )
+
+    assert diagnosis.action in format_cli_diagnosis(diagnosis)
+    assert f"Next: {diagnosis.action}" in mds._row_html(item)
 
 
 def test_empty_diagnostics_payload_clears_stale_ui_state() -> None:


### PR DESCRIPTION
Closes #357.

**Problem.** The terminal prints the engine's `Next:` action for a live
verdict (`renderers/step_time/renderer.py:79`), but the dashboard's
diagnostics rail rendered only source, status, reason, confidence and
evidence chips. The same engine verdict gave a next step on one surface and
none on the other (#357).

**Fix.** Render-only change in `model_diagnostics_section._row_html`. The
payload already carried `action` and `note`
(`diagnostics/model_diagnostics.py:69-70`), so no engine or payload change
was needed. The row now prints `Next: <action>` verbatim under the same label
the terminal uses, and the `note` below it in muted 11px. Both are escaped
and length-capped through a new `_line_text` helper that reason now shares,
replacing the duplicated 130/127 literals with one `_MAX_LINE_CHARS`. Empty
or missing fields render nothing.

**Testing.** Five tests in `tests/display/test_model_combined_section.py`,
including a cross-surface parity test that takes one real INPUT_BOUND verdict
and asserts the same action string appears in `format_cli_diagnosis` and in
the rail HTML. `tests/display` 75 passed; full suite 1049 passed, 2 skipped.

GATE: repo-pinned black/isort/ruff hooks pass on both changed files; full
suite 1049 passed / 2 skipped, exit 0.
TRANSITIONS: present, absent, empty-string, whitespace-only and over-length
action all covered; note covered present/absent.
RANKS: view-only change, rank-agnostic; no per-rank or per-metric logic
touched.
TRIPWIRE: with the source change reverted, the four positive tests fail and
the negative cases stay green; restored, all eight pass.
