### PR TITLE
Dashboard: System block as four tiles, two charts, and per-GPU rows that open on spread

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/context_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/context_section.py
@@ -38,10 +38,9 @@ STEP_SECTIONS: Tuple[str, ...] = (
     "step_memory",
     "model_diagnostics",
 )
-RESOURCE_SECTIONS: Tuple[str, ...] = ("gpu_gauge", "system", "process")
+RESOURCE_SECTIONS: Tuple[str, ...] = ("system", "process")
 RUN_SECTIONS: Tuple[str, ...] = (
     "model_combined",
-    "gpu_gauge",
     "system",
     "process",
     "step_memory",

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/pages.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/pages.py
@@ -32,12 +32,7 @@ from .step_memory_section import (
     build_step_memory_section,
     update_step_memory_section,
 )
-from .system_section import (
-    build_gpu_gauge_section,
-    build_system_section,
-    update_gpu_gauge_section,
-    update_system_section,
-)
+from .system_section import build_system_section, update_system_section
 
 
 def _cell(flex: str):
@@ -76,66 +71,47 @@ def define_pages(cls):
 
             hero_cards = None
             if "model_combined" in shown:
-                # Row 1: hero (step-time ribbon + verdict) | GPU gauge
+                # Row 1: hero (step-time ribbon + verdict). A watch session
+                # has no step loop, so no hero: the resource panes lead.
                 with (
                     ui.row()
                     .classes("w-full items-stretch")
                     .style("gap:16px; flex-wrap:wrap;")
                 ):
-                    with _cell("2.4"):
+                    with _cell("1"):
                         hero_cards = build_model_combined_section()
                         cls.subscribe_layout(
                             MODEL_COMBINED_LAYOUT,
                             hero_cards,
                             update_model_combined_section,
                         )
-                    with _cell("1"):
-                        gauge_cards = build_gpu_gauge_section()
 
-                # Row 2: System | Process
-                with (
-                    ui.row()
-                    .classes("w-full items-stretch")
-                    .style("gap:16px; flex-wrap:wrap;")
-                ):
-                    with _cell("2"):
-                        system_cards = build_system_section()
-                    with _cell("1.3"):
-                        cards = build_process_section()
-                        cls.subscribe_layout(
-                            PROCESS_LAYOUT, cards, update_process_section
-                        )
-            else:
-                # A watch session has no step loop, so no hero: the
-                # resource panes take the page. Row 1: System | GPU gauge,
-                # Row 2: Process.
-                with (
-                    ui.row()
-                    .classes("w-full items-stretch")
-                    .style("gap:16px; flex-wrap:wrap;")
-                ):
-                    with _cell("2"):
-                        system_cards = build_system_section()
-                    with _cell("1"):
-                        gauge_cards = build_gpu_gauge_section()
-                with (
-                    ui.row()
-                    .classes("w-full items-stretch")
-                    .style("gap:16px; flex-wrap:wrap;")
-                ):
-                    with _cell("1"):
-                        cards = build_process_section()
-                        cls.subscribe_layout(
-                            PROCESS_LAYOUT, cards, update_process_section
-                        )
+            # System | Process: the evidence pair (the node, its ranks),
+            # side by side at exactly half the width each. Heights are not
+            # stretched to match (items-start): the two blocks share one
+            # skeleton (a tiles row, fixed-height chart slots, one
+            # disclosure), so they are equal by construction while their
+            # disclosures are closed, and an opened disclosure grows only
+            # its own card. Process adopts the skeleton in its own PR; until
+            # then it is today's card. The System block carries the GPU
+            # headline itself (util tile + per-GPU rows), so there is no
+            # gauge.
+            with (
+                ui.row()
+                .classes("w-full items-start")
+                .style("gap:16px; flex-wrap:wrap;")
+            ):
+                with _cell("1 1 0"):
+                    system_cards = build_system_section()
+                with _cell("1 1 0"):
+                    cards = build_process_section()
+                    cls.subscribe_layout(
+                        PROCESS_LAYOUT, cards, update_process_section
+                    )
 
-            # One SYSTEM_LAYOUT subscriber drives the chart and the gauge
-            # (two subscribers on one layout/client would evict each other).
-            def _update_system(_c, d, _sc=system_cards, _gc=gauge_cards):
-                update_system_section(_sc, d)
-                update_gpu_gauge_section(_gc, d)
-
-            cls.subscribe_layout(SYSTEM_LAYOUT, system_cards, _update_system)
+            cls.subscribe_layout(
+                SYSTEM_LAYOUT, system_cards, update_system_section
+            )
 
             # Row 3: Step Memory | Diagnostics (training runs only)
             if "step_memory" in shown or "model_diagnostics" in shown:

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -249,10 +249,6 @@ def odd_ones_out(gpus: List[Dict[str, Any]]) -> set:
 # wire; carrying it would let this read "avg of 10 cores".)
 CPU_LABEL = "host cpu util · avg across cores"
 
-# A run longer than the window by this factor is charted whole rather than
-# as its last 100 samples; below it, the window IS the whole run.
-RUN_VIEW_FACTOR = 1.2
-
 # Absent value marker. "n/a" rather than a dash: the Process card on the
 # same page already reads "N/A", and one page should not spell absence two
 # ways.
@@ -561,10 +557,10 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
     run_avg = run.get("avg") or []
     run_max = run.get("max") or []
     run_span = float(run.get("span_s") or 0.0)
-    cpu_whole = len(run_t) > 2 and run_span > span * RUN_VIEW_FACTOR
+    cpu_whole = len(run_t) > 2
     prun = series.get("gpu_power_run") or []
     prun_span = float(prun[0].get("span_s") or 0.0) if prun else 0.0
-    power_whole = bool(prun) and prun_span > span * RUN_VIEW_FACTOR
+    power_whole = bool(prun)
     # The two whole-run charts sit one above the other, so they share one
     # anchor and one span: a dip in power and a rise in CPU at the same x
     # are then the same moment. Their own spans differ by a window (the

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -84,10 +84,6 @@ def format_span(seconds: Optional[float]) -> str:
     return f"last {seconds / 60.0:.0f} min"
 
 
-# Per-GPU utilisation below this reads as idle in the rows' header.
-IDLE_UTIL_PCT = 20.0
-
-
 def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
     """A level against its capacity: ('6.3', '/ 16.1 GB')."""
     used = theme.gb(used_bytes) if used_bytes is not None else None
@@ -101,15 +97,16 @@ def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
     return (num, f"/ {total_s} GB")
 
 
-def disclosure_text(
-    gpus: List[Dict[str, Any]], *, over: bool, is_open: bool
-) -> str:
-    """Header of the per-GPU rows, in GPU words: what the user needs to know.
+def disclosure_text(gpus: List[Dict[str, Any]], *, is_open: bool) -> str:
+    """Header of the per-GPU rows: the utilisation range, and nothing else.
 
-    ``over`` is the trigger's verdict (the across-GPU spread crossed the
-    bar); the words say what that means on this node, never how it was
-    computed. The tail follows the rows' real state, which a click may have
-    changed: the rows open on their own only on a rising edge.
+    It states what the GPUs read, low to high, and leaves the reading to
+    the person or to the diagnosis engine. An earlier version said "1 of 4
+    GPUs busy, 3 idle" off a 20 % bar invented here, while the engine calls
+    anything under 30 % low (``GPUUtilizationBands``): one page, two
+    thresholds, and a word this layer had no standing to say. The trigger
+    that opens the rows is unchanged and stays off the screen. The tail
+    follows the rows' real state, which a click may have changed.
     """
     utils = []
     for g in gpus:
@@ -124,15 +121,8 @@ def disclosure_text(
     tail = " · click to close" if is_open else " · click to open"
     if n == 1:
         return "1 GPU" + tail
-    if over:
-        idle = sum(1 for u in utils if u < IDLE_UTIL_PCT)
-        if idle:
-            head = f"{n - idle} of {n} GPUs busy, {idle} idle"
-        else:
-            head = "uneven load across GPUs"
-    else:
-        head = f"all {n} GPUs alike"
-    return head + tail
+    lo, hi = min(utils), max(utils)
+    return f"{n} GPUs · util {lo:.0f} to {hi:.0f}%" + tail
 
 
 def node_scope_text(ctx: Dict[str, Any]) -> str:
@@ -824,6 +814,6 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
         panel["rows"].value = True
     panel["_over"] = over
     panel["rows_hint"].text = disclosure_text(
-        gpus, over=over, is_open=bool(panel["rows"].value)
+        gpus, is_open=bool(panel["rows"].value)
     )
     panel["rows_html"].content = rows_html(gpus, pseries, spread=spread)

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -733,17 +733,26 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
             refs = []
             if limit is not None:
                 refs.append(
-                    (float(limit), f"{float(limit):.0f} W limit", _LIMIT_RED)
+                    (
+                        float(limit),
+                        f"{float(limit):.0f} W limit",
+                        _LIMIT_RED,
+                        "insideEndTop",
+                    )
                 )
             floor_w = gp.get("floor")
             if floor_w is not None and (
                 limit is None or float(floor_w) < float(limit) * 0.9
             ):
+                # Opposite corner from the limit, and below its own line,
+                # where the chart is empty: the two labels would otherwise
+                # stack at the right edge and the longer one be cut off.
                 refs.append(
                     (
                         float(floor_w),
                         f"{float(floor_w):.0f} W lowest seen",
                         _FLOOR_GREY,
+                        "insideStartBottom",
                     )
                 )
             lines[0]["markLine"] = (

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -1,28 +1,340 @@
-"""System metrics — CPU/GPU utilization time-series + a GPU-util gauge (PR2).
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
 
-Two subscribers on the same System payload (the driver's multi-subscriber
-registry): the dual-line chart card and the gauge card. Payload unchanged.
+"""
+System block: the host and its GPUs, as four tiles, two charts and rows.
+
+Tiles (one plain number each): GPU utilisation = across-GPU average, a
+short-window median; GPU memory = the max-used GPU against its capacity;
+GPU temperature = the hottest GPU; host RAM = used against total. Levels
+always carry their denominator, rates carry the estimator in words.
+
+Charts: GPU power per GPU against the board limit (power is the one system
+metric that moves on every run), and host CPU as a small zero-anchored
+series (its shape drifts over long runs). Both label their gridlines and
+their window span, and neither narrates its mechanism.
+
+Rows: one line per GPU behind a disclosure that opens on its own when the
+across-GPU utilisation spread crosses ``SPREAD_EXPAND_PTS``. The average
+describes the node; the rows are what make it honest when one GPU of four
+is busy, so the two are one design, not two.
+
+No verdict words anywhere: judgement comes from the diagnosis engine or it
+does not appear.
 """
 
 from __future__ import annotations
 
+import math
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from nicegui import ui
 
 from . import theme
 
+# Across-GPU utilisation spread (max - min, percentage points, window p95)
+# above which the per-GPU rows open on their own. Measured separation on
+# the reference runs is 0 (all busy) vs 100 (one busy of four).
+SPREAD_EXPAND_PTS = 20.0
 
-def _to_ms(s: str) -> Optional[int]:
-    try:
-        return int(datetime.fromisoformat(s).timestamp() * 1000)
-    except Exception:
-        return None
+_GPU_COLORS = (
+    "#f97316",
+    "#3b82f6",
+    "#10b981",
+    "#a855f7",
+    "#0d9488",
+    "#0ea5e9",
+    "#eab308",
+    "#ec4899",
+)
+_LIMIT_RED = "#dc2626"
+_MONO = "font-family:var(--mono);"
 
 
+# --- pure display rules ----------------------------------------------------
+def gpu_color(index: int) -> str:
+    return _GPU_COLORS[int(index) % len(_GPU_COLORS)]
+
+
+def format_span(seconds: Optional[float]) -> str:
+    """The window a chart covers, as one phrase in its label: 'last 3 min'."""
+    if not seconds or seconds <= 0:
+        return ""
+    if seconds < 90:
+        return f"last {seconds:.0f} s"
+    return f"last {seconds / 60.0:.0f} min"
+
+
+# Per-GPU utilisation below this reads as idle in the rows' header.
+IDLE_UTIL_PCT = 20.0
+
+
+def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
+    """A level against its capacity: ('6.3', '/ 16.1 GB')."""
+    used = theme.gb(used_bytes) if used_bytes is not None else None
+    if used is None:
+        return (NA, "")
+    num = f"{used:.1f}"
+    total = theme.gb(total_bytes) if total_bytes is not None else None
+    if total is None or total <= 0:
+        return (num, "GB")
+    total_s = f"{total:.0f}" if total >= 100 else f"{total:.1f}"
+    return (num, f"/ {total_s} GB")
+
+
+def disclosure_text(
+    gpus: List[Dict[str, Any]], *, over: bool, is_open: bool
+) -> str:
+    """Header of the per-GPU rows, in GPU words: what the user needs to know.
+
+    ``over`` is the trigger's verdict (the across-GPU spread crossed the
+    bar); the words say what that means on this node, never how it was
+    computed. The tail follows the rows' real state, which a click may have
+    changed: the rows open on their own only on a rising edge.
+    """
+    utils = []
+    for g in gpus:
+        u = g.get("util_p50")
+        if u is None:
+            u = g.get("util_now")
+        if u is not None:
+            utils.append(float(u))
+    n = len(utils)
+    if n == 0:
+        return ""
+    tail = " · click to close" if is_open else " · click to open"
+    if n == 1:
+        return "1 GPU" + tail
+    if over:
+        idle = sum(1 for u in utils if u < IDLE_UTIL_PCT)
+        if idle:
+            head = f"{n - idle} of {n} GPUs busy, {idle} idle"
+        else:
+            head = "uneven load across GPUs"
+    else:
+        head = f"all {n} GPUs alike"
+    return head + tail
+
+
+def node_scope_text(ctx: Dict[str, Any]) -> str:
+    """'node 0 of 2' when the payload dropped other machines, else ''.
+
+    Reads only the System payload's own ``system_node`` (the hosts seen in
+    this window); the strip's node count lives on the CONTEXT payload and
+    is not this block's to read.
+    """
+    node = ctx.get("system_node") if isinstance(ctx, dict) else None
+    if not isinstance(node, dict):
+        return ""
+    in_window = int(node.get("nodes_in_window") or 1)
+    if in_window <= 1:
+        return ""
+    rank = node.get("node_rank")
+    label = f"node {rank}" if rank is not None else node.get("hostname", "")
+    return f"{label} of {in_window}"
+
+
+def should_auto_open(*, prev_over: bool, over: bool) -> bool:
+    """Open on the rising edge only: never fight a user who closed it."""
+    return bool(over and not prev_over)
+
+
+def power_axis_bounds(
+    values: List[Optional[float]], limit: Optional[float]
+) -> Tuple[float, float, float]:
+    """(min, max, tick) in round watts that keep data and limit in frame.
+
+    At most four intervals of a round size (10 / 20 / 25 / 50 W), the
+    bounds multiples of it, so labels read 40 / 60 / 80 / 100 / 120 and
+    never 20 / 50 / 110.
+    """
+    vals = [float(v) for v in values if v is not None]
+    if limit is not None:
+        vals.append(float(limit))
+    if not vals:
+        return (0.0, 100.0, 50.0)
+    low = max(0.0, min(vals) - 5.0)
+    high = max(vals) + 5.0
+    for tick in (10.0, 20.0, 25.0, 50.0, 100.0, 250.0, 500.0):
+        lo = math.floor(low / tick) * tick
+        hi = math.ceil(high / tick) * tick
+        if hi <= lo:
+            hi = lo + tick
+        if (hi - lo) / tick <= 4:
+            return (lo, hi, tick)
+    return (lo, hi, tick)
+
+
+def cpu_axis_max(values: List[Any]) -> float:
+    """Zero-anchored ceiling whose half is a whole percent (0 / 5 / 10)."""
+    vals = [float(v) for v in values if v is not None]
+    peak = (max(vals) * 1.2) if vals else 0.0
+    for top in (4.0, 10.0, 20.0, 30.0, 40.0, 60.0, 80.0, 100.0):
+        if peak <= top:
+            return top
+    return 100.0
+
+
+def sparkline_svg(
+    values: List[Optional[float]],
+    color: str,
+    *,
+    width: int = 64,
+    height: int = 14,
+) -> str:
+    """Inline SVG polyline; gaps are dropped, an empty trace is no SVG."""
+    points = [(i, float(v)) for i, v in enumerate(values) if v is not None]
+    if not points:
+        return ""
+    lo = min(v for _, v in points)
+    hi = max(v for _, v in points)
+    span = (hi - lo) or 1.0
+    step = width / max(len(values) - 1, 1)
+    inner = height - 4
+    coords = " ".join(
+        f"{i * step:.1f},{1 + inner - (v - lo) / span * inner:.1f}"
+        for i, v in points
+    )
+    return (
+        f'<svg viewBox="0 0 {width} {height}" '
+        f'style="width:{width}px;height:{height}px;vertical-align:middle">'
+        f'<polyline points="{coords}" fill="none" stroke="{color}" '
+        'stroke-width="1.4"/></svg>'
+    )
+
+
+def odd_ones_out(gpus: List[Dict[str, Any]]) -> set:
+    """GPU indices on the smaller side of the utilisation split.
+
+    Split at the midpoint between the highest and lowest per-GPU window
+    median; the smaller group is the anomaly (ties go to the busy side,
+    which keeps the 1-busy-of-N reference shape tinting the busy GPU).
+    """
+    utils = []
+    for g in gpus:
+        u = g.get("util_p50")
+        if u is None:
+            u = g.get("util_now")
+        if u is not None:
+            utils.append((int(g.get("gpu_idx", 0)), float(u)))
+    if len(utils) < 2:
+        return set()
+    lo = min(u for _, u in utils)
+    hi = max(u for _, u in utils)
+    if hi <= lo:
+        return set()
+    mid = (hi + lo) / 2.0
+    high = {i for i, u in utils if u > mid}
+    low = {i for i, u in utils if u <= mid}
+    return high if len(high) <= len(low) else low
+
+
+# Absent value marker. "n/a" rather than a dash: the Process card on the
+# same page already reads "N/A", and one page should not spell absence two
+# ways.
+NA = "n/a"
+
+
+def _num(value: Any, fmt: str = "{:.0f}") -> str:
+    return fmt.format(float(value)) if value is not None else NA
+
+
+def rows_html(
+    gpus: List[Dict[str, Any]],
+    power_series: List[Dict[str, Any]],
+    *,
+    spread: Optional[float],
+) -> str:
+    """Per-GPU table: util (window median), power trend, mem, temp, W/limit.
+
+    When the spread is over the bar, the rows on the minority side of it
+    are tinted so the eye lands on the odd ones out: the one busy GPU of
+    four, or the one idle GPU of four. Absent values read as a dash,
+    never as a zero.
+    """
+    series_by_idx = {
+        int(p.get("gpu_idx", -1)): p.get("values") or []
+        for p in power_series or []
+    }
+    over = spread is not None and spread > SPREAD_EXPAND_PTS
+    marked = odd_ones_out(gpus) if over else set()
+    head = (
+        "<tr><th>gpu</th><th>util</th><th>power trend</th>"
+        "<th>mem GB</th><th>temp °C</th><th>W / limit</th></tr>"
+    )
+    rows = []
+    for g in gpus:
+        idx = int(g.get("gpu_idx", 0))
+        color = gpu_color(idx)
+        used, total = g.get("mem_used"), g.get("mem_total")
+        if used is not None and total:
+            mem = f"{theme.gb(used):.2f} / {theme.gb(total):.1f}"
+        elif used is not None:
+            mem = f"{theme.gb(used):.2f}"
+        else:
+            mem = NA
+        power, limit = g.get("power"), g.get("power_limit")
+        if power is not None and limit:
+            watts = f"{power:.0f} / {limit:.0f}"
+        elif power is not None:
+            watts = f"{power:.0f} W"
+        else:
+            watts = NA
+        util = g.get("util_p50")
+        if util is None:
+            util = g.get("util_now")
+        cls = ' class="tml-mark"' if idx in marked else ""
+        rows.append(
+            f"<tr{cls}>"
+            f'<td><span style="color:{color}">■</span> gpu{idx}</td>'
+            f'<td class="tml-util">{_num(util)}</td>'
+            f"<td>{sparkline_svg(series_by_idx.get(idx, []), color)}</td>"
+            f"<td>{mem}</td><td>{_num(g.get('temp'))}</td><td>{watts}</td>"
+            "</tr>"
+        )
+    return f'<table class="tml-gpus">{head}{"".join(rows)}</table>'
+
+
+# --- relative time axis ----------------------------------------------------
+def _relative_seconds(x_time: List[str]) -> List[Optional[float]]:
+    """Seconds before the newest sample (<= 0), aligned with ``x_time``."""
+    stamps: List[Optional[float]] = []
+    for s in x_time:
+        try:
+            stamps.append(datetime.fromisoformat(s).timestamp())
+        except Exception:
+            stamps.append(None)
+    present = [t for t in stamps if t is not None]
+    if not present:
+        return []
+    last = max(present)
+    return [t - last if t is not None else None for t in stamps]
+
+
+def _apply_span_axis(axis: Dict[str, Any], span: float) -> None:
+    """Pin the axis to the window; the span itself is said in the label
+    row ('last 3 min'), not as axis furniture."""
+    span = max(float(span), 1.0)
+    axis["min"] = -span
+    axis["max"] = 0
+    axis["interval"] = span
+    axis["axisLabel"]["show"] = False
+
+
+# --- build / update --------------------------------------------------------
 def build_system_section() -> Dict[str, Any]:
