### PR TITLE
fix: preserve unavailable process metrics as null

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
           pytest \
             tests/arch \
             tests/config \
+            tests/samplers \
             tests/core \
             tests/step_time \
             tests/diagnostics \

--- a/src/traceml_ai/samplers/process_sampler.py
+++ b/src/traceml_ai/samplers/process_sampler.py
@@ -88,7 +88,7 @@ class ProcessSampler(BaseSampler):
         """
         Read total system RAM.
         """
-        self.ram_total = 0.0
+        self.ram_total: Optional[float] = None
         try:
             self.ram_total = float(psutil.virtual_memory().total)
         except Exception as e:
@@ -136,7 +136,7 @@ class ProcessSampler(BaseSampler):
         self.gpu_count: int = 0
         self.device_index: Optional[int] = None
 
-    def _sample_cpu(self) -> float:
+    def _sample_cpu(self) -> Optional[float]:
         """
         Return process CPU utilization as a percentage.
         """
@@ -148,9 +148,9 @@ class ProcessSampler(BaseSampler):
             )
         except Exception as e:
             self.logger.error(f"[TraceML] WARNING: CPU sample failed: {e}")
-            return 0.0
+            return None
 
-    def _sample_ram(self) -> float:
+    def _sample_ram(self) -> Optional[float]:
         """
         Return process resident memory (RSS) in bytes.
         """
@@ -160,7 +160,7 @@ class ProcessSampler(BaseSampler):
             )
         except Exception as e:
             self.logger.error(f"[TraceML] WARNING: RAM sample failed: {e}")
-            return 0.0
+            return None
 
     def _cuda_safe_to_touch(self) -> bool:
         """
@@ -235,12 +235,12 @@ class ProcessSampler(BaseSampler):
         try:
             gpu_metrics = self._sample_gpu()
 
-            gpu_available = (
-                bool(self.gpu_available)
-                if self.gpu_available is not None
-                else False
+            # ``None`` means CUDA has not been safely probed yet. Preserve
+            # that distinction instead of reporting a fabricated ``False``.
+            gpu_available = self.gpu_available
+            gpu_count = (
+                int(self.gpu_count) if self.gpu_available is not None else None
             )
-            gpu_count = int(self.gpu_count) if self.gpu_available else 0
 
             sample = ProcessSample(
                 sample_idx=self.sample_idx,

--- a/src/traceml_ai/samplers/process_sampler.py
+++ b/src/traceml_ai/samplers/process_sampler.py
@@ -140,12 +140,10 @@ class ProcessSampler(BaseSampler):
         """
         Return process CPU utilization as a percentage.
         """
+        if self.process is None:
+            return None
         try:
-            return (
-                float(self.process.cpu_percent(interval=None))
-                if self.process
-                else 0.0
-            )
+            return float(self.process.cpu_percent(interval=None))
         except Exception as e:
             self.logger.error(f"[TraceML] WARNING: CPU sample failed: {e}")
             return None
@@ -154,10 +152,10 @@ class ProcessSampler(BaseSampler):
         """
         Return process resident memory (RSS) in bytes.
         """
+        if self.process is None:
+            return None
         try:
-            return (
-                float(self.process.memory_info().rss) if self.process else 0.0
-            )
+            return float(self.process.memory_info().rss)
         except Exception as e:
             self.logger.error(f"[TraceML] WARNING: RAM sample failed: {e}")
             return None

--- a/src/traceml_ai/samplers/schema/process.py
+++ b/src/traceml_ai/samplers/schema/process.py
@@ -112,14 +112,14 @@ class ProcessSample:
     timestamp: float
     pid: int
 
-    cpu_percent: float
+    cpu_percent: Optional[float]
     cpu_logical_core_count: int
 
-    ram_used: float
-    ram_total: float
+    ram_used: Optional[float]
+    ram_total: Optional[float]
 
-    gpu_available: bool
-    gpu_count: int
+    gpu_available: Optional[bool]
+    gpu_count: Optional[int]
     gpu: Optional[ProcessGPUMetrics]
 
     def to_wire(self) -> Dict[str, Any]:

--- a/tests/samplers/test_process_sampler.py
+++ b/tests/samplers/test_process_sampler.py
@@ -1,0 +1,28 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from traceml_ai.samplers.process_sampler import ProcessSampler
+
+
+class _Logger:
+    def error(self, *args, **kwargs) -> None:
+        return None
+
+
+class _FailingProcess:
+    def cpu_percent(self, interval=None):
+        raise RuntimeError("cpu unavailable")
+
+    def memory_info(self):
+        raise RuntimeError("memory unavailable")
+
+
+def test_collection_failure_is_unavailable_not_zero() -> None:
+    sampler = ProcessSampler.__new__(ProcessSampler)
+    sampler.process = _FailingProcess()
+    sampler.logger = _Logger()
+
+    assert sampler._sample_cpu() is None
+    assert sampler._sample_ram() is None

--- a/tests/samplers/test_process_sampler.py
+++ b/tests/samplers/test_process_sampler.py
@@ -26,3 +26,11 @@ def test_collection_failure_is_unavailable_not_zero() -> None:
 
     assert sampler._sample_cpu() is None
     assert sampler._sample_ram() is None
+
+
+def test_missing_process_handle_is_unavailable_not_zero() -> None:
+    sampler = ProcessSampler.__new__(ProcessSampler)
+    sampler.process = None
+
+    assert sampler._sample_cpu() is None
+    assert sampler._sample_ram() is None


### PR DESCRIPTION
## Changes

- Return `None` when CPU or RSS collection fails.
- Keep total RAM unknown when initialization fails.
- Preserve unknown CUDA availability and GPU count until CUDA can be safely probed.
- Update the Process sample schema to allow these nullable values.
- Add focused sampler tests.

## Scope

This PR changes upstream collection and wire semantics only. SQLite already preserves these values as `NULL`.

Legacy terminal, dashboard, and diagnosis handling of unavailable values is intentionally out of scope and will be addressed separately.
