### PR TITLE
Dashboard: escalate a server that never binds to ERROR with diagnostics; add real server-start test

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui.py
@@ -32,6 +32,11 @@ Important reliability notes
 - Locks are held only for snapshots / swapping payload dicts:
   - We do NOT compute while holding the lock.
   - We do NOT update UI while holding the lock.
+- NiceGUI prints its "ready" banner from the ASGI lifespan, which runs
+  BEFORE the socket is bound. A server that never binds therefore looks
+  healthy in stdout. start() probes the socket, and if the bind is not
+  confirmed in time a watchdog keeps probing and logs an ERROR with the
+  server thread's stack, so the failure reaches the error log.
 
 Aggregator contract (required by trace_aggregator)
 --------------------------------------------------
@@ -42,6 +47,8 @@ Aggregator contract (required by trace_aggregator)
 
 from __future__ import annotations
 
+import importlib
+import sys
 import threading
 import time
 import traceback
@@ -60,8 +67,10 @@ from traceml_ai.aggregator.display_drivers.nicegui_sections.pages import (
 )
 from traceml_ai.aggregator.display_drivers.server_readiness import (
     ServerReadiness,
+    ServerWatchOutcome,
     socket_is_listening,
     wait_for_server_ready,
+    watch_server_startup,
 )
 from traceml_ai.aggregator.display_drivers.staleness import format_staleness
 from traceml_ai.renderers.base_renderer import DashboardRenderer
@@ -77,6 +86,23 @@ from traceml_ai.step_time.pipeline import LiveStepTimeSession
 # Max seconds start() waits to confirm the dashboard server is listening before
 # returning anyway. Training must never block on the dashboard (TRA-68).
 _SERVER_STARTUP_TIMEOUT_SEC = 10.0
+
+# After start() gave up waiting, a daemon watchdog keeps probing for this long
+# before logging an ERROR with diagnostics (a server that never binds is
+# otherwise indistinguishable from a slow one, and stays silent).
+_SERVER_STARTUP_GRACE_SEC = 60.0
+
+
+def _stack_versions() -> str:
+    """Versions of the serving stack, for startup log lines."""
+    parts = []
+    for name in ("nicegui", "uvicorn"):
+        try:
+            module = importlib.import_module(name)
+            parts.append(f"{name} {getattr(module, '__version__', '?')}")
+        except Exception:
+            parts.append(f"{name} ?")
+    return ", ".join(parts)
 
 
 @dataclass
@@ -131,6 +157,8 @@ class NiceGUIDisplayDriver(BaseDisplayDriver):
         self._lifespan_started = threading.Event()
         self._server_thread: Optional[threading.Thread] = None
         self._startup_timeout_sec: float = _SERVER_STARTUP_TIMEOUT_SEC
+        self._startup_grace_sec: float = _SERVER_STARTUP_GRACE_SEC
+        self._startup_watchdog: Optional[threading.Thread] = None
 
         # ---- Staleness (TRA-68): seconds since payloads last refreshed,
         # computed UI-side so a wedged display loop stops looking fresh. ----
@@ -211,11 +239,21 @@ class NiceGUIDisplayDriver(BaseDisplayDriver):
             timeout=self._startup_timeout_sec,
         )
         self._log_startup_result(result)
+        if result is ServerReadiness.TIMEOUT:
+            # Keep watching in the background: a slow bind becomes an INFO
+            # line, a bind that never happens becomes an ERROR with the
+            # server thread's stack (best effort, never blocks the caller).
+            self._startup_watchdog = threading.Thread(
+                target=self._watch_startup, daemon=True
+            )
+            self._startup_watchdog.start()
 
     def _log_startup_result(self, result: ServerReadiness) -> None:
         url = f"http://localhost:{self._port}"
         if result is ServerReadiness.READY:
-            self._logger.info(f"[TraceML] Dashboard ready at {url}")
+            self._logger.info(
+                f"[TraceML] Dashboard ready at {url} ({_stack_versions()})"
+            )
         elif result is ServerReadiness.FAILED:
             self._logger.error(
                 f"[TraceML] Dashboard server failed to start on port "
@@ -228,6 +266,60 @@ class NiceGUIDisplayDriver(BaseDisplayDriver):
                 f"{self._startup_timeout_sec:.0f}s; continuing. It may still "
                 f"come up at {url}."
             )