-    kpis: Dict[str, Any] = {}
+    panel: Dict[str, Any] = {
+        "tiles": {},
+        "subs": {},
+        "tile_els": {},
+        "gpu_visible": True,
+        "_over": False,
+        "_sig": None,
+    }
     card = ui.element("div").classes("glass reveal")
     card.style(
         "padding:18px 20px; width:100%; height:100%; "
@@ -32,126 +344,281 @@ def build_system_section() -> Dict[str, Any]:
         with (
             ui.row()
             .classes("w-full items-center")
-            .style("margin-bottom:8px; gap:12px;")
+            .style("margin-bottom:10px; gap:12px;")
         ):
             ui.label("System").classes("ctitle")
-            for nm, col in [("CPU", theme.C_CPU), ("GPU", theme.C_GPU)]:
-                with ui.element("div").classes("legchip"):
-                    ui.element("div").classes("legdot").style(
-                        f"background:{col};"
-                    )
-                    ui.label(nm)
             ui.element("div").style("flex:1;")
-            win = ui.label("waiting for data").classes("cmeta")
-        chart = ui.echart(theme.dual_line_options("CPU", "GPU")).style(
-            "height:210px; width:100%; flex:1; min-height:170px;"
-        )
+            panel["note"] = ui.label("waiting for data").classes("cmeta")
+
         with (
             ui.row()
             .classes("w-full")
-            .style("gap:9px; margin-top:12px; flex-wrap:wrap;")
+            .style("gap:9px; flex-wrap:wrap; margin-bottom:10px;")
         ):
-            for key, lab, acc, qual in [
-                ("cpu", "CPU", theme.C_CPU, "now"),
-                ("ram", "RAM", theme.C_CPU, "now"),
-                ("gmem", "GPU MEM", theme.C_GPU, "worst gpu"),
-                ("gtemp", "GPU TEMP", theme.C_GPU, "hottest"),
-            ]:
-                with (
+            for key, label, acc in (
+                ("util", "gpu util", theme.C_GPU),
+                ("mem", "gpu mem", theme.C_GPU),
+                ("temp", "gpu temp", theme.C_GPU),
+                ("ram", "host ram", theme.C_CPU),
+            ):
+                tile = (
                     ui.element("div")
                     .classes("kpi")
-                    .style(f"--acc:{acc}; min-width:104px;")
-                ):
-                    ui.html(
-                        f"{lab} <span class='kq'>{qual}</span>",
-                        sanitize=False,
-                    ).classes("klab")
-                    kpis[key] = ui.html("—", sanitize=False).classes("kval")
-    return {"chart": chart, "win": win, "kpis": kpis}
+                    .style(
+                        f"--acc:{acc}; flex:1 1 0; min-width:112px; "
+                        "max-width:320px;"
+                    )
+                )
+                with tile:
+                    ui.label(label).classes("klab")
+                    panel["tiles"][key] = ui.html(NA, sanitize=False).classes(
+                        "kval"
+                    )
+                    panel["subs"][key] = ui.label("").classes("ksub")
+                panel["tile_els"][key] = tile
+
+        with (
+            ui.row()
+            .classes("w-full items-baseline")
+            .style("gap:8px; margin:2px 0 2px;")
+        ):
+            panel["cpu_label"] = ui.label("host cpu %").classes("estlabel")
+            ui.element("div").style("flex:1;")
+            panel["cpu_value"] = ui.label("").style(
+                f"{_MONO} font-size:13px; font-weight:600; color:var(--ink);"
+            )
+        panel["cpu_chart"] = ui.echart(
+            theme.span_line_options(theme.C_CPU, "%")
+        ).style("height:92px; width:100%;")
+
+        panel["power_head"] = (
+            ui.row()
+            .classes("w-full items-baseline")
+            .style("gap:8px; margin:8px 0 2px;")
+        )
+        with panel["power_head"]:
+            panel["power_label"] = ui.label("gpu power · per GPU").classes(
+                "estlabel"
+            )
+        panel["power_chart"] = ui.echart(theme.multi_line_options(" W")).style(
+            "height:150px; width:100%;"
+        )
+        # Same slot, same height, when there is no GPU: the card keeps its
+        # shape on every host instead of shrinking around a missing chart.
+        panel["power_placeholder"] = ui.label("no GPU reported").style(
+            f"{_MONO} font-size:11px; color:var(--muted); height:150px; "
+            "width:100%; display:none; align-items:center; "
+            "justify-content:center;"
+        )
+
+        exp = (
+            ui.expansion()
+            .classes("w-full tml-exp")
+            .props("dense expand-icon-class=text-grey-6")
+            .style("margin-top:6px;")
+        )
+        with exp.add_slot("header"):
+            with (
+                ui.row()
+                .classes("w-full items-center")
+                .style("gap:10px; min-width:0;")
+            ):
+                ui.label("per-GPU rows").style(
+                    f"{_MONO} font-size:11px; font-weight:600; "
+                    "color:var(--ink);"
+                )
+                panel["rows_hint"] = ui.label("").classes("cmeta")
+        with exp:
+            panel["rows_html"] = ui.html("", sanitize=False).classes("w-full")
+        panel["rows"] = exp
+        panel["rows_placeholder"] = ui.label("per-GPU rows · no GPU").style(
+            f"{_MONO} font-size:11px; color:var(--muted); margin-top:6px; "
+            "padding:4px 2px; display:none;"
+        )
+    return panel
+
+
+def _set_gpu_visible(panel: Dict[str, Any], visible: bool) -> None:
+    if panel.get("gpu_visible") == visible:
+        return
+    panel["gpu_visible"] = visible
+    # Every slot keeps its place and height on every host (one shape to
+    # learn); the GPU slots show their one-line state instead of vanishing.
+    disp = "block" if visible else "none"
+    panel["power_chart"].style(f"display:{disp};")
+    panel["power_placeholder"].style(
+        f"display:{'none' if visible else 'flex'};"
+    )
+    panel["rows"].style(f"display:{disp};")
+    panel["rows_placeholder"].style(
+        f"display:{'none' if visible else 'block'};"
+    )
 
 
 def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
     if not isinstance(data, dict):
         return
+    roll = data.get("rollups", {}) or {}
     series = data.get("series", {}) or {}
-    roll = data.get("rollups", {}) or {}
-    xs = series.get("x_time", []) or []
+    gpu_on = bool(data.get("gpu_available") or roll.get("gpu_available"))
+    _set_gpu_visible(panel, gpu_on)
+
+    x_time = series.get("x_time", []) or []
+    secs = _relative_seconds(x_time)
+    present = [s for s in secs if s is not None]
+    span = -min(present) if present else 0.0
+
+    # The UI timer runs faster than the data arrives; re-sending a full
+    # chart options dict for an unchanged window is pure websocket
+    # traffic, so the charts only update when the window moved.
+    gp = roll.get("gpu_power", {}) or {}
+    limit = gp.get("limit")
+    pseries = series.get("gpu_power", []) or []
+    sig = (
+        x_time[-1] if x_time else None,
+        data.get("window_len"),
+        len(pseries),
+        limit,
+        gpu_on,
+    )
+    changed = sig != panel.get("_sig")
+    panel["_sig"] = sig
+
+    # Host CPU: a small zero-anchored series, the window median as its
+    # one number.
     cpu = series.get("cpu", []) or []
-    gpu = series.get("gpu_avg", []) or []
-    xms = [_to_ms(s) for s in xs]
-    chart = panel["chart"]
-    chart.options["series"][0]["data"] = [
-        [t, v] for t, v in zip(xms, cpu) if t is not None
-    ]
-    chart.options["series"][1]["data"] = (
-        [[t, v] for t, v in zip(xms, gpu) if t is not None] if gpu else []
+    chart = panel["cpu_chart"]
+    if changed:
+        chart.options["series"][0]["data"] = [
+            [s, v] for s, v in zip(secs, cpu) if s is not None
+        ]
+        _apply_span_axis(chart.options["xAxis"], span)
+        ymax = cpu_axis_max(cpu)
+        chart.options["yAxis"]["max"] = ymax
+        chart.options["yAxis"]["interval"] = ymax / 2.0
+        chart.update()
+    cpu_p50 = (roll.get("cpu", {}) or {}).get("p50")
+    panel["cpu_value"].text = f"{cpu_p50:.0f}%" if cpu_p50 is not None else ""
+
+    # Host RAM: a level against its capacity.
+    ram = roll.get("ram", {}) or {}
+    num, rest = format_gb_pair(ram.get("now"), ram.get("total"))
+    panel["tiles"]["ram"].content = theme.kval(num, f" {rest}" if rest else "")
+    panel["subs"]["ram"].text = "used / total"
+
+    notes = []
+    node_note = node_scope_text(roll.get("ctx", {}) or {})
+    if node_note:
+        notes.append(node_note)
+    if not data.get("window_len"):
+        notes.append("waiting for data")
+    panel["note"].text = " · ".join(notes)
+    span_words = format_span(span)
+    panel["cpu_label"].text = (
+        f"host cpu % · {span_words}" if span_words else "host cpu %"
     )
-    ymax = theme.nice_ymax(list(cpu) + list(gpu))
-    chart.options["yAxis"][0]["max"] = ymax
-    chart.options["yAxis"][1]["max"] = ymax
-    chart.update()
-
-    wl = data.get("window_len", 0)
-    panel["win"].text = f"last {wl} samples" if wl else "waiting for data"
-    k = panel["kpis"]
-    c = roll.get("cpu", {}) or {}
-    r = roll.get("ram", {}) or {}
-    k["cpu"].content = theme.kval(f"{c.get('now', 0):.0f}", "%")
-    ram_now = theme.gb(r.get("now"))
-    k["ram"].content = theme.kval(
-        f"{ram_now:.2f}" if ram_now is not None else "—", "GB"
-    )
-    if roll.get("gpu_available", False):
-        gm = theme.gb((roll.get("gpu_mem", {}) or {}).get("now"))
-        gt = (roll.get("temp", {}) or {}).get("now", 0)
-        k["gmem"].content = theme.kval(
-            f"{gm:.2f}" if gm is not None else "—", "GB"
+    if not gpu_on:
+        seen = bool(data.get("window_len"))
+        for key in ("util", "mem", "temp"):
+            panel["tiles"][key].content = NA
+            panel["subs"][key].text = "no GPU" if seen else ""
+        panel["power_label"].text = "gpu power"
+        panel["power_placeholder"].text = (
+            "no GPU reported" if seen else "waiting for data"
         )
-        k["gtemp"].content = theme.kval(f"{gt:.0f}", "°C")
-    else:
-        k["gmem"].content = "N/A"
-        k["gtemp"].content = "N/A"
-
-
-# --- GPU utilization gauge (second subscriber on the System payload) ------
-def build_gpu_gauge_section() -> Dict[str, Any]:
-    card = ui.element("div").classes("glass reveal")
-    card.style(
-        "padding:18px 20px; width:100%; height:100%; "
-        "display:flex; flex-direction:column; overflow:hidden;"
-    )
-    with card:
-        ui.html(
-            "GPU utilization <span class='kq'>avg · now</span>",
-            sanitize=False,
-        ).classes("ctitle")
-        chart = ui.echart(theme.gauge_options()).style(
-            "height:180px; width:100%; flex:1; min-height:150px;"
+        panel["rows_placeholder"].text = (
+            "per-GPU rows · no GPU" if seen else "per-GPU rows"
         )
-        sub = ui.label("").style(
-            "font-family:var(--mono); font-size:11px; color:var(--muted); "
-            "text-align:center; margin-top:-4px;"
-        )
-    return {"chart": chart, "sub": sub}
-
-
-def update_gpu_gauge_section(
-    panel: Dict[str, Any], data: Dict[str, Any]
-) -> None:
-    if not isinstance(data, dict):
         return
-    roll = data.get("rollups", {}) or {}
-    chart = panel["chart"]
-    if roll.get("gpu_available", False):
-        gu = (roll.get("gpu_util", {}) or {}).get("now", 0)
-        gm = theme.gb((roll.get("gpu_mem", {}) or {}).get("now"))
-        gt = (roll.get("temp", {}) or {}).get("now", 0)
-        chart.options["series"][0]["data"][0]["value"] = float(gu)
-        chart.update()
-        panel["sub"].text = (
-            f"{gm:.1f} GB · {gt:.0f}°C" if gm is not None else f"{gt:.0f}°C"
-        )
+
+    gpus = roll.get("gpus", []) or []
+    n_gpus = len(gpus) or int((roll.get("ctx", {}) or {}).get("gpu_count", 0))
+    # Every GPU unreported on the newest tick (the sampler's all-zero
+    # fallback): the level tiles say so instead of printing zeros.
+    unreported = bool(gpus) and all(
+        g.get("mem_total") is None and g.get("power") is None for g in gpus
+    )
+
+    util_p50 = (roll.get("gpu_util", {}) or {}).get("p50")
+    panel["tiles"]["util"].content = theme.kval(_num(util_p50), "%")
+    panel["subs"]["util"].text = (
+        f"avg of {n_gpus} GPUs" if n_gpus != 1 else "1 GPU"
+    )
+
+    gm = roll.get("gpu_mem", {}) or {}
+    if unreported:
+        panel["tiles"]["mem"].content = NA
+        panel["subs"]["mem"].text = "GPU sample unreported"
+        panel["tiles"]["temp"].content = NA
+        panel["subs"]["temp"].text = "GPU sample unreported"
     else:
-        chart.options["series"][0]["data"][0]["value"] = 0
-        chart.update()
-        panel["sub"].text = "no GPU"
+        num, rest = format_gb_pair(gm.get("now"), gm.get("total"))
+        panel["tiles"]["mem"].content = theme.kval(
+            num, f" {rest}" if rest else ""
+        )
+        panel["subs"]["mem"].text = (
+            "max GPU" if n_gpus != 1 else "used / total"
+        )
+        temp_now = (roll.get("temp", {}) or {}).get("now")
+        panel["tiles"]["temp"].content = theme.kval(_num(temp_now), " °C")
+        panel["subs"]["temp"].text = "max GPU" if n_gpus != 1 else ""
+
+    # GPU power per GPU against the board limit.
+    flat = [v for p in pseries for v in (p.get("values") or [])]
+    pchart = panel["power_chart"]
+    if not any(v is not None for v in flat):
+        pchart.style("display:none;")
+        panel["power_label"].text = "gpu power · not reported"
+    elif changed:
+        lines = []
+        for p in pseries:
+            idx = int(p.get("gpu_idx", 0))
+            lines.append(
+                theme.line_series(
+                    f"gpu{idx}",
+                    gpu_color(idx),
+                    [
+                        [s, v]
+                        for s, v in zip(secs, p.get("values") or [])
+                        if s is not None
+                    ],
+                )
+            )
+        if lines:
+            # An explicit empty markLine clears a previous limit line:
+            # ECharts merges options, so omitting the key would keep it.
+            lines[0]["markLine"] = (
+                theme.limit_mark_line(
+                    float(limit), f"{float(limit):.0f} W limit", _LIMIT_RED
+                )
+                if limit is not None
+                else {"data": []}
+            )
+        pchart.options["series"] = lines
+        lo, hi, tick = power_axis_bounds(flat, limit)
+        pchart.options["yAxis"]["min"] = lo
+        pchart.options["yAxis"]["max"] = hi
+        pchart.options["yAxis"]["interval"] = tick
+        _apply_span_axis(pchart.options["xAxis"], span)
+        pchart.style("display:block;")
+        pchart.update()
+        head = (
+            f"gpu power · per GPU vs {float(limit):.0f} W limit"
+            if limit is not None
+            else "gpu power · per GPU"
+        )
+        panel["power_label"].text = (
+            f"{head} · {span_words}" if span_words else head
+        )
+
+    # Per-GPU rows, opened by the spread on its rising edge; the hint
+    # follows the rows' real state, which a click may have changed.
+    spread = (roll.get("gpu_delta", {}) or {}).get("p95")
+    over = spread is not None and float(spread) > SPREAD_EXPAND_PTS
+    if should_auto_open(prev_over=panel["_over"], over=over):
+        panel["rows"].value = True
+    panel["_over"] = over
+    panel["rows_hint"].text = disclosure_text(
+        gpus, over=over, is_open=bool(panel["rows"].value)
+    )
+    panel["rows_html"].content = rows_html(gpus, pseries, spread=spread)

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -350,11 +350,7 @@ def build_system_section() -> Dict[str, Any]:
             ui.element("div").style("flex:1;")
             panel["note"] = ui.label("waiting for data").classes("cmeta")
 
-        with (
-            ui.row()
-            .classes("w-full")
-            .style("gap:9px; flex-wrap:wrap; margin-bottom:10px;")
-        ):
+        with ui.element("div").classes("tilerow").style("margin-bottom:10px;"):
             for key, label, acc in (
                 ("util", "gpu util", theme.C_GPU),
                 ("mem", "gpu mem", theme.C_GPU),
@@ -364,10 +360,7 @@ def build_system_section() -> Dict[str, Any]:
                 tile = (
                     ui.element("div")
                     .classes("kpi")
-                    .style(
-                        f"--acc:{acc}; flex:1 1 0; min-width:112px; "
-                        "max-width:320px;"
-                    )
+                    .style(f"--acc:{acc}; min-width:0;")
                 )
                 with tile:
                     ui.label(label).classes("klab")
@@ -541,8 +534,9 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
 
     util_p50 = (roll.get("gpu_util", {}) or {}).get("p50")
     panel["tiles"]["util"].content = theme.kval(_num(util_p50), "%")
+    one_gpu = n_gpus == 1
     panel["subs"]["util"].text = (
-        f"avg of {n_gpus} GPUs" if n_gpus != 1 else "1 GPU"
+        "1 GPU" if one_gpu else f"avg of {n_gpus} GPUs"
     )
 
     gm = roll.get("gpu_mem", {}) or {}
@@ -556,12 +550,12 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
         panel["tiles"]["mem"].content = theme.kval(
             num, f" {rest}" if rest else ""
         )
-        panel["subs"]["mem"].text = (
-            "max GPU" if n_gpus != 1 else "used / total"
-        )
+        panel["subs"]["mem"].text = "used / total" if one_gpu else "max GPU"
         temp_now = (roll.get("temp", {}) or {}).get("now")
         panel["tiles"]["temp"].content = theme.kval(_num(temp_now), " °C")
-        panel["subs"]["temp"].text = "max GPU" if n_gpus != 1 else ""
+        # Never blank: an empty qualifier made this tile a line shorter
+        # than its neighbours on a single-GPU host.
+        panel["subs"]["temp"].text = "1 GPU" if one_gpu else "max GPU"
 
     # GPU power per GPU against the board limit.
     flat = [v for p in pseries for v in (p.get("values") or [])]

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -233,6 +233,21 @@ def odd_ones_out(gpus: List[Dict[str, Any]]) -> set:
     return high if len(high) <= len(low) else low
 
 
+# The host CPU series is psutil.cpu_percent(): the MEAN utilisation across
+# all logical cores, so 100% is every core saturated and one busy core of
+# ten reads 10%. Measured 2026-08-21 on a 10-core box with one core
+# spinning: cpu_percent() == mean(percpu) == 36.6%, sum(percpu) == 366.5%.
+# The wording mirrors the GPU tile's "avg of 4 GPUs", and it has to be
+# explicit because the Process block on the same page reports PER-RANK cpu
+# from psutil.Process.cpu_percent(), which sums across cores and can pass
+# 100%. (The sampler reads psutil.cpu_count() but never puts it on the
+# wire; carrying it would let this read "avg of 10 cores".)
+CPU_LABEL = "host cpu util · avg across cores"
+
+# A run longer than the window by this factor is charted whole rather than
+# as its last 100 samples; below it, the window IS the whole run.
+RUN_VIEW_FACTOR = 1.2
+
 # Absent value marker. "n/a" rather than a dash: the Process card on the
 # same page already reads "N/A", and one page should not spell absence two
 # ways.
@@ -375,7 +390,7 @@ def build_system_section() -> Dict[str, Any]:
             .classes("w-full items-baseline")
             .style("gap:8px; margin:2px 0 2px;")
         ):
-            panel["cpu_label"] = ui.label("host cpu %").classes("estlabel")
+            panel["cpu_label"] = ui.label(CPU_LABEL).classes("estlabel")
             ui.element("div").style("flex:1;")
             panel["cpu_value"] = ui.label("").style(
                 f"{_MONO} font-size:13px; font-weight:600; color:var(--ink);"
@@ -383,6 +398,13 @@ def build_system_section() -> Dict[str, Any]:
         panel["cpu_chart"] = ui.echart(
             theme.span_line_options(theme.C_CPU, "%")
         ).style("height:92px; width:100%;")
+        # Faint upper trace: each slice's peak, so decimating the whole run
+        # cannot hide a spike.
+        panel["cpu_peak"] = theme.line_series(
+            "peak", theme.C_CPU, [], width=0.9
+        )
+        panel["cpu_peak"]["lineStyle"]["opacity"] = 0.3
+        panel["cpu_chart"].options["series"].append(panel["cpu_peak"])
 
         panel["power_head"] = (
             ui.row()
@@ -480,13 +502,32 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
     # Host CPU: a small zero-anchored series, the window median as its
     # one number.
     cpu = series.get("cpu", []) or []
+    run = series.get("cpu_run") or {}
+    run_t = run.get("t") or []
+    run_avg = run.get("avg") or []
+    run_max = run.get("max") or []
+    run_span = float(run.get("span_s") or 0.0)
+    cpu_whole = len(run_t) > 2 and run_span > span * RUN_VIEW_FACTOR
     chart = panel["cpu_chart"]
-    if changed:
+    peak = panel.get("cpu_peak")
+    if changed and cpu_whole:
+        newest = run_t[-1]
+        chart.options["series"][0]["data"] = [
+            [t - newest, v] for t, v in zip(run_t, run_avg)
+        ]
+        if peak is not None:
+            peak["data"] = [[t - newest, v] for t, v in zip(run_t, run_max)]
+        _apply_span_axis(chart.options["xAxis"], run_span)
+        ymax = cpu_axis_max(run_max)
+    elif changed:
         chart.options["series"][0]["data"] = [
             [s, v] for s, v in zip(secs, cpu) if s is not None
         ]
+        if peak is not None:
+            peak["data"] = []
         _apply_span_axis(chart.options["xAxis"], span)
         ymax = cpu_axis_max(cpu)
+    if changed:
         chart.options["yAxis"]["max"] = ymax
         chart.options["yAxis"]["interval"] = ymax / 2.0
         chart.update()
@@ -507,9 +548,14 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
         notes.append("waiting for data")
     panel["note"].text = " · ".join(notes)
     span_words = format_span(span)
-    panel["cpu_label"].text = (
-        f"host cpu % · {span_words}" if span_words else "host cpu %"
-    )
+    if cpu_whole:
+        panel["cpu_label"].text = (
+            f"{CPU_LABEL} · whole run, {format_span(run_span)[5:]}"
+        )
+    else:
+        panel["cpu_label"].text = (
+            f"{CPU_LABEL} · {span_words}" if span_words else CPU_LABEL
+        )
     if not gpu_on:
         seen = bool(data.get("window_len"))
         for key in ("util", "mem", "temp"):
@@ -559,25 +605,43 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
 
     # GPU power per GPU against the board limit.
     flat = [v for p in pseries for v in (p.get("values") or [])]
+    prun = series.get("gpu_power_run") or []
+    prun_span = float(prun[0].get("span_s") or 0.0) if prun else 0.0
+    power_whole = bool(prun) and prun_span > span * RUN_VIEW_FACTOR
     pchart = panel["power_chart"]
     if not any(v is not None for v in flat):
         pchart.style("display:none;")
         panel["power_label"].text = "gpu power · not reported"
     elif changed:
         lines = []
-        for p in pseries:
-            idx = int(p.get("gpu_idx", 0))
-            lines.append(
-                theme.line_series(
-                    f"gpu{idx}",
-                    gpu_color(idx),
-                    [
-                        [s, v]
-                        for s, v in zip(secs, p.get("values") or [])
-                        if s is not None
-                    ],
+        if power_whole:
+            # Each slice's PEAK, never its mean: averaging a 60-100 W
+            # sawtooth over 30 s collapses it to a flat ribbon and erases
+            # the peaks the limit line exists to be compared against.
+            newest = max(e["t"][-1] for e in prun if e.get("t"))
+            for e in prun:
+                idx = int(e.get("gpu_idx", 0))
+                lines.append(
+                    theme.line_series(
+                        f"gpu{idx}",
+                        gpu_color(idx),
+                        [[t - newest, v] for t, v in zip(e["t"], e["max"])],
+                    )
                 )
-            )
+        else:
+            for p in pseries:
+                idx = int(p.get("gpu_idx", 0))
+                lines.append(
+                    theme.line_series(
+                        f"gpu{idx}",
+                        gpu_color(idx),
+                        [
+                            [s, v]
+                            for s, v in zip(secs, p.get("values") or [])
+                            if s is not None
+                        ],
+                    )
+                )
         if lines:
             # An explicit empty markLine clears a previous limit line:
             # ECharts merges options, so omitting the key would keep it.
@@ -589,21 +653,32 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
                 else {"data": []}
             )
         pchart.options["series"] = lines
-        lo, hi, tick = power_axis_bounds(flat, limit)
+        bounds_src = (
+            [v for e in prun for v in e["max"]] if power_whole else flat
+        )
+        lo, hi, tick = power_axis_bounds(bounds_src, limit)
         pchart.options["yAxis"]["min"] = lo
         pchart.options["yAxis"]["max"] = hi
         pchart.options["yAxis"]["interval"] = tick
-        _apply_span_axis(pchart.options["xAxis"], span)
+        _apply_span_axis(
+            pchart.options["xAxis"], prun_span if power_whole else span
+        )
         pchart.style("display:block;")
         pchart.update()
+        per = "per GPU peak" if power_whole else "per GPU"
         head = (
-            f"gpu power · per GPU vs {float(limit):.0f} W limit"
+            f"gpu power · {per} vs {float(limit):.0f} W limit"
             if limit is not None
-            else "gpu power · per GPU"
+            else f"gpu power · {per}"
         )
-        panel["power_label"].text = (
-            f"{head} · {span_words}" if span_words else head
-        )
+        if power_whole:
+            panel["power_label"].text = (
+                f"{head} · whole run, {format_span(prun_span)[5:]}"
+            )
+        else:
+            panel["power_label"].text = (
+                f"{head} · {span_words}" if span_words else head
+            )
 
     # Per-GPU rows, opened by the spread on its rising edge; the hint
     # follows the rows' real state, which a click may have changed.

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -52,12 +52,27 @@ _GPU_COLORS = (
     "#ec4899",
 )
 _LIMIT_RED = "#dc2626"
+# The floor reference is deliberately not red: red belongs to the limit.
+_FLOOR_GREY = "#94a3b8"
 _MONO = "font-family:var(--mono);"
 
 
 # --- pure display rules ----------------------------------------------------
 def gpu_color(index: int) -> str:
     return _GPU_COLORS[int(index) % len(_GPU_COLORS)]
+
+
+def format_window(window_s: float) -> str:
+    """The rolling window in words: '30 s', '2 min'.
+
+    The payload picks round windows (see ``choose_window_s``) so this reads
+    as a duration a person recognises.
+    """
+    if not window_s or window_s <= 0:
+        return ""
+    if window_s < 60:
+        return f"{window_s:.0f} s"
+    return f"{window_s / 60.0:.0f} min"
 
 
 def format_span(seconds: Optional[float]) -> str:
@@ -315,6 +330,32 @@ def rows_html(
 
 
 # --- relative time axis ----------------------------------------------------
+def shared_run_axis(
+    run_t: List[float], prun: List[Dict[str, Any]]
+) -> Optional[Tuple[float, float]]:
+    """One (anchor, span) covering both whole-run series.
+
+    Returns the newest clock across the two and the reach back to the
+    oldest, so both charts can be pinned to the same interval.
+    """
+    starts = [run_t[0]] + [e["t"][0] for e in prun if e.get("t")]
+    ends = [run_t[-1]] + [e["t"][-1] for e in prun if e.get("t")]
+    if not starts or not ends:
+        return None
+    newest = max(ends)
+    return (newest, max(newest - min(starts), 1.0))
+
+
+def _newest_epoch(x_time: List[str]) -> Optional[float]:
+    """Epoch seconds of the newest parseable stamp, for the clock axis."""
+    for value in reversed(x_time):
+        try:
+            return datetime.fromisoformat(value).timestamp()
+        except Exception:
+            continue
+    return None
+
+
 def _relative_seconds(x_time: List[str]) -> List[Optional[float]]:
     """Seconds before the newest sample (<= 0), aligned with ``x_time``."""
     stamps: List[Optional[float]] = []
@@ -330,14 +371,32 @@ def _relative_seconds(x_time: List[str]) -> List[Optional[float]]:
     return [t - last if t is not None else None for t in stamps]
 
 
-def _apply_span_axis(axis: Dict[str, Any], span: float) -> None:
-    """Pin the axis to the window; the span itself is said in the label
-    row ('last 3 min'), not as axis furniture."""
+def _apply_span_axis(
+    axis: Dict[str, Any], span: float, newest_epoch: Optional[float] = None
+) -> None:
+    """Pin the axis to the window and label it in wall-clock time.
+
+    The x values are seconds before the newest sample, which keeps the
+    series arithmetic simple, but a reader debugging a slowdown needs the
+    clock: it is what their logs and every other dashboard are keyed on,
+    and it is what the Process card beside this one already shows. The
+    formatter converts on the fly from the newest sample's epoch.
+    """
     span = max(float(span), 1.0)
     axis["min"] = -span
     axis["max"] = 0
-    axis["interval"] = span
-    axis["axisLabel"]["show"] = False
+    axis["interval"] = span / 3.0
+    if newest_epoch is None:
+        axis["axisLabel"]["show"] = False
+        return
+    axis["axisLabel"]["show"] = True
+    seconds = "true" if span < 600 else "false"
+    axis["axisLabel"][":formatter"] = (
+        "v=>{const d=new Date((%f+v)*1000);"
+        "const p=n=>('0'+n).slice(-2);"
+        "return p(d.getHours())+':'+p(d.getMinutes())"
+        "+(%s?':'+p(d.getSeconds()):'');}" % (float(newest_epoch), seconds)
+    )
 
 
 # --- build / update --------------------------------------------------------
@@ -400,11 +459,6 @@ def build_system_section() -> Dict[str, Any]:
         ).style("height:92px; width:100%;")
         # Faint upper trace: each slice's peak, so decimating the whole run
         # cannot hide a spike.
-        panel["cpu_peak"] = theme.line_series(
-            "peak", theme.C_CPU, [], width=0.9
-        )
-        panel["cpu_peak"]["lineStyle"]["opacity"] = 0.3
-        panel["cpu_chart"].options["series"].append(panel["cpu_peak"])
 
         panel["power_head"] = (
             ui.row()
@@ -480,6 +534,7 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
 
     x_time = series.get("x_time", []) or []
     secs = _relative_seconds(x_time)
+    newest_epoch = _newest_epoch(x_time)
     present = [s for s in secs if s is not None]
     span = -min(present) if present else 0.0
 
@@ -508,24 +563,32 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
     run_max = run.get("max") or []
     run_span = float(run.get("span_s") or 0.0)
     cpu_whole = len(run_t) > 2 and run_span > span * RUN_VIEW_FACTOR
+    prun = series.get("gpu_power_run") or []
+    prun_span = float(prun[0].get("span_s") or 0.0) if prun else 0.0
+    power_whole = bool(prun) and prun_span > span * RUN_VIEW_FACTOR
+    # The two whole-run charts sit one above the other, so they share one
+    # anchor and one span: a dip in power and a rise in CPU at the same x
+    # are then the same moment. Their own spans differ by a window (the
+    # rolling mean drops its first partial window), which without this
+    # would offset the pair by a minute or two.
+    aligned = (
+        shared_run_axis(run_t, prun) if cpu_whole and power_whole else None
+    )
     chart = panel["cpu_chart"]
-    peak = panel.get("cpu_peak")
     if changed and cpu_whole:
-        newest = run_t[-1]
+        newest, axis_span = aligned or (run_t[-1], run_span)
         chart.options["series"][0]["data"] = [
             [t - newest, v] for t, v in zip(run_t, run_avg)
         ]
-        if peak is not None:
-            peak["data"] = [[t - newest, v] for t, v in zip(run_t, run_max)]
-        _apply_span_axis(chart.options["xAxis"], run_span)
-        ymax = cpu_axis_max(run_max)
+        _apply_span_axis(chart.options["xAxis"], axis_span, newest)
+        # Headroom from the peaks the rolling mean smooths away, so a
+        # spike is never drawn off the top of the chart.
+        ymax = cpu_axis_max(run_max or run_avg)
     elif changed:
         chart.options["series"][0]["data"] = [
             [s, v] for s, v in zip(secs, cpu) if s is not None
         ]
-        if peak is not None:
-            peak["data"] = []
-        _apply_span_axis(chart.options["xAxis"], span)
+        _apply_span_axis(chart.options["xAxis"], span, newest_epoch)
         ymax = cpu_axis_max(cpu)
     if changed:
         chart.options["yAxis"]["max"] = ymax
@@ -549,8 +612,16 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
     panel["note"].text = " · ".join(notes)
     span_words = format_span(span)
     if cpu_whole:
-        panel["cpu_label"].text = (
-            f"{CPU_LABEL} · whole run, {format_span(run_span)[5:]}"
+        win = format_window(float(run.get("window_s") or 0.0))
+        panel["cpu_label"].text = f"{CPU_LABEL} · whole run" + (
+            f" · rolling {win}" if win else ""
+        )
+        panel["cpu_label"].tooltip(
+            f"The whole run, {format_span(run_span)[5:]}. Each point is the "
+            f"average of the last {win} of samples, a rolling window, so a "
+            "slow drift over the run is visible instead of being hidden by "
+            "second-to-second noise. Host CPU is the mean across all "
+            "logical cores: 100% means every core busy."
         )
     else:
         panel["cpu_label"].text = (
@@ -605,79 +676,126 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
 
     # GPU power per GPU against the board limit.
     flat = [v for p in pseries for v in (p.get("values") or [])]
-    prun = series.get("gpu_power_run") or []
-    prun_span = float(prun[0].get("span_s") or 0.0) if prun else 0.0
-    power_whole = bool(prun) and prun_span > span * RUN_VIEW_FACTOR
     pchart = panel["power_chart"]
     if not any(v is not None for v in flat):
         pchart.style("display:none;")
         panel["power_label"].text = "gpu power · not reported"
     elif changed:
-        lines = []
         if power_whole:
-            # Each slice's PEAK, never its mean: averaging a 60-100 W
-            # sawtooth over 30 s collapses it to a flat ribbon and erases
-            # the peaks the limit line exists to be compared against.
-            newest = max(e["t"][-1] for e in prun if e.get("t"))
+            # Per GPU, two traces: each bucket's MEAN solid, its FLOOR
+            # faint below. Sustained draw against the limit says whether
+            # the GPU is being fed; a floor dropping to idle says it went
+            # idle inside that window, which is what a dataloader stall
+            # looks like in watts. Peak is deliberately not drawn: it
+            # saturates on any healthy work and separates nothing.
+            newest = (
+                aligned or (max(e["t"][-1] for e in prun if e.get("t")),)
+            )[0]
+            lines = []
             for e in prun:
                 idx = int(e.get("gpu_idx", 0))
+                xs = [t - newest for t in e["t"]]
+                floor_line = theme.line_series(
+                    f"gpu{idx} floor",
+                    gpu_color(idx),
+                    [[x, v] for x, v in zip(xs, e.get("min") or [])],
+                    width=0.9,
+                )
+                floor_line["lineStyle"]["opacity"] = 0.35
+                floor_line["tooltip"] = {"show": False}
+                lines.append(floor_line)
                 lines.append(
                     theme.line_series(
                         f"gpu{idx}",
                         gpu_color(idx),
-                        [[t - newest, v] for t, v in zip(e["t"], e["max"])],
+                        [[x, v] for x, v in zip(xs, e["avg"])],
                     )
                 )
         else:
-            for p in pseries:
-                idx = int(p.get("gpu_idx", 0))
-                lines.append(
-                    theme.line_series(
-                        f"gpu{idx}",
-                        gpu_color(idx),
-                        [
-                            [s, v]
-                            for s, v in zip(secs, p.get("values") or [])
-                            if s is not None
-                        ],
+            lines = [
+                theme.line_series(
+                    f"gpu{int(p.get('gpu_idx', 0))}",
+                    gpu_color(int(p.get("gpu_idx", 0))),
+                    [
+                        [s, v]
+                        for s, v in zip(secs, p.get("values") or [])
+                        if s is not None
+                    ],
+                )
+                for p in pseries
+            ]
+        if lines:
+            # Two reference lines: the board limit above, and the lowest
+            # draw seen in this run below (idle, on any run whose sampler
+            # was up before the first step). Between them is the band the
+            # GPU actually works in. An explicit empty markLine clears a
+            # previous one, since ECharts merges options.
+            refs = []
+            if limit is not None:
+                refs.append(
+                    (float(limit), f"{float(limit):.0f} W limit", _LIMIT_RED)
+                )
+            floor_w = gp.get("floor")
+            if floor_w is not None and (
+                limit is None or float(floor_w) < float(limit) * 0.9
+            ):
+                refs.append(
+                    (
+                        float(floor_w),
+                        f"{float(floor_w):.0f} W lowest seen",
+                        _FLOOR_GREY,
                     )
                 )
-        if lines:
-            # An explicit empty markLine clears a previous limit line:
-            # ECharts merges options, so omitting the key would keep it.
             lines[0]["markLine"] = (
-                theme.limit_mark_line(
-                    float(limit), f"{float(limit):.0f} W limit", _LIMIT_RED
-                )
-                if limit is not None
-                else {"data": []}
+                theme.mark_lines(refs) if refs else {"data": []}
             )
         pchart.options["series"] = lines
         bounds_src = (
-            [v for e in prun for v in e["max"]] if power_whole else flat
+            [v for e in prun for v in e["avg"] + (e.get("min") or [])]
+            if power_whole
+            else flat
         )
         lo, hi, tick = power_axis_bounds(bounds_src, limit)
         pchart.options["yAxis"]["min"] = lo
         pchart.options["yAxis"]["max"] = hi
         pchart.options["yAxis"]["interval"] = tick
-        _apply_span_axis(
-            pchart.options["xAxis"], prun_span if power_whole else span
-        )
+        if power_whole:
+            anchor, axis_span = aligned or (
+                max(e["t"][-1] for e in prun if e.get("t")),
+                prun_span,
+            )
+            _apply_span_axis(pchart.options["xAxis"], axis_span, anchor)
+        else:
+            _apply_span_axis(pchart.options["xAxis"], span, newest_epoch)
         pchart.style("display:block;")
         pchart.update()
-        per = "per GPU peak" if power_whole else "per GPU"
         head = (
-            f"gpu power · {per} vs {float(limit):.0f} W limit"
+            f"gpu power · per GPU vs {float(limit):.0f} W limit"
             if limit is not None
-            else f"gpu power · {per}"
+            else "gpu power · per GPU"
         )
         if power_whole:
-            panel["power_label"].text = (
-                f"{head} · whole run, {format_span(prun_span)[5:]}"
+            win = format_window(float(prun[0].get("window_s") or 0.0))
+            panel["power_label"].text = f"{head} · whole run" + (
+                f" · mean and floor of every {win}" if win else ""
+            )
+            panel["power_label"].tooltip(
+                f"The whole run, {format_span(prun_span)[5:]}. Per GPU, the "
+                f"solid line is the average watts over each {win} and the "
+                "faint line below it is the lowest reading in that same "
+                "window. Read them together: a mean far under the board "
+                "limit means the GPU is not being kept fed, and a floor "
+                "that drops toward idle means it went idle inside that "
+                "window, which is what a stalled input pipeline looks like "
+                "in watts."
             )
         else:
             panel["power_label"].text = (
                 f"{head} · {span_words}" if span_words else head
+            )
+            panel["power_label"].tooltip(
+                "The most recent samples, one point each, per GPU, against "
+                "the board's power limit."
             )
 
     # Per-GPU rows, opened by the spread on its rising edge; the hint

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -4,26 +4,15 @@
 # you may not use this file except in compliance with the License.
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-System block: the host and its GPUs, as four tiles, two charts and rows.
+"""System dashboard block: four resource tiles, two charts and GPU rows.
 
-Tiles (one plain number each): GPU utilisation = across-GPU average, a
-short-window median; GPU memory = the max-used GPU against its capacity;
-GPU temperature = the hottest GPU; host RAM = used against total. Levels
-always carry their denominator, rates carry the estimator in words.
+The tiles summarize GPU utilisation, memory and temperature plus host RAM.
+The CPU and GPU-power charts initially show recent raw samples. After the run
+outgrows that window, they use bounded whole-run series: rolling CPU values
+and fixed-duration GPU-power buckets. Both charts share a wall-clock axis.
 
-Charts: GPU power per GPU against the board limit (power is the one system
-metric that moves on every run), and host CPU as a small zero-anchored
-series (its shape drifts over long runs). Both label their gridlines and
-their window span, and neither narrates its mechanism.
-
-Rows: one line per GPU behind a disclosure that opens on its own when the
-across-GPU utilisation spread crosses ``SPREAD_EXPAND_PTS``. The average
-describes the node; the rows are what make it honest when one GPU of four
-is busy, so the two are one design, not two.
-
-No verdict words anywhere: judgement comes from the diagnosis engine or it
-does not appear.
+Per-GPU rows open when utilisation spread crosses ``SPREAD_EXPAND_PTS``.
+This section presents measurements and leaves verdicts to diagnostics.
 """
 
 from __future__ import annotations
@@ -36,9 +25,8 @@ from nicegui import ui
 
 from . import theme
 
-# Across-GPU utilisation spread (max - min, percentage points, window p95)
-# above which the per-GPU rows open on their own. Measured separation on
-# the reference runs is 0 (all busy) vs 100 (one busy of four).
+# Window-p95 GPU utilisation spread (max - min, percentage points) that
+# automatically opens the per-GPU rows.
 SPREAD_EXPAND_PTS = 20.0
 
 _GPU_COLORS = (
@@ -100,13 +88,8 @@ def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
 def disclosure_text(gpus: List[Dict[str, Any]], *, is_open: bool) -> str:
     """Header of the per-GPU rows: the utilisation range, and nothing else.
 
-    It states what the GPUs read, low to high, and leaves the reading to
-    the person or to the diagnosis engine. An earlier version said "1 of 4
-    GPUs busy, 3 idle" off a 20 % bar invented here, while the engine calls
-    anything under 30 % low (``GPUUtilizationBands``): one page, two
-    thresholds, and a word this layer had no standing to say. The trigger
-    that opens the rows is unchanged and stays off the screen. The tail
-    follows the rows' real state, which a click may have changed.
+    The text reports the observed range without assigning a verdict. Its tail
+    reflects the disclosure's current state, including user changes.
     """
     utils = []
     for g in gpus:
@@ -215,9 +198,8 @@ def sparkline_svg(
 def odd_ones_out(gpus: List[Dict[str, Any]]) -> set:
     """GPU indices on the smaller side of the utilisation split.
 
-    Split at the midpoint between the highest and lowest per-GPU window
-    median; the smaller group is the anomaly (ties go to the busy side,
-    which keeps the 1-busy-of-N reference shape tinting the busy GPU).
+    Values split at the midpoint between the lowest and highest per-GPU
+    median. The smaller group is highlighted; ties select the higher group.
     """
     utils = []
     for g in gpus:
@@ -238,15 +220,8 @@ def odd_ones_out(gpus: List[Dict[str, Any]]) -> set:
     return high if len(high) <= len(low) else low
 
 
-# The host CPU series is psutil.cpu_percent(): the MEAN utilisation across
-# all logical cores, so 100% is every core saturated and one busy core of
-# ten reads 10%. Measured 2026-08-21 on a 10-core box with one core
-# spinning: cpu_percent() == mean(percpu) == 36.6%, sum(percpu) == 366.5%.
-# The wording mirrors the GPU tile's "avg of 4 GPUs", and it has to be
-# explicit because the Process block on the same page reports PER-RANK cpu
-# from psutil.Process.cpu_percent(), which sums across cores and can pass
-# 100%. (The sampler reads psutil.cpu_count() but never puts it on the
-# wire; carrying it would let this read "avg of 10 cores".)
+# Host CPU is psutil.cpu_percent(): the mean across logical cores, where 100%
+# means all cores are fully used. Process CPU uses per-rank semantics.
 CPU_LABEL = "host cpu util · avg across cores"
 
 # Absent value marker. "n/a" rather than a dash: the Process card on the
@@ -265,12 +240,9 @@ def rows_html(
     *,
     spread: Optional[float],
 ) -> str:
-    """Per-GPU table: util (window median), power trend, mem, temp, W/limit.
+    """Build GPU rows and highlight the smaller side of a wide util split.
 
-    When the spread is over the bar, the rows on the minority side of it
-    are tinted so the eye lands on the odd ones out: the one busy GPU of
-    four, or the one idle GPU of four. Absent values read as a dash,
-    never as a zero.
+    Absent values use ``NA`` and are never represented as zero.
     """
     series_by_idx = {
         int(p.get("gpu_idx", -1)): p.get("values") or []
@@ -452,8 +424,6 @@ def build_system_section() -> Dict[str, Any]:
         panel["cpu_chart"] = ui.echart(
             theme.span_line_options(theme.C_CPU, "%")
         ).style("height:92px; width:100%;")
-        # Faint upper trace: each slice's peak, so decimating the whole run
-        # cannot hide a spike.
 
         panel["power_head"] = (
             ui.row()
@@ -677,8 +647,7 @@ def _update_power_chart(
     run = series.get("gpu_power_run") or []
     run_span = float(run[0].get("span_s") or 0.0) if run else 0.0
     if whole_run:
-        # Whole-run mean shows sustained draw; its faint floor exposes idle
-        # intervals without adding a third peak trace that usually saturates.
+        # Draw each bucket's mean and minimum. The maximum stays in the payload.
         newest = (
             aligned or (max(item["t"][-1] for item in run if item.get("t")),)
         )[0]

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -519,69 +519,40 @@ def _set_gpu_visible(panel: Dict[str, Any], visible: bool) -> None:
     )
 
 
-def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
-    if not isinstance(data, dict):
-        return
-    roll = data.get("rollups", {}) or {}
-    series = data.get("series", {}) or {}
-    gpu_on = bool(data.get("gpu_available") or roll.get("gpu_available"))
-    _set_gpu_visible(panel, gpu_on)
-
-    x_time = series.get("x_time", []) or []
-    secs = _relative_seconds(x_time)
-    newest_epoch = _newest_epoch(x_time)
-    present = [s for s in secs if s is not None]
-    span = -min(present) if present else 0.0
-
-    # The UI timer runs faster than the data arrives; re-sending a full
-    # chart options dict for an unchanged window is pure websocket
-    # traffic, so the charts only update when the window moved.
-    gp = roll.get("gpu_power", {}) or {}
-    limit = gp.get("limit")
-    pseries = series.get("gpu_power", []) or []
-    sig = (
-        x_time[-1] if x_time else None,
-        data.get("window_len"),
-        len(pseries),
-        limit,
-        gpu_on,
-    )
-    changed = sig != panel.get("_sig")
-    panel["_sig"] = sig
-
-    # Host CPU: a small zero-anchored series, the window median as its
-    # one number.
+def _update_cpu_chart(
+    panel: Dict[str, Any],
+    roll: Dict[str, Any],
+    series: Dict[str, Any],
+    *,
+    changed: bool,
+    secs: List[Optional[float]],
+    span: float,
+    newest_epoch: Optional[float],
+    whole_run: bool,
+    aligned: Optional[Tuple[float, float]],
+) -> None:
+    """Update the CPU trace, axis, value and label for the selected view."""
     cpu = series.get("cpu", []) or []
     run = series.get("cpu_run") or {}
     run_t = run.get("t") or []
     run_avg = run.get("avg") or []
     run_max = run.get("max") or []
     run_span = float(run.get("span_s") or 0.0)
-    cpu_whole = len(run_t) > 2
-    prun = series.get("gpu_power_run") or []
-    prun_span = float(prun[0].get("span_s") or 0.0) if prun else 0.0
-    power_whole = bool(prun)
-    # The two whole-run charts sit one above the other, so they share one
-    # anchor and one span: a dip in power and a rise in CPU at the same x
-    # are then the same moment. Their own spans differ by a window (the
-    # rolling mean drops its first partial window), which without this
-    # would offset the pair by a minute or two.
-    aligned = (
-        shared_run_axis(run_t, prun) if cpu_whole and power_whole else None
-    )
     chart = panel["cpu_chart"]
-    if changed and cpu_whole:
+
+    if changed and whole_run:
         newest, axis_span = aligned or (run_t[-1], run_span)
         chart.options["series"][0]["data"] = [
-            [t - newest, v] for t, v in zip(run_t, run_avg)
+            [t - newest, value] for t, value in zip(run_t, run_avg)
         ]
         _apply_span_axis(chart.options, axis_span, newest)
-        # Headroom from the peaks the rolling mean smooths away, so a
-        # spike is never drawn off the top of the chart.
+        # Peaks are not drawn, but they keep a smoothed spike inside the axis.
         ymax = cpu_axis_max(run_max or run_avg)
     elif changed:
         chart.options["series"][0]["data"] = [
-            [s, v] for s, v in zip(secs, cpu) if s is not None
+            [second, value]
+            for second, value in zip(secs, cpu)
+            if second is not None
         ]
         _apply_span_axis(chart.options, span, newest_epoch)
         ymax = cpu_axis_max(cpu)
@@ -589,10 +560,34 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
         chart.options["yAxis"]["max"] = ymax
         chart.options["yAxis"]["interval"] = ymax / 2.0
         chart.update()
+
     cpu_p50 = (roll.get("cpu", {}) or {}).get("p50")
     panel["cpu_value"].text = f"{cpu_p50:.0f}%" if cpu_p50 is not None else ""
+    span_words = format_span(span)
+    if whole_run:
+        window = format_window(float(run.get("window_s") or 0.0))
+        panel["cpu_label"].text = f"{CPU_LABEL} · whole run" + (
+            f" · rolling {window}" if window else ""
+        )
+        panel["cpu_label"].tooltip(
+            f"Whole run, {format_span(run_span)[5:]}. Each point shows "
+            f"average host CPU use over the previous {window}. 100% means "
+            "all logical CPU cores are fully used."
+        )
+    else:
+        panel["cpu_label"].text = (
+            f"{CPU_LABEL} · {span_words}" if span_words else CPU_LABEL
+        )
 
-    # Host RAM: a level against its capacity.
+
+def _update_system_tiles(
+    panel: Dict[str, Any],
+    roll: Dict[str, Any],
+    *,
+    gpu_on: bool,
+    has_data: bool,
+) -> None:
+    """Update the System header and four resource tiles."""
     ram = roll.get("ram", {}) or {}
     num, rest = format_gb_pair(ram.get("now"), ram.get("total"))
     panel["tiles"]["ram"].content = theme.kval(num, f" {rest}" if rest else "")
@@ -602,46 +597,23 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
     node_note = node_scope_text(roll.get("ctx", {}) or {})
     if node_note:
         notes.append(node_note)
-    if not data.get("window_len"):
+    if not has_data:
         notes.append("waiting for data")
     panel["note"].text = " · ".join(notes)
-    span_words = format_span(span)
-    if cpu_whole:
-        win = format_window(float(run.get("window_s") or 0.0))
-        panel["cpu_label"].text = f"{CPU_LABEL} · whole run" + (
-            f" · rolling {win}" if win else ""
-        )
-        panel["cpu_label"].tooltip(
-            f"The whole run, {format_span(run_span)[5:]}. Each point is the "
-            f"average of the last {win} of samples, a rolling window, so a "
-            "slow drift over the run is visible instead of being hidden by "
-            "second-to-second noise. Host CPU is the mean across all "
-            "logical cores: 100% means every core busy."
-        )
-    else:
-        panel["cpu_label"].text = (
-            f"{CPU_LABEL} · {span_words}" if span_words else CPU_LABEL
-        )
+
     if not gpu_on:
-        seen = bool(data.get("window_len"))
         for key in ("util", "mem", "temp"):
             panel["tiles"][key].content = NA
-            panel["subs"][key].text = "no GPU" if seen else ""
-        panel["power_label"].text = "gpu power"
-        panel["power_placeholder"].text = (
-            "no GPU reported" if seen else "waiting for data"
-        )
-        panel["rows_placeholder"].text = (
-            "per-GPU rows · no GPU" if seen else "per-GPU rows"
-        )
+            panel["subs"][key].text = "no GPU" if has_data else ""
         return
 
     gpus = roll.get("gpus", []) or []
-    n_gpus = len(gpus) or int((roll.get("ctx", {}) or {}).get("gpu_count", 0))
-    # Every GPU unreported on the newest tick (the sampler's all-zero
-    # fallback): the level tiles say so instead of printing zeros.
+    ctx = roll.get("ctx", {}) or {}
+    n_gpus = len(gpus) or int(ctx.get("gpu_count", 0))
+    # The sampler's all-zero fallback is unreported, not a zero-valued GPU.
     unreported = bool(gpus) and all(
-        g.get("mem_total") is None and g.get("power") is None for g in gpus
+        gpu.get("mem_total") is None and gpu.get("power") is None
+        for gpu in gpus
     )
 
     util_p50 = (roll.get("gpu_util", {}) or {}).get("p50")
@@ -651,159 +623,196 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
         "1 GPU" if one_gpu else f"avg of {n_gpus} GPUs"
     )
 
-    gm = roll.get("gpu_mem", {}) or {}
+    gpu_mem = roll.get("gpu_mem", {}) or {}
     if unreported:
         panel["tiles"]["mem"].content = NA
         panel["subs"]["mem"].text = "GPU sample unreported"
         panel["tiles"]["temp"].content = NA
         panel["subs"]["temp"].text = "GPU sample unreported"
-    else:
-        num, rest = format_gb_pair(gm.get("now"), gm.get("total"))
-        panel["tiles"]["mem"].content = theme.kval(
-            num, f" {rest}" if rest else ""
-        )
-        panel["subs"]["mem"].text = "used / total" if one_gpu else "max GPU"
-        temp_now = (roll.get("temp", {}) or {}).get("now")
-        panel["tiles"]["temp"].content = theme.kval(_num(temp_now), " °C")
-        # Never blank: an empty qualifier made this tile a line shorter
-        # than its neighbours on a single-GPU host.
-        panel["subs"]["temp"].text = "1 GPU" if one_gpu else "max GPU"
+        return
 
-    # GPU power per GPU against the board limit.
-    flat = [v for p in pseries for v in (p.get("values") or [])]
-    pchart = panel["power_chart"]
-    if not any(v is not None for v in flat):
-        pchart.style("display:none;")
+    num, rest = format_gb_pair(gpu_mem.get("now"), gpu_mem.get("total"))
+    panel["tiles"]["mem"].content = theme.kval(num, f" {rest}" if rest else "")
+    panel["subs"]["mem"].text = "used / total" if one_gpu else "max GPU"
+    temp_now = (roll.get("temp", {}) or {}).get("now")
+    panel["tiles"]["temp"].content = theme.kval(_num(temp_now), " °C")
+    # A qualifier keeps all four tile heights equal on single-GPU hosts.
+    panel["subs"]["temp"].text = "1 GPU" if one_gpu else "max GPU"
+
+
+def _update_power_chart(
+    panel: Dict[str, Any],
+    roll: Dict[str, Any],
+    series: Dict[str, Any],
+    *,
+    gpu_on: bool,
+    has_data: bool,
+    changed: bool,
+    secs: List[Optional[float]],
+    span: float,
+    newest_epoch: Optional[float],
+    whole_run: bool,
+    aligned: Optional[Tuple[float, float]],
+) -> None:
+    """Update the per-GPU power chart or its no-data presentation."""
+    if not gpu_on:
+        panel["power_label"].text = "gpu power"
+        panel["power_placeholder"].text = (
+            "no GPU reported" if has_data else "waiting for data"
+        )
+        return
+
+    gpu_power = roll.get("gpu_power", {}) or {}
+    limit = gpu_power.get("limit")
+    pseries = series.get("gpu_power", []) or []
+    flat = [value for item in pseries for value in (item.get("values") or [])]
+    chart = panel["power_chart"]
+    if not any(value is not None for value in flat):
+        chart.style("display:none;")
         panel["power_label"].text = "gpu power · not reported"
-    elif changed:
-        if power_whole:
-            # Per GPU, two traces: each bucket's MEAN solid, its FLOOR
-            # faint below. Sustained draw against the limit says whether
-            # the GPU is being fed; a floor dropping to idle says it went
-            # idle inside that window, which is what a dataloader stall
-            # looks like in watts. Peak is deliberately not drawn: it
-            # saturates on any healthy work and separates nothing.
-            newest = (
-                aligned or (max(e["t"][-1] for e in prun if e.get("t")),)
-            )[0]
-            lines = []
-            for e in prun:
-                idx = int(e.get("gpu_idx", 0))
-                xs = [t - newest for t in e["t"]]
-                floor_line = theme.line_series(
-                    f"gpu{idx} floor",
-                    gpu_color(idx),
-                    [[x, v] for x, v in zip(xs, e.get("min") or [])],
-                    width=0.9,
-                )
-                floor_line["lineStyle"]["opacity"] = 0.35
-                floor_line["tooltip"] = {"show": False}
-                lines.append(floor_line)
-                lines.append(
-                    theme.line_series(
-                        f"gpu{idx}",
-                        gpu_color(idx),
-                        [[x, v] for x, v in zip(xs, e["avg"])],
-                    )
-                )
-        else:
-            lines = [
-                theme.line_series(
-                    f"gpu{int(p.get('gpu_idx', 0))}",
-                    gpu_color(int(p.get("gpu_idx", 0))),
-                    [
-                        [s, v]
-                        for s, v in zip(secs, p.get("values") or [])
-                        if s is not None
-                    ],
-                )
-                for p in pseries
-            ]
-        if lines:
-            # Two reference lines: the board limit above, and the lowest
-            # draw seen in this run below (idle, on any run whose sampler
-            # was up before the first step). Between them is the band the
-            # GPU actually works in. An explicit empty markLine clears a
-            # previous one, since ECharts merges options.
-            refs = []
-            if limit is not None:
-                refs.append(
-                    (
-                        float(limit),
-                        f"{float(limit):.0f} W limit",
-                        _LIMIT_RED,
-                        "insideEndTop",
-                    )
-                )
-            floor_w = gp.get("floor")
-            if floor_w is not None and (
-                limit is None or float(floor_w) < float(limit) * 0.9
-            ):
-                # Opposite corner from the limit, and below its own line,
-                # where the chart is empty: the two labels would otherwise
-                # stack at the right edge and the longer one be cut off.
-                refs.append(
-                    (
-                        float(floor_w),
-                        f"{float(floor_w):.0f} W lowest seen",
-                        _FLOOR_GREY,
-                        "insideStartBottom",
-                    )
-                )
-            lines[0]["markLine"] = (
-                theme.mark_lines(refs) if refs else {"data": []}
-            )
-        pchart.options["series"] = lines
-        bounds_src = (
-            [v for e in prun for v in e["avg"] + (e.get("min") or [])]
-            if power_whole
-            else flat
-        )
-        lo, hi, tick = power_axis_bounds(bounds_src, limit)
-        pchart.options["yAxis"]["min"] = lo
-        pchart.options["yAxis"]["max"] = hi
-        pchart.options["yAxis"]["interval"] = tick
-        if power_whole:
-            anchor, axis_span = aligned or (
-                max(e["t"][-1] for e in prun if e.get("t")),
-                prun_span,
-            )
-            _apply_span_axis(pchart.options, axis_span, anchor)
-        else:
-            _apply_span_axis(pchart.options, span, newest_epoch)
-        pchart.style("display:block;")
-        pchart.update()
-        head = (
-            f"gpu power · per GPU vs {float(limit):.0f} W limit"
-            if limit is not None
-            else "gpu power · per GPU"
-        )
-        if power_whole:
-            win = format_window(float(prun[0].get("window_s") or 0.0))
-            panel["power_label"].text = f"{head} · whole run" + (
-                f" · mean and floor of every {win}" if win else ""
-            )
-            panel["power_label"].tooltip(
-                f"The whole run, {format_span(prun_span)[5:]}. Per GPU, the "
-                f"solid line is the average watts over each {win} and the "
-                "faint line below it is the lowest reading in that same "
-                "window. Read them together: a mean far under the board "
-                "limit means the GPU is not being kept fed, and a floor "
-                "that drops toward idle means it went idle inside that "
-                "window, which is what a stalled input pipeline looks like "
-                "in watts."
-            )
-        else:
-            panel["power_label"].text = (
-                f"{head} · {span_words}" if span_words else head
-            )
-            panel["power_label"].tooltip(
-                "The most recent samples, one point each, per GPU, against "
-                "the board's power limit."
-            )
+        return
+    if not changed:
+        return
 
-    # Per-GPU rows, opened by the spread on its rising edge; the hint
-    # follows the rows' real state, which a click may have changed.
+    run = series.get("gpu_power_run") or []
+    run_span = float(run[0].get("span_s") or 0.0) if run else 0.0
+    if whole_run:
+        # Whole-run mean shows sustained draw; its faint floor exposes idle
+        # intervals without adding a third peak trace that usually saturates.
+        newest = (
+            aligned or (max(item["t"][-1] for item in run if item.get("t")),)
+        )[0]
+        lines = []
+        for item in run:
+            index = int(item.get("gpu_idx", 0))
+            xs = [timestamp - newest for timestamp in item["t"]]
+            floor_line = theme.line_series(
+                f"gpu{index} floor",
+                gpu_color(index),
+                [[x, value] for x, value in zip(xs, item.get("min") or [])],
+                width=0.9,
+            )
+            floor_line["lineStyle"]["opacity"] = 0.35
+            floor_line["tooltip"] = {"show": False}
+            lines.append(floor_line)
+            lines.append(
+                theme.line_series(
+                    f"gpu{index}",
+                    gpu_color(index),
+                    [[x, value] for x, value in zip(xs, item["avg"])],
+                )
+            )
+    else:
+        lines = [
+            theme.line_series(
+                f"gpu{int(item.get('gpu_idx', 0))}",
+                gpu_color(int(item.get("gpu_idx", 0))),
+                [
+                    [second, value]
+                    for second, value in zip(secs, item.get("values") or [])
+                    if second is not None
+                ],
+            )
+            for item in pseries
+        ]
+
+    if lines:
+        refs = []
+        if limit is not None:
+            refs.append(
+                (
+                    float(limit),
+                    f"{float(limit):.0f} W limit",
+                    _LIMIT_RED,
+                    "insideEndTop",
+                )
+            )
+        floor_w = gpu_power.get("floor")
+        if floor_w is not None and (
+            limit is None or float(floor_w) < float(limit) * 0.9
+        ):
+            # Opposite label corners prevent the two reference lines from
+            # colliding or being clipped at the card edge.
+            refs.append(
+                (
+                    float(floor_w),
+                    f"{float(floor_w):.0f} W lowest seen",
+                    _FLOOR_GREY,
+                    "insideStartBottom",
+                )
+            )
+        # ECharts merges options, so an explicit empty markLine clears old
+        # reference lines when a later payload no longer reports them.
+        lines[0]["markLine"] = theme.mark_lines(refs) if refs else {"data": []}
+
+    chart.options["series"] = lines
+    bounds_source = (
+        [
+            value
+            for item in run
+            for value in item["avg"] + (item.get("min") or [])
+        ]
+        if whole_run
+        else flat
+    )
+    low, high, tick = power_axis_bounds(bounds_source, limit)
+    chart.options["yAxis"]["min"] = low
+    chart.options["yAxis"]["max"] = high
+    chart.options["yAxis"]["interval"] = tick
+    if whole_run:
+        anchor, axis_span = aligned or (
+            max(item["t"][-1] for item in run if item.get("t")),
+            run_span,
+        )
+        _apply_span_axis(chart.options, axis_span, anchor)
+    else:
+        _apply_span_axis(chart.options, span, newest_epoch)
+    chart.style("display:block;")
+    chart.update()
+
+    head = (
+        f"gpu power · per GPU vs {float(limit):.0f} W limit"
+        if limit is not None
+        else "gpu power · per GPU"
+    )
+    if whole_run:
+        window = format_window(float(run[0].get("window_s") or 0.0))
+        panel["power_label"].text = f"{head} · whole run" + (
+            f" · average and lowest every {window}" if window else ""
+        )
+        panel["power_label"].tooltip(
+            f"Whole run, {format_span(run_span)[5:]}. Solid lines show each "
+            f"GPU's average power every {window}; faint lines show the "
+            "lowest reading during the same interval."
+        )
+    else:
+        span_words = format_span(span)
+        panel["power_label"].text = (
+            f"{head} · {span_words}" if span_words else head
+        )
+        panel["power_label"].tooltip(
+            "Recent power readings for each GPU, compared with its power "
+            "limit."
+        )
+
+
+def _update_gpu_rows(
+    panel: Dict[str, Any],
+    roll: Dict[str, Any],
+    series: Dict[str, Any],
+    *,
+    gpu_on: bool,
+    has_data: bool,
+) -> None:
+    """Update per-GPU disclosure state, summary text and row contents."""
+    if not gpu_on:
+        panel["rows_placeholder"].text = (
+            "per-GPU rows · no GPU" if has_data else "per-GPU rows"
+        )
+        return
+
+    gpus = roll.get("gpus", []) or []
+    pseries = series.get("gpu_power", []) or []
     spread = (roll.get("gpu_delta", {}) or {}).get("p95")
     over = spread is not None and float(spread) > SPREAD_EXPAND_PTS
     if should_auto_open(prev_over=panel["_over"], over=over):
@@ -813,3 +822,83 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
         gpus, is_open=bool(panel["rows"].value)
     )
     panel["rows_html"].content = rows_html(gpus, pseries, spread=spread)
+
+
+def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
+    """Coordinate System presentation updates from one computed payload."""
+    if not isinstance(data, dict):
+        return
+    roll = data.get("rollups", {}) or {}
+    series = data.get("series", {}) or {}
+    gpu_on = bool(data.get("gpu_available") or roll.get("gpu_available"))
+    has_data = bool(data.get("window_len"))
+    _set_gpu_visible(panel, gpu_on)
+
+    x_time = series.get("x_time", []) or []
+    secs = _relative_seconds(x_time)
+    newest_epoch = _newest_epoch(x_time)
+    present = [second for second in secs if second is not None]
+    span = -min(present) if present else 0.0
+
+    # The UI timer is faster than sampling; avoid resending unchanged charts.
+    gpu_power = roll.get("gpu_power", {}) or {}
+    pseries = series.get("gpu_power", []) or []
+    signature = (
+        x_time[-1] if x_time else None,
+        data.get("window_len"),
+        len(pseries),
+        gpu_power.get("limit"),
+        gpu_on,
+    )
+    changed = signature != panel.get("_sig")
+    panel["_sig"] = signature
+
+    cpu_run = series.get("cpu_run") or {}
+    cpu_run_t = cpu_run.get("t") or []
+    power_run = series.get("gpu_power_run") or []
+    cpu_whole = len(cpu_run_t) > 2
+    power_whole = bool(power_run)
+    # Whole-run charts share one clock so vertical comparisons align.
+    aligned = (
+        shared_run_axis(cpu_run_t, power_run)
+        if cpu_whole and power_whole
+        else None
+    )
+
+    _update_cpu_chart(
+        panel,
+        roll,
+        series,
+        changed=changed,
+        secs=secs,
+        span=span,
+        newest_epoch=newest_epoch,
+        whole_run=cpu_whole,
+        aligned=aligned,
+    )
+    _update_system_tiles(
+        panel,
+        roll,
+        gpu_on=gpu_on,
+        has_data=has_data,
+    )
+    _update_power_chart(
+        panel,
+        roll,
+        series,
+        gpu_on=gpu_on,
+        has_data=has_data,
+        changed=changed,
+        secs=secs,
+        span=span,
+        newest_epoch=newest_epoch,
+        whole_run=power_whole,
+        aligned=aligned,
+    )
+    _update_gpu_rows(
+        panel,
+        roll,
+        series,
+        gpu_on=gpu_on,
+        has_data=has_data,
+    )

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -372,17 +372,20 @@ def _relative_seconds(x_time: List[str]) -> List[Optional[float]]:
 
 
 def _apply_span_axis(
-    axis: Dict[str, Any], span: float, newest_epoch: Optional[float] = None
+    options: Dict[str, Any], span: float, newest_epoch: Optional[float] = None
 ) -> None:
-    """Pin the axis to the window and label it in wall-clock time.
+    """Pin a chart to its span and label it in wall-clock time.
 
     The x values are seconds before the newest sample, which keeps the
     series arithmetic simple, but a reader debugging a slowdown needs the
     clock: it is what their logs and every other dashboard are keyed on,
-    and it is what the Process card beside this one already shows. The
-    formatter converts on the fly from the newest sample's epoch.
+    and it is what the Process block beside this one already shows. The
+    formatters convert on the fly from the newest sample's epoch, and the
+    hover label carries both readings ("19:10 · 45 min ago") so the axis
+    and the tooltip never speak two different vocabularies.
     """
     span = max(float(span), 1.0)
+    axis = options["xAxis"]
     axis["min"] = -span
     axis["max"] = 0
     axis["interval"] = span / 3.0
@@ -390,13 +393,19 @@ def _apply_span_axis(
         axis["axisLabel"]["show"] = False
         return
     axis["axisLabel"]["show"] = True
-    seconds = "true" if span < 600 else "false"
-    axis["axisLabel"][":formatter"] = (
-        "v=>{const d=new Date((%f+v)*1000);"
-        "const p=n=>('0'+n).slice(-2);"
-        "return p(d.getHours())+':'+p(d.getMinutes())"
-        "+(%s?':'+p(d.getSeconds()):'');}" % (float(newest_epoch), seconds)
+    clock = (
+        "const d=new Date((%f+%%s)*1000);const q=n=>('0'+n).slice(-2);"
+        "const c=q(d.getHours())+':'+q(d.getMinutes())%s;"
+        % (float(newest_epoch), "+':'+q(d.getSeconds())" if span < 600 else "")
     )
+    axis["axisLabel"][":formatter"] = "v=>{%s return c;}" % (clock % "v")
+    pointer = options.get("tooltip", {}).get("axisPointer", {}).get("label")
+    if pointer is not None:
+        pointer[":formatter"] = (
+            "p=>{%s const s=Math.round(-p.value);"
+            "return c+(s<1?' · now':(s<120?' · '+s+' s ago':"
+            "' · '+Math.floor(s/60)+' min ago'));}" % (clock % "p.value")
+        )
 
 
 # --- build / update --------------------------------------------------------
@@ -580,7 +589,7 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
         chart.options["series"][0]["data"] = [
             [t - newest, v] for t, v in zip(run_t, run_avg)
         ]
-        _apply_span_axis(chart.options["xAxis"], axis_span, newest)
+        _apply_span_axis(chart.options, axis_span, newest)
         # Headroom from the peaks the rolling mean smooths away, so a
         # spike is never drawn off the top of the chart.
         ymax = cpu_axis_max(run_max or run_avg)
@@ -588,7 +597,7 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
         chart.options["series"][0]["data"] = [
             [s, v] for s, v in zip(secs, cpu) if s is not None
         ]
-        _apply_span_axis(chart.options["xAxis"], span, newest_epoch)
+        _apply_span_axis(chart.options, span, newest_epoch)
         ymax = cpu_axis_max(cpu)
     if changed:
         chart.options["yAxis"]["max"] = ymax
@@ -773,9 +782,9 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
                 max(e["t"][-1] for e in prun if e.get("t")),
                 prun_span,
             )
-            _apply_span_axis(pchart.options["xAxis"], axis_span, anchor)
+            _apply_span_axis(pchart.options, axis_span, anchor)
         else:
-            _apply_span_axis(pchart.options["xAxis"], span, newest_epoch)
+            _apply_span_axis(pchart.options, span, newest_epoch)
         pchart.style("display:block;")
         pchart.update()
         head = (

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
@@ -422,22 +422,31 @@ def line_series(
     }
 
 
-def limit_mark_line(y: float, label: str, col: str) -> Dict[str, Any]:
-    """Dashed horizontal limit line with its label at the right end."""
+def mark_lines(entries: List[Any]) -> Dict[str, Any]:
+    """Several horizontal reference lines on one series.
+
+    Each entry is (y, label, colour); ECharts takes them as markLine data
+    with per-item style, so one series can carry a limit and a floor.
+    """
     return {
         "silent": True,
         "symbol": "none",
         "animation": False,
-        "lineStyle": {"color": col, "type": "dashed", "width": 1},
-        "label": {
-            "show": True,
-            "position": "insideEndTop",
-            "formatter": label,
-            "color": col,
-            "fontFamily": "Geist Mono",
-            "fontSize": 10,
-        },
-        "data": [{"yAxis": y}],
+        "data": [
+            {
+                "yAxis": y,
+                "lineStyle": {"color": col, "type": "dashed", "width": 1},
+                "label": {
+                    "show": True,
+                    "position": "insideEndTop",
+                    "formatter": label,
+                    "color": col,
+                    "fontFamily": "Geist Mono",
+                    "fontSize": 10,
+                },
+            }
+            for y, label, col in entries
+        ],
     }
 
 
@@ -449,7 +458,9 @@ def span_line_options(col: str, unit: str) -> Dict[str, Any]:
         "color": [col],
         "grid": {
             "left": 4,
-            "right": 12,
+            # room for the last clock label, which is centred on the axis
+            # maximum and would otherwise be cut in half by the card edge
+            "right": 26,
             "top": 8,
             "bottom": 4,
             "containLabel": True,
@@ -477,7 +488,9 @@ def multi_line_options(unit: str) -> Dict[str, Any]:
         "animationDuration": 300,
         "grid": {
             "left": 4,
-            "right": 12,
+            # room for the last clock label, which is centred on the axis
+            # maximum and would otherwise be cut in half by the card edge
+            "right": 26,
             "top": 10,
             "bottom": 4,
             "containLabel": True,

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
@@ -148,6 +148,15 @@ body{{
 .diagrow{{display:flex; align-items:flex-start; gap:10px; padding:10px 0; border-top:1px solid rgba(17,24,39,0.07);}}
 .diagdot{{width:9px; height:9px; border-radius:999px; margin-top:5px; flex:none;}}
 .staleband{{font-family:var(--mono); font-size:11px; color:#b45309; background:rgba(239,108,0,0.10); border:1px solid rgba(239,108,0,0.22); padding:2px 9px; border-radius:999px;}}
+/* System block: estimator labels, per-GPU rows, disclosure header */
+.estlabel{{font-family:var(--mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase; color:var(--muted);}}
+.tml-gpus{{width:100%; border-collapse:collapse; font-family:var(--mono); font-size:11px; color:var(--ink); font-variant-numeric:tabular-nums;}}
+.tml-gpus th{{font-size:9.5px; font-weight:500; letter-spacing:.06em; text-transform:uppercase; color:var(--muted); text-align:left; padding:4px 8px 5px;}}
+.tml-gpus td{{padding:4px 8px; border-top:1px solid rgba(17,24,39,0.07); white-space:nowrap;}}
+.tml-gpus td.tml-util{{font-weight:700;}}
+.tml-gpus tr.tml-mark td{{background:rgba(255,140,0,0.08);}}
+.tml-exp .q-item{{padding:4px 2px; min-height:0;}}
+.tml-exp .q-expansion-item__content{{padding:0 0 4px;}}
 </style>
 """
 
@@ -322,6 +331,155 @@ def dual_line_options(
                 "rgba(255,140,0,0.06)",
             ),
         ],
+    }
+
+
+def _span_axis() -> Dict[str, Any]:
+    """Seconds-before-newest x axis; the section sets min/interval/labels."""
+    return {
+        "type": "value",
+        "min": -1,
+        "max": 0,
+        "interval": 1,
+        # No tick labels: the window is named once in the chart's label row.
+        "axisLabel": {"show": False},
+        "axisLine": {"lineStyle": {"color": _AXIS, "opacity": 0.5}},
+        "axisTick": {"show": False},
+        "splitLine": {"show": False},
+    }
+
+
+def _value_axis(unit: str, *, zero: bool) -> Dict[str, Any]:
+    ax: Dict[str, Any] = {
+        "type": "value",
+        "splitNumber": 2,
+        "axisLabel": {
+            "color": _TXT,
+            "fontFamily": "Geist Mono",
+            "fontSize": 10,
+            ":formatter": f"v=>v+'{unit}'",
+        },
+        "axisLine": {"show": False},
+        "axisTick": {"show": False},
+        "splitLine": {"lineStyle": {"color": _GRID}},
+    }
+    if zero:
+        ax["min"] = 0
+    return ax
+
+
+# The span x axis holds seconds before the newest sample (<= 0); the
+# tooltip header must read the same way as the axis ('42 s ago'), not
+# the raw float.
+_SPAN_POINTER_LABEL = (
+    "p=>{const s=Math.round(-p.value);return s<1?'now':"
+    "(s<120?s+' s ago':Math.floor(s/60)+' min '+(s%60)+' s ago');}"
+)
+
+
+def _tooltip(unit: str) -> Dict[str, Any]:
+    return {
+        "trigger": "axis",
+        "backgroundColor": "rgba(255,253,250,0.97)",
+        "borderColor": BORDER,
+        "textStyle": {
+            "color": INK,
+            "fontFamily": "Geist Mono",
+            "fontSize": 11,
+        },
+        "axisPointer": {
+            "type": "line",
+            "lineStyle": {"color": _AXIS, "type": "dashed"},
+            "label": {
+                "backgroundColor": INK,
+                "fontFamily": "Geist Mono",
+                "fontSize": 10,
+                ":formatter": _SPAN_POINTER_LABEL,
+            },
+        },
+        ":valueFormatter": f"v=>(v==null?'-':Math.round(v)+'{unit}')",
+    }
+
+
+def line_series(
+    name: str, col: str, data: List[Any], *, width: float = 1.6
+) -> Dict[str, Any]:
+    """One plain line (no area, no end label) for a multi-trace chart."""
+    return {
+        "name": name,
+        "type": "line",
+        "smooth": True,
+        "showSymbol": False,
+        "lineStyle": {"width": width, "color": col},
+        "itemStyle": {"color": col},
+        "data": data,
+    }
+
+
+def limit_mark_line(y: float, label: str, col: str) -> Dict[str, Any]:
+    """Dashed horizontal limit line with its label at the right end."""
+    return {
+        "silent": True,
+        "symbol": "none",
+        "animation": False,
+        "lineStyle": {"color": col, "type": "dashed", "width": 1},
+        "label": {
+            "show": True,
+            "position": "insideEndTop",
+            "formatter": label,
+            "color": col,
+            "fontFamily": "Geist Mono",
+            "fontSize": 10,
+        },
+        "data": [{"yAxis": y}],
+    }
+
+
+def span_line_options(col: str, unit: str) -> Dict[str, Any]:
+    """Small zero-anchored single series over a window-span x axis."""
+    return {
+        "backgroundColor": "transparent",
+        "animationDuration": 300,
+        "color": [col],
+        "grid": {
+            "left": 4,
+            "right": 12,
+            "top": 8,
+            "bottom": 4,
+            "containLabel": True,
+        },
+        "tooltip": _tooltip(unit),
+        "xAxis": _span_axis(),
+        "yAxis": _value_axis(unit, zero=True),
+        "series": [
+            {
+                **line_series("", col, []),
+                "areaStyle": {
+                    "color": _area(
+                        "rgba(37,99,235,0.14)", "rgba(37,99,235,0.03)"
+                    )
+                },
+            }
+        ],
+    }
+
+
+def multi_line_options(unit: str) -> Dict[str, Any]:
+    """Several plain traces over a window-span x axis (one per GPU)."""
+    return {
+        "backgroundColor": "transparent",
+        "animationDuration": 300,
+        "grid": {
+            "left": 4,
+            "right": 12,
+            "top": 10,
+            "bottom": 4,
+            "containLabel": True,
+        },
+        "tooltip": _tooltip(unit),
+        "xAxis": _span_axis(),
+        "yAxis": _value_axis(unit, zero=False),
+        "series": [],
     }
 
 

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
@@ -425,8 +425,11 @@ def line_series(
 def mark_lines(entries: List[Any]) -> Dict[str, Any]:
     """Several horizontal reference lines on one series.
 
-    Each entry is (y, label, colour); ECharts takes them as markLine data
-    with per-item style, so one series can carry a limit and a floor.
+    Each entry is (y, label, colour, position); ECharts takes them as
+    markLine data with per-item style, so one series can carry a limit and
+    a floor. Give two lines different positions: a label anchored at the
+    same end as its neighbour collides with it, and a long one anchored at
+    the right end is cut off by the card edge.
     """
     return {
         "silent": True,
@@ -438,14 +441,14 @@ def mark_lines(entries: List[Any]) -> Dict[str, Any]:
                 "lineStyle": {"color": col, "type": "dashed", "width": 1},
                 "label": {
                     "show": True,
-                    "position": "insideEndTop",
+                    "position": pos,
                     "formatter": label,
                     "color": col,
                     "fontFamily": "Geist Mono",
                     "fontSize": 10,
                 },
             }
-            for y, label, col in entries
+            for y, label, col, pos in entries
         ],
     }
 

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
@@ -137,6 +137,12 @@ body{{
 .verdict{{font-family:var(--sans); font-size:21px; font-weight:500; color:var(--ink); letter-spacing:-.01em;}}
 .sevpill{{font-family:var(--mono); font-size:10.5px; font-weight:600; padding:3px 9px; border-radius:999px; text-transform:uppercase; letter-spacing:.06em;}}
 /* KPI tiles */
+/* Tile row: a grid, not a wrapping flex row. Four equal columns that
+   become two equal columns when the card is narrow, so a tile can never
+   wrap alone and stretch to its max width. */
+.tilerow{{display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:9px; width:100%;}}
+@media (max-width:1180px){{.tilerow{{grid-template-columns:repeat(2,minmax(0,1fr));}}}}
+@media (max-width:560px){{.tilerow{{grid-template-columns:minmax(0,1fr);}}}}
 .kpi{{position:relative; background:rgba(255,255,255,0.4); border:1px solid rgba(17,24,39,0.08); border-radius:13px; padding:11px 13px 10px; min-width:118px; transition:background .2s, transform .2s, box-shadow .2s;}}
 .kpi:hover{{background:rgba(255,255,255,0.72); transform:translateY(-2px); box-shadow:0 8px 20px rgba(17,24,39,0.07);}}
 .kpi::before{{content:''; position:absolute; left:0; top:0; height:100%; width:3px; background:var(--acc,var(--orange)); opacity:.85;}}
@@ -144,7 +150,7 @@ body{{
 .kq{{display:block; margin-top:2px; text-transform:none; letter-spacing:0; color:var(--muted); font-weight:500; font-size:9px;}}
 .kval{{font-family:var(--mono); font-size:19px; font-weight:600; color:var(--ink); font-variant-numeric:tabular-nums; margin-top:4px; line-height:1.1;}}
 .kunit{{font-size:0.62em; color:var(--muted); font-weight:500; margin-left:2px;}}
-.ksub{{font-family:var(--mono); font-size:10px; color:var(--muted); margin-top:2px;}}
+.ksub{{font-family:var(--mono); font-size:10px; color:var(--muted); margin-top:2px; min-height:13px;}}
 .diagrow{{display:flex; align-items:flex-start; gap:10px; padding:10px 0; border-top:1px solid rgba(17,24,39,0.07);}}
 .diagdot{{width:9px; height:9px; border-radius:999px; margin-top:5px; flex:none;}}
 .staleband{{font-family:var(--mono); font-size:11px; color:#b45309; background:rgba(239,108,0,0.10); border:1px solid rgba(239,108,0,0.22); padding:2px 9px; border-radius:999px;}}

--- a/src/traceml_ai/renderers/system/common.py
+++ b/src/traceml_ai/renderers/system/common.py
@@ -171,6 +171,143 @@ class SystemMetricsDB:
         """
         return conn.execute(sql, (*bound, int(limit))).fetchall()
 
+    def fetch_cpu_run_history(
+        self,
+        conn: sqlite3.Connection,
+        buckets: int = 180,
+        hostname: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Whole-run host CPU, decimated to ``buckets`` equal time slices.
+
+        The window series answers "what is CPU doing now"; this answers
+        "what has it done over the run", which is the only form that can
+        show a drift (the 96-minute reference run climbs about 25%).
+        Decimation happens in SQL so the payload stays a fixed size no
+        matter how long the run is: one row per slice carrying the slice's
+        mean and its max, because a mean alone would erase the spikes that
+        a stalling dataloader produces.
+        """
+        empty: Dict[str, Any] = {"t": [], "avg": [], "max": [], "span_s": 0.0}
+        where_sql, params = self.node_rank_filter()
+        bound: List[Any] = list(params)
+        if hostname is not None:
+            where_sql = (
+                f"{where_sql} AND hostname IS ?"
+                if where_sql
+                else "WHERE hostname IS ?"
+            )
+            bound.append(str(hostname))
+        try:
+            row = conn.execute(
+                f"SELECT MIN(sample_ts_s), MAX(sample_ts_s) FROM "
+                f"system_samples {where_sql}",
+                tuple(bound),
+            ).fetchone()
+        except sqlite3.Error:
+            return empty
+        if not row or row[0] is None or row[1] is None:
+            return empty
+        first, last = float(row[0]), float(row[1])
+        span = last - first
+        if span <= 0:
+            return empty
+        width = span / float(max(1, int(buckets)))
+        try:
+            rows = conn.execute(
+                f"""
+                SELECT
+                    MIN(sample_ts_s),
+                    AVG(cpu_percent),
+                    MAX(cpu_percent)
+                FROM system_samples
+                {where_sql}
+                {'AND' if where_sql else 'WHERE'} cpu_percent IS NOT NULL
+                GROUP BY CAST((sample_ts_s - ?) / ? AS INTEGER)
+                ORDER BY 1 ASC
+                """,
+                (*bound, first, width),
+            ).fetchall()
+        except sqlite3.Error:
+            return empty
+        return {
+            "t": [float(r[0]) for r in rows],
+            "avg": [float(r[1]) for r in rows],
+            "max": [float(r[2]) for r in rows],
+            "span_s": span,
+        }
+
+    def fetch_gpu_power_run_history(
+        self,
+        conn: sqlite3.Connection,
+        buckets: int = 180,
+        hostname: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Whole-run per-GPU power, decimated to ``buckets`` time slices.
+
+        Same shape as ``fetch_cpu_run_history`` but grouped per GPU. The
+        window view shows the oscillation between steps; this shows what
+        the oscillation DOES over the run (a declining ceiling is thermal
+        throttling, a dropping floor is a stall), which the step-time
+        block cannot answer because it is about watts, not seconds.
+        Each slice carries its mean and its max so the decimation cannot
+        hide a spike.
+        """
+        where_sql, params = self.node_rank_filter()
+        bound: List[Any] = list(params)
+        if hostname is not None:
+            where_sql = (
+                f"{where_sql} AND hostname IS ?"
+                if where_sql
+                else "WHERE hostname IS ?"
+            )
+            bound.append(str(hostname))
+        try:
+            row = conn.execute(
+                f"SELECT MIN(sample_ts_s), MAX(sample_ts_s) FROM "
+                f"system_gpu_samples {where_sql}",
+                tuple(bound),
+            ).fetchone()
+        except sqlite3.Error:
+            return []
+        if not row or row[0] is None or row[1] is None:
+            return []
+        first, last = float(row[0]), float(row[1])
+        span = last - first
+        if span <= 0:
+            return []
+        width = span / float(max(1, int(buckets)))
+        try:
+            rows = conn.execute(
+                f"""
+                SELECT
+                    gpu_idx,
+                    MIN(sample_ts_s),
+                    AVG(power_usage_w),
+                    MAX(power_usage_w)
+                FROM system_gpu_samples
+                {where_sql}
+                {'AND' if where_sql else 'WHERE'} power_usage_w IS NOT NULL
+                GROUP BY gpu_idx, CAST((sample_ts_s - ?) / ? AS INTEGER)
+                ORDER BY gpu_idx ASC, 2 ASC
+                """,
+                (*bound, first, width),
+            ).fetchall()
+        except sqlite3.Error:
+            return []
+        by_gpu: Dict[int, Dict[str, Any]] = {}
+        for gpu_idx, ts, avg, mx in rows:
+            e = by_gpu.setdefault(
+                int(gpu_idx),
+                {"gpu_idx": int(gpu_idx), "t": [], "avg": [], "max": []},
+            )
+            e["t"].append(float(ts))
+            e["avg"].append(float(avg))
+            e["max"].append(float(mx))
+        out = [by_gpu[i] for i in sorted(by_gpu)]
+        for e in out:
+            e["span_s"] = span
+        return out
+
     def fetch_gpu_rows_for_sample(
         self,
         conn: sqlite3.Connection,

--- a/src/traceml_ai/renderers/system/common.py
+++ b/src/traceml_ai/renderers/system/common.py
@@ -329,10 +329,20 @@ class SystemMetricsDB:
                 else "WHERE hostname IS ?"
             )
             bound.append(str(hostname))
+        # An all-zero capacity row is the sampler's NVML failure fallback,
+        # not a real 0 W observation.
+        reported_sql = """
+            power_usage_w IS NOT NULL
+            AND (
+                COALESCE(mem_total_bytes, 0) > 0
+                OR COALESCE(power_limit_w, 0) > 0
+            )
+        """
         try:
             row = conn.execute(
                 f"SELECT MIN(sample_ts_s), MAX(sample_ts_s) FROM "
-                f"system_gpu_samples {where_sql}",
+                f"system_gpu_samples {where_sql} "
+                f"{'AND' if where_sql else 'WHERE'} {reported_sql}",
                 tuple(bound),
             ).fetchone()
         except sqlite3.Error:
@@ -355,7 +365,7 @@ class SystemMetricsDB:
                     MAX(power_usage_w)
                 FROM system_gpu_samples
                 {where_sql}
-                {'AND' if where_sql else 'WHERE'} power_usage_w IS NOT NULL
+                {'AND' if where_sql else 'WHERE'} {reported_sql}
                 GROUP BY gpu_idx, CAST((sample_ts_s - ?) / ? AS INTEGER)
                 ORDER BY gpu_idx ASC, 2 ASC
                 """,

--- a/src/traceml_ai/renderers/system/common.py
+++ b/src/traceml_ai/renderers/system/common.py
@@ -254,9 +254,16 @@ class SystemMetricsDB:
             return empty
         cadence = span / max(count - 1, 1)
         preceding = max(1, int(round(window_s / max(cadence, 1e-6))) - 1)
-        # Only points whose rolling window is COMPLETE: the first rows
-        # have partial windows, so an early spike would show unsmoothed.
-        stride = max(1, count // _MAX_RUN_POINTS)
+        # The first ``preceding`` samples are valid telemetry, but they do not
+        # yet cover a complete rolling window and are excluded by the query
+        # below. Calculate the stride from only the remaining chart-eligible
+        # points: this guarantees the 120-point limit without unnecessarily
+        # discarding detail when the eligible series already fits.
+        eligible_count = max(0, count - preceding)
+        stride = max(
+            1,
+            (eligible_count + _MAX_RUN_POINTS - 1) // _MAX_RUN_POINTS,
+        )
         try:
             rows = conn.execute(
                 f"""

--- a/src/traceml_ai/renderers/system/common.py
+++ b/src/traceml_ai/renderers/system/common.py
@@ -199,6 +199,7 @@ class SystemMetricsDB:
         self,
         conn: sqlite3.Connection,
         hostname: Optional[str] = None,
+        min_span_s: float = 0.0,
     ) -> Dict[str, Any]:
         """Whole-run host CPU, decimated to ``buckets`` equal time slices.
 
@@ -209,6 +210,8 @@ class SystemMetricsDB:
         matter how long the run is: one row per slice carrying the slice's
         mean and its max, because a mean alone would erase the spikes that
         a stalling dataloader produces.
+
+        Aggregation is skipped when the run does not exceed ``min_span_s``.
         """
         empty: Dict[str, Any] = {
             "t": [],
@@ -238,7 +241,9 @@ class SystemMetricsDB:
             return empty
         first, last = float(row[0]), float(row[1])
         span = last - first
-        if span <= 0:
+        # The recent window already represents short runs; avoid their
+        # rolling-history query until a whole-run view adds information.
+        if span <= max(0.0, float(min_span_s)):
             return empty
         window_s = choose_window_s(span)
         count = 0
@@ -303,6 +308,7 @@ class SystemMetricsDB:
         self,
         conn: sqlite3.Connection,
         hostname: Optional[str] = None,
+        min_span_s: float = 0.0,
     ) -> List[Dict[str, Any]]:
         """Whole-run per-GPU power: each bucket's mean, floor and peak.
 
@@ -319,6 +325,8 @@ class SystemMetricsDB:
         falls to idle means the GPU went idle inside that window, which is
         what a dataloader stall looks like in watts. The peak is kept for
         callers that want it, but it barely moves on healthy work.
+
+        Aggregation is skipped when the run does not exceed ``min_span_s``.
         """
         where_sql, params = self.node_rank_filter()
         bound: List[Any] = list(params)
@@ -351,7 +359,7 @@ class SystemMetricsDB:
             return []
         first, last = float(row[0]), float(row[1])
         span = last - first
-        if span <= 0:
+        if span <= max(0.0, float(min_span_s)):
             return []
         width = choose_window_s(span)
         try:

--- a/src/traceml_ai/renderers/system/common.py
+++ b/src/traceml_ai/renderers/system/common.py
@@ -10,12 +10,8 @@ import sqlite3
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
-# Whole-run charts smooth with a ROLLING window, the way the metrics
-# notebook plots them, not with disjoint buckets. Consecutive points then
-# share most of their samples, so the line is smooth; disjoint buckets each
-# catch a different phase of a fast oscillation and stay jagged (measured:
-# mean absolute change per point 0.48 raw, 0.02 rolling over 30 samples).
-# The window is a duration, so it means the same thing at any cadence.
+# Whole-run CPU history uses a duration-based rolling window before sampling.
+# The duration keeps the aggregation consistent across sampling cadences.
 _ROLL_MIN_S = 30.0
 _ROLL_MAX_S = 300.0
 _ROLL_FRACTION = 50.0  # about a fiftieth of the run
@@ -201,15 +197,11 @@ class SystemMetricsDB:
         hostname: Optional[str] = None,
         min_span_s: float = 0.0,
     ) -> Dict[str, Any]:
-        """Whole-run host CPU, decimated to ``buckets`` equal time slices.
+        """Whole-run host CPU as rolling values sampled to a bounded series.
 
         The window series answers "what is CPU doing now"; this answers
-        "what has it done over the run", which is the only form that can
-        show a drift (the 96-minute reference run climbs about 25%).
-        Decimation happens in SQL so the payload stays a fixed size no
-        matter how long the run is: one row per slice carrying the slice's
-        mean and its max, because a mean alone would erase the spikes that
-        a stalling dataloader produces.
+        "what has it done over the run". SQL computes a rolling mean and
+        maximum, then samples the result so the payload remains bounded.
 
         Aggregation is skipped when the run does not exceed ``min_span_s``.
         """
@@ -310,21 +302,10 @@ class SystemMetricsDB:
         hostname: Optional[str] = None,
         min_span_s: float = 0.0,
     ) -> List[Dict[str, Any]]:
-        """Whole-run per-GPU power: each bucket's mean, floor and peak.
+        """Whole-run per-GPU power grouped into fixed-duration buckets.
 
-        Buckets are disjoint, unlike the rolling window the CPU series
-        uses, and deliberately: a rolling MIN or MAX holds one extreme
-        sample across the whole window and draws square plateaus, while a
-        per-bucket extreme varies with the run.
-
-        The display pairs the MEAN with the FLOOR, because that is the
-        pair that answers the questions this tool exists for. Sustained
-        draw well under the board limit means the GPU is not being fed
-        (measured on our own corpus: an input-straggler run averages
-        45.9 W against a compute-bound run's 61.9 W), and a floor that
-        falls to idle means the GPU went idle inside that window, which is
-        what a dataloader stall looks like in watts. The peak is kept for
-        callers that want it, but it barely moves on healthy work.
+        Each bucket carries mean, minimum and maximum power. The dashboard
+        draws the mean and minimum; the maximum remains available to callers.
 
         Aggregation is skipped when the run does not exceed ``min_span_s``.
         """

--- a/src/traceml_ai/renderers/system/common.py
+++ b/src/traceml_ai/renderers/system/common.py
@@ -81,7 +81,9 @@ class SystemDashboardPayload:
     window_len: int
     gpu_available: bool
     rollups: Dict[str, Any]
-    series: Dict[str, List[float]]
+    # Series includes both flat sample arrays and structured whole-run
+    # histories, so its values are intentionally heterogeneous.
+    series: Dict[str, Any]
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/src/traceml_ai/renderers/system/common.py
+++ b/src/traceml_ai/renderers/system/common.py
@@ -10,6 +10,28 @@ import sqlite3
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
+# Whole-run charts smooth with a ROLLING window, the way the metrics
+# notebook plots them, not with disjoint buckets. Consecutive points then
+# share most of their samples, so the line is smooth; disjoint buckets each
+# catch a different phase of a fast oscillation and stay jagged (measured:
+# mean absolute change per point 0.48 raw, 0.02 rolling over 30 samples).
+# The window is a duration, so it means the same thing at any cadence.
+_ROLL_MIN_S = 30.0
+_ROLL_MAX_S = 300.0
+_ROLL_FRACTION = 50.0  # about a fiftieth of the run
+_MAX_RUN_POINTS = 120
+
+
+def choose_window_s(span_s: float) -> float:
+    """The rolling window for a run of ``span_s`` seconds, in round steps."""
+    if span_s <= 0:
+        return _ROLL_MIN_S
+    raw = max(_ROLL_MIN_S, min(_ROLL_MAX_S, span_s / _ROLL_FRACTION))
+    for step in (30.0, 60.0, 120.0, 300.0):
+        if raw <= step:
+            return step
+    return _ROLL_MAX_S
+
 
 @dataclass(frozen=True)
 class SystemCLISnapshot:
@@ -174,7 +196,6 @@ class SystemMetricsDB:
     def fetch_cpu_run_history(
         self,
         conn: sqlite3.Connection,
-        buckets: int = 180,
         hostname: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Whole-run host CPU, decimated to ``buckets`` equal time slices.
@@ -187,7 +208,13 @@ class SystemMetricsDB:
         mean and its max, because a mean alone would erase the spikes that
         a stalling dataloader produces.
         """
-        empty: Dict[str, Any] = {"t": [], "avg": [], "max": [], "span_s": 0.0}
+        empty: Dict[str, Any] = {
+            "t": [],
+            "avg": [],
+            "max": [],
+            "span_s": 0.0,
+            "window_s": 0.0,
+        }
         where_sql, params = self.node_rank_filter()
         bound: List[Any] = list(params)
         if hostname is not None:
@@ -211,46 +238,78 @@ class SystemMetricsDB:
         span = last - first
         if span <= 0:
             return empty
-        width = span / float(max(1, int(buckets)))
+        window_s = choose_window_s(span)
+        count = 0
+        try:
+            row = conn.execute(
+                f"SELECT COUNT(*) FROM system_samples {where_sql}",
+                tuple(bound),
+            ).fetchone()
+            count = int(row[0]) if row else 0
+        except sqlite3.Error:
+            return empty
+        if count < 2:
+            return empty
+        cadence = span / max(count - 1, 1)
+        preceding = max(1, int(round(window_s / max(cadence, 1e-6))) - 1)
+        # Only points whose rolling window is COMPLETE: the first rows
+        # have partial windows, so an early spike would show unsmoothed.
+        stride = max(1, count // _MAX_RUN_POINTS)
         try:
             rows = conn.execute(
                 f"""
-                SELECT
-                    MIN(sample_ts_s),
-                    AVG(cpu_percent),
-                    MAX(cpu_percent)
-                FROM system_samples
-                {where_sql}
-                {'AND' if where_sql else 'WHERE'} cpu_percent IS NOT NULL
-                GROUP BY CAST((sample_ts_s - ?) / ? AS INTEGER)
-                ORDER BY 1 ASC
+                WITH rolled AS (
+                    SELECT
+                        sample_ts_s AS t,
+                        AVG(cpu_percent) OVER w AS a,
+                        MAX(cpu_percent) OVER w AS m,
+                        ROW_NUMBER() OVER (ORDER BY sample_ts_s) AS rn
+                    FROM system_samples
+                    {where_sql}
+                    {'AND' if where_sql else 'WHERE'} cpu_percent IS NOT NULL
+                    WINDOW w AS (
+                        ORDER BY sample_ts_s
+                        ROWS BETWEEN {preceding} PRECEDING AND CURRENT ROW
+                    )
+                )
+                SELECT t, a, m FROM rolled
+                WHERE rn % ? = 0 AND rn > {preceding}
+                ORDER BY t ASC
                 """,
-                (*bound, first, width),
+                (*bound, stride),
             ).fetchall()
         except sqlite3.Error:
+            # Window functions need SQLite >= 3.25; without them the whole
+            # run view is simply unavailable and the window view stands.
             return empty
         return {
             "t": [float(r[0]) for r in rows],
             "avg": [float(r[1]) for r in rows],
             "max": [float(r[2]) for r in rows],
             "span_s": span,
+            "window_s": window_s,
         }
 
     def fetch_gpu_power_run_history(
         self,
         conn: sqlite3.Connection,
-        buckets: int = 180,
         hostname: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """Whole-run per-GPU power, decimated to ``buckets`` time slices.
+        """Whole-run per-GPU power: each bucket's mean, floor and peak.
 
-        Same shape as ``fetch_cpu_run_history`` but grouped per GPU. The
-        window view shows the oscillation between steps; this shows what
-        the oscillation DOES over the run (a declining ceiling is thermal
-        throttling, a dropping floor is a stall), which the step-time
-        block cannot answer because it is about watts, not seconds.
-        Each slice carries its mean and its max so the decimation cannot
-        hide a spike.
+        Buckets are disjoint, unlike the rolling window the CPU series
+        uses, and deliberately: a rolling MIN or MAX holds one extreme
+        sample across the whole window and draws square plateaus, while a
+        per-bucket extreme varies with the run.
+
+        The display pairs the MEAN with the FLOOR, because that is the
+        pair that answers the questions this tool exists for. Sustained
+        draw well under the board limit means the GPU is not being fed
+        (measured on our own corpus: an input-straggler run averages
+        45.9 W against a compute-bound run's 61.9 W), and a floor that
+        falls to idle means the GPU went idle inside that window, which is
+        what a dataloader stall looks like in watts. The peak is kept for
+        callers that want it, but it barely moves on healthy work.
         """
         where_sql, params = self.node_rank_filter()
         bound: List[Any] = list(params)
@@ -275,7 +334,7 @@ class SystemMetricsDB:
         span = last - first
         if span <= 0:
             return []
-        width = span / float(max(1, int(buckets)))
+        width = choose_window_s(span)
         try:
             rows = conn.execute(
                 f"""
@@ -283,6 +342,7 @@ class SystemMetricsDB:
                     gpu_idx,
                     MIN(sample_ts_s),
                     AVG(power_usage_w),
+                    MIN(power_usage_w),
                     MAX(power_usage_w)
                 FROM system_gpu_samples
                 {where_sql}
@@ -295,17 +355,25 @@ class SystemMetricsDB:
         except sqlite3.Error:
             return []
         by_gpu: Dict[int, Dict[str, Any]] = {}
-        for gpu_idx, ts, avg, mx in rows:
+        for gpu_idx, ts, avg, mn, mx in rows:
             e = by_gpu.setdefault(
                 int(gpu_idx),
-                {"gpu_idx": int(gpu_idx), "t": [], "avg": [], "max": []},
+                {
+                    "gpu_idx": int(gpu_idx),
+                    "t": [],
+                    "avg": [],
+                    "min": [],
+                    "max": [],
+                },
             )
             e["t"].append(float(ts))
             e["avg"].append(float(avg))
+            e["min"].append(float(mn))
             e["max"].append(float(mx))
         out = [by_gpu[i] for i in sorted(by_gpu)]
         for e in out:
             e["span_s"] = span
+            e["window_s"] = width
         return out
 
     def fetch_gpu_rows_for_sample(

--- a/src/traceml_ai/renderers/system/common.py
+++ b/src/traceml_ai/renderers/system/common.py
@@ -137,14 +137,27 @@ class SystemMetricsDB:
         self,
         conn: sqlite3.Connection,
         limit: int,
+        hostname: Optional[str] = None,
     ) -> List[sqlite3.Row]:
         """
         Fetch the most recent system samples in ascending time order.
 
         The inner query limits the read size first, then the outer query
         restores ascending order for downstream time-series compute.
+        ``hostname`` narrows the window to one node: system telemetry is
+        per machine, and a window that interleaves two hosts is not a
+        series of anything.
         """
         where_sql, params = self.node_rank_filter()
+        bound: List[Any] = list(params)
+        if hostname is not None:
+            # IS, not =: a NULL hostname must round-trip as NULL.
+            where_sql = (
+                f"{where_sql} AND hostname IS ?"
+                if where_sql
+                else "WHERE hostname IS ?"
+            )
+            bound.append(str(hostname))
         sql = f"""
             SELECT *
             FROM (
@@ -156,7 +169,7 @@ class SystemMetricsDB:
             )
             ORDER BY id ASC;
         """
-        return conn.execute(sql, (*params, int(limit))).fetchall()
+        return conn.execute(sql, (*bound, int(limit))).fetchall()
 
     def fetch_gpu_rows_for_sample(
         self,

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -299,6 +299,13 @@ class SystemDashboardComputer:
         }
 
         x_time = [self._format_time_iso(ts) for ts in ts_hist.tolist()]
+        host = (
+            system_node["hostname"]
+            if system_node["nodes_in_window"] > 1
+            else None
+        )
+        cpu_run = self._db.fetch_cpu_run_history(conn, hostname=host)
+        power_run = self._db.fetch_gpu_power_run_history(conn, hostname=host)
 
         return SystemDashboardPayload(
             window_len=len(samples),
@@ -318,6 +325,10 @@ class SystemDashboardComputer:
                     if gpu_available
                     else []
                 ),
+                # Whole-run views (decimated in SQL): the window says what
+                # the host is doing now, these say what it has done.
+                "cpu_run": cpu_run,
+                "gpu_power_run": power_run if gpu_available else [],
             },
         ).to_dict()
 

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -338,10 +338,8 @@ class SystemDashboardComputer:
                 "now": power_max_hist[-1],
                 "p50": _median(power_max_hist),
                 "limit": power_limit,
-                # The lowest draw seen anywhere in the run. On almost any
-                # run that is the idle level (the sampler is up before the
-                # first step and after the last), which is what a starved
-                # GPU falls back to, so it is worth a reference line.
+                # Lowest reported power across the whole run, or across the
+                # recent window when whole-run aggregation is skipped.
                 "floor": (
                     run_power_floor
                     if run_power_floor is not None

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -10,11 +10,45 @@ from __future__ import annotations
 
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 
 from .common import SystemDashboardPayload, SystemMetricsDB
+
+
+def _opt_float(value: Any) -> Optional[float]:
+    """Float or None: an unreported column stays unreported, never 0."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _median(values: List[Optional[float]]) -> Optional[float]:
+    present = [v for v in values if v is not None]
+    return float(np.percentile(present, 50)) if present else None
+
+
+def _positive(value: Any) -> Optional[float]:
+    """A capacity-like value: None unless it is a real positive number."""
+    v = _opt_float(value)
+    return v if v is not None and v > 0.0 else None
+
+
+def _gpu_reported(row: Any) -> bool:
+    """False for the sampler's exception fallback (an all-zero GPU row).
+
+    A real GPU always has a memory capacity and a board power limit; the
+    sampler writes zeros for every field when NVML fails on a device, and
+    those zeros must not render as 0 W, 0 C or 0 GB.
+    """
+    return (
+        _positive(row["mem_total_bytes"]) is not None
+        or _positive(row["power_limit_w"]) is not None
+    )
 
 
 class SystemDashboardComputer:
@@ -68,6 +102,18 @@ class SystemDashboardComputer:
         if not samples:
             return self._empty_payload()
 
+        # System telemetry is per machine. When the window holds more than
+        # one host, show the leader node alone and say so, rather than a
+        # series that zig-zags between two machines and GPU rows in which
+        # both nodes' gpu0 collapse into one.
+        system_node = self._pick_node(samples)
+        if system_node["nodes_in_window"] > 1:
+            samples = self._db.fetch_recent_system_samples(
+                conn, limit=window_n, hostname=system_node["hostname"]
+            )
+            if not samples:
+                return self._empty_payload()
+
         last = samples[-1]
         gpu_available = bool(last["gpu_available"] or False)
 
@@ -101,6 +147,20 @@ class SystemDashboardComputer:
         gpu_mem_worst = np.zeros(n, dtype=np.float64)
         gpu_mem_headroom_min = np.zeros(n, dtype=np.float64)
         temp_max = np.zeros(n, dtype=np.float64)
+        gpu_mem_worst_total = 0.0
+
+        # Per-GPU history keyed by gpu_idx, one slot per tick. A tick in
+        # which a GPU has no row stays None: a gap in its trace, not a 0.
+        # Power feeds the power chart and the per-GPU rows; per-GPU util
+        # gives each row its own window median.
+        power_hist: Dict[int, List[Optional[float]]] = {}
+        util_hist: Dict[int, List[Optional[float]]] = {}
+        power_max_hist: List[Optional[float]] = [None] * n
+        latest_rows: Dict[int, Any] = {}
+        # The board limit is a constant per GPU; remember the largest one
+        # reported anywhere in the window so one unreported tick does not
+        # make the limit line flicker.
+        power_limit: Optional[float] = None
 
         for i, sample in enumerate(samples):
             key = (sample["global_rank"], sample["seq"])
@@ -116,6 +176,29 @@ class SystemDashboardComputer:
                 gpu_delta[i] = max(utils) - min(utils)
                 gpu_mem_worst[i] = max(mem_useds)
                 temp_max[i] = max(temps)
+                if i == n - 1:
+                    worst = max(range(len(rows)), key=lambda j: mem_useds[j])
+                    gpu_mem_worst_total = mem_totals[worst]
+                    latest_rows = {int(g["gpu_idx"]): g for g in rows}
+
+                powers = []
+                for g in rows:
+                    idx = int(g["gpu_idx"])
+                    reported = _gpu_reported(g)
+                    power = (
+                        _opt_float(g["power_usage_w"]) if reported else None
+                    )
+                    util = _opt_float(g["util"]) if reported else None
+                    power_hist.setdefault(idx, [None] * n)[i] = power
+                    util_hist.setdefault(idx, [None] * n)[i] = util
+                    if power is not None:
+                        powers.append(power)
+                    limit = _positive(g["power_limit_w"])
+                    if limit is not None and (
+                        power_limit is None or limit > power_limit
+                    ):
+                        power_limit = limit
+                power_max_hist[i] = max(powers) if powers else None
 
                 headrooms = [
                     max(mt - mu, 0.0)
@@ -184,18 +267,35 @@ class SystemDashboardComputer:
                 "now": float(gpu_mem_worst[-1]),
                 "p95": mem_p95,
                 "headroom": float(gpu_mem_headroom_min[-1]),
+                # Capacity of the GPU shown in "now" (the max-used one),
+                # so the tile can read "used / total".
+                "total": gpu_mem_worst_total,
             },
             "temp": {
                 "now": temp_now,
                 "p95": temp_p95,
                 "status": temp_status,
             },
+            # Power is a per-GPU quantity; any aggregate cell is the max
+            # GPU, never a sum. None when no GPU reported power.
+            "gpu_power": {
+                "now": power_max_hist[-1],
+                "p50": _median(power_max_hist),
+                "limit": power_limit,
+            },
+            "gpus": (
+                self._gpu_rows(latest_rows, util_hist, power_hist)
+                if gpu_available
+                else []
+            ),
         }
 
         rollups["ctx"] = {
             "world_size": int(last["world_size"] or 0),
             "gpu_count": int(last["gpu_count"] or 0),
             "hostname": str(last["hostname"] or ""),
+            # Which node this payload's series and rows describe.
+            "system_node": system_node,
         }
 
         x_time = [self._format_time_iso(ts) for ts in ts_hist.tolist()]
@@ -210,8 +310,107 @@ class SystemDashboardComputer:
                 "gpu_avg": (
                     gpu_avg.astype(float).tolist() if gpu_available else []
                 ),
+                "gpu_power": (
+                    [
+                        {"gpu_idx": idx, "values": power_hist[idx]}
+                        for idx in sorted(power_hist)
+                    ]
+                    if gpu_available
+                    else []
+                ),
             },
         ).to_dict()
+
+    @staticmethod
+    def _pick_node(samples: List[Any]) -> Dict[str, Any]:
+        """The node whose window this is: the lowest node_rank seen.
+
+        Hosts are told apart by hostname (node_rank breaks the tie order);
+        ``nodes_in_window`` > 1 means other machines were dropped from
+        this payload, which the block must say. Rows without a hostname
+        (pre-0.3.0 writers, malformed meta) are not a node of their own:
+        they neither count nor select, the same rule the strip's node
+        count applies.
+        """
+        nodes: Dict[str, Optional[int]] = {}
+        for row in samples:
+            host = row["hostname"]
+            if host is None or str(host) == "":
+                continue
+            host = str(host)
+            rank = row["node_rank"]
+            rank = int(rank) if rank is not None else None
+            if host not in nodes or (
+                rank is not None
+                and (nodes[host] is None or rank < nodes[host])
+            ):
+                nodes[host] = rank
+        if not nodes:
+            return {"hostname": None, "node_rank": None, "nodes_in_window": 1}
+        host = min(
+            nodes,
+            key=lambda h: (
+                nodes[h] if nodes[h] is not None else float("inf"),
+                h,
+            ),
+        )
+        return {
+            "hostname": host,
+            "node_rank": nodes[host],
+            "nodes_in_window": len(nodes),
+        }
+
+    @staticmethod
+    def _gpu_rows(
+        latest_rows: Dict[int, Any],
+        util_hist: Dict[int, List[Optional[float]]],
+        power_hist: Dict[int, List[Optional[float]]],
+    ) -> List[Dict[str, Any]]:
+        """One entry per GPU seen in the window, newest values per GPU.
+
+        A GPU absent from the newest tick keeps its slot with None values
+        rather than vanishing, so a row count never silently drops.
+        """
+        out: List[Dict[str, Any]] = []
+        for idx in sorted(set(util_hist) | set(power_hist)):
+            g = latest_rows.get(idx)
+            if g is not None and not _gpu_reported(g):
+                g = None  # the sampler's all-zero fallback: unreported
+            out.append(
+                {
+                    "gpu_idx": idx,
+                    "util_now": (
+                        _opt_float(g["util"]) if g is not None else None
+                    ),
+                    "util_p50": _median(util_hist.get(idx, [])),
+                    "mem_used": (
+                        _opt_float(g["mem_used_bytes"])
+                        if g is not None
+                        else None
+                    ),
+                    "mem_total": (
+                        _positive(g["mem_total_bytes"])
+                        if g is not None
+                        else None
+                    ),
+                    "temp": (
+                        _opt_float(g["temperature_c"])
+                        if g is not None
+                        else None
+                    ),
+                    "power": (
+                        _opt_float(g["power_usage_w"])
+                        if g is not None
+                        else None
+                    ),
+                    "power_limit": (
+                        _positive(g["power_limit_w"])
+                        if g is not None
+                        else None
+                    ),
+                }
+            )
+        return out
 
     def _format_time_iso(self, ts_s: float) -> str:
         """
@@ -249,7 +448,12 @@ class SystemDashboardComputer:
                     "rollups": rollups,
                     "series": cached.get(
                         "series",
-                        {"x_time": [], "cpu": [], "gpu_avg": []},
+                        {
+                            "x_time": [],
+                            "cpu": [],
+                            "gpu_avg": [],
+                            "gpu_power": [],
+                        },
                     ),
                 }
 
@@ -257,7 +461,12 @@ class SystemDashboardComputer:
             "window_len": 0,
             "gpu_available": False,
             "rollups": {"status": "No fresh system data"},
-            "series": {"x_time": [], "cpu": [], "gpu_avg": []},
+            "series": {
+                "x_time": [],
+                "cpu": [],
+                "gpu_avg": [],
+                "gpu_power": [],
+            },
         }
 
     def _empty_payload(self) -> Dict[str, Any]:
@@ -268,5 +477,10 @@ class SystemDashboardComputer:
             window_len=0,
             gpu_available=False,
             rollups={},
-            series={"x_time": [], "cpu": [], "gpu_avg": []},
+            series={
+                "x_time": [],
+                "cpu": [],
+                "gpu_avg": [],
+                "gpu_power": [],
+            },
         ).to_dict()

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -51,6 +51,24 @@ def _gpu_reported(row: Any) -> bool:
     )
 
 
+def _empty_dashboard_series() -> Dict[str, Any]:
+    """Return the complete dashboard-series schema with no observations."""
+    return {
+        "x_time": [],
+        "cpu": [],
+        "gpu_avg": [],
+        "gpu_power": [],
+        "cpu_run": {
+            "t": [],
+            "avg": [],
+            "max": [],
+            "span_s": 0.0,
+            "window_s": 0.0,
+        },
+        "gpu_power_run": [],
+    }
+
+
 class SystemDashboardComputer:
     """Compute dashboard rollups and short time-series."""
 
@@ -468,12 +486,7 @@ class SystemDashboardComputer:
                     "rollups": rollups,
                     "series": cached.get(
                         "series",
-                        {
-                            "x_time": [],
-                            "cpu": [],
-                            "gpu_avg": [],
-                            "gpu_power": [],
-                        },
+                        _empty_dashboard_series(),
                     ),
                 }
 
@@ -481,12 +494,7 @@ class SystemDashboardComputer:
             "window_len": 0,
             "gpu_available": False,
             "rollups": {"status": "No fresh system data"},
-            "series": {
-                "x_time": [],
-                "cpu": [],
-                "gpu_avg": [],
-                "gpu_power": [],
-            },
+            "series": _empty_dashboard_series(),
         }
 
     def _empty_payload(self) -> Dict[str, Any]:
@@ -497,10 +505,5 @@ class SystemDashboardComputer:
             window_len=0,
             gpu_available=False,
             rollups={},
-            series={
-                "x_time": [],
-                "cpu": [],
-                "gpu_avg": [],
-                "gpu_power": [],
-            },
+            series=_empty_dashboard_series(),
         ).to_dict()

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -16,6 +16,9 @@ import numpy as np
 
 from .common import SystemDashboardPayload, SystemMetricsDB
 
+# Whole-run charts add value only after the run outgrows the recent window.
+_RUN_VIEW_FACTOR = 1.2
+
 
 def _opt_float(value: Any) -> Optional[float]:
     """Float or None: an unreported column stays unreported, never 0."""
@@ -264,8 +267,35 @@ class SystemDashboardComputer:
             if system_node["nodes_in_window"] > 1
             else None
         )
-        cpu_run = self._db.fetch_cpu_run_history(conn, hostname=host)
-        power_run = self._db.fetch_gpu_power_run_history(conn, hostname=host)
+        window_span = max(float(ts_hist[-1] - ts_hist[0]), 0.0)
+        min_run_span = window_span * _RUN_VIEW_FACTOR
+        cpu_run = self._db.fetch_cpu_run_history(
+            conn,
+            hostname=host,
+            min_span_s=min_run_span,
+        )
+        power_run = (
+            self._db.fetch_gpu_power_run_history(
+                conn,
+                hostname=host,
+                min_span_s=min_run_span,
+            )
+            if gpu_available
+            else []
+        )
+        run_power_floor = min(
+            (v for e in power_run for v in (e.get("min") or [])),
+            default=None,
+        )
+        window_power_floor = min(
+            (
+                v
+                for values in power_hist.values()
+                for v in values
+                if v is not None
+            ),
+            default=None,
+        )
 
         rollups = {
             "gpu_available": gpu_available,
@@ -312,9 +342,10 @@ class SystemDashboardComputer:
                 # run that is the idle level (the sampler is up before the
                 # first step and after the last), which is what a starved
                 # GPU falls back to, so it is worth a reference line.
-                "floor": min(
-                    (v for e in power_run for v in (e.get("min") or [])),
-                    default=None,
+                "floor": (
+                    run_power_floor
+                    if run_power_floor is not None
+                    else window_power_floor
                 ),
             },
             "gpus": (

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -241,6 +241,14 @@ class SystemDashboardComputer:
             "Hot" if temp_now >= 85 else "Warm" if temp_now >= 80 else "OK"
         )
 
+        host = (
+            system_node["hostname"]
+            if system_node["nodes_in_window"] > 1
+            else None
+        )
+        cpu_run = self._db.fetch_cpu_run_history(conn, hostname=host)
+        power_run = self._db.fetch_gpu_power_run_history(conn, hostname=host)
+
         rollups = {
             "gpu_available": gpu_available,
             "cpu": {
@@ -282,6 +290,14 @@ class SystemDashboardComputer:
                 "now": power_max_hist[-1],
                 "p50": _median(power_max_hist),
                 "limit": power_limit,
+                # The lowest draw seen anywhere in the run. On almost any
+                # run that is the idle level (the sampler is up before the
+                # first step and after the last), which is what a starved
+                # GPU falls back to, so it is worth a reference line.
+                "floor": min(
+                    (v for e in power_run for v in (e.get("min") or [])),
+                    default=None,
+                ),
             },
             "gpus": (
                 self._gpu_rows(latest_rows, util_hist, power_hist)
@@ -299,13 +315,6 @@ class SystemDashboardComputer:
         }
 
         x_time = [self._format_time_iso(ts) for ts in ts_hist.tolist()]
-        host = (
-            system_node["hostname"]
-            if system_node["nodes_in_window"] > 1
-            else None
-        )
-        cpu_run = self._db.fetch_cpu_run_history(conn, hostname=host)
-        power_run = self._db.fetch_gpu_power_run_history(conn, hostname=host)
 
         return SystemDashboardPayload(
             window_len=len(samples),

--- a/tests/display/test_context_section.py
+++ b/tests/display/test_context_section.py
@@ -78,7 +78,7 @@ def test_coverage_never_invents_a_missing_fact() -> None:
 def test_watch_profile_shows_no_step_sections() -> None:
     watch = sections_for_profile("watch")
     assert not set(watch) & set(STEP_SECTIONS)
-    assert {"system", "process", "gpu_gauge"} <= set(watch)
+    assert {"system", "process"} <= set(watch)
     assert sections_for_profile("run") == RUN_SECTIONS
     assert sections_for_profile("deep") == RUN_SECTIONS
     assert sections_for_profile("") == RUN_SECTIONS

--- a/tests/display/test_nicegui_driver.py
+++ b/tests/display/test_nicegui_driver.py
@@ -158,14 +158,12 @@ def test_dashboard_sections_build_without_error() -> None:
         build_step_memory_section,
     )
     from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section import (
-        build_gpu_gauge_section,
         build_system_section,
     )
 
     # Smoke the actual section construction performed when a browser renders
     # the dashboard route. This catches NiceGUI element signature changes.
     build_model_combined_section()
-    build_gpu_gauge_section()
     build_system_section()
     build_process_section()
     build_step_memory_section()

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -24,6 +24,7 @@ from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section impor
     disclosure_text,
     format_gb_pair,
     format_span,
+    format_window,
     gpu_color,
     odd_ones_out,
     power_axis_bounds,
@@ -228,6 +229,163 @@ def test_rows_table_shows_absence_not_zero() -> None:
     assert "0 / 0" not in html
 
 
+def test_whole_run_charts_share_one_clock_axis() -> None:
+    """A vertical read across the pair must land on the same moment.
+
+    The two series reach back different distances (the CPU rolling mean
+    drops its first partial window, the power buckets do not), so pinning
+    each chart to its own span would offset them by a window. The run's
+    length itself is not repeated in the labels: the context strip states
+    it once, and the axis now carries the clock.
+    """
+    from nicegui import ui
+
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section import (  # noqa: E501
+        build_system_section,
+        update_system_section,
+    )
+
+    base = 1_755_000_000.0
+    cpu_t = [base + 120.0 + 60.0 * i for i in range(40)]  # starts later
+    pwr_t = [base + 30.0 * i for i in range(80)]  # starts earlier
+    with ui.element("div"):
+        panel = build_system_section()
+    payload = {
+        "window_len": 2,
+        "gpu_available": True,
+        "rollups": {
+            "gpu_available": True,
+            "cpu": {"now": 30.0, "p50": 32.0, "p95": 44.0},
+            "ram": {"now": 9.0 * GB, "total": 200.0 * GB},
+            "gpu_util": {"now": 99.0, "p50": 99.0, "p95": 99.0},
+            "gpu_delta": {"now": 0.0, "p95": 0.0},
+            "gpu_mem": {"now": 6.3 * GB, "total": 16.1 * GB},
+            "temp": {"now": 48.0, "status": "OK"},
+            "gpu_power": {
+                "now": 68.0,
+                "p50": 67.0,
+                "limit": 70.0,
+                "floor": 30.0,
+            },
+            "gpus": _gpus()[:1],
+            "ctx": {"gpu_count": 1},
+        },
+        "series": {
+            "x_time": [
+                "2026-08-21T10:00:00+00:00",
+                "2026-08-21T10:03:20+00:00",
+            ],
+            "cpu": [30.0, 31.0],
+            "gpu_avg": [99.0, 99.0],
+            "gpu_power": [{"gpu_idx": 0, "values": [66.0, 68.0]}],
+            "cpu_run": {
+                "t": cpu_t,
+                "avg": [30.0] * 40,
+                "max": [44.0] * 40,
+                "span_s": cpu_t[-1] - cpu_t[0],
+                "window_s": 120.0,
+            },
+            "gpu_power_run": [
+                {
+                    "gpu_idx": 0,
+                    "t": pwr_t,
+                    "avg": [67.0] * 80,
+                    "min": [57.0] * 80,
+                    "max": [69.0] * 80,
+                    "span_s": pwr_t[-1] - pwr_t[0],
+                    "window_s": 120.0,
+                }
+            ],
+        },
+    }
+    update_system_section(panel, payload)
+    cpu_axis = panel["cpu_chart"].options["xAxis"]
+    pwr_axis = panel["power_chart"].options["xAxis"]
+    assert (cpu_axis["min"], cpu_axis["max"]) == (
+        pwr_axis["min"],
+        pwr_axis["max"],
+    )
+    # The span reaches back to the earlier of the two starts.
+    assert cpu_axis["min"] == -(
+        max(cpu_t[-1], pwr_t[-1]) - min(cpu_t[0], pwr_t[0])
+    )
+    # Same clock in both formatters, so equal x means equal wall time.
+    assert (
+        cpu_axis["axisLabel"][":formatter"]
+        == pwr_axis["axisLabel"][":formatter"]
+    )
+    # The duration is the strip's fact; the labels say the view, not the
+    # length.
+    assert panel["cpu_label"].text == (
+        "host cpu util · avg across cores · whole run · rolling 2 min"
+    )
+    assert panel["power_label"].text == (
+        "gpu power · per GPU vs 70 W limit · whole run · "
+        "mean and floor of every 2 min"
+    )
+    assert "min," not in panel["cpu_label"].text
+
+
+def test_power_chart_draws_limit_and_floor_reference_lines() -> None:
+    """The band the GPUs actually work in needs both edges.
+
+    The limit alone says how much headroom is unused; the run's lowest
+    draw says where 'this GPU is waiting' sits on the same axis, so a
+    dip toward it reads as a stall rather than as a small number.
+    """
+    from nicegui import ui
+
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section import (  # noqa: E501
+        build_system_section,
+        update_system_section,
+    )
+
+    def refs_for(power: dict) -> list:
+        with ui.element("div"):
+            panel = build_system_section()
+        payload = {
+            "window_len": 2,
+            "gpu_available": True,
+            "rollups": {
+                "gpu_available": True,
+                "cpu": {"now": 9.0, "p50": 8.0, "p95": 12.0},
+                "ram": {"now": 9.0 * GB, "total": 200.0 * GB},
+                "gpu_util": {"now": 25.0, "p50": 25.0, "p95": 25.0},
+                "gpu_delta": {"now": 0.0, "p95": 0.0},
+                "gpu_mem": {"now": 6.67 * GB, "total": 16.1 * GB},
+                "temp": {"now": 54.0, "status": "OK"},
+                "gpu_power": power,
+                "gpus": _gpus(),
+                "ctx": {"gpu_count": 2},
+            },
+            "series": {
+                "x_time": [
+                    "2026-08-21T10:00:00+00:00",
+                    "2026-08-21T10:03:20+00:00",
+                ],
+                "cpu": [8.0, 9.0],
+                "gpu_avg": [25.0, 25.0],
+                "gpu_power": [{"gpu_idx": 0, "values": [66.0, 68.0]}],
+            },
+        }
+        update_system_section(panel, payload)
+        data = panel["power_chart"].options["series"][0]["markLine"]["data"]
+        return [(r["yAxis"], r["label"]["formatter"]) for r in data]
+
+    both = refs_for({"now": 68.0, "p50": 67.0, "limit": 70.0, "floor": 33.0})
+    assert both == [(70.0, "70 W limit"), (33.0, "33 W lowest seen")]
+    # The two lines carry different colours: the limit keeps the red.
+    # A floor that sits at the limit would draw two lines on top of each
+    # other and say nothing, so it is dropped.
+    assert refs_for(
+        {"now": 68.0, "p50": 67.0, "limit": 70.0, "floor": 69.0}
+    ) == [(70.0, "70 W limit")]
+    # A board that reports no limit still gets the floor.
+    assert refs_for(
+        {"now": 68.0, "p50": 67.0, "limit": None, "floor": 33.0}
+    ) == [(33.0, "33 W lowest seen")]
+
+
 def test_section_builds_and_updates_without_a_browser() -> None:
     from nicegui import ui
 
@@ -285,12 +443,19 @@ def test_section_builds_and_updates_without_a_browser() -> None:
         == "host cpu util · avg across cores · last 3 min"
     )
     assert panel["power_label"].text.endswith("70 W limit · last 3 min")
-    assert panel["cpu_chart"].options["xAxis"]["axisLabel"]["show"] is False
+    assert panel["cpu_chart"].options["xAxis"]["axisLabel"]["show"] is True
+    assert (
+        "getHours"
+        in panel["cpu_chart"].options["xAxis"]["axisLabel"][":formatter"]
+    )
     assert ":formatter" in (
         panel["cpu_chart"].options["tooltip"]["axisPointer"]["label"]
     )
-    assert panel["power_chart"].options["series"][0]["markLine"]["data"] == [
-        {"yAxis": 70.0}
+    # One reference line, the board limit, since this payload reports no
+    # run floor; each line carries its own colour and label.
+    refs = panel["power_chart"].options["series"][0]["markLine"]["data"]
+    assert [(r["yAxis"], r["label"]["formatter"]) for r in refs] == [
+        (70.0, "70 W limit")
     ]
 
     # The user closes the rows; the next identical tick must neither
@@ -462,3 +627,19 @@ def test_every_tile_keeps_a_qualifier_line() -> None:
         else:
             assert subs["util"] == "avg of 4 GPUs"
             assert subs["mem"] == "max GPU" and subs["temp"] == "max GPU"
+
+
+def test_rolling_window_is_spelled_out_not_named() -> None:
+    """A whole-run point smooths a stretch of the run; say how long it is.
+
+    "rolling 2 min" needs no glossary; "per slice" made a reader ask what a
+    slice was, and disjoint slices did not smooth a fast oscillation anyway.
+    """
+    from traceml_ai.renderers.system.common import choose_window_s
+
+    assert format_window(choose_window_s(96 * 60)) == "2 min"  # 96-min run
+    assert format_window(choose_window_s(178 * 60)) == "5 min"  # 3-hour
+    assert format_window(choose_window_s(23 * 60)) == "30 s"
+    assert format_window(choose_window_s(4 * 60)) == "30 s"  # the floor
+    assert format_window(choose_window_s(48 * 3600)) == "5 min"  # the cap
+    assert format_window(0.0) == ""

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -388,3 +388,74 @@ def test_header_names_the_node_when_others_were_dropped() -> None:
     # Only the System payload's own facts are read: a strip-style
     # node_count on the dict changes nothing.
     assert node_scope_text({"system_node": one, "node_count": 2}) == ""
+
+
+def test_every_tile_keeps_a_qualifier_line() -> None:
+    """A blank qualifier made one tile a line shorter than its neighbours.
+
+    On a single-GPU host the temperature tile had nothing to say under it
+    ("max GPU" is meaningless with one GPU), so the box lost its third
+    line and the row of four read as uneven.
+    """
+    from nicegui import ui
+
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section import (  # noqa: E501
+        build_system_section,
+        update_system_section,
+    )
+
+    def payload(n_gpus: int) -> dict:
+        return {
+            "window_len": 2,
+            "gpu_available": True,
+            "rollups": {
+                "gpu_available": True,
+                "cpu": {"now": 9.0, "p50": 8.0},
+                "ram": {"now": 9.0 * GB, "total": 200.0 * GB},
+                "gpu_util": {"now": 99.0, "p50": 99.0},
+                "gpu_delta": {"now": 0.0, "p95": 0.0},
+                "gpu_mem": {"now": 6.3 * GB, "total": 16.1 * GB},
+                "temp": {"now": 48.0},
+                "gpu_power": {"now": 66.0, "p50": 66.0, "limit": 70.0},
+                "gpus": [
+                    {
+                        "gpu_idx": i,
+                        "util_now": 99.0,
+                        "util_p50": 99.0,
+                        "mem_used": 6.3 * GB,
+                        "mem_total": 16.1 * GB,
+                        "temp": 48.0,
+                        "power": 66.0,
+                        "power_limit": 70.0,
+                    }
+                    for i in range(n_gpus)
+                ],
+            },
+            "series": {
+                "x_time": [
+                    "2026-08-21T10:00:00+00:00",
+                    "2026-08-21T10:03:20+00:00",
+                ],
+                "cpu": [8.0, 9.0],
+                "gpu_avg": [99.0, 99.0],
+                "gpu_power": [
+                    {"gpu_idx": i, "values": [66.0, 66.0]}
+                    for i in range(n_gpus)
+                ],
+            },
+        }
+
+    for n in (1, 4):
+        with ui.element("div"):
+            panel = build_system_section()
+        update_system_section(panel, payload(n))
+        subs = {
+            k: panel["subs"][k].text for k in ("util", "mem", "temp", "ram")
+        }
+        assert all(subs.values()), (n, subs)
+        if n == 1:
+            assert subs["util"] == "1 GPU" and subs["temp"] == "1 GPU"
+            assert subs["mem"] == "used / total"
+        else:
+            assert subs["util"] == "avg of 4 GPUs"
+            assert subs["mem"] == "max GPU" and subs["temp"] == "max GPU"

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -322,7 +322,7 @@ def test_whole_run_charts_share_one_clock_axis() -> None:
     )
     assert panel["power_label"].text == (
         "gpu power · per GPU vs 70 W limit · whole run · "
-        "mean and floor of every 2 min"
+        "average and lowest every 2 min"
     )
     assert "min," not in panel["cpu_label"].text
 

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -19,7 +19,6 @@ import pytest
 pytest.importorskip("nicegui")
 
 from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section import (  # noqa: E402,E501
-    SPREAD_EXPAND_PTS,
     cpu_axis_max,
     disclosure_text,
     format_gb_pair,
@@ -51,44 +50,46 @@ def test_levels_carry_their_denominator() -> None:
     assert format_gb_pair(0.47 * GB, None) == ("0.5", "GB")
 
 
-def test_disclosure_text_speaks_in_gpu_words() -> None:
-    def g(i, u):
-        return {"gpu_idx": i, "util_p50": u}
+def test_disclosure_text_states_the_range_and_no_verdict() -> None:
+    """The header reads the GPUs out, it does not judge them.
+
+    Calling a GPU "idle" needs a threshold, and the one this layer used
+    (20 %) disagreed with the diagnosis engine's low band (30 %), which is
+    the surface inventing vocabulary the engine owns. The range says the
+    same thing to a person without either.
+    """
+
+    def g(idx, util):
+        return {"gpu_idx": idx, "util_p50": util, "util_now": util}
 
     one_busy = [g(0, 100), g(1, 0), g(2, 0), g(3, 0)]
-    all_busy = [g(i, 100) for i in range(4)]
-    ramp = [g(0, 98), g(1, 100), g(2, 100), g(3, 100)]
-    # The trigger fired and GPUs sit idle: say which.
-    assert disclosure_text(one_busy, over=True, is_open=True) == (
-        "1 of 4 GPUs busy, 3 idle · click to close"
+    all_busy = [g(i, 99) for i in range(4)]
+    ramp = [g(0, 100), g(1, 60), g(2, 55), g(3, 40)]
+
+    assert disclosure_text(one_busy, is_open=True) == (
+        "4 GPUs · util 0 to 100% · click to close"
     )
-    # A user closed the rows while the spread stays over the bar: the
-    # words keep the fact, the tail follows the real state.
-    assert disclosure_text(one_busy, over=True, is_open=False) == (
-        "1 of 4 GPUs busy, 3 idle · click to open"
+    assert disclosure_text(one_busy, is_open=False) == (
+        "4 GPUs · util 0 to 100% · click to open"
     )
-    # The trigger fired on a ramp (nobody idle): honest, no mechanism.
-    assert disclosure_text(ramp, over=True, is_open=True) == (
-        "uneven load across GPUs · click to close"
+    assert disclosure_text(ramp, is_open=True) == (
+        "4 GPUs · util 40 to 100% · click to close"
     )
-    assert disclosure_text(all_busy, over=False, is_open=False) == (
-        "all 4 GPUs alike · click to open"
+    assert disclosure_text(all_busy, is_open=False) == (
+        "4 GPUs · util 99 to 99% · click to open"
     )
-    assert disclosure_text(all_busy, over=False, is_open=True) == (
-        "all 4 GPUs alike · click to close"
+    # One GPU has no range to speak of, and no rows worth naming.
+    assert (
+        disclosure_text([g(0, 99)], is_open=False) == "1 GPU · click to open"
     )
-    assert disclosure_text([g(0, 99)], over=False, is_open=False) == (
-        "1 GPU · click to open"
-    )
-    assert disclosure_text([], over=False, is_open=False) == ""
-    # No mechanism words anywhere in the header.
+    assert disclosure_text([], is_open=False) == ""
+    # No word anywhere claims a verdict the engine owns.
     for text in (
-        disclosure_text(one_busy, over=True, is_open=True),
-        disclosure_text(all_busy, over=False, is_open=False),
+        disclosure_text(one_busy, is_open=True),
+        disclosure_text(all_busy, is_open=False),
     ):
-        for banned in ("spread", "auto", ">", "20"):
-            assert banned not in text
-    assert SPREAD_EXPAND_PTS == 20.0
+        for word in ("idle", "busy", "alike", "uneven", "low", "healthy"):
+            assert word not in text
 
 
 def test_rows_open_on_the_rising_edge_only() -> None:
@@ -445,7 +446,7 @@ def test_section_builds_and_updates_without_a_browser() -> None:
     assert panel["cpu_value"].text == "8%"
     assert panel["rows"].value is True  # spread 100 crossed the bar
     assert (
-        panel["rows_hint"].text == "1 of 2 GPUs busy, 1 idle · click to close"
+        panel["rows_hint"].text == "2 GPUs · util 0 to 100% · click to close"
     )
     # The window is named once in each chart's label, never on the axis.
     assert (
@@ -477,9 +478,7 @@ def test_section_builds_and_updates_without_a_browser() -> None:
     panel["power_chart"].update = lambda: sent.append("power")
     update_system_section(panel, payload)
     assert panel["rows"].value is False
-    assert (
-        panel["rows_hint"].text == "1 of 2 GPUs busy, 1 idle · click to open"
-    )
+    assert panel["rows_hint"].text == "2 GPUs · util 0 to 100% · click to open"
     assert sent == []
 
     # The limit disappears on a later tick: the mark line is cleared

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -1,0 +1,390 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""System block: four tiles, two charts, spread-triggered per-GPU rows.
+
+Pure helpers carry the display rules so they can be checked without a
+browser: levels read "used / total", rates read one window median, the
+per-GPU rows open on their own when the across-GPU spread crosses the bar,
+and nothing on the block carries a verdict word.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section import (  # noqa: E402,E501
+    SPREAD_EXPAND_PTS,
+    cpu_axis_max,
+    disclosure_text,
+    format_gb_pair,
+    format_span,
+    gpu_color,
+    odd_ones_out,
+    power_axis_bounds,
+    rows_html,
+    should_auto_open,
+    sparkline_svg,
+)
+
+GB = 1e9
+
+
+def test_span_reads_as_a_window_not_a_clock() -> None:
+    assert format_span(200.0) == "last 3 min"
+    assert format_span(238.0) == "last 4 min"
+    assert format_span(50.0) == "last 50 s"
+    assert format_span(0.0) == ""
+    assert format_span(None) == ""
+
+
+def test_levels_carry_their_denominator() -> None:
+    assert format_gb_pair(6.31 * GB, 16.1 * GB) == ("6.3", "/ 16.1 GB")
+    assert format_gb_pair(9.0 * GB, 200.0 * GB) == ("9.0", "/ 200 GB")
+    assert format_gb_pair(None, 16.1 * GB) == ("n/a", "")
+    assert format_gb_pair(0.47 * GB, None) == ("0.5", "GB")
+
+
+def test_disclosure_text_speaks_in_gpu_words() -> None:
+    def g(i, u):
+        return {"gpu_idx": i, "util_p50": u}
+
+    one_busy = [g(0, 100), g(1, 0), g(2, 0), g(3, 0)]
+    all_busy = [g(i, 100) for i in range(4)]
+    ramp = [g(0, 98), g(1, 100), g(2, 100), g(3, 100)]
+    # The trigger fired and GPUs sit idle: say which.
+    assert disclosure_text(one_busy, over=True, is_open=True) == (
+        "1 of 4 GPUs busy, 3 idle · click to close"
+    )
+    # A user closed the rows while the spread stays over the bar: the
+    # words keep the fact, the tail follows the real state.
+    assert disclosure_text(one_busy, over=True, is_open=False) == (
+        "1 of 4 GPUs busy, 3 idle · click to open"
+    )
+    # The trigger fired on a ramp (nobody idle): honest, no mechanism.
+    assert disclosure_text(ramp, over=True, is_open=True) == (
+        "uneven load across GPUs · click to close"
+    )
+    assert disclosure_text(all_busy, over=False, is_open=False) == (
+        "all 4 GPUs alike · click to open"
+    )
+    assert disclosure_text(all_busy, over=False, is_open=True) == (
+        "all 4 GPUs alike · click to close"
+    )
+    assert disclosure_text([g(0, 99)], over=False, is_open=False) == (
+        "1 GPU · click to open"
+    )
+    assert disclosure_text([], over=False, is_open=False) == ""
+    # No mechanism words anywhere in the header.
+    for text in (
+        disclosure_text(one_busy, over=True, is_open=True),
+        disclosure_text(all_busy, over=False, is_open=False),
+    ):
+        for banned in ("spread", "auto", ">", "20"):
+            assert banned not in text
+    assert SPREAD_EXPAND_PTS == 20.0
+
+
+def test_rows_open_on_the_rising_edge_only() -> None:
+    # Crossing the bar opens the rows once; staying above it does not
+    # reopen rows the user closed; dropping below never closes them.
+    assert should_auto_open(prev_over=False, over=True) is True
+    assert should_auto_open(prev_over=True, over=True) is False
+    assert should_auto_open(prev_over=True, over=False) is False
+    assert should_auto_open(prev_over=False, over=False) is False
+
+
+def test_power_axis_keeps_the_limit_in_frame() -> None:
+    lo, hi, tick = power_axis_bounds([60.0, 66.0, 95.0], 70.0)
+    assert lo <= 60.0 and hi >= 95.0 and hi >= 70.0
+    # Round ticks, the bottom one a multiple of the tick size.
+    assert tick % 10 == 0 and lo % tick == 0 and (hi - lo) % tick == 0
+    # The reference shape: idle GPUs near 33 W, a busy one up to ~100 W.
+    assert power_axis_bounds([33.0, 68.0, 101.0], 70.0) == (
+        25.0,
+        125.0,
+        25.0,
+    )
+    # All busy: 60-100 W under a 70 W limit.
+    assert power_axis_bounds([60.0, 100.0], 70.0) == (40.0, 120.0, 20.0)
+    # No limit reported: bounds still cover the data.
+    lo, hi, tick = power_axis_bounds([33.0, 34.0], None)
+    assert lo <= 33.0 and hi >= 34.0 and lo >= 0.0
+    assert power_axis_bounds([], None) == (0.0, 100.0, 50.0)
+
+
+def test_cpu_axis_halves_to_whole_percents() -> None:
+    assert cpu_axis_max([2.0, 2.4]) == 4.0
+    assert cpu_axis_max([8.0, 9.0]) == 20.0
+    assert cpu_axis_max([95.0]) == 100.0
+    assert cpu_axis_max([]) == 4.0
+
+
+def test_sparkline_is_inline_svg_with_gaps_dropped() -> None:
+    svg = sparkline_svg([66.0, None, 68.0, 67.0], gpu_color(0))
+    assert svg.startswith("<svg") and "<polyline" in svg
+    assert gpu_color(0) in svg
+    assert sparkline_svg([], gpu_color(1)) == ""
+    assert sparkline_svg([None, None], gpu_color(1)) == ""
+
+
+def _gpus():
+    return [
+        {
+            "gpu_idx": 0,
+            "util_now": 100.0,
+            "util_p50": 100.0,
+            "mem_used": 6.67 * GB,
+            "mem_total": 16.1 * GB,
+            "temp": 54.0,
+            "power": 68.0,
+            "power_limit": 70.0,
+        },
+        {
+            "gpu_idx": 1,
+            "util_now": 0.0,
+            "util_p50": 0.0,
+            "mem_used": 0.47 * GB,
+            "mem_total": 16.1 * GB,
+            "temp": 41.0,
+            "power": 33.0,
+            "power_limit": 70.0,
+        },
+    ]
+
+
+def test_rows_table_reads_per_gpu_and_tints_only_the_busy_row() -> None:
+    series = [
+        {"gpu_idx": 0, "values": [66.0, 68.0]},
+        {"gpu_idx": 1, "values": [33.0, 33.0]},
+    ]
+    html = rows_html(_gpus(), series, spread=100.0)
+    assert "gpu0" in html and "gpu1" in html
+    assert "6.67 / 16.1" in html and "0.47 / 16.1" in html
+    assert "68 / 70" in html and "33 / 70" in html
+    assert "<polyline" in html
+    # One tinted row (the busy one) when the spread is over the bar...
+    assert html.count("tml-mark") == 1
+    assert (
+        'class="tml-mark"><td><span style="color:#f97316">■</span> gpu0'
+        in html
+    )
+    # ...and none when every GPU reads the same.
+    calm = rows_html(_gpus(), series, spread=0.0)
+    assert "tml-mark" not in calm
+    # No verdict words anywhere on the block.
+    for word in ("Hot", "Warm", "HIGH", "verdict"):
+        assert word not in html
+
+
+def test_tint_marks_the_odd_ones_out() -> None:
+    def g(i, u):
+        return {"gpu_idx": i, "util_p50": u, "util_now": u}
+
+    # 1 busy of 4: the busy GPU is the anomaly.
+    assert odd_ones_out([g(0, 100), g(1, 0), g(2, 0), g(3, 0)]) == {0}
+    # 3 busy of 4 (a starved or dead rank): the idle GPU is the anomaly,
+    # not the first busy row.
+    assert odd_ones_out([g(0, 100), g(1, 100), g(2, 100), g(3, 0)]) == {3}
+    # 2 and 2: ties go to the busy side.
+    assert odd_ones_out([g(0, 100), g(1, 0), g(2, 100), g(3, 0)]) == {0, 2}
+    # Nothing to mark when every GPU reads the same, or only one reports.
+    assert odd_ones_out([g(0, 100), g(1, 100)]) == set()
+    assert odd_ones_out([g(0, 100), {"gpu_idx": 1}]) == set()
+
+
+def test_no_gpu_colour_is_the_limit_red() -> None:
+    import colorsys
+
+    def hue(hex_colour: str) -> float:
+        r, gg, b = (int(hex_colour[i : i + 2], 16) / 255 for i in (1, 3, 5))
+        return colorsys.rgb_to_hls(r, gg, b)[0] * 360
+
+    for i in range(8):
+        h = hue(gpu_color(i))
+        assert not (h < 15 or h > 345), (i, gpu_color(i))
+
+
+def test_rows_table_shows_absence_not_zero() -> None:
+    gpus = _gpus()
+    gpus[1].update(
+        {
+            "util_now": None,
+            "mem_used": None,
+            "mem_total": None,
+            "temp": None,
+            "power": None,
+            "power_limit": None,
+        }
+    )
+    html = rows_html(gpus, [], spread=None)
+    assert "gpu1" in html
+    assert "n/a" in html
+    assert "0 / 0" not in html
+
+
+def test_section_builds_and_updates_without_a_browser() -> None:
+    from nicegui import ui
+
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section import (  # noqa: E501
+        build_system_section,
+        update_system_section,
+    )
+
+    with ui.element("div"):
+        panel = build_system_section()
+    payload = {
+        "window_len": 2,
+        "gpu_available": True,
+        "rollups": {
+            "gpu_available": True,
+            "cpu": {"now": 9.0, "p50": 8.0, "p95": 12.0},
+            "ram": {"now": 9.0 * GB, "total": 200.0 * GB},
+            "gpu_util": {"now": 0.0, "p50": 25.0, "p95": 25.0},
+            "gpu_delta": {"now": 0.0, "p95": 100.0},
+            "gpu_mem": {"now": 6.67 * GB, "total": 16.1 * GB},
+            "temp": {"now": 54.0, "status": "OK"},
+            "gpu_power": {"now": 68.0, "p50": 67.0, "limit": 70.0},
+            "gpus": _gpus(),
+            "ctx": {"gpu_count": 4},
+        },
+        "series": {
+            "x_time": [
+                "2026-08-21T10:00:00+00:00",
+                "2026-08-21T10:03:20+00:00",
+            ],
+            "cpu": [8.0, 9.0],
+            "gpu_avg": [25.0, 25.0],
+            "gpu_power": [
+                {"gpu_idx": 0, "values": [66.0, 68.0]},
+                {"gpu_idx": 1, "values": [33.0, 33.0]},
+            ],
+        },
+    }
+    update_system_section(panel, payload)
+    # The util tile is the window median, not the raw last tick (0).
+    assert "25" in panel["tiles"]["util"].content
+    assert "0<" not in panel["tiles"]["util"].content
+    assert "6.7" in panel["tiles"]["mem"].content
+    assert "16.1" in panel["tiles"]["mem"].content
+    assert "54" in panel["tiles"]["temp"].content
+    assert "200" in panel["tiles"]["ram"].content
+    assert panel["cpu_value"].text == "8%"
+    assert panel["rows"].value is True  # spread 100 crossed the bar
+    assert (
+        panel["rows_hint"].text == "1 of 2 GPUs busy, 1 idle · click to close"
+    )
+    # The window is named once in each chart's label, never on the axis.
+    assert panel["cpu_label"].text == "host cpu % · last 3 min"
+    assert panel["power_label"].text.endswith("70 W limit · last 3 min")
+    assert panel["cpu_chart"].options["xAxis"]["axisLabel"]["show"] is False
+    assert ":formatter" in (
+        panel["cpu_chart"].options["tooltip"]["axisPointer"]["label"]
+    )
+    assert panel["power_chart"].options["series"][0]["markLine"]["data"] == [
+        {"yAxis": 70.0}
+    ]
+
+    # The user closes the rows; the next identical tick must neither
+    # reopen them nor describe them as expanded, and must not re-send
+    # the charts.
+    panel["rows"].value = False
+    sent = []
+    panel["cpu_chart"].update = lambda: sent.append("cpu")
+    panel["power_chart"].update = lambda: sent.append("power")
+    update_system_section(panel, payload)
+    assert panel["rows"].value is False
+    assert (
+        panel["rows_hint"].text == "1 of 2 GPUs busy, 1 idle · click to open"
+    )
+    assert sent == []
+
+    # The limit disappears on a later tick: the mark line is cleared
+    # explicitly (ECharts merges options, omitting the key keeps it).
+    later = dict(payload)
+    later["rollups"] = dict(payload["rollups"])
+    later["rollups"]["gpu_power"] = {"now": 68.0, "p50": 67.0, "limit": None}
+    later["series"] = dict(payload["series"])
+    later["series"]["x_time"] = payload["series"]["x_time"][:1] + [
+        "2026-08-21T10:03:22+00:00"
+    ]
+    update_system_section(panel, later)
+    # (option mutations also notify the element, so count kinds not calls)
+    assert set(sent) == {"cpu", "power"}
+    assert panel["power_chart"].options["series"][0]["markLine"] == {
+        "data": []
+    }
+    assert panel["power_label"].text == "gpu power · per GPU · last 3 min"
+
+    # Every GPU unreported on the newest tick (the sampler's all-zero
+    # fallback): level tiles say so instead of printing 0 °C / 0.0 GB.
+    zeroed = dict(later)
+    zeroed["rollups"] = dict(later["rollups"])
+    zeroed["rollups"]["gpus"] = [
+        {
+            "gpu_idx": i,
+            "util_now": None,
+            "util_p50": 100.0,
+            "mem_used": None,
+            "mem_total": None,
+            "temp": None,
+            "power": None,
+            "power_limit": None,
+        }
+        for i in range(2)
+    ]
+    update_system_section(panel, zeroed)
+    assert panel["tiles"]["mem"].content == "n/a"
+    assert panel["subs"]["temp"].text == "GPU sample unreported"
+
+    # A CPU-only box hides the GPU tiles, the power chart and the rows.
+    update_system_section(
+        panel,
+        {
+            "window_len": 1,
+            "gpu_available": False,
+            "rollups": {
+                "gpu_available": False,
+                "cpu": {"now": 3.0, "p50": 3.0},
+                "ram": {"now": 1.0 * GB, "total": 16.0 * GB},
+                "gpu_power": {"now": None, "p50": None, "limit": None},
+                "gpus": [],
+            },
+            "series": {
+                "x_time": ["2026-08-21T10:00:00+00:00"],
+                "cpu": [3.0],
+                "gpu_avg": [],
+                "gpu_power": [],
+            },
+        },
+    )
+    assert panel["gpu_visible"] is False
+    # The four tiles stay in place; the GPU ones read a dash and say why.
+    for key in ("util", "mem", "temp"):
+        assert panel["tiles"][key].content == "n/a"
+        assert panel["subs"][key].text == "no GPU"
+    assert "16.0" in panel["tiles"]["ram"].content  # the RAM tile still works
+    # The chart and rows slots keep their place with a one-line state.
+    assert panel["power_label"].text == "gpu power"
+    assert panel["power_placeholder"].text == "no GPU reported"
+    assert panel["rows_placeholder"].text == "per-GPU rows · no GPU"
+
+
+def test_header_names_the_node_when_others_were_dropped() -> None:
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section import (  # noqa: E501
+        node_scope_text,
+    )
+
+    assert node_scope_text({}) == ""
+    one = {"hostname": "a", "node_rank": 0, "nodes_in_window": 1}
+    two = {"hostname": "a", "node_rank": 0, "nodes_in_window": 2}
+    assert node_scope_text({"system_node": one}) == ""
+    assert node_scope_text({"system_node": two}) == "node 0 of 2"
+    # Only the System payload's own facts are read: a strip-style
+    # node_count on the dict changes nothing.
+    assert node_scope_text({"system_node": one, "node_count": 2}) == ""

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -280,7 +280,10 @@ def test_section_builds_and_updates_without_a_browser() -> None:
         panel["rows_hint"].text == "1 of 2 GPUs busy, 1 idle · click to close"
     )
     # The window is named once in each chart's label, never on the axis.
-    assert panel["cpu_label"].text == "host cpu % · last 3 min"
+    assert (
+        panel["cpu_label"].text
+        == "host cpu util · avg across cores · last 3 min"
+    )
     assert panel["power_label"].text.endswith("70 W limit · last 3 min")
     assert panel["cpu_chart"].options["xAxis"]["axisLabel"]["show"] is False
     assert ":formatter" in (

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -340,6 +340,8 @@ def test_power_chart_draws_limit_and_floor_reference_lines() -> None:
         update_system_section,
     )
 
+    _last_refs: dict = {}
+
     def refs_for(power: dict) -> list:
         with ui.element("div"):
             panel = build_system_section()
@@ -369,11 +371,19 @@ def test_power_chart_draws_limit_and_floor_reference_lines() -> None:
             },
         }
         update_system_section(panel, payload)
-        data = panel["power_chart"].options["series"][0]["markLine"]["data"]
-        return [(r["yAxis"], r["label"]["formatter"]) for r in data]
+        mark = panel["power_chart"].options["series"][0]["markLine"]
+        _last_refs.clear()
+        _last_refs.update(mark)
+        return [(r["yAxis"], r["label"]["formatter"]) for r in mark["data"]]
 
     both = refs_for({"now": 68.0, "p50": 67.0, "limit": 70.0, "floor": 33.0})
     assert both == [(70.0, "70 W limit"), (33.0, "33 W lowest seen")]
+    # Opposite corners, so neither label lands on the other.
+    data = _last_refs["data"]
+    assert [r["label"]["position"] for r in data] == [
+        "insideEndTop",
+        "insideStartBottom",
+    ]
     # The two lines carry different colours: the limit keeps the red.
     # A floor that sits at the limit would draw two lines on top of each
     # other and say nothing, so it is dropped.

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -110,7 +110,12 @@ def test_one_busy_of_four_reads_average_with_full_spread(
     assert roll["gpu_delta"]["p95"] == 100.0
 
     # Every aggregate cell is the max GPU, never a sum.
-    assert roll["gpu_power"] == {"now": 68.0, "p50": 68.0, "limit": LIMIT}
+    assert roll["gpu_power"] == {
+        "now": 68.0,
+        "p50": 68.0,
+        "limit": LIMIT,
+        "floor": 33.0,  # the idle GPUs' draw, the run's lowest
+    }
     assert roll["gpu_mem"]["now"] == 6.67 * GB
     assert roll["gpu_mem"]["total"] == 16.1 * GB
     assert roll["temp"]["now"] == 54.0
@@ -174,6 +179,7 @@ def test_no_gpu_payload_carries_empty_gpu_lists(tmp_path: Path) -> None:
         "now": None,
         "p50": None,
         "limit": None,
+        "floor": None,
     }
     assert out["series"]["gpu_power"] == []
     assert out["series"]["cpu"] == [8.0] * TICKS
@@ -187,6 +193,7 @@ def test_unreported_power_stays_none(tmp_path: Path) -> None:
         "now": None,
         "p50": None,
         "limit": None,
+        "floor": None,
     }
     assert out["rollups"]["gpus"][0]["power"] is None
     assert out["series"]["gpu_power"][0]["values"] == [None] * TICKS
@@ -380,7 +387,9 @@ def test_whole_run_series_are_decimated_and_keep_peaks(tmp_path: Path) -> None:
     # the spike at tick 0 lands inside the first slice and lifts its mean.
     assert run["avg"][-1] > min(run["avg"]) + 20
     assert max(run["max"]) >= 95.0  # and so do the spikes
-    assert max(run["avg"]) < 95.0  # which the mean alone would have hidden
+    # The rolling mean never reaches the spike: it is smoothed away
+    # there and preserved in "max", which is the point of carrying both.
+    assert max(run["avg"]) < 95.0
 
     power = out["series"]["gpu_power_run"]
     assert [p["gpu_idx"] for p in power] == [0]

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -74,9 +74,15 @@ def _all_busy() -> List[Dict[str, Any]]:
     ]
 
 
-def _write(path: Path, rows_for_tick, *, gpu_available: bool = True) -> None:
+def _write(
+    path: Path,
+    rows_for_tick,
+    *,
+    gpu_available: bool = True,
+    ticks: int = TICKS,
+) -> None:
     with sqlite_database(path, init_summary_schema) as conn:
-        for seq in range(TICKS):
+        for seq in range(ticks):
             insert_system_sample(
                 conn,
                 row_id=seq + 1,
@@ -140,6 +146,8 @@ def test_one_busy_of_four_reads_average_with_full_spread(
     assert power[0]["values"] == [68.0] * TICKS
     assert power[1]["values"] == [33.0] * TICKS
     assert len(out["series"]["x_time"]) == TICKS
+    assert out["series"]["cpu_run"]["t"] == []
+    assert out["series"]["gpu_power_run"] == []
 
 
 def test_all_busy_reads_zero_spread(tmp_path: Path) -> None:
@@ -345,11 +353,32 @@ def test_reported_zero_power_remains_in_whole_run_history(
         lambda seq: [
             _gpu(0, 0.0, 0.0, temp=35.0, mem_used=0.5 * GB),
         ],
+        ticks=130,
     )
 
     out = _payload(db)
     assert out["rollups"]["gpu_power"]["floor"] == 0.0
-    assert out["series"]["gpu_power_run"][0]["min"] == [0.0, 0.0]
+    assert set(out["series"]["gpu_power_run"][0]["min"]) == {0.0}
+
+
+def test_cpu_only_run_does_not_read_gpu_power_history(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "cpu-only.db"
+    _write(db, lambda seq: (), gpu_available=False)
+    computer = SystemDashboardComputer(str(db))
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("CPU-only runs must not query GPU power history")
+
+    monkeypatch.setattr(
+        computer._db,
+        "fetch_gpu_power_run_history",
+        fail_if_called,
+    )
+    out = computer.compute(window_n=100)
+    assert out["series"]["gpu_power_run"] == []
 
 
 def test_rows_without_a_hostname_are_not_a_node(tmp_path: Path) -> None:
@@ -469,7 +498,7 @@ def test_cpu_whole_run_series_honors_point_cap(tmp_path: Path) -> None:
 def test_cpu_whole_run_keeps_all_eligible_points_under_cap(
     tmp_path: Path,
 ) -> None:
-    """Valid samples after the initial rolling window are not over-decimated."""
+    """Do not over-decimate valid samples after the initial rolling window."""
     db = tmp_path / "cpu-near-cap.db"
     ticks = 130
     with sqlite_database(db, init_summary_schema) as conn:
@@ -500,7 +529,9 @@ def test_whole_run_series_follow_the_node_scope(tmp_path: Path) -> None:
     db = tmp_path / "n.db"
     with sqlite_database(db, init_summary_schema) as conn:
         row_id = 0
-        for seq in range(60):
+        # Longer than the recent 100-sample window, so whole-run mode is
+        # active and its node scoping is exercised rather than bypassed.
+        for seq in range(160):
             for node, (host, cpu) in enumerate(
                 (("node-a", 10.0), ("node-b", 90.0))
             ):

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import pytest
+
 from tests.sqlite_fixtures import (
     init_summary_schema,
     insert_system_sample,
@@ -331,3 +333,93 @@ def test_rows_without_a_hostname_are_not_a_node(tmp_path: Path) -> None:
         "node_rank": 0,
         "nodes_in_window": 1,
     }
+
+
+def test_whole_run_series_are_decimated_and_keep_peaks(tmp_path: Path) -> None:
+    """The window says what the host is doing now; these say what it did.
+
+    Both are decimated in SQL so the payload stays a fixed size however long
+    the run is, and every slice keeps its max as well as its mean, because a
+    mean alone erases what matters: a CPU spike, a power peak.
+    """
+    db = tmp_path / "run.db"
+    ticks = 600  # 20 minutes at a 2 s cadence
+    with sqlite_database(db, init_summary_schema) as conn:
+        for seq in range(ticks):
+            cpu = 10.0 + 30.0 * (seq / ticks)  # drifts 10 -> 40%
+            if seq % 50 == 0:
+                cpu = 95.0  # with a periodic spike
+            insert_system_sample(
+                conn,
+                row_id=seq + 1,
+                rank=0,
+                ts=1000.0 + 2.0 * seq,
+                gpu_available=True,
+                gpu_count=1,
+                seq=seq,
+                cpu_percent=cpu,
+                ram_used_bytes=9.0 * GB,
+                ram_total_bytes=200.0 * GB,
+                gpu_samples=[
+                    _gpu(
+                        0,
+                        100.0,
+                        60.0 if seq % 2 else 100.0,  # a sawtooth
+                        temp=54.0,
+                        mem_used=6.3 * GB,
+                    )
+                ],
+            )
+    out = _payload(db)
+
+    run = out["series"]["cpu_run"]
+    assert 2 < len(run["t"]) <= 181  # decimated, not one point per sample
+    assert len(run["avg"]) == len(run["t"]) == len(run["max"])
+    assert run["span_s"] == pytest.approx(2.0 * (ticks - 1))
+    # The drift survives. Measured against the run's floor, not slice 0:
+    # the spike at tick 0 lands inside the first slice and lifts its mean.
+    assert run["avg"][-1] > min(run["avg"]) + 20
+    assert max(run["max"]) >= 95.0  # and so do the spikes
+    assert max(run["avg"]) < 95.0  # which the mean alone would have hidden
+
+    power = out["series"]["gpu_power_run"]
+    assert [p["gpu_idx"] for p in power] == [0]
+    e = power[0]
+    assert 2 < len(e["t"]) <= 181
+    assert max(e["max"]) == pytest.approx(100.0)  # the sawtooth's peak
+    assert 60.0 < max(e["avg"]) < 100.0  # its mean sits between the levels
+    assert e["span_s"] == pytest.approx(2.0 * (ticks - 1))
+
+
+def test_whole_run_series_follow_the_node_scope(tmp_path: Path) -> None:
+    """A two-host window shows one node, and its whole-run view must too."""
+    db = tmp_path / "n.db"
+    with sqlite_database(db, init_summary_schema) as conn:
+        row_id = 0
+        for seq in range(60):
+            for node, (host, cpu) in enumerate(
+                (("node-a", 10.0), ("node-b", 90.0))
+            ):
+                row_id += 1
+                insert_system_sample(
+                    conn,
+                    row_id=row_id,
+                    rank=node,
+                    ts=1000.0 + 2.0 * seq + 0.3 * node,
+                    gpu_available=True,
+                    gpu_count=1,
+                    global_rank=node,
+                    node_rank=node,
+                    hostname=host,
+                    seq=seq,
+                    cpu_percent=cpu,
+                    ram_used_bytes=2.0 * GB,
+                    ram_total_bytes=16.0 * GB,
+                    gpu_samples=[
+                        _gpu(0, 100.0, 66.0, temp=45.0, mem_used=6.3 * GB)
+                    ],
+                )
+    out = _payload(db)
+    assert out["rollups"]["ctx"]["system_node"]["hostname"] == "node-a"
+    # node-a alone: never blended with node-b's 90%
+    assert max(out["series"]["cpu_run"]["max"]) == pytest.approx(10.0)

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -208,6 +208,30 @@ def test_empty_database_payload_keeps_the_schema(tmp_path: Path) -> None:
     out = _payload(db)
     assert out["window_len"] == 0
     assert out["series"]["gpu_power"] == []
+    assert out["series"]["cpu_run"] == {
+        "t": [],
+        "avg": [],
+        "max": [],
+        "span_s": 0.0,
+        "window_s": 0.0,
+    }
+    assert out["series"]["gpu_power_run"] == []
+
+
+def test_failed_first_read_keeps_the_series_schema(tmp_path: Path) -> None:
+    db = tmp_path / "missing" / "run.db"
+    out = _payload(db)
+
+    assert out["window_len"] == 0
+    assert out["rollups"]["status"] == "No fresh system data"
+    assert out["series"]["cpu_run"] == {
+        "t": [],
+        "avg": [],
+        "max": [],
+        "span_s": 0.0,
+        "window_s": 0.0,
+    }
+    assert out["series"]["gpu_power_run"] == []
 
 
 def test_two_node_window_shows_the_leader_node_only(tmp_path: Path) -> None:

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -424,6 +424,60 @@ def test_whole_run_series_are_decimated_and_keep_peaks(tmp_path: Path) -> None:
     assert e["span_s"] == pytest.approx(2.0 * (ticks - 1))
 
 
+def test_cpu_whole_run_series_honors_point_cap(tmp_path: Path) -> None:
+    """A run inside the old floor-division gap never exceeds 120 points."""
+    db = tmp_path / "cpu-cap.db"
+    ticks = 200
+    with sqlite_database(db, init_summary_schema) as conn:
+        for seq in range(ticks):
+            insert_system_sample(
+                conn,
+                row_id=seq + 1,
+                rank=0,
+                ts=1000.0 + 2.0 * seq,
+                gpu_available=False,
+                gpu_count=0,
+                seq=seq,
+                cpu_percent=float(seq % 100),
+                ram_used_bytes=9.0 * GB,
+                ram_total_bytes=200.0 * GB,
+                gpu_samples=(),
+            )
+
+    run = _payload(db)["series"]["cpu_run"]
+    assert 2 < len(run["t"]) <= 120
+    assert len(run["t"]) == len(run["avg"]) == len(run["max"])
+
+
+def test_cpu_whole_run_keeps_all_eligible_points_under_cap(
+    tmp_path: Path,
+) -> None:
+    """Valid samples after the initial rolling window are not over-decimated."""
+    db = tmp_path / "cpu-near-cap.db"
+    ticks = 130
+    with sqlite_database(db, init_summary_schema) as conn:
+        for seq in range(ticks):
+            insert_system_sample(
+                conn,
+                row_id=seq + 1,
+                rank=0,
+                ts=1000.0 + 2.0 * seq,
+                gpu_available=False,
+                gpu_count=0,
+                seq=seq,
+                cpu_percent=float(seq % 100),
+                ram_used_bytes=9.0 * GB,
+                ram_total_bytes=200.0 * GB,
+                gpu_samples=(),
+            )
+
+    run = _payload(db)["series"]["cpu_run"]
+    # A 30-second rolling window at a 2-second cadence excludes the first
+    # 14 samples. The remaining 116 fit under the cap and should all survive.
+    assert len(run["t"]) == 116
+    assert len(run["t"]) == len(run["avg"]) == len(run["max"])
+
+
 def test_whole_run_series_follow_the_node_scope(tmp_path: Path) -> None:
     """A two-host window shows one node, and its whole-run view must too."""
     db = tmp_path / "n.db"

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -327,12 +327,29 @@ def test_sampler_zero_fallback_tick_is_unreported(tmp_path: Path) -> None:
     # The limit is a constant seen earlier in the window: it stays.
     assert roll["gpu_power"]["limit"] == LIMIT
     assert roll["gpu_power"]["now"] is None
+    assert roll["gpu_power"]["floor"] == 66.0
     for g in roll["gpus"]:
         assert g["power"] is None and g["power_limit"] is None
         assert g["mem_total"] is None and g["temp"] is None
         assert g["util_p50"] == 100.0
     assert out["series"]["gpu_power"][0]["values"][-1] is None
     assert out["series"]["gpu_power"][0]["values"][-2] == 66.0
+
+
+def test_reported_zero_power_remains_in_whole_run_history(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "zero-watts.db"
+    _write(
+        db,
+        lambda seq: [
+            _gpu(0, 0.0, 0.0, temp=35.0, mem_used=0.5 * GB),
+        ],
+    )
+
+    out = _payload(db)
+    assert out["rollups"]["gpu_power"]["floor"] == 0.0
+    assert out["series"]["gpu_power_run"][0]["min"] == [0.0, 0.0]
 
 
 def test_rows_without_a_hostname_are_not_a_node(tmp_path: Path) -> None:

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -1,0 +1,333 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-GPU facts in the SYSTEM dashboard payload: power and the GPU rows.
+
+The settled System block shows the across-GPU average for utilisation and
+pairs it with the per-GPU rows, so the payload has to carry what the rows
+need: each GPU's own utilisation, memory, temperature, power and limit, plus
+a power history per GPU for the power chart. Every aggregate cell is the
+max GPU, never a sum, and a GPU that did not report in a tick is a gap in
+its series, not a zero.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from tests.sqlite_fixtures import (
+    init_summary_schema,
+    insert_system_sample,
+    sqlite_database,
+)
+from traceml_ai.renderers.system.dashboard_compute import (
+    SystemDashboardComputer,
+)
+
+GB = 1e9
+TICKS = 20
+LIMIT = 70.0
+
+
+def _gpu(
+    idx: int,
+    util: float,
+    power: Optional[float],
+    *,
+    temp: float,
+    mem_used: float,
+    limit: Optional[float] = LIMIT,
+) -> Dict[str, Any]:
+    return {
+        "gpu_idx": idx,
+        "util": util,
+        "mem_used_bytes": mem_used,
+        "mem_total_bytes": 16.1 * GB,
+        "temperature_c": temp,
+        "power_usage_w": power,
+        "power_limit_w": limit,
+    }
+
+
+def _one_busy_of_four(power: bool = True) -> List[Dict[str, Any]]:
+    busy = 68.0 if power else None
+    idle = 33.0 if power else None
+    limit = LIMIT if power else None
+    return [
+        _gpu(0, 100.0, busy, temp=54.0, mem_used=6.67 * GB, limit=limit),
+        _gpu(1, 0.0, idle, temp=41.0, mem_used=0.47 * GB, limit=limit),
+        _gpu(2, 0.0, idle, temp=40.0, mem_used=0.47 * GB, limit=limit),
+        _gpu(3, 0.0, idle, temp=39.0, mem_used=0.47 * GB, limit=limit),
+    ]
+
+
+def _all_busy() -> List[Dict[str, Any]]:
+    return [
+        _gpu(i, 100.0, 66.0 + i, temp=53.0 + i, mem_used=6.31 * GB)
+        for i in range(4)
+    ]
+
+
+def _write(path: Path, rows_for_tick, *, gpu_available: bool = True) -> None:
+    with sqlite_database(path, init_summary_schema) as conn:
+        for seq in range(TICKS):
+            insert_system_sample(
+                conn,
+                row_id=seq + 1,
+                rank=0,
+                ts=1000.0 + 2.0 * seq,
+                gpu_available=gpu_available,
+                gpu_count=4 if gpu_available else 0,
+                seq=seq,
+                cpu_percent=8.0,
+                ram_used_bytes=9.0 * GB,
+                ram_total_bytes=200.0 * GB,
+                gpu_samples=rows_for_tick(seq) if gpu_available else (),
+            )
+
+
+def _payload(path: Path) -> Dict[str, Any]:
+    return SystemDashboardComputer(str(path)).compute(window_n=100)
+
+
+def test_one_busy_of_four_reads_average_with_full_spread(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "b.db"
+    _write(db, lambda seq: _one_busy_of_four())
+    out = _payload(db)
+    roll = out["rollups"]
+
+    # The headline stays the across-GPU average (25) and the spread that
+    # opens the per-GPU rows reads the full 100 points.
+    assert roll["gpu_util"]["p50"] == 25.0
+    assert roll["gpu_delta"]["p95"] == 100.0
+
+    # Every aggregate cell is the max GPU, never a sum.
+    assert roll["gpu_power"] == {"now": 68.0, "p50": 68.0, "limit": LIMIT}
+    assert roll["gpu_mem"]["now"] == 6.67 * GB
+    assert roll["gpu_mem"]["total"] == 16.1 * GB
+    assert roll["temp"]["now"] == 54.0
+
+    gpus = roll["gpus"]
+    assert [g["gpu_idx"] for g in gpus] == [0, 1, 2, 3]
+    assert gpus[0] == {
+        "gpu_idx": 0,
+        "util_now": 100.0,
+        "util_p50": 100.0,
+        "mem_used": 6.67 * GB,
+        "mem_total": 16.1 * GB,
+        "temp": 54.0,
+        "power": 68.0,
+        "power_limit": LIMIT,
+    }
+    assert gpus[3]["util_p50"] == 0.0
+    assert gpus[3]["power"] == 33.0
+
+    power = out["series"]["gpu_power"]
+    assert [p["gpu_idx"] for p in power] == [0, 1, 2, 3]
+    assert power[0]["values"] == [68.0] * TICKS
+    assert power[1]["values"] == [33.0] * TICKS
+    assert len(out["series"]["x_time"]) == TICKS
+
+
+def test_all_busy_reads_zero_spread(tmp_path: Path) -> None:
+    db = tmp_path / "a.db"
+    _write(db, lambda seq: _all_busy())
+    roll = _payload(db)["rollups"]
+    assert roll["gpu_util"]["p50"] == 100.0
+    assert roll["gpu_delta"]["p95"] == 0.0
+    assert roll["gpu_power"]["now"] == 69.0  # max GPU (gpu3), not 270
+    assert roll["temp"]["now"] == 56.0
+
+
+def test_missing_gpu_row_is_a_gap_not_a_zero(tmp_path: Path) -> None:
+    db = tmp_path / "g.db"
+
+    def rows(seq: int):
+        full = _all_busy()
+        return full[:3] if seq == 10 else full
+
+    _write(db, rows)
+    out = _payload(db)
+    gpu3 = out["series"]["gpu_power"][3]["values"]
+    assert len(gpu3) == TICKS
+    assert gpu3[10] is None
+    assert gpu3[9] == 69.0
+    # The rows still list every GPU seen in the window.
+    assert [g["gpu_idx"] for g in out["rollups"]["gpus"]] == [0, 1, 2, 3]
+
+
+def test_no_gpu_payload_carries_empty_gpu_lists(tmp_path: Path) -> None:
+    db = tmp_path / "c.db"
+    _write(db, lambda seq: (), gpu_available=False)
+    out = _payload(db)
+    assert out["gpu_available"] is False
+    assert out["rollups"]["gpus"] == []
+    assert out["rollups"]["gpu_power"] == {
+        "now": None,
+        "p50": None,
+        "limit": None,
+    }
+    assert out["series"]["gpu_power"] == []
+    assert out["series"]["cpu"] == [8.0] * TICKS
+
+
+def test_unreported_power_stays_none(tmp_path: Path) -> None:
+    db = tmp_path / "p.db"
+    _write(db, lambda seq: _one_busy_of_four(power=False))
+    out = _payload(db)
+    assert out["rollups"]["gpu_power"] == {
+        "now": None,
+        "p50": None,
+        "limit": None,
+    }
+    assert out["rollups"]["gpus"][0]["power"] is None
+    assert out["series"]["gpu_power"][0]["values"] == [None] * TICKS
+    # Utilisation is unaffected by a missing power column.
+    assert out["rollups"]["gpu_util"]["p50"] == 25.0
+
+
+def test_empty_database_payload_keeps_the_schema(tmp_path: Path) -> None:
+    db = tmp_path / "e.db"
+    with sqlite_database(db, init_summary_schema):
+        pass
+    out = _payload(db)
+    assert out["window_len"] == 0
+    assert out["series"]["gpu_power"] == []
+
+
+def test_two_node_window_shows_the_leader_node_only(tmp_path: Path) -> None:
+    """System telemetry is per machine: no pooled series, no merged gpu0."""
+    db = tmp_path / "n.db"
+    with sqlite_database(db, init_summary_schema) as conn:
+        row_id = 0
+        for seq in range(TICKS):
+            for node, (host, cpu, util, power) in enumerate(
+                (("node-a", 10.0, 100.0, 66.0), ("node-b", 90.0, 0.0, 33.0))
+            ):
+                row_id += 1
+                insert_system_sample(
+                    conn,
+                    row_id=row_id,
+                    rank=node,
+                    ts=1000.0 + 2.0 * seq + 0.3 * node,
+                    gpu_available=True,
+                    gpu_count=1,
+                    global_rank=node,
+                    node_rank=node,
+                    hostname=host,
+                    seq=seq,
+                    cpu_percent=cpu,
+                    ram_used_bytes=2.0 * GB,
+                    ram_total_bytes=16.0 * GB,
+                    gpu_samples=[
+                        _gpu(0, util, power, temp=45.0, mem_used=6.3 * GB)
+                    ],
+                )
+    out = _payload(db)
+    roll = out["rollups"]
+    assert roll["ctx"]["system_node"] == {
+        "hostname": "node-a",
+        "node_rank": 0,
+        "nodes_in_window": 2,
+    }
+    # Node 0's own window, not a zig-zag between the two hosts.
+    assert set(out["series"]["cpu"]) == {10.0}
+    assert roll["cpu"]["p50"] == 10.0
+    assert roll["gpu_util"]["p50"] == 100.0
+    assert [g["gpu_idx"] for g in roll["gpus"]] == [0]
+    assert roll["gpus"][0]["power"] == 66.0
+    assert out["series"]["gpu_power"][0]["values"] == [66.0] * TICKS
+    assert len(out["series"]["x_time"]) == TICKS
+
+
+def test_null_util_and_temp_stay_none_not_zero(tmp_path: Path) -> None:
+    """A NULL column is unreported: no phantom 0 in the rows, no phantom
+    spread opening them."""
+    db = tmp_path / "u.db"
+
+    def rows(seq: int):
+        full = _all_busy()
+        if seq >= TICKS - 6:
+            full[1]["util"] = None
+            full[1]["temperature_c"] = None
+        return full
+
+    _write(db, rows)
+    out = _payload(db)
+    g1 = out["rollups"]["gpus"][1]
+    assert g1["util_now"] is None
+    assert g1["temp"] is None
+    assert g1["power"] == 67.0  # still reported
+    assert g1["util_p50"] == 100.0  # the median ignores the unreported ticks
+
+
+def test_sampler_zero_fallback_tick_is_unreported(tmp_path: Path) -> None:
+    """The sampler writes all-zero GPU rows when NVML fails on a device;
+    those zeros are not a 0 W limit, 0 degrees or 0 GB."""
+    db = tmp_path / "z.db"
+
+    def rows(seq: int):
+        if seq == TICKS - 1:
+            return [
+                {
+                    "gpu_idx": i,
+                    "util": 0.0,
+                    "mem_used_bytes": 0.0,
+                    "mem_total_bytes": 0.0,
+                    "temperature_c": 0.0,
+                    "power_usage_w": 0.0,
+                    "power_limit_w": 0.0,
+                }
+                for i in range(4)
+            ]
+        return _all_busy()
+
+    _write(db, rows)
+    out = _payload(db)
+    roll = out["rollups"]
+    # The limit is a constant seen earlier in the window: it stays.
+    assert roll["gpu_power"]["limit"] == LIMIT
+    assert roll["gpu_power"]["now"] is None
+    for g in roll["gpus"]:
+        assert g["power"] is None and g["power_limit"] is None
+        assert g["mem_total"] is None and g["temp"] is None
+        assert g["util_p50"] == 100.0
+    assert out["series"]["gpu_power"][0]["values"][-1] is None
+    assert out["series"]["gpu_power"][0]["values"][-2] == 66.0
+
+
+def test_rows_without_a_hostname_are_not_a_node(tmp_path: Path) -> None:
+    """A database upgraded from a pre-0.3.0 writer has NULL hostnames on
+    its oldest rows; they are not a second machine and are not dropped."""
+    db = tmp_path / "h.db"
+    with sqlite_database(db, init_summary_schema) as conn:
+        for seq in range(TICKS):
+            named = seq >= 5
+            insert_system_sample(
+                conn,
+                row_id=seq + 1,
+                rank=0,
+                ts=1000.0 + 2.0 * seq,
+                gpu_available=True,
+                gpu_count=4,
+                node_rank=0 if named else None,
+                hostname="box" if named else None,
+                seq=seq,
+                cpu_percent=8.0,
+                ram_used_bytes=9.0 * GB,
+                ram_total_bytes=200.0 * GB,
+                gpu_samples=_all_busy(),
+            )
+    out = _payload(db)
+    assert out["window_len"] == TICKS
+    assert out["rollups"]["ctx"]["system_node"] == {
+        "hostname": "box",
+        "node_rank": 0,
+        "nodes_in_window": 1,
+    }


### PR DESCRIPTION
# Dashboard: System block as four tiles, two charts, and per-GPU rows that open on spread

> **Review scope: the System block only.** The context strip above it is #388, already merged. The Process, Step Time, Step memory and Diagnostics panes in the screenshots are today's rendering, untouched by this PR and still work in progress; they are rebuilt one PR at a time after this one. System and Process now sit side by side at equal width without height stretching; Process will match the System block's height once it takes the same skeleton in its own PR, so the pair is uneven in these screenshots on purpose. That half-width layout is also why the power chart will not hold 5 to 10 GPUs on one node; see the second open item under Scope.

## What

The System block is rebuilt to the design we settled on 19 and 20 August: four number tiles, two small charts, and per-GPU rows behind a disclosure that opens on its own when the GPUs disagree.

- Tiles, one plain number each. `gpu util` is the across-GPU average, shown as the median of the last ~100 samples (`avg of 4 GPUs`). `gpu mem` is the GPU with the most memory in use, against its capacity (`6.3 / 16.1 GB`, `max GPU`). `gpu temp` is the hottest GPU (`52 °C`, `max GPU`). `host ram` is used against total (`5.9 / 200 GB`). Levels always carry their denominator; rates name their estimator in words.
- Host CPU chart: a small zero-anchored series with its one number (the window median) in the label, gridlines at 0 / half / top, and the x axis labelled in wall-clock time. The ceiling adapts (4 / 10 / 20 ... 100 %) so a 2 % line stays visible. The label reads `host cpu util · avg across cores`, because this is `psutil.cpu_percent()`: the mean across logical cores, where 100 % is every core saturated. That qualifier matters on this page, since the Process block reports per-rank CPU from `psutil.Process.cpu_percent()`, which sums across cores and can exceed 100 %.
- GPU power chart: one trace per GPU, with two dashed reference lines. The board limit in red (`70 W limit`), read from the payload rather than a constant, and the lowest draw seen in the run in grey (`30 W lowest seen`), which on any run whose sampler was up before the first step is the idle draw. Between them is the band the GPUs actually work in, so a trace sagging toward the grey line reads as idling rather than as a small number. The floor line is dropped when it sits within 10 % of the limit, where it would say nothing. Red belongs to the limit line, so no GPU trace uses it. Any aggregate power cell is the max GPU, never a sum.
- Per-GPU rows (`gpu` · `util` · `power trend` · `mem GB` · `temp °C` · `W / limit`), one sparkline per GPU, collapsed by default. They open on their own when the across-GPU utilisation spread (max - min, window p95) crosses 20 points. The header states the utilisation range and nothing else: `4 GPUs · util 0 to 100% · click to close`, `4 GPUs · util 99 to 99% · click to open`; the tail always reflects the rows' real open state, which a click may have changed. The 20-point trigger lives in the code, not on the screen. The rows on the minority side of the split are tinted (the one busy GPU of four, or the one idle GPU of four). Opening happens on the rising edge only, so a reviewer who closes the rows is not fought every tick.
- No verdict words anywhere. The renderer's `Hot` / `Warm` temperature word is no longer shown, and there is no high-power chip: on T4 every healthy run we measured averages 89-98 % of the 70 W limit against the rule's 80 % bar, so that chip would be permanently on. Judgement comes from the diagnosis engine or it does not appear.
- The four tiles are one CSS grid of equal columns (four, dropping to two then one as the card narrows), and every tile always carries its qualifier line, so the boxes are identical in width and height on every host: measured 147x80 / 233x80 / 183x80 at 1400 / 1100 / 900 px viewports. Before this, a single-GPU host left the temperature tile's qualifier blank ("max GPU" says nothing with one GPU) so that box was a line shorter, and a narrow card wrapped the RAM tile onto its own row where it stretched to its cap.
- No GPU: on a CPU-only host every slot keeps its place and height (one shape to learn on every host); the three GPU tiles read `n/a` with `no GPU` under them (the same word the Process card uses, so one page does not spell absence two ways), the power-chart slot shows `no GPU reported` at chart height, the rows slot is the one line `per-GPU rows · no GPU`; the RAM tile and the CPU chart work as on any host. Unreported is never zero: a NULL column stays a dash, and the sampler's all-zero fallback row (what it writes when NVML fails on a device) is treated as unreported, so it cannot render as a `0 W limit` line, `0 °C` or `0.0 GB`; the limit line is the largest limit seen in the window, so one unreported tick does not make it flicker.
- One node per block. System telemetry is per machine. When the window holds more than one host, the block shows the lowest `node_rank` host alone and its header says `node 0 of 2`. Before this, a 2-node run rendered one CPU line that zig-zagged between the two hosts and merged both nodes' `gpu0` into one row. Per-node rows and a node selector are the platform's job; this keeps the single-node block honest until then.
- The GPU utilisation gauge is gone: the util tile plus the rows carry that headline, and the gauge showed the raw last tick, which reads `0 %` at the moment someone inspects a just-finished run (both campaign runs end on `gpu_util.now = 0.0` with `p50 = 100 / 25`).

### Two views of the same chart: the sample window, and the whole run

Both charts render in one of two modes, and the label always says which one is on screen. This is the part of the PR most worth a careful read, because it changes what the chart means, not just how it looks.

**The switch.** `run_span > window_span * 1.2` in `system_section.py`. If the run is more than 20 % longer than what the last 100 system samples cover, the charts draw the whole run. Otherwise the window already is the whole run and there is nothing to gain. Every run passes through both: it starts windowed and flips a few minutes in.

**Window mode** draws the raw samples, exactly as before, and names the real extent of the data it has: `last 41 s`, `last 2 min`. Nothing is smoothed or bucketed, because at 100 points there is nothing to smooth away.

**Whole-run mode** reads a second, decimated query per chart, capped at 120 points however long the run gets, so the payload does not grow with run length. The two charts summarise differently, on purpose:

- Host CPU is a **rolling mean** over a window that scales with the run (30 s / 1 min / 2 min / 5 min, about a fiftieth of the run, rounded to a step a person recognises), computed in SQL with a window function and then sampled every Nth row. A rolling mean over an hour-long run shows the slow drift; tumbling buckets of the same width show the same drift with a sawtooth on top, which reads as noise. The label spells the window out (`rolling 2 min`) rather than naming the technique. Peaks are not drawn, but they still set the axis ceiling, so a spike the mean smooths away can never be drawn off the top of the chart.
- GPU power is a **mean and a floor per bucket, per GPU**: the mean solid, the bucket's minimum faint beneath it. Mean says whether the GPU is being fed. The floor says whether it went idle inside that bucket, which is what a stall looks like in watts and what a mean alone hides.

**Why not the peak.** A peak trace saturates. On every GPU-busy capture we own the busy GPUs' p95 draw is 85.7 W, 86.8 W and 91.2 W against the same 70 W board limit (NVML reports instantaneous draw, which overshoots the cap briefly), while their means are 67.7 W, 68.3 W and 66.2 W. So a peak trace sits above the limit line on any healthy run, which leaves the limit line with nothing to be compared against, and it reads about the same for three unrelated runs. The three captures also show what idle looks like on this hardware: their lowest samples are 33.0 W, 30.1 W and 30.7 W, and on the 1-busy-of-4 captures the three idle GPUs sit flat at about 33 W. That is the value the floor trace and the floor line are measured against. We do not yet own an input-starved GPU capture, so the floor's ability to separate a stalling run from a healthy one is argued from that idle draw rather than measured against a stalling run; the capture that would settle it is on the list.

The x axis of both charts is labelled in wall-clock time (`18:38`, and `HH:MM:SS` under ten minutes), because that is what logs and the Process block beside it are keyed on, and because a whole-run view spanning hours is not locatable otherwise. The two charts also share one anchor and one span, so a vertical read across the pair lands on the same moment in both. Without that they drift apart by a window, since the rolling mean drops its first partial window and the power buckets do not.

The run's length is not repeated on the charts: the context strip states it once (`ranks 1/1 reporting · 1 GPU observed · 1 node · 1h 36m`), so the chart labels name the view (`whole run`, `last 2 min`) and not the duration.

The window could not show the thing that justified having these charts. Host CPU on the 96-minute reference run climbs from 25.2 % to 32.1 % (+6.9 points, +27 % relative), and on the 3-hour two-node capture from 82.7 % to 92.0 %, comparing the first and last 5 % of samples. A 3-minute window renders both as a flat line at the final value.

Cost, measured as medians of 40 renders per fixture, CPU time rather than wall clock, expressed as a share of one core at the 2 s render interval, measured on the same machine with nothing else running, before (`642cbc1`, window only) against after (this head):

| fixture | before | after | payload before | payload after |
|---|---|---|---|---|
| 4-GPU, 40 s | 0.66 % | 0.88 % | 3.2 KB | 4.3 KB |
| 4-GPU, 23 min | 0.37 % | 0.37 % | 9.3 KB | 24.5 KB |
| 1-GPU, 96 min | 0.13 % | 0.42 % | 6.5 KB | 14.3 KB |
| 2-node, 3 h | 0.20 % | 0.89 % | 6.5 KB | 13.8 KB |

So at most about +0.7 points of a single core, on the longest capture we own. Browser main-thread time is unchanged within noise (75.2 ms per tick before, 66.2 ms after, 20 ticks each via CDP `Performance.getMetrics`), because the charts only re-send when the window moves. Nothing here runs per rank or per step, so the training path the overhead budget covers is untouched.

## Why

One number hid the failure we exist to find: with one GPU of four busy, every surface read ~25 % and nothing on the page said that three GPUs were idle, although the payload computed the spread (`gpu_delta`) every tick and rendered it nowhere. The average stays because it describes the node; it is safe only because the rows open at the same moment. Power was the one system metric missing from the dashboard and the only one that moves on every run we measured, so it gets the chart; everything else sits still for whole runs and gets a number. The per-metric reasoning (which estimator, why a number or a chart) is written up per metric in the block's design record; this PR description is the short form of it.

## Scope

Data path: `system_section` <- `SYSTEM_LAYOUT` <- `SystemRenderer.get_dashboard_renderable` <- `SystemDashboardComputer` <- `system_samples` + `system_gpu_samples`. Everything new reads System tables only and rides the System payload; the section formats and does not query; no other section's payload is read (the strip keeps its own `CONTEXT_LAYOUT`, #388).

`nicegui_sections/`: `system_section.py` (rewritten), `theme.py` (span-axis chart builders, reference-line builder, block CSS), `pages.py` (hero row, then System | Process side by side at exactly half the width each with `items-start`, so heights are never stretched to match; no gauge), `context_section.py` (section list without the gauge).

Outside the directory, stated on purpose because the rebuild rule is to change representation and not data: the dashboard payload grows by six fields, all additive, no existing key changes.

- `rollups.gpu_power = {now, p50, limit, floor}`: max across GPUs at the newest tick, median of that over the window, the largest positive limit reported anywhere in the window, and the lowest draw seen anywhere in the run (the minimum across every whole-run bucket minimum), which is what the grey reference line draws. Each is `None` when nothing reports it; with no power at all the chart hides and the label reads `gpu power · not reported`.
- `rollups.gpus[]`: per GPU, `gpu_idx`, `util_now`, `util_p50`, `mem_used`, `mem_total`, `temp`, `power`, `power_limit` from the newest tick, plus util as the window median. A GPU missing from the newest tick keeps its row with `None` values rather than vanishing.
- `rollups.gpu_mem.total`: capacity of the GPU shown in `gpu_mem.now`.
- `series.gpu_power[]`: `{gpu_idx, values}` aligned with `x_time`; a tick without a row for that GPU is `None` (a gap), never `0`.
- `rollups.ctx.system_node = {hostname, node_rank, nodes_in_window}` and a `hostname=` filter on `SystemMetricsDB.fetch_recent_system_samples`, used only when a window contains more than one named host (rows without a hostname are not a node of their own).
- `series.cpu_run = {t, avg, max, span_s, window_s}`: the whole-run CPU view from `fetch_cpu_run_history`, a rolling mean and rolling max over `window_s` computed with SQL window functions (`AVG/MAX OVER (ORDER BY sample_ts_s ROWS BETWEEN n PRECEDING AND CURRENT ROW)`, SQLite 3.25 and newer, which the packaging test already requires), then sampled every Nth row to at most 120 points. Partial windows at the start of the run are excluded rather than drawn short.
- `series.gpu_power_run = [{gpu_idx, t, avg, min, max, span_s, window_s}]`: the whole-run power view from `fetch_gpu_power_run_history`, disjoint buckets of `window_s` grouped per GPU, carrying each bucket's mean, minimum and maximum, likewise capped at 120 buckets. Both reads take only System tables and both follow the node scope above, so a two-host capture charts one machine rather than a blend, and both are skipped entirely while a run is still short enough to be drawn from its window.

Estimator per item, so the two surfaces can be compared later:

| item | form | estimator |
|---|---|---|
| gpu util tile | number | across-GPU mean per tick, window median (p50) |
| gpu mem tile | number + denominator | newest tick, GPU with max used, its own total |
| gpu temp tile | number | newest tick, max across GPUs |
| host ram tile | number + denominator | newest tick |
| host cpu chart, window mode | series + number | raw samples; label = window median |
| host cpu chart, whole run | series + number | rolling mean over `window_s`; axis ceiling from the rolling max |
| gpu power chart, window mode | per-GPU series | raw samples per GPU |
| gpu power chart, whole run | per-GPU series x2 | per bucket, mean (solid) and minimum (faint), per GPU |
| power reference lines | two dashed lines | limit = max reported in the window; floor = minimum across all bucket minima |
| rows: util | number | per-GPU window median |
| rows: mem / temp / W | numbers | per-GPU newest tick |
| rows trigger | hidden | `gpu_delta` window p95 > 20 points |

The rows header used to say `1 of 4 GPUs busy, 3 idle`, counting a GPU as idle below 20 % utilisation. That bar was invented in the display layer, and it disagreed with the diagnosis engine, whose `GPUUtilizationBands` calls anything under 30 % low. One page would have carried two thresholds and a word this layer has no standing to say, so the header now reports the range it observes and leaves the verdict to the engine. The trigger that opens the rows is unchanged and stays off the screen.

Three things for review rather than decided here:

1. Trigger statistic. p95 of the spread over the window opens the rows about five ticks (10 s) after one GPU goes idle, which is the responsiveness we want; the cost is that an 11-second, 4-rank FSDP run opened them on `spread 30 > 20` from its own start-up ramp (a 6-tick window, so p95 is the max). Now that the header reports the range rather than a verdict, that capture reads `4 GPUs · util 98 to 100% · click to close`: open rows beside a range that gives the reader no reason for them, which is the clearest argument yet for the median. A window median would ignore ramps but take ~100 s to react to a GPU going idle. The code carries p95; say the word and it is one constant.
2. Known limit, many GPUs on one node: in whole-run mode the power chart draws two traces per GPU (mean and floor) and the rows one line per GPU. Every fixture we own is 1 or 4 GPUs; at roughly 5 to 10 GPUs on a node the chart gets cluttered (traces overlapping in one 150 px slot at half the page width), and past that it is not usable as drawn. We know it and it needs a revision, not a fix in this PR. Candidates in the order we would try them: give System and Process the full page width one below the other instead of the side-by-side half each; aggregate the chart (a band for the GPU range plus the max trace) and leave per-GPU detail to the rows; make the traces selectable; or move the many-GPU form to its own scrollable page, which the design record already anticipates for the 32 to 100 GPU case. Layout only, nothing about what the block computes; decide it with a real many-GPU capture in front of us.
3. Cross-surface power: the run card sums power across GPUs (`cli_compute.py`, `power_total`); the dashboard shows the max GPU and per-GPU values. The card's form is untouched here; which one the card should follow is part of the open card-vs-dashboard estimator question.

Not in this PR: the least-headroom refinement of the memory tile (open), per-node rows (platform lane), the driver's step-time refresh under watch (#355 compute side).

## Verification

- `pytest tests/display tests/renderers tests/reporting tests/aggregator tests/core/test_packaging_constraints.py tests/integrations/test_telemetry_conformance.py`: 629 passed, 1 skipped, on `version_0.3.7` at `b05fb73` (which includes #388).
- 17 tests in `tests/display/test_system_section.py`: span words, denominators, disclosure text against the trigger and against the rows' real open state, rising-edge opening, power axis bounds, CPU axis ceilings, sparkline gaps, the rows table with the odd-ones-out tint and dashes for absent values, no GPU trace in the limit's red, every tile keeping a qualifier line, the rolling window spelled out rather than named, the two whole-run charts sharing one clock axis, both power reference lines with their positions, and build + update without a browser (CPU-only state, a user-closed disclosure, a vanished limit, an all-unreported tick, the no-resend guard, the node header).
- 12 tests in `tests/renderers/test_system_dashboard_gpu_payload.py`: 1-busy-of-4 reads `p50 = 25` with `delta p95 = 100`, all-busy reads spread 0, a missing GPU row is a `None` gap, no-GPU and unreported-power payloads, empty database schema, a two-node window keeps node 0 only, NULL util and temp stay `None`, the sampler's zero fallback counts as unreported, rows without a hostname are not a node of their own.
- Replays of every fixtured scenario cell through the live dashboard (gallery below), plus live local sessions through the real launcher: a CPU-only single-process run captured in both modes (windowed at `last 51 s`, then whole run at `rolling 30 s`), a CPU-only two-process run, and an unnamed watch session.
- The chart formatters are JavaScript strings, so they were executed rather than eyeballed: the axis formatter returns `14:00` at the span start and `14:59` at the newest sample, and the hover formatter returns `14:00 · 59 min ago`, `14:58 · 45 s ago` and `14:59 · now` for the same three positions.
- Charts only re-send when the window moved (the UI timer runs faster than the data arrives), and the reference lines are cleared explicitly when a limit disappears, since ECharts merges options rather than replacing them.
- black / isort / ruff clean at line length 79, the repo's pinned black applied. The five ruff findings elsewhere in `tests/` predate this branch and are left alone.

## Scenarios (screenshots)

Each image is the System block alone, the only block this PR changes; the rest of the page is today's rendering and out of scope here.

**B · B_xf_1gpu_long** · 96 min, 15k steps, the metrics-tour run; CPU drift visible  
`System / GPU UTIL / 99% / 1 GPU / GPU MEM / 6.3 / 16.1 GB / used / total / GPU TEMP / 48 °C / 1 GPU / HOST RAM / 2.8 / 16.6 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · WHOLE RUN · ROLLING 2 MIN / 32% / GPU POWER · PER GPU VS 70 W LIMIT · WHOLE RUN · MEAN AND FLOOR OF EVERY 2 MIN / per-GPU rows / 1 GPU · click to open`  
![B B_xf_1gpu_long](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/B_xf_1gpu_long.jpg)

**B · B_cnn_1gpu** · 4 min cnn, 1000 steps  
`System / GPU UTIL / 93% / 1 GPU / GPU MEM / 4.6 / 16.1 GB / used / total / GPU TEMP / 47 °C / 1 GPU / HOST RAM / 3.1 / 16.6 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · WHOLE RUN · ROLLING 30 S / 27% / GPU POWER · PER GPU VS 70 W LIMIT · WHOLE RUN · MEAN AND FLOOR OF EVERY 30 S / per-GPU rows / 1 GPU · click to open`  
![B B_cnn_1gpu](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/B_cnn_1gpu.jpg)

**C · C_M1_bert** · bert-base, 220 steps, COMPUTE-BOUND, 1 rank on a 4xT4 node  
`System / GPU UTIL / 25% / avg of 4 GPUs / GPU MEM / 9.1 / 16.1 GB / max GPU / GPU TEMP / 49 °C / max GPU / HOST RAM / 5.9 / 200 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · LAST 2 MIN / 2% / GPU POWER · PER GPU VS 70 W LIMIT · LAST 2 MIN / per-GPU rows / 4 GPUs · util 0 to 100% · click to close`  
![C C_M1_bert](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/C_M1_bert.jpg)

**C · C_sysB_1of4** · 19-Aug campaign run B: 1 busy GPU of 4, 800 steps; the aggregate-hides-idle case  
`System / GPU UTIL / 25% / avg of 4 GPUs / GPU MEM / 6.3 / 16.1 GB / max GPU / GPU TEMP / 52 °C / max GPU / HOST RAM / 5.9 / 200 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · WHOLE RUN · ROLLING 30 S / 2% / GPU POWER · PER GPU VS 70 W LIMIT · WHOLE RUN · MEAN AND FLOOR OF EVERY 30 S / per-GPU rows / 4 GPUs · util 0 to 100% · click to close`  
![C C_sysB_1of4](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/C_sysB_1of4.jpg)

**D · D_S2_ddp4** · 4-rank DDP, healthy, 40 s  
`System / GPU UTIL / 97% / avg of 4 GPUs / GPU MEM / 1.9 / 16.1 GB / max GPU / GPU TEMP / 44 °C / max GPU / HOST RAM / 7.7 / 200 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · LAST 41 S / 8% / GPU POWER · PER GPU VS 70 W LIMIT · LAST 41 S / per-GPU rows / 4 GPUs · util 97 to 97% · click to open`  
![D D_S2_ddp4](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/D_S2_ddp4.jpg)

**D · D_F1_fsdp4** · 4-rank FSDP (strategy chip)  
`System / GPU UTIL / 100% / avg of 4 GPUs / GPU MEM / 1.0 / 16.1 GB / max GPU / GPU TEMP / 41 °C / max GPU / HOST RAM / 8.0 / 200 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · LAST 12 S / 7% / GPU POWER · PER GPU VS 70 W LIMIT · LAST 12 S / per-GPU rows / 4 GPUs · util 98 to 100% · click to close`  
![D D_F1_fsdp4](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/D_F1_fsdp4.jpg)

**D · D_sysA_ddp4_3k** · 19-Aug campaign run A: 4-rank DDP, 3000 steps, 23 min  
`System / GPU UTIL / 100% / avg of 4 GPUs / GPU MEM / 6.3 / 16.1 GB / max GPU / GPU TEMP / 53 °C / max GPU / HOST RAM / 8.8 / 200 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · WHOLE RUN · ROLLING 30 S / 8% / GPU POWER · PER GPU VS 70 W LIMIT · WHOLE RUN · MEAN AND FLOOR OF EVERY 30 S / per-GPU rows / 4 GPUs · util 100 to 100% · click to open`  
![D D_sysA_ddp4_3k](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/D_sysA_ddp4_3k.jpg)

**D' · Dd_S2_rank3_dead** · S2 with rank 3's last 10 ticks removed  
`System / GPU UTIL / 97% / avg of 4 GPUs / GPU MEM / 1.9 / 16.1 GB / max GPU / GPU TEMP / 44 °C / max GPU / HOST RAM / 7.7 / 200 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · LAST 41 S / 8% / GPU POWER · PER GPU VS 70 W LIMIT · LAST 41 S / per-GPU rows / 4 GPUs · util 97 to 97% · click to open`  
![D' Dd_S2_rank3_dead](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/Dd_S2_rank3_dead.jpg)

**E · E_xf_2x1_long** · 2 nodes x 1 GPU, 178 min, 30k step rows; the seq-drift case  
`System / node 0 of 2 / GPU UTIL / 100% / 1 GPU / GPU MEM / 6.3 / 16.1 GB / used / total / GPU TEMP / 45 °C / 1 GPU / HOST RAM / 2.9 / 16.6 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · WHOLE RUN · ROLLING 5 MIN / 92% / GPU POWER · PER GPU VS 70 W LIMIT · WHOLE RUN · MEAN AND FLOOR OF EVERY 5 MIN / per-GPU rows / 1 GPU · click to open`  
![E E_xf_2x1_long](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/E_xf_2x1_long.jpg)

**E · E_cnn_2x1_fsdp** · 2 nodes x 1 GPU FSDP, 5 min  
`System / node 0 of 2 / GPU UTIL / 90% / 1 GPU / GPU MEM / 4.6 / 16.1 GB / used / total / GPU TEMP / 46 °C / 1 GPU / HOST RAM / 3.1 / 16.6 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · WHOLE RUN · ROLLING 30 S / 65% / GPU POWER · PER GPU VS 70 W LIMIT · WHOLE RUN · MEAN AND FLOOR OF EVERY 30 S / per-GPU rows / 1 GPU · click to open`  
![E E_cnn_2x1_fsdp](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/E_cnn_2x1_fsdp.jpg)

**E' · Ed_2x1_rank1_dead** · 2x1 with node 1's rank cut 10 ticks early  
`System / node 0 of 2 / GPU UTIL / 90% / 1 GPU / GPU MEM / 4.6 / 16.1 GB / used / total / GPU TEMP / 46 °C / 1 GPU / HOST RAM / 3.1 / 16.6 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · WHOLE RUN · ROLLING 30 S / 65% / GPU POWER · PER GPU VS 70 W LIMIT · WHOLE RUN · MEAN AND FLOOR OF EVERY 30 S / per-GPU rows / 1 GPU · click to open`  
![E' Ed_2x1_rank1_dead](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/Ed_2x1_rank1_dead.jpg)

**W · W_W1_busy** · watch, 4 GPUs, 1 busy (98/0/0/0)  
`System / GPU UTIL / 25% / avg of 4 GPUs / GPU MEM / 0.8 / 16.1 GB / max GPU / GPU TEMP / 51 °C / max GPU / HOST RAM / 5.0 / 200 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · LAST 2 MIN / 2% / GPU POWER · PER GPU VS 70 W LIMIT · LAST 2 MIN / per-GPU rows / 4 GPUs · util 0 to 100% · click to close`  
![W W_W1_busy](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/W_W1_busy.jpg)

**W · W_W2_idle** · watch, 4 GPUs, all idle  
`System / GPU UTIL / 0% / avg of 4 GPUs / GPU MEM / 0.6 / 16.1 GB / max GPU / GPU TEMP / 39 °C / max GPU / HOST RAM / 5.0 / 200 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · LAST 2 MIN / 0% / GPU POWER · PER GPU VS 70 W LIMIT · LAST 2 MIN / per-GPU rows / 4 GPUs · util 0 to 0% · click to open`  
![W W_W2_idle](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/W_W2_idle.jpg)

**A · live, CPU only, 1 process, window mode** · the first minutes of any run, before it outlives its window
`System / GPU UTIL / n/a / no GPU / GPU MEM / n/a / no GPU / GPU TEMP / n/a / no GPU / HOST RAM / 6.9 / 17.2 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · LAST 51 S / 50% / GPU POWER / no GPU reported / per-GPU rows · no GPU`
![A cpu windowed](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/A_cpu_windowed.jpg)

**A · the same live run, eight minutes in, whole-run mode** · same session, after the switch
`System / ... / HOST CPU UTIL · AVG ACROSS CORES · WHOLE RUN · ROLLING 30 S / 42% / GPU POWER / no GPU reported / per-GPU rows · no GPU`
![A cpu whole run](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/A_cpu_wholerun.jpg)

**A2 · live, CPU only, 2 processes**
`System / GPU UTIL / n/a / no GPU / GPU MEM / n/a / no GPU / GPU TEMP / n/a / no GPU / HOST RAM / 7.2 / 17.2 GB / used / total / HOST CPU UTIL · AVG ACROSS CORES · LAST 38 S / 52% / GPU POWER / no GPU reported / per-GPU rows · no GPU`
![A2 cpu 2 processes](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr2-system-r5/A2_cpu_2proc.jpg)

## Evidence

GATE: conformance ran=true, `tests/integrations/test_telemetry_conformance.py` 1 passed / 0 failed / 1 skipped on this branch.
TRANSITIONS: tested closed->open on the rising edge of the spread (`test_rows_open_on_the_rising_edge_only`; the 1-busy-of-4 replays open reading `util 0 to 100%`, the healthy 4-rank replays stay closed reading `util 99 to 100%`), window mode -> whole-run mode on one live session (the same CPU run captured at `last 51 s` and then at `whole run · rolling 30 s`), GPU -> no GPU on the same panel (`test_section_builds_and_updates_without_a_browser` and the live CPU sessions), and single-node -> multi-node window (`test_two_node_window_shows_the_leader_node_only`; the 2x1 replay reads `node 0 of 2`).
RANKS: per-GPU asymmetry tested? yes: 100/0/0/0 reads `25 % avg` with the rows open and gpu0 tinted (unit test plus three replays); a GPU absent from one tick is a gap in its trace, not a zero (`test_missing_gpu_row_is_a_gap_not_a_zero`). Rank death does not touch this block, since the system sampler outlives the rank, which the D' and E' replays confirm.
TRIPWIRE: made the spread trigger fire on purpose? yes, the 1-busy-of-4 payload in the tests and the M1, sysB and W1 replays; and the inverse, all-busy (3000 steps) and healthy DDP stay collapsed at spread 0 and 1. The two-mode switch was also fired both ways rather than assumed: the same live run was captured on both sides of it.
SCENARIOS: A single-node CPU 1 process ok, captured live in both modes. A2 single-node CPU 2 processes ok, captured live. B single-node 1 GPU ok (96-min and 4-min runs: `99 %` / `93 %`, whole-run charts with `rolling 2 min` / `rolling 30 s`). C single-node 4 GPUs 1 process ok (`25 %`, rows open, `util 0 to 100%`; one capture windowed at `last 2 min`, one whole run). D single-node 4 GPUs 4 ranks ok (`97 %` and `100 %`, both closed with a narrow range; the 12-second FSDP capture opened on its start-up ramp, see the first open item under Scope). D' one rank dead ok, block unchanged. E 2 nodes x 1 GPU ok and honest (`node 0 of 2`, no pooled series, 178-min capture on `rolling 5 min`); E' 2 nodes with one rank dead ok. F 2 nodes x N GPUs: no capture exists. W watch ok (busy: `25 %`, rows open, gpu0 `69 / 70` W; idle: `0 %`, closed). Wc watch on CPU with no run name: covered by the two live CPU-only captures above at this head; the earlier separate watch capture predates the chart changes and is not shown stale.
PLATFORM: EVIDENCE: n/a (no `sys.platform` / `os.name` branch in this change).
