### PR TITLE
fix(dashboard): watch profile hides step panels and states the watch boundary (#355)

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/pages.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/pages.py
@@ -9,6 +9,7 @@ from traceml_ai.aggregator.display_drivers.layout import (
     PROCESS_LAYOUT,
     SYSTEM_LAYOUT,
 )
+from traceml_ai.reporting.summary_card import _WATCH_BOUNDARY
 
 from . import theme
 from .model_combined_section import (
@@ -31,6 +32,56 @@ from .system_section import (
     update_gpu_gauge_section,
     update_system_section,
 )
+
+# Section groups the dashboard page can build. This is layout SELECTION --
+# which panels exist for a profile -- never interpretation: no thresholds and
+# no severity live here.
+SECTION_HERO = "hero"
+SECTION_GPU_GAUGE = "gpu_gauge"
+SECTION_SYSTEM = "system"
+SECTION_PROCESS = "process"
+SECTION_STEP_MEMORY = "step_memory"
+SECTION_DIAGNOSTICS = "diagnostics"
+
+ALL_SECTIONS = frozenset(
+    {
+        SECTION_HERO,
+        SECTION_GPU_GAUGE,
+        SECTION_SYSTEM,
+        SECTION_PROCESS,
+        SECTION_STEP_MEMORY,
+        SECTION_DIAGNOSTICS,
+    }
+)
+
+# Panels that only step telemetry can ever fill.
+STEP_COUPLED_SECTIONS = frozenset({SECTION_HERO, SECTION_STEP_MEMORY})
+
+WATCH_PROFILE = "watch"
+
+# The watch boundary is stated in exactly one place. The dashboard renders
+# the summary card's sentence rather than wording its own, so the two
+# surfaces cannot drift and no surface invents user-facing copy. Private
+# import on purpose: summary_card owns the sentence, and a rename there
+# should break loudly here rather than leave a stale duplicate behind.
+WATCH_BOUNDARY_LINE = _WATCH_BOUNDARY
+
+
+def _is_watch(profile: str) -> bool:
+    """Watch-profile check, normalized the way the summary card does it."""
+    return str(profile or "").strip().lower() == WATCH_PROFILE
+
+
+def _sections_for_profile(profile: str) -> frozenset[str]:
+    """Section groups the dashboard builds for ``profile``.
+
+    ``watch`` never collects step timing, so the step-coupled panels are not
+    built at all rather than left permanently empty. Every other profile,
+    including an unknown or missing one, builds the full run layout.
+    """
+    if _is_watch(profile):
+        return ALL_SECTIONS - STEP_COUPLED_SECTIONS
+    return ALL_SECTIONS
 
 
 def _run_context_text(payload) -> str:
@@ -104,29 +155,35 @@ def _cell(flex: str):
     )
 
 
-def define_pages(cls):
-    """Attach the NiceGUI pages with the revamped bento layout."""
-    theme.register_static_fonts(app)
-    deep_enabled = getattr(cls._settings, "profile", "run") == "deep"
+def build_main_page(cls, profile: str) -> None:
+    """Build the dashboard body for one client, for ``profile``'s sections.
 
-    @ui.page("/")
-    def main_page():
-        ui.add_head_html(theme.head_html())
+    A panel outside the profile's section set is never created and never
+    subscribed: under ``watch`` there is no step telemetry to show, so the
+    step-coupled panels are omitted instead of sitting permanently empty.
+    The remaining cells expand to fill the row they are left alone in.
+    """
+    sections = _sections_for_profile(profile)
+    ui.add_head_html(theme.head_html())
+    with (
+        ui.column()
+        .classes("w-full")
+        .style("gap:16px; padding:22px 26px; max-width:1380px; margin:0 auto;")
+    ):
+        header_ctx = build_header(cls, profile == "deep")
+
+        if _is_watch(profile):
+            # State the boundary once, where the step panels would have been.
+            ui.label(WATCH_BOUNDARY_LINE).classes("cmeta")
+
+        # Row 1: hero (step-time ribbon + verdict) | GPU gauge
+        hero_cards = None
         with (
-            ui.column()
-            .classes("w-full")
-            .style(
-                "gap:16px; padding:22px 26px; max-width:1380px; margin:0 auto;"
-            )
+            ui.row()
+            .classes("w-full items-stretch")
+            .style("gap:16px; flex-wrap:wrap;")
         ):
-            header_ctx = build_header(cls, deep_enabled)
-
-            # Row 1: hero (step-time ribbon + verdict) | GPU gauge
-            with (
-                ui.row()
-                .classes("w-full items-stretch")
-                .style("gap:16px; flex-wrap:wrap;")
-            ):
+            if SECTION_HERO in sections:
                 with _cell("2.4"):
                     hero_cards = build_model_combined_section()
                     cls.subscribe_layout(
@@ -134,67 +191,82 @@ def define_pages(cls):
                         hero_cards,
                         update_model_combined_section,
                     )
-                with _cell("1"):
-                    gauge_cards = build_gpu_gauge_section()
+            with _cell("1"):
+                gauge_cards = build_gpu_gauge_section()
 
-            # Row 2: System | Process
-            with (
-                ui.row()
-                .classes("w-full items-stretch")
-                .style("gap:16px; flex-wrap:wrap;")
-            ):
-                with _cell("2"):
-                    system_cards = build_system_section()
-                with _cell("1.3"):
-                    cards = build_process_section()
-                    cls.subscribe_layout(
-                        PROCESS_LAYOUT, cards, update_process_section
-                    )
+        # Row 2: System | Process. Both are in every profile's section set,
+        # so they are built unconditionally.
+        with (
+            ui.row()
+            .classes("w-full items-stretch")
+            .style("gap:16px; flex-wrap:wrap;")
+        ):
+            with _cell("2"):
+                system_cards = build_system_section()
+            with _cell("1.3"):
+                cards = build_process_section()
+                cls.subscribe_layout(
+                    PROCESS_LAYOUT, cards, update_process_section
+                )
 
-            # One SYSTEM_LAYOUT subscriber drives both the chart and the gauge
-            # (two subscribers on one layout/client would evict each other).
-            def _update_system(
-                _c, d, _sc=system_cards, _gc=gauge_cards, _h=header_ctx
-            ):
-                update_system_section(_sc, d)
-                update_gpu_gauge_section(_gc, d)
-                txt = _run_context_text(d)
-                if txt:
-                    _h.text = txt
-                    _h.style(
-                        "font-family:var(--mono); font-size:11px; "
-                        "color:var(--muted); display:inline-block;"
-                    )
+        # One SYSTEM_LAYOUT subscriber drives both the chart and the gauge
+        # (two subscribers on one layout/client would evict each other).
+        def _update_system(
+            _c, d, _sc=system_cards, _gc=gauge_cards, _h=header_ctx
+        ):
+            update_system_section(_sc, d)
+            update_gpu_gauge_section(_gc, d)
+            txt = _run_context_text(d)
+            if txt:
+                _h.text = txt
+                _h.style(
+                    "font-family:var(--mono); font-size:11px; "
+                    "color:var(--muted); display:inline-block;"
+                )
 
-            cls.subscribe_layout(SYSTEM_LAYOUT, system_cards, _update_system)
+        cls.subscribe_layout(SYSTEM_LAYOUT, system_cards, _update_system)
 
-            # Row 3: Step Memory | Diagnostics
-            with (
-                ui.row()
-                .classes("w-full items-stretch")
-                .style("gap:16px; flex-wrap:wrap;")
-            ):
+        # Row 3: Step Memory | Diagnostics. The rail stays in every profile:
+        # it carries the System and Process findings too.
+        with (
+            ui.row()
+            .classes("w-full items-stretch")
+            .style("gap:16px; flex-wrap:wrap;")
+        ):
+            if SECTION_STEP_MEMORY in sections:
                 with _cell("1.3"):
                     cards = build_step_memory_section()
                     cls.subscribe_layout(
                         MODEL_MEMORY_LAYOUT, cards, update_step_memory_section
                     )
-                with _cell("1"):
-                    diag_cards = build_model_diagnostics_section()
+            with _cell("1"):
+                diag_cards = build_model_diagnostics_section()
 
-                    # One MODEL_DIAGNOSTICS_LAYOUT subscriber drives BOTH the
-                    # rail and the hero verdict, so the hero shows the engine's
-                    # step-time status verbatim (single source of truth) and
-                    # auto-tracks any diagnosis-vocab change. Two subscribers on
-                    # one layout/client would evict each other.
-                    def _update_diag(_c, d, _dc=diag_cards, _hc=hero_cards):
-                        update_model_diagnostics_section(_dc, d)
+                # One MODEL_DIAGNOSTICS_LAYOUT subscriber drives BOTH the
+                # rail and the hero verdict, so the hero shows the engine's
+                # step-time status verbatim (single source of truth) and
+                # auto-tracks any diagnosis-vocab change. Two subscribers on
+                # one layout/client would evict each other. Without a hero
+                # the same subscriber updates the rail alone.
+                def _update_diag(_c, d, _dc=diag_cards, _hc=hero_cards):
+                    update_model_diagnostics_section(_dc, d)
+                    if _hc is not None:
                         update_step_verdict(_hc, d)
 
-                    cls.subscribe_layout(
-                        MODEL_DIAGNOSTICS_LAYOUT, diag_cards, _update_diag
-                    )
+                cls.subscribe_layout(
+                    MODEL_DIAGNOSTICS_LAYOUT, diag_cards, _update_diag
+                )
 
-        cls.ensure_ui_timer(0.75)
-        if not cls._ui_ready:
-            cls._ui_ready = True
+    cls.ensure_ui_timer(0.75)
+    if not cls._ui_ready:
+        cls._ui_ready = True
+
+
+def define_pages(cls):
+    """Attach the NiceGUI pages with the revamped bento layout."""
+    theme.register_static_fonts(app)
+    profile = getattr(cls._settings, "profile", "run")
+
+    @ui.page("/")
+    def main_page():
+        build_main_page(cls, profile)

--- a/tests/display/test_nicegui_profile_layout.py
+++ b/tests/display/test_nicegui_profile_layout.py
@@ -1,0 +1,193 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Profile-aware dashboard layout tests (#355).
+
+The dashboard used to build the step-coupled panels for every profile, so a
+``traceml watch --mode dashboard`` run showed a Step Time hero and a Step
+Memory panel that nothing could ever fill. These tests pin the selection
+(which panels exist per profile), the resulting subscriptions, and the one
+boundary line that replaces them.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from nicegui import ui  # noqa: E402
+
+from traceml_ai.aggregator.display_drivers.layout import (  # noqa: E402
+    MODEL_COMBINED_LAYOUT,
+    MODEL_DIAGNOSTICS_LAYOUT,
+    MODEL_MEMORY_LAYOUT,
+    PROCESS_LAYOUT,
+    SYSTEM_LAYOUT,
+)
+from traceml_ai.aggregator.display_drivers.nicegui import (  # noqa: E402
+    NiceGUIDisplayDriver,
+)
+from traceml_ai.aggregator.display_drivers.nicegui_sections import (  # noqa: E402,E501
+    pages,
+)
+from traceml_ai.reporting import summary_card  # noqa: E402
+from traceml_ai.runtime.settings import TraceMLSettings  # noqa: E402
+
+# The dashboard does not word its own boundary sentence: it renders the
+# summary card's. These tests assert that single source rather than pinning
+# the text, so the wording stays owned by one module and a change there needs
+# no edit here.
+
+
+def _driver(profile: str) -> NiceGUIDisplayDriver:
+    settings = TraceMLSettings(
+        mode="dashboard",
+        db_path=tempfile.mktemp(suffix=".db"),
+        profile=profile,
+    )
+    return NiceGUIDisplayDriver(logging.getLogger("test"), settings)
+
+
+def _build_page(profile: str) -> Tuple[NiceGUIDisplayDriver, List[str]]:
+    """Build the dashboard body headlessly; return the driver and new texts.
+
+    NiceGUI builds into the auto-index client outside a page context, and that
+    client is shared by the whole test session, so only the elements this call
+    added are collected.
+    """
+    driver = _driver(profile)
+    client = ui.context.client
+    before = set(client.elements)
+    pages.build_main_page(driver, profile)
+    texts = [
+        element.text
+        for element_id, element in client.elements.items()
+        if element_id not in before
+        and isinstance(getattr(element, "text", None), str)
+    ]
+    return driver, texts
+
+
+# --- selection ------------------------------------------------------------
+
+
+def test_run_profile_builds_every_section() -> None:
+    assert pages._sections_for_profile("run") == pages.ALL_SECTIONS
+
+
+def test_watch_profile_excludes_only_the_step_coupled_sections() -> None:
+    sections = pages._sections_for_profile("watch")
+
+    assert pages.SECTION_HERO not in sections
+    assert pages.SECTION_STEP_MEMORY not in sections
+    assert sections == pages.ALL_SECTIONS - pages.STEP_COUPLED_SECTIONS
+
+
+def test_watch_profile_keeps_the_resource_and_diagnostics_sections() -> None:
+    sections = pages._sections_for_profile("watch")
+
+    # The rail stays: it carries the System and Process findings too.
+    assert pages.SECTION_DIAGNOSTICS in sections
+    assert pages.SECTION_SYSTEM in sections
+    assert pages.SECTION_PROCESS in sections
+    assert pages.SECTION_GPU_GAUGE in sections
+
+
+@pytest.mark.parametrize(
+    "profile",
+    ("run", "deep", "bogus", "", "   ", None),
+)
+def test_non_watch_profiles_build_the_full_run_layout(profile: Any) -> None:
+    assert pages._sections_for_profile(profile) == pages.ALL_SECTIONS
+
+
+@pytest.mark.parametrize("profile", ("watch", "WATCH", "  Watch  "))
+def test_watch_profile_matching_is_normalized(profile: str) -> None:
+    # Mirrors the summary card's own strip/lower profile comparison.
+    assert pages._is_watch(profile) is True
+    assert pages.SECTION_HERO not in pages._sections_for_profile(profile)
+
+
+# --- boundary line --------------------------------------------------------
+
+
+def test_watch_boundary_comes_from_the_summary_card() -> None:
+    """The dashboard states the card's sentence, never one of its own."""
+    card_line = getattr(summary_card, "_WATCH_BOUNDARY", None)
+
+    assert card_line is not None, (
+        "summary_card no longer exposes _WATCH_BOUNDARY; re-point the "
+        "dashboard at wherever the watch card's boundary sentence now lives."
+    )
+    assert pages.WATCH_BOUNDARY_LINE is card_line
+
+
+def test_watch_page_states_the_boundary_once() -> None:
+    _driver_obj, texts = _build_page("watch")
+
+    assert texts.count(pages.WATCH_BOUNDARY_LINE) == 1
+
+
+def test_run_page_states_no_boundary() -> None:
+    _driver_obj, texts = _build_page("run")
+
+    assert pages.WATCH_BOUNDARY_LINE not in texts
+
+
+# --- subscriptions --------------------------------------------------------
+
+
+def test_watch_page_omits_the_step_layout_subscriptions() -> None:
+    driver, _texts = _build_page("watch")
+
+    assert set(driver._layout_subscribers) == {
+        SYSTEM_LAYOUT,
+        PROCESS_LAYOUT,
+        MODEL_DIAGNOSTICS_LAYOUT,
+    }
+
+
+def test_run_page_subscribes_the_step_layouts() -> None:
+    driver, _texts = _build_page("run")
+
+    assert set(driver._layout_subscribers) == {
+        SYSTEM_LAYOUT,
+        PROCESS_LAYOUT,
+        MODEL_DIAGNOSTICS_LAYOUT,
+        MODEL_COMBINED_LAYOUT,
+        MODEL_MEMORY_LAYOUT,
+    }
+
+
+def test_watch_diagnostics_subscriber_updates_the_rail_without_a_hero() -> (
+    None
+):
+    """The shared subscriber must not reach for a hero that was not built."""
+    driver, _texts = _build_page("watch")
+    _client_id, cards, update_fn = driver._layout_subscribers[
+        MODEL_DIAGNOSTICS_LAYOUT
+    ][-1]
+    payload: Dict[str, Any] = {
+        "overall_severity": "warn",
+        "items": [
+            {
+                "source": "system",
+                "status": "MEMORY PRESSURE",
+                "severity": "warn",
+                "reason": "host RAM is nearly full",
+            }
+        ],
+    }
+
+    update_fn(cards, payload)
+
+    assert cards["overall"].text == "WARN"
+    assert "MEMORY PRESSURE" in cards["body"].content


### PR DESCRIPTION
Closes #355.

## Problem

The dashboard built the full run layout for every profile.
`traceml watch --mode dashboard` therefore showed a Step Time hero and a Step
Memory panel that watch telemetry can never fill, with nothing on screen
saying why (#355). The terminal driver already selects its layout per profile
(`cli.py:150-152`); the dashboard did not.

## Fix

- `_sections_for_profile(profile)` in `nicegui_sections/pages.py` answers
  which section groups a profile's page builds. Watch drops the step-coupled
  groups (hero, step memory); every other profile, including an unknown or
  missing one, builds everything as before. Layout selection only: no
  thresholds, no severity, no diagnosis.
- Excluded panels are neither created nor subscribed, so no layout
  subscription is registered for step data that will not arrive. The shared
  diagnostics subscriber drives the rail alone when there is no hero.
- Under watch the page states the boundary once, under the header. The
  sentence is not written here: `pages.WATCH_BOUNDARY_LINE` is the summary
  card's own `_WATCH_BOUNDARY` constant, so the two surfaces state the same
  boundary by construction and no new user-facing copy is introduced.
- The Diagnostics rail, System, Process and GPU gauge stay in watch; the rail
  carries System and Process findings.
- The page body moved to a module-level `build_main_page(cls, profile)` so
  the layout is testable without a browser. Read the diff with `-w`: most of
  it is re-indentation (83 insertions / 13 deletions whitespace-insensitive).

## Testing

`tests/display/test_nicegui_profile_layout.py`, 19 tests: profile selection
(run / watch / deep / unknown / empty / None, plus case and whitespace
normalization), the boundary line, and the resulting subscriptions built
headlessly through the real driver (watch subscribes system + process +
diagnostics only; run adds the two step layouts; the watch diagnostics
subscriber updates the rail with no hero present).

- new file: 19 passed; `tests/display/`: 87 passed
- full suite: 1061 passed, 2 skipped
- black / ruff / isort clean

GATE: full suite green (1061 passed, 2 skipped) and the layout tests fail on
the base commit; verified by reverting pages.py (18 failed) and restoring
(19 passed).
TRANSITIONS: profile run / watch / deep / unknown / empty / None all covered;
watch matching is case- and whitespace-normalized the way the summary card
does it.
RANKS: rank-agnostic. This changes which panels are built for a profile, not
any per-rank payload, metric, or aggregation; no rank data is read on the
changed path.
TRIPWIRE: reverting the pages.py change turns the layout tests red (18
failed, 1 passed); restored, 19 pass. test_watch_boundary_comes_from_the_
summary_card additionally fails if the dashboard ever stops sourcing the
card's constant and words its own boundary sentence again.

Known, deliberately out of scope:

- `traceml serve` cannot express a profile (`_resolve_serve_settings` never
  sets it), so serve + dashboard is always the run layout. Needs a
  `--profile` flag decision.
- The dashboard still computes step payloads under watch
  (`nicegui.py:157-170`); this PR changes layout only.
- `reporting/html/sections.py` renders Step time / Step memory cards
  unconditionally, the same class of issue on the HTML report surface.