+
+    def _watch_startup(self) -> None:
+        """Daemon watchdog: settle a timed-out startup within the grace."""
+        url = f"http://localhost:{self._port}"
+        thread = self._server_thread
+        try:
+            started = time.monotonic()
+            outcome = watch_server_startup(
+                is_listening=lambda: socket_is_listening(
+                    "127.0.0.1", self._port
+                ),
+                is_alive=thread.is_alive if thread else (lambda: False),
+                lifespan_started=self._lifespan_started.is_set,
+                grace=self._startup_grace_sec,
+            )
+            elapsed = time.monotonic() - started + self._startup_timeout_sec
+            if outcome is ServerWatchOutcome.READY_LATE:
+                self._logger.info(
+                    f"[TraceML] Dashboard ready at {url} after "
+                    f"{elapsed:.0f}s ({_stack_versions()})"
+                )
+            elif outcome is ServerWatchOutcome.THREAD_DIED:
+                self._logger.error(
+                    f"[TraceML] Dashboard server thread exited without "
+                    f"binding port {self._port}; training continues without "
+                    f"the dashboard. Diagnostics:\n"
+                    + self._startup_diagnostics()
+                )
+            else:
+                self._logger.error(
+                    f"[TraceML] Dashboard still not listening on port "
+                    f"{self._port} after {elapsed:.0f}s; training continues "
+                    f"without the dashboard. Diagnostics:\n"
+                    + self._startup_diagnostics()
+                )
+        except Exception as e:  # the watchdog itself must never raise
+            self._logger.error(f"[TraceML] Dashboard startup watchdog: {e}")
+
+    def _startup_diagnostics(self) -> str:
+        """State of the serving thread, including its live Python stack."""
+        thread = self._server_thread
+        alive = bool(thread is not None and thread.is_alive())
+        lines = [
+            f"port={self._port}",
+            f"server_thread_alive={alive}",
+            f"lifespan_started={self._lifespan_started.is_set()}",
+            f"versions={_stack_versions()}",
+        ]
+        ident = getattr(thread, "ident", None)
+        frame = sys._current_frames().get(ident) if ident else None
+        if frame is not None:
+            stack = "".join(traceback.format_stack(frame, limit=12))
+            lines.append("server thread stack (innermost last):\n" + stack)
+        return "\n".join(lines)
 
     def tick(self) -> None:
         """

--- a/src/traceml_ai/aggregator/display_drivers/server_readiness.py
+++ b/src/traceml_ai/aggregator/display_drivers/server_readiness.py
@@ -79,3 +79,45 @@ def wait_for_server_ready(
         if monotonic() >= deadline:
             return ServerReadiness.TIMEOUT
         sleep(interval)
+
+
+class ServerWatchOutcome(enum.Enum):
+    """Outcome of the post-timeout startup watchdog."""
+
+    READY_LATE = "ready_late"  # bound after start() had already returned
+    THREAD_DIED = "thread_died"  # the server thread exited without binding
+    STILL_NOT_LISTENING = "still_not_listening"  # alive, never bound
+
+
+def watch_server_startup(
+    *,
+    is_listening: Callable[[], bool],
+    is_alive: Callable[[], bool],
+    lifespan_started: Callable[[], bool],
+    grace: float,
+    interval: float = 0.5,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> ServerWatchOutcome:
+    """Keep watching a server that ``wait_for_server_ready`` timed out on.
+
+    ``start()`` must return quickly, so it gives up confirming the bind after
+    a short timeout. That leaves a server that never binds indistinguishable
+    from one that is merely slow. This watchdog runs after ``start()`` has
+    returned and settles the question within ``grace`` seconds, so the
+    driver can log a real ERROR (with diagnostics) instead of a one-off
+    WARNING that the error log never sees.
+
+    Same READY guard as ``wait_for_server_ready``: a foreign listener on our
+    port is never reported as our server.
+    """
+    deadline = monotonic() + grace
+    while True:
+        alive = is_alive()
+        if alive and lifespan_started() and is_listening():
+            return ServerWatchOutcome.READY_LATE
+        if not alive:
+            return ServerWatchOutcome.THREAD_DIED
+        if monotonic() >= deadline:
+            return ServerWatchOutcome.STILL_NOT_LISTENING
+        sleep(interval)

--- a/tests/display/test_nicegui_server_start.py
+++ b/tests/display/test_nicegui_server_start.py
@@ -1,0 +1,150 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dashboard serving floor: the server must bind, and a server that does not
+bind must say so at ERROR level with enough detail to diagnose it.
+
+Background: on a GPU box the dashboard once printed NiceGUI's "ready" banner
+and then never listened on its port, with empty error logs. The banner is
+printed from the ASGI lifespan, which runs before the socket is bound, and
+the driver only logged the not-yet-listening case at WARNING, below the error
+logger's floor. These tests pin both halves of the fix.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from traceml_ai.aggregator.display_drivers.nicegui import (  # noqa: E402
+    NiceGUIDisplayDriver,
+)
+from traceml_ai.runtime.settings import TraceMLSettings  # noqa: E402
+
+
+def _free_port() -> int:
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    return port
+
+
+def _driver(port: int) -> NiceGUIDisplayDriver:
+    settings = TraceMLSettings(
+        mode="dashboard",
+        db_path=tempfile.mktemp(suffix=".db"),
+        dashboard_port=port,
+        dashboard_auto_open=False,
+    )
+    return NiceGUIDisplayDriver(logging.getLogger("test.serving"), settings)
+
+
+def test_never_binding_server_escalates_to_error_with_thread_stack(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    driver = _driver(_free_port())
+    release = threading.Event()
+
+    def _stuck_server_never_binds() -> None:
+        driver._lifespan_started.set()  # banner-equivalent: lifespan ran
+        release.wait(timeout=30)  # ...but the socket is never bound
+
+    driver._start_ui_server = _stuck_server_never_binds  # type: ignore
+    driver._startup_timeout_sec = 0.0
+    # A short but non-zero grace: the watchdog keeps probing until it
+    # elapses, so the stub thread has certainly run (and set the lifespan
+    # flag) by the time the diagnostics are sampled.
+    driver._startup_grace_sec = 1.0
+
+    with caplog.at_level(logging.INFO, logger="test.serving"):
+        driver.start()
+        watchdog = driver._startup_watchdog
+        assert watchdog is not None
+        watchdog.join(timeout=10)
+    release.set()
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert errors, "no ERROR was logged for a server that never bound"
+    text = "\n".join(r.getMessage() for r in errors)
+    assert "not listening" in text
+    assert f"port={driver._port}" in text
+    assert "server_thread_alive=True" in text
+    assert "lifespan_started=True" in text
+    # The diagnostics carry the server thread's live Python stack, so a stuck
+    # startup names the function it is stuck in.
+    assert "_stuck_server_never_binds" in text
+
+
+# Runs in a child process on purpose: NiceGUI keeps process-global state
+# (registered pages, script-mode detection, its pytest port hook), so an
+# in-process start is order-dependent on other display tests. A child
+# process is also exactly how the aggregator starts the dashboard.
+_CHILD = """
+import logging, sys, tempfile, urllib.request
+logging.basicConfig(level=logging.INFO, stream=sys.stderr, format="%(message)s")
+from traceml_ai.aggregator.display_drivers.nicegui import NiceGUIDisplayDriver
+from traceml_ai.aggregator.display_drivers.server_readiness import (
+    socket_is_listening,
+)
+from traceml_ai.runtime.settings import TraceMLSettings
+
+port = int(sys.argv[1])
+driver = NiceGUIDisplayDriver(
+    logging.getLogger("child"),
+    TraceMLSettings(
+        mode="dashboard",
+        db_path=tempfile.mktemp(suffix=".db"),
+        dashboard_port=port,
+        dashboard_auto_open=False,
+    ),
+)
+driver.start()
+listening = socket_is_listening("127.0.0.1", port)
+status = None
+if listening:
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/", timeout=10) as r:
+        status = r.status
+print(f"LISTENING={listening} HTTP={status}", flush=True)
+sys.exit(0 if listening and status == 200 else 1)
+"""
+
+
+def test_real_server_binds_and_serves_http() -> None:
+    import traceml_ai
+
+    port = _free_port()
+    src_root = str(Path(traceml_ai.__file__).resolve().parents[1])
+    # pytest exports PYTEST_* markers that NiceGUI reads as "running under
+    # pytest" and then switches ui.run() to its screen-test port hook; the
+    # child must look like a plain production process.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("PYTEST_")}
+    env["PYTHONPATH"] = os.pathsep.join(
+        p for p in (src_root, env.get("PYTHONPATH", "")) if p
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", _CHILD, str(port)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+    detail = f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    assert proc.returncode == 0, detail
+    assert "LISTENING=True HTTP=200" in proc.stdout, detail
+    # The ready line names the serving stack so a field log is diagnosable.
+    assert "Dashboard ready at" in proc.stderr, detail
+    assert "nicegui" in proc.stderr, detail

--- a/tests/display/test_server_readiness.py
+++ b/tests/display/test_server_readiness.py
@@ -12,8 +12,10 @@ import socket
 
 from traceml_ai.aggregator.display_drivers.server_readiness import (
     ServerReadiness,
+    ServerWatchOutcome,
     socket_is_listening,
     wait_for_server_ready,
+    watch_server_startup,
 )
 
 
@@ -103,3 +105,45 @@ def test_wait_timeout_when_never_ready() -> None:
         timeout=0.0,
     )
     assert result is ServerReadiness.TIMEOUT
+
+
+def test_watch_ready_late_when_listening_after_lifespan() -> None:
+    result = watch_server_startup(
+        is_listening=lambda: True,
+        is_alive=lambda: True,
+        lifespan_started=lambda: True,
+        grace=1.0,
+    )
+    assert result is ServerWatchOutcome.READY_LATE
+
+
+def test_watch_thread_died_without_binding() -> None:
+    result = watch_server_startup(
+        is_listening=lambda: False,
+        is_alive=lambda: False,
+        lifespan_started=lambda: True,
+        grace=1.0,
+    )
+    assert result is ServerWatchOutcome.THREAD_DIED
+
+
+def test_watch_still_not_listening_after_grace() -> None:
+    result = watch_server_startup(
+        is_listening=lambda: False,
+        is_alive=lambda: True,
+        lifespan_started=lambda: True,
+        grace=0.0,
+    )
+    assert result is ServerWatchOutcome.STILL_NOT_LISTENING
+
+
+def test_watch_foreign_listener_is_not_ready_before_lifespan() -> None:
+    # Same guard as wait_for_server_ready: a foreign listener on our port must
+    # not be reported as our late-but-ready server.
+    result = watch_server_startup(
+        is_listening=lambda: True,
+        is_alive=lambda: True,
+        lifespan_started=lambda: False,
+        grace=0.0,
+    )
+    assert result is ServerWatchOutcome.STILL_NOT_LISTENING


### PR DESCRIPTION
## What

- `start()` already probes the socket and returns within 10 s. When that probe times out, a daemon watchdog now keeps probing for a grace period (60 s). A late bind logs INFO ("ready after Ns"); a server thread that exits without binding, or one still not listening after the grace, logs ERROR with diagnostics: port, thread alive, lifespan state, nicegui/uvicorn versions, and the server thread's live Python stack.
- The "Dashboard ready" line now names the serving stack versions.
- New `watch_server_startup()` in `server_readiness.py`, same injected-clock shape as `wait_for_server_ready()`, same foreign-listener guard.
- Tests: four pure-function tests for the watchdog outcomes; a driver test that forces the never-binds path and asserts the ERROR names the stuck function from the captured stack; a real server-start test that launches the driver in a child process on a free port and asserts HTTP 200 (the NiceGUI server-start test asked for in #325).

## Why

NiceGUI prints its "ready" banner from the ASGI lifespan, which runs before the socket is bound, so a dashboard that never binds looks healthy on stdout. The driver logged that case once at WARNING, and the aggregator's error log only keeps ERROR, so a run on a GPU box that printed the banner and never listened left empty logs behind. This change does not claim to know why that box failed to bind; it makes the next occurrence self-diagnosing (the stack shows where the server thread is stuck) and gives CI a floor against the whole class.

## Scope

Touches `display_drivers/nicegui.py` and `display_drivers/server_readiness.py` only (outside `nicegui_sections/`, as a serving-floor fix, no representation change). No behavior change on the healthy path beyond the extra versions in the ready line.

## Verification

- `pytest tests/display tests/core/test_packaging_constraints.py tests/runtime/test_launcher.py`: 137 passed (py3.12, nicegui 3.12.1).
- New test file on py3.13 + nicegui 3.16.0 and py3.12 + nicegui 3.16.0: 14 passed each, including the real bind.
- black / isort / ruff clean at line length 79.
- On a fresh DLAMI g4dn.xlarge (py3.13.13, nicegui 3.16.0, uvicorn 0.47.0 + uvloop): `traceml run --mode dashboard` with default flags bound in 1-6 s on 4/4 launches, HTTP 200. The original box failure does not reproduce on the AMI.

## Evidence

- GATE: conformance ran=true, `tests/integrations/test_telemetry_conformance.py` 1 passed / 0 failed / 1 skipped on this branch (the change touches no stream or payload).
- TRANSITIONS: tested timeout->ready-late, timeout->thread-died, timeout->still-not-listening with injected clocks (`test_server_readiness.py`), plus the forced never-binds path end to end through `start()` (`test_nicegui_server_start.py`).
- RANKS: EVIDENCE: n/a (serving-floor change; no per-rank rendering or aggregation is touched).
- TRIPWIRE: yes. Forced the watchdog to fire on purpose (server stub sets the lifespan flag and never binds, grace 1 s) and asserted the ERROR carries the stuck function's name from the captured stack.
- PLATFORM: EVIDENCE: n/a (no platform branch added; the diff has no `sys.platform` / `os.name` condition).
