### PR TITLE
Dashboard: Process block as four tiles, two per-rank charts and rank rows

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
@@ -84,11 +84,17 @@ def rows_hint(roll: Dict[str, Any], *, is_open: bool) -> str:
         return ""
     stale = int(roll.get("ranks_stale") or 0)
     parts = [f"{total} rank{'s' if total != 1 else ''}"]
-    if stale:
+    if stale and roll.get("excluding_stale"):
         parts.append(f"{stale} stale, excluded")
+    elif stale:
+        # Nothing is reporting, so nothing was excluded: the numbers above
+        # are the last ones these ranks sent.
+        parts.append("none reporting")
     imbalance = roll.get("reserved_imbalance_pct")
     if imbalance is not None:
-        parts.append(f"reserved imbalance {float(imbalance):.0f}%")
+        value = float(imbalance)
+        shown = "<1" if 0 < value < 1 else f"{value:.0f}"
+        parts.append(f"reserved imbalance {shown}%")
     parts.append("click to close" if is_open else "click to open")
     return " · ".join(parts)
 
@@ -100,7 +106,9 @@ def format_age(seconds: Any) -> str:
     value = float(seconds)
     if value < 90:
         return f"{value:.0f} s"
-    return f"{value / 60.0:.0f} min"
+    if value < 90 * 60:
+        return f"{value / 60.0:.0f} min"
+    return f"{value / 3600.0:.1f} h"
 
 
 def rows_html(

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
@@ -33,9 +33,9 @@ from .theme import (
     format_gb_pair,
     format_span,
     format_window,
-    num as _num,
-    sparkline_svg,
 )
+from .theme import num as _num
+from .theme import sparkline_svg
 
 # One colour per rank, shared by the charts and the rows' chips so a line
 # and a row are recognisably the same rank. Red is not among them: it reads

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
@@ -156,6 +156,26 @@ def rows_html(
     return f'<table class="tml-gpus">{head}{body}</table>'
 
 
+def drift_axis_bounds(values: List[Any]) -> Tuple[float, float, float]:
+    """A y range that fits the data, for a series whose signal is DRIFT.
+
+    RSS is a level a few GB high that moves by tens of MB across a run.
+    Zero-anchoring it (right for a share of capacity, like CPU) puts that
+    whole movement inside one pixel: measured on the 3-hour capture, the
+    ranks sit at 1.48-1.50 GB on an axis that would run to 5. The leak
+    this chart exists to show would be invisible.
+    """
+    numbers = [float(value) for value in values if value is not None]
+    if not numbers:
+        return (0.0, 1.0, 0.5)
+    low, high = min(numbers), max(numbers)
+    if high <= low:
+        high = low + max(abs(low) * 0.01, 0.01)
+    pad = (high - low) * 0.25
+    low, high = max(0.0, low - pad), high + pad
+    return (low, high, (high - low) / 2.0)
+
+
 def _series_axis(
     *groups: List[Dict[str, Any]],
 ) -> Optional[Tuple[float, float]]:
@@ -318,7 +338,14 @@ def _update_chart(
         for entry in entries
         for value in (entry.get("max") or entry.get(values_key) or [])
     ]
-    chart.options["yAxis"]["max"] = ymax_of(flat)
+    bounds = ymax_of(flat)
+    if isinstance(bounds, tuple):
+        low, high, tick = bounds
+        chart.options["yAxis"]["min"] = low
+        chart.options["yAxis"]["max"] = high
+        chart.options["yAxis"]["interval"] = tick
+    else:
+        chart.options["yAxis"]["max"] = bounds
     chart.update()
     window_s = float((run[0].get("window_s") if run else 0.0) or 0.0)
     words = format_window(window_s)
@@ -435,7 +462,7 @@ def update_process_section(
             window=series.get("rss") or [],
             aligned=aligned,
             scale=float(1024**3),
-            ymax_of=lambda values: theme.nice_ymax(values, floor=1.0),
+            ymax_of=drift_axis_bounds,
             tooltip=(
                 "Host memory held by each rank's trainer process. The "
                 "shape is the point: steady growth across the run is the "

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
@@ -1,176 +1,462 @@
-"""Process metrics — RAM% / GPU-mem% time-series + KPIs (PR2 revamp).
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
 
-Reuses the original client-side rollup math; renders with glass + ECharts.
-Renderer payload (history rows + series + gpu_used_imbalance) is unchanged.
+"""
+Process block: the trainer process on every rank, as four tiles, two charts
+and per-rank rows.
+
+Scope, stated on the block because it is the block's most useful fact: one
+process per rank, its own PID only. DataLoader workers are separate
+processes, so their CPU lands in the System block and never here. Reading
+the two blocks together is what the page is for: host CPU high while every
+rank's process CPU is low means the work is outside the trainer.
+
+Tiles are levels with their denominator; charts carry the two quantities
+whose information is their shape over time (CPU capacity, RSS); memory is a
+step function and stays a number. No verdict words: the diagnosis engine
+owns those.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from nicegui import ui
 
 from . import theme
+from .theme import (
+    apply_span_axis,
+    cpu_axis_max,
+    format_gb_pair,
+    format_span,
+    format_window,
+    num as _num,
+    sparkline_svg,
+)
+
+# One colour per rank, shared by the charts and the rows' chips so a line
+# and a row are recognisably the same rank. Red is not among them: it reads
+# as a verdict.
+_RANK_COLORS = (
+    "#f97316",
+    "#3b82f6",
+    "#0d9488",
+    "#a855f7",
+    "#0ea5e9",
+    "#eab308",
+    "#ec4899",
+    "#10b981",
+)
+
+NA = "n/a"
+_MONO = "font-family:var(--mono);"
+
+# The block's scope, on screen rather than in a tooltip: without it the
+# CPU numbers read as the whole box's, and the pairing that makes them
+# diagnostic is invisible.
+SCOPE_NOTE = "one process per rank · DataLoader workers not included"
 
 
-def _to_ms(s: str) -> Optional[int]:
-    try:
-        return int(datetime.fromisoformat(s).timestamp() * 1000)
-    except Exception:
-        return None
+def rank_color(rank: int) -> str:
+    return _RANK_COLORS[int(rank) % len(_RANK_COLORS)]
 
 
-def _percentile(vals: List[float], p: float) -> float:
-    vals = sorted(v for v in vals if v is not None)
-    if not vals:
-        return 0.0
-    k = (len(vals) - 1) * p / 100.0
-    f = int(k)
-    c = min(int(k) + 1, len(vals) - 1)
-    return vals[f] if f == c else vals[f] * (c - k) + vals[c] * (k - f)
+def should_auto_open(*, prev_over: bool, over: bool) -> bool:
+    """Open on the rising edge only.
+
+    Twin of the System block's rule: a reader who closes the rows must not
+    be fought every tick while the condition persists.
+    """
+    return bool(over and not prev_over)
 
 
-def _compute_rollups(window: List[Dict[str, Any]]) -> Dict[str, Any]:
-    last = window[-1]
-    cpu_hist = [float(r.get("cpu_max", 0.0) or 0.0) for r in window]
-    ram_hist = [float(r.get("ram_used_max", 0.0) or 0.0) for r in window]
-    gpu_hist = [
-        float(r.get("gpu_used", 0.0) or 0.0)
-        for r in window
-        if r.get("gpu_used") is not None
-    ]
-    return {
-        "gpu_available": last.get("gpu_used") is not None,
-        "cpu": {
-            "now": cpu_hist[-1],
-            "p50": _percentile(cpu_hist, 50),
-            "p95": _percentile(cpu_hist, 95),
-        },
-        "ram": {
-            "now": ram_hist[-1],
-            "p95": _percentile(ram_hist, 95),
-            "total": float(last.get("ram_total", 0.0) or 0.0),
-        },
-        "gpu": {
-            "now": gpu_hist[-1] if gpu_hist else 0.0,
-            "p95": _percentile(gpu_hist, 95) if gpu_hist else 0.0,
-        },
+def rows_hint(roll: Dict[str, Any], *, is_open: bool) -> str:
+    """Header of the per-rank rows: coverage, imbalance, and nothing else.
+
+    It states what was observed. Whether that is bad is the engine's call,
+    so no word here classifies it.
+    """
+    total = int(roll.get("ranks_total") or 0)
+    if not total:
+        return ""
+    stale = int(roll.get("ranks_stale") or 0)
+    parts = [f"{total} rank{'s' if total != 1 else ''}"]
+    if stale:
+        parts.append(f"{stale} stale, excluded")
+    imbalance = roll.get("reserved_imbalance_pct")
+    if imbalance is not None:
+        parts.append(f"reserved imbalance {float(imbalance):.0f}%")
+    parts.append("click to close" if is_open else "click to open")
+    return " · ".join(parts)
+
+
+def format_age(seconds: Any) -> str:
+    """A per-rank age in the same words the strip uses."""
+    if seconds is None:
+        return NA
+    value = float(seconds)
+    if value < 90:
+        return f"{value:.0f} s"
+    return f"{value / 60.0:.0f} min"
+
+
+def rows_html(
+    ranks: List[Dict[str, Any]], series: List[Dict[str, Any]]
+) -> str:
+    """Per-rank table: identity, capacity, memory, and how fresh it is.
+
+    A stale rank is dimmed and kept. Dropping it would hide the one fact
+    worth having when a job stalls, which is WHICH rank stopped.
+    """
+    trend = {
+        int(entry.get("global_rank", -1)): (
+            entry.get("avg") or entry.get("v") or []
+        )
+        for entry in series or []
     }
+    head = (
+        "<tr><th>rank</th><th>gpu</th><th>node</th><th>cpu cap</th>"
+        "<th>rss</th><th>cpu trend</th><th>cuda allocated</th>"
+        "<th>cuda reserved</th><th>age</th></tr>"
+    )
+    body = ""
+    for rank in ranks:
+        idx = int(rank.get("global_rank", 0))
+        colour = rank_color(idx)
+        used, rest = format_gb_pair(
+            rank.get("ram_used"), rank.get("ram_total")
+        )
+        reserved, reserved_rest = format_gb_pair(
+            rank.get("gpu_reserved"), rank.get("gpu_total")
+        )
+        alloc, alloc_rest = format_gb_pair(rank.get("gpu_alloc"), None)
+        cap = rank.get("cpu_capacity")
+        stale = bool(rank.get("stale"))
+        row_open = '<tr class="tml-stale">' if stale else "<tr>"
+        gpu_index = rank.get("gpu_index")
+        node_rank = rank.get("node_rank")
+        gpu_cell = f"G{int(gpu_index)}" if gpu_index is not None else NA
+        node_cell = f"N{int(node_rank)}" if node_rank is not None else NA
+        cap_cell = f"{_num(cap, '{:.1f}')} %" if cap is not None else NA
+        body += (
+            row_open + f'<td><span style="color:{colour}">■</span> R{idx}</td>'
+            f"<td>{gpu_cell}</td>"
+            f"<td>{node_cell}</td>"
+            f"<td>{cap_cell}</td>"
+            f"<td>{used} {rest}</td>"
+            f"<td>{sparkline_svg(trend.get(idx, []), colour)}</td>"
+            f"<td>{alloc} {alloc_rest}</td>"
+            f"<td>{reserved} {reserved_rest}</td>"
+            f"<td>{format_age(rank.get('age_s'))}</td>"
+            "</tr>"
+        )
+    return f'<table class="tml-gpus">{head}{body}</table>'
+
+
+def _series_axis(
+    *groups: List[Dict[str, Any]],
+) -> Optional[Tuple[float, float]]:
+    """One anchor and span covering every series on the block.
+
+    Both charts are pinned to it so a vertical read across the pair, and
+    across to the System block's charts above, lands on the same moment.
+    """
+    starts, ends = [], []
+    for group in groups:
+        for entry in group or []:
+            stamps = entry.get("t") or []
+            if stamps:
+                starts.append(stamps[0])
+                ends.append(stamps[-1])
+    if not ends:
+        return None
+    newest = max(ends)
+    return (newest, max(newest - min(starts), 1.0))
 
 
 def build_process_section() -> Dict[str, Any]:
-    kpis: Dict[str, Any] = {}
+    """Build the block once; ``update_process_section`` fills it per tick."""
+    panel: Dict[str, Any] = {"tiles": {}, "subs": {}}
     card = ui.element("div").classes("glass reveal")
     card.style(
-        "padding:18px 20px; width:100%; height:100%; "
-        "display:flex; flex-direction:column; overflow:hidden;"
+        "padding:18px 20px; width:100%; display:flex; "
+        "flex-direction:column; overflow:hidden;"
     )
     with card:
         with (
             ui.row()
             .classes("w-full items-center")
-            .style("margin-bottom:8px; gap:12px;")
+            .style("margin-bottom:10px; gap:12px;")
         ):
             ui.label("Process").classes("ctitle")
-            for nm, col in [("RAM", theme.C_CPU), ("GPU mem", theme.C_GPU)]:
-                with ui.element("div").classes("legchip"):
-                    ui.element("div").classes("legdot").style(
-                        f"background:{col};"
-                    )
-                    ui.label(nm)
             ui.element("div").style("flex:1;")
-            win = ui.label("waiting for data").classes("cmeta")
-        chart = ui.echart(theme.dual_line_options("RAM", "GPU mem")).style(
-            "height:200px; width:100%; flex:1; min-height:160px;"
-        )
-        with (
-            ui.row()
-            .classes("w-full")
-            .style("gap:8px; margin-top:12px; flex-wrap:nowrap;")
-        ):
-            for key, lab, acc, qual in [
-                ("cpu", "CPU", theme.C_CPU, "max · rank"),
-                ("ram", "RAM", theme.C_CPU, "max · rank"),
-                ("gmem", "GPU MEM", theme.C_GPU, "worst rank"),
-                ("gimb", "GPU IMBAL", theme.C_GPU, "spread"),
-            ]:
+            panel["note"] = ui.label(SCOPE_NOTE).classes("cmeta")
+
+        with ui.element("div").classes("tilerow").style("margin-bottom:10px;"):
+            for key, label, accent in (
+                ("cpu", "cpu capacity", theme.C_CPU),
+                ("rss", "rss", theme.C_CPU),
+                ("reserved", "cuda reserved", theme.C_GPU),
+                ("alloc", "cuda allocated", theme.C_GPU),
+            ):
                 with (
                     ui.element("div")
                     .classes("kpi")
-                    .style(f"--acc:{acc}; flex:1 1 0; min-width:0;")
+                    .style(f"--acc:{accent}; min-width:0;")
                 ):
-                    ui.html(
-                        f"{lab} <span class='kq'>{qual}</span>",
-                        sanitize=False,
-                    ).classes("klab")
-                    kpis[key] = ui.html("—", sanitize=False).classes("kval")
-    return {"chart": chart, "win": win, "kpis": kpis}
+                    ui.label(label).classes("klab")
+                    panel["tiles"][key] = ui.html(NA, sanitize=False).classes(
+                        "kval"
+                    )
+                    panel["subs"][key] = ui.label("").classes("ksub")
+
+        with (
+            ui.row()
+            .classes("w-full items-baseline")
+            .style("gap:8px; margin:2px 0 2px;")
+        ):
+            panel["cpu_label"] = ui.label("process cpu").classes("estlabel")
+            ui.element("div").style("flex:1;")
+            panel["cpu_value"] = ui.label("").style(
+                f"{_MONO} font-size:14px; font-weight:600;"
+            )
+        panel["cpu_chart"] = ui.echart(theme.multi_line_options("%")).style(
+            "height:92px; width:100%;"
+        )
+
+        with (
+            ui.row()
+            .classes("w-full items-baseline")
+            .style("gap:8px; margin:8px 0 2px;")
+        ):
+            panel["rss_label"] = ui.label("rss").classes("estlabel")
+            ui.element("div").style("flex:1;")
+            panel["rss_value"] = ui.label("").style(
+                f"{_MONO} font-size:14px; font-weight:600;"
+            )
+        panel["rss_chart"] = ui.echart(theme.multi_line_options(" GB")).style(
+            "height:92px; width:100%;"
+        )
+
+        exp = (
+            ui.expansion()
+            .classes("w-full tml-exp")
+            .props("dense dense-toggle expand-icon-toggle")
+            .style("margin-top:6px;")
+        )
+        with exp.add_slot("header"):
+            with (
+                ui.row()
+                .classes("w-full items-center")
+                .style("gap:10px; min-width:0;")
+            ):
+                ui.label("per-rank rows").style(
+                    f"{_MONO} font-size:12px; font-weight:700;"
+                )
+                panel["rows_hint"] = ui.label("").classes("cmeta")
+        with exp:
+            panel["rows_html"] = ui.html("", sanitize=False).classes("w-full")
+        panel["rows"] = exp
+        panel["_over"] = False
+        panel["_sig"] = None
+    panel["card"] = card
+    return panel
+
+
+def _chart_series(
+    entries: List[Dict[str, Any]], anchor: float, key: str, scale: float
+) -> List[Dict[str, Any]]:
+    """One line per rank, x in seconds before the shared anchor."""
+    lines = []
+    for entry in entries or []:
+        idx = int(entry.get("global_rank", 0))
+        stamps = entry.get("t") or []
+        values = entry.get(key) or []
+        lines.append(
+            theme.line_series(
+                f"R{idx}",
+                rank_color(idx),
+                [
+                    [stamp - anchor, value / scale]
+                    for stamp, value in zip(stamps, values)
+                ],
+            )
+        )
+    return lines
+
+
+def _update_chart(
+    panel: Dict[str, Any],
+    *,
+    chart_key: str,
+    label_key: str,
+    head: str,
+    run: List[Dict[str, Any]],
+    window: List[Dict[str, Any]],
+    aligned: Optional[Tuple[float, float]],
+    scale: float,
+    ymax_of: Any,
+    tooltip: str,
+) -> None:
+    """Draw whichever view the payload carried, and name it."""
+    chart = panel[chart_key]
+    entries = run or window
+    if not entries or aligned is None:
+        chart.options["series"] = []
+        chart.update()
+        panel[label_key].text = head
+        return
+    anchor, span = aligned
+    values_key = "avg" if run else "v"
+    chart.options["series"] = _chart_series(entries, anchor, values_key, scale)
+    apply_span_axis(chart.options, span, anchor)
+    flat = [
+        value / scale
+        for entry in entries
+        for value in (entry.get("max") or entry.get(values_key) or [])
+    ]
+    chart.options["yAxis"]["max"] = ymax_of(flat)
+    chart.update()
+    window_s = float((run[0].get("window_s") if run else 0.0) or 0.0)
+    words = format_window(window_s)
+    panel[label_key].text = f"{head} · {format_span(span)}" + (
+        f" · rolling {words}" if run and words else ""
+    )
+    panel[label_key].tooltip(tooltip)
 
 
 def update_process_section(
     panel: Dict[str, Any], data: Dict[str, Any]
 ) -> None:
+    """Fill the block from one PROCESS payload."""
     if not isinstance(data, dict):
         return
-    history = data.get("history", []) or []
-    if not history:
-        return
-    window = history[-100:]
+    roll = data.get("rollups", {}) or {}
     series = data.get("series", {}) or {}
-    x_time = series.get("x_time", []) or []
+    ranks = roll.get("ranks", []) or []
 
-    ram_total = max(float(window[-1].get("ram_total", 1.0) or 1.0), 1.0)
-    ram_pct = [
-        (float(r.get("ram_used_max", 0.0) or 0.0) / ram_total) * 100.0
-        for r in window
-    ]
-    if x_time and len(x_time) >= len(window):
-        xms = [_to_ms(s) for s in x_time[-len(window) :]]
-    else:
-        xms = [None] * len(window)
+    # The charts are re-sent only when the newest point moved: the UI timer
+    # ticks faster than telemetry arrives, and a full options dict per tick
+    # is pure websocket traffic.
+    signature = (
+        data.get("window_len"),
+        len(ranks),
+        roll.get("ranks_stale"),
+        tuple(
+            (entry.get("t") or [None])[-1]
+            for entry in series.get("cpu_capacity_run")
+            or series.get("cpu_capacity")
+            or []
+        ),
+    )
+    changed = signature != panel.get("_sig")
+    panel["_sig"] = signature
 
-    chart = panel["chart"]
-    chart.options["series"][0]["data"] = [
-        [t, v] for t, v in zip(xms, ram_pct) if t is not None
-    ]
+    cpu = roll.get("cpu_capacity", {}) or {}
+    rss = roll.get("rss", {}) or {}
+    cuda = roll.get("cuda", {}) or {}
+    has_gpu = bool(data.get("gpu_available") or roll.get("gpu_available"))
 
-    gpu_window = [
-        (i, r) for i, r in enumerate(window) if r.get("gpu_used") is not None
-    ]
-    if gpu_window and window[-1].get("gpu_total") is not None:
-        gtot = max(float(window[-1].get("gpu_total", 1.0) or 1.0), 1.0)
-        gdata = [
-            [xms[i], (float(r.get("gpu_used", 0.0) or 0.0) / gtot) * 100.0]
-            for i, r in gpu_window
-            if i < len(xms) and xms[i] is not None
-        ]
-        chart.options["series"][1]["data"] = gdata
-    else:
-        gdata = []
-        chart.options["series"][1]["data"] = []
-    ymax = theme.nice_ymax(ram_pct + [v for _, v in gdata])
-    chart.options["yAxis"][0]["max"] = ymax
-    chart.options["yAxis"][1]["max"] = ymax
-    chart.update()
+    p50 = cpu.get("p50")
+    panel["tiles"]["cpu"].content = theme.kval(
+        _num(p50, "{:.1f}") if p50 is not None else NA,
+        "%" if p50 is not None else "",
+    )
+    panel["subs"]["cpu"].text = "median rank · of host capacity"
 
-    roll = _compute_rollups(window)
-    panel["win"].text = f"last {len(window)} samples"
-    k = panel["kpis"]
-    k["cpu"].content = theme.kval(f"{roll['cpu']['now']:.0f}", "%")
-    rn = theme.gb(roll["ram"]["now"])
-    k["ram"].content = theme.kval(f"{rn:.2f}" if rn is not None else "—", "GB")
-    if roll["gpu_available"]:
-        gm = theme.gb(roll["gpu"]["now"])
-        k["gmem"].content = theme.kval(
-            f"{gm:.2f}" if gm is not None else "—", "GB"
+    used, rest = format_gb_pair(rss.get("used"), rss.get("total"))
+    panel["tiles"]["rss"].content = theme.kval(
+        used, f" {rest}" if rest else ""
+    )
+    worst_rank = rss.get("rank")
+    panel["subs"]["rss"].text = (
+        f"worst rank · R{int(worst_rank)}"
+        if worst_rank is not None
+        else "used / total"
+    )
+
+    if has_gpu:
+        reserved, reserved_rest = format_gb_pair(
+            cuda.get("reserved"), cuda.get("reserved_total")
         )
-        imb = data.get("gpu_used_imbalance")
-        gi = theme.gb(imb) if imb is not None else None
-        k["gimb"].content = theme.kval(
-            f"{gi:.2f}" if gi is not None else "—",
-            "GB" if gi is not None else "",
+        panel["tiles"]["reserved"].content = theme.kval(
+            reserved, f" {reserved_rest}" if reserved_rest else ""
         )
+        tight = cuda.get("reserved_rank")
+        panel["subs"]["reserved"].text = (
+            f"least-headroom rank · R{int(tight)}"
+            if tight is not None
+            else "reserved / total"
+        )
+        alloc, alloc_rest = format_gb_pair(cuda.get("alloc_p50"), None)
+        panel["tiles"]["alloc"].content = theme.kval(
+            alloc, f" {alloc_rest}" if alloc_rest else ""
+        )
+        panel["subs"]["alloc"].text = "median rank · live tensors"
     else:
-        k["gmem"].content = "N/A"
-        k["gimb"].content = "—"
+        seen = bool(data.get("window_len"))
+        for key in ("reserved", "alloc"):
+            panel["tiles"][key].content = NA
+            panel["subs"][key].text = "no GPU" if seen else ""
+
+    aligned = _series_axis(
+        series.get("cpu_capacity_run") or series.get("cpu_capacity"),
+        series.get("rss_run") or series.get("rss"),
+    )
+    if changed:
+        _update_chart(
+            panel,
+            chart_key="cpu_chart",
+            label_key="cpu_label",
+            head="process cpu · capacity per rank",
+            run=series.get("cpu_capacity_run") or [],
+            window=series.get("cpu_capacity") or [],
+            aligned=aligned,
+            scale=1.0,
+            ymax_of=cpu_axis_max,
+            tooltip=(
+                "Each rank's trainer process, as a share of the host's "
+                "total CPU capacity: 100% means every logical core busy. "
+                "DataLoader workers are separate processes and are not "
+                "included, so host CPU high with these low means the work "
+                "is outside the trainer. On a hyperthreaded host, logical "
+                "capacity is reached before the cores saturate."
+            ),
+        )
+        _update_chart(
+            panel,
+            chart_key="rss_chart",
+            label_key="rss_label",
+            head="rss · per rank",
+            run=series.get("rss_run") or [],
+            window=series.get("rss") or [],
+            aligned=aligned,
+            scale=float(1024**3),
+            ymax_of=lambda values: theme.nice_ymax(values, floor=1.0),
+            tooltip=(
+                "Host memory held by each rank's trainer process. The "
+                "shape is the point: steady growth across the run is the "
+                "signature of a leak, which ends with the OS killing one "
+                "rank. It covers the history retained for this run, not "
+                "necessarily the whole run."
+            ),
+        )
+    panel["cpu_value"].text = f"{float(p50):.1f}%" if p50 is not None else ""
+    worst_used, worst_rest = format_gb_pair(rss.get("used"), None)
+    panel["rss_value"].text = (
+        f"{worst_used} {worst_rest}".strip() if rss.get("used") else ""
+    )
+
+    over = bool(roll.get("rows_over"))
+    if should_auto_open(prev_over=bool(panel.get("_over")), over=over):
+        panel["rows"].value = True
+    panel["_over"] = over
+    panel["rows_hint"].text = rows_hint(
+        roll, is_open=bool(panel["rows"].value)
+    )
+    panel["rows_html"].content = rows_html(
+        ranks, series.get("cpu_capacity_run") or series.get("cpu_capacity")
+    )

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
@@ -399,12 +399,17 @@ def update_process_section(
     cuda = roll.get("cuda", {}) or {}
     has_gpu = bool(data.get("gpu_available") or roll.get("gpu_available"))
 
-    p50 = cpu.get("p50")
+    worst_cpu = cpu.get("worst")
+    worst_cpu_rank = cpu.get("worst_rank")
     panel["tiles"]["cpu"].content = theme.kval(
-        _num(p50, "{:.1f}") if p50 is not None else NA,
-        "%" if p50 is not None else "",
+        _num(worst_cpu, "{:.1f}") if worst_cpu is not None else NA,
+        "%" if worst_cpu is not None else "",
     )
-    panel["subs"]["cpu"].text = "median rank · of host capacity"
+    panel["subs"]["cpu"].text = (
+        f"worst rank · R{int(worst_cpu_rank)} · of host capacity"
+        if worst_cpu_rank is not None
+        else "of host capacity"
+    )
 
     used, rest = format_gb_pair(rss.get("used"), rss.get("total"))
     panel["tiles"]["rss"].content = theme.kval(
@@ -484,7 +489,9 @@ def update_process_section(
                 "necessarily the whole run."
             ),
         )
-    panel["cpu_value"].text = f"{float(p50):.1f}%" if p50 is not None else ""
+    panel["cpu_value"].text = (
+        f"{float(worst_cpu):.1f}%" if worst_cpu is not None else ""
+    )
     worst_used, worst_rest = format_gb_pair(rss.get("used"), None)
     panel["rss_value"].text = (
         f"{worst_used} {worst_rest}".strip() if rss.get("used") else ""

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
@@ -320,6 +320,7 @@ def _update_chart(
     scale: float,
     ymax_of: Any,
     tooltip: str,
+    unit: str = "",
 ) -> None:
     """Draw whichever view the payload carried, and name it."""
     chart = panel[chart_key]
@@ -344,6 +345,9 @@ def _update_chart(
         chart.options["yAxis"]["min"] = low
         chart.options["yAxis"]["max"] = high
         chart.options["yAxis"]["interval"] = tick
+        chart.options["yAxis"]["axisLabel"][":formatter"] = (
+            theme.value_axis_formatter(high - low, unit)
+        )
     else:
         chart.options["yAxis"]["max"] = bounds
     chart.update()
@@ -463,6 +467,7 @@ def update_process_section(
             aligned=aligned,
             scale=float(1024**3),
             ymax_of=drift_axis_bounds,
+            unit=" GB",
             tooltip=(
                 "Host memory held by each rank's trainer process. The "
                 "shape is the point: steady growth across the run is the "

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -18,12 +18,23 @@ This section presents measurements and leaves verdicts to diagnostics.
 from __future__ import annotations
 
 import math
-from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 from nicegui import ui
 
 from . import theme
+from .theme import (  # helpers shared with the Process block
+    apply_span_axis,
+    cpu_axis_max,
+    format_gb_pair,
+    format_span,
+    format_window,
+    newest_epoch,
+    num as _num,
+    relative_seconds,
+    shared_run_axis,
+    sparkline_svg,
+)
 
 # Window-p95 GPU utilisation spread (max - min, percentage points) that
 # automatically opens the per-GPU rows.
@@ -48,41 +59,6 @@ _MONO = "font-family:var(--mono);"
 # --- pure display rules ----------------------------------------------------
 def gpu_color(index: int) -> str:
     return _GPU_COLORS[int(index) % len(_GPU_COLORS)]
-
-
-def format_window(window_s: float) -> str:
-    """The rolling window in words: '30 s', '2 min'.
-
-    The payload picks round windows (see ``choose_window_s``) so this reads
-    as a duration a person recognises.
-    """
-    if not window_s or window_s <= 0:
-        return ""
-    if window_s < 60:
-        return f"{window_s:.0f} s"
-    return f"{window_s / 60.0:.0f} min"
-
-
-def format_span(seconds: Optional[float]) -> str:
-    """The window a chart covers, as one phrase in its label: 'last 3 min'."""
-    if not seconds or seconds <= 0:
-        return ""
-    if seconds < 90:
-        return f"last {seconds:.0f} s"
-    return f"last {seconds / 60.0:.0f} min"
-
-
-def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
-    """A level against its capacity: ('6.3', '/ 16.1 GB')."""
-    used = theme.gb(used_bytes) if used_bytes is not None else None
-    if used is None:
-        return (NA, "")
-    num = f"{used:.1f}"
-    total = theme.gb(total_bytes) if total_bytes is not None else None
-    if total is None or total <= 0:
-        return (num, "GB")
-    total_s = f"{total:.0f}" if total >= 100 else f"{total:.1f}"
-    return (num, f"/ {total_s} GB")
 
 
 def disclosure_text(gpus: List[Dict[str, Any]], *, is_open: bool) -> str:
@@ -157,44 +133,6 @@ def power_axis_bounds(
     return (lo, hi, tick)
 
 
-def cpu_axis_max(values: List[Any]) -> float:
-    """Zero-anchored ceiling whose half is a whole percent (0 / 5 / 10)."""
-    vals = [float(v) for v in values if v is not None]
-    peak = (max(vals) * 1.2) if vals else 0.0
-    for top in (4.0, 10.0, 20.0, 30.0, 40.0, 60.0, 80.0, 100.0):
-        if peak <= top:
-            return top
-    return 100.0
-
-
-def sparkline_svg(
-    values: List[Optional[float]],
-    color: str,
-    *,
-    width: int = 64,
-    height: int = 14,
-) -> str:
-    """Inline SVG polyline; gaps are dropped, an empty trace is no SVG."""
-    points = [(i, float(v)) for i, v in enumerate(values) if v is not None]
-    if not points:
-        return ""
-    lo = min(v for _, v in points)
-    hi = max(v for _, v in points)
-    span = (hi - lo) or 1.0
-    step = width / max(len(values) - 1, 1)
-    inner = height - 4
-    coords = " ".join(
-        f"{i * step:.1f},{1 + inner - (v - lo) / span * inner:.1f}"
-        for i, v in points
-    )
-    return (
-        f'<svg viewBox="0 0 {width} {height}" '
-        f'style="width:{width}px;height:{height}px;vertical-align:middle">'
-        f'<polyline points="{coords}" fill="none" stroke="{color}" '
-        'stroke-width="1.4"/></svg>'
-    )
-
-
 def odd_ones_out(gpus: List[Dict[str, Any]]) -> set:
     """GPU indices on the smaller side of the utilisation split.
 
@@ -228,10 +166,6 @@ CPU_LABEL = "host cpu util · avg across cores"
 # same page already reads "N/A", and one page should not spell absence two
 # ways.
 NA = "n/a"
-
-
-def _num(value: Any, fmt: str = "{:.0f}") -> str:
-    return fmt.format(float(value)) if value is not None else NA
 
 
 def rows_html(
@@ -288,82 +222,6 @@ def rows_html(
 
 
 # --- relative time axis ----------------------------------------------------
-def shared_run_axis(
-    run_t: List[float], prun: List[Dict[str, Any]]
-) -> Optional[Tuple[float, float]]:
-    """One (anchor, span) covering both whole-run series.
-
-    Returns the newest clock across the two and the reach back to the
-    oldest, so both charts can be pinned to the same interval.
-    """
-    starts = [run_t[0]] + [e["t"][0] for e in prun if e.get("t")]
-    ends = [run_t[-1]] + [e["t"][-1] for e in prun if e.get("t")]
-    if not starts or not ends:
-        return None
-    newest = max(ends)
-    return (newest, max(newest - min(starts), 1.0))
-
-
-def _newest_epoch(x_time: List[str]) -> Optional[float]:
-    """Epoch seconds of the newest parseable stamp, for the clock axis."""
-    for value in reversed(x_time):
-        try:
-            return datetime.fromisoformat(value).timestamp()
-        except Exception:
-            continue
-    return None
-
-
-def _relative_seconds(x_time: List[str]) -> List[Optional[float]]:
-    """Seconds before the newest sample (<= 0), aligned with ``x_time``."""
-    stamps: List[Optional[float]] = []
-    for s in x_time:
-        try:
-            stamps.append(datetime.fromisoformat(s).timestamp())
-        except Exception:
-            stamps.append(None)
-    present = [t for t in stamps if t is not None]
-    if not present:
-        return []
-    last = max(present)
-    return [t - last if t is not None else None for t in stamps]
-
-
-def _apply_span_axis(
-    options: Dict[str, Any], span: float, newest_epoch: Optional[float] = None
-) -> None:
-    """Pin a chart to its span and label it in wall-clock time.
-
-    The x values are seconds before the newest sample, which keeps the
-    series arithmetic simple, but a reader debugging a slowdown needs the
-    clock: it is what their logs and every other dashboard are keyed on,
-    and it is what the Process block beside this one already shows. The
-    formatters convert on the fly from the newest sample's epoch, and the
-    hover label carries both readings ("19:10 · 45 min ago") so the axis
-    and the tooltip never speak two different vocabularies.
-    """
-    span = max(float(span), 1.0)
-    axis = options["xAxis"]
-    axis["min"] = -span
-    axis["max"] = 0
-    axis["interval"] = span / 3.0
-    if newest_epoch is None:
-        axis["axisLabel"]["show"] = False
-        return
-    axis["axisLabel"]["show"] = True
-    clock = (
-        "const d=new Date((%f+%%s)*1000);const q=n=>('0'+n).slice(-2);"
-        "const c=q(d.getHours())+':'+q(d.getMinutes())%s;"
-        % (float(newest_epoch), "+':'+q(d.getSeconds())" if span < 600 else "")
-    )
-    axis["axisLabel"][":formatter"] = "v=>{%s return c;}" % (clock % "v")
-    pointer = options.get("tooltip", {}).get("axisPointer", {}).get("label")
-    if pointer is not None:
-        pointer[":formatter"] = (
-            "p=>{%s const s=Math.round(-p.value);"
-            "return c+(s<1?' · now':(s<120?' · '+s+' s ago':"
-            "' · '+Math.floor(s/60)+' min ago'));}" % (clock % "p.value")
-        )
 
 
 # --- build / update --------------------------------------------------------
@@ -515,7 +373,7 @@ def _update_cpu_chart(
         chart.options["series"][0]["data"] = [
             [t - newest, value] for t, value in zip(run_t, run_avg)
         ]
-        _apply_span_axis(chart.options, axis_span, newest)
+        apply_span_axis(chart.options, axis_span, newest)
         # Peaks are not drawn, but they keep a smoothed spike inside the axis.
         ymax = cpu_axis_max(run_max or run_avg)
     elif changed:
@@ -524,7 +382,7 @@ def _update_cpu_chart(
             for second, value in zip(secs, cpu)
             if second is not None
         ]
-        _apply_span_axis(chart.options, span, newest_epoch)
+        apply_span_axis(chart.options, span, newest_epoch)
         ymax = cpu_axis_max(cpu)
     if changed:
         chart.options["yAxis"]["max"] = ymax
@@ -536,11 +394,17 @@ def _update_cpu_chart(
     span_words = format_span(span)
     if whole_run:
         window = format_window(float(run.get("window_s") or 0.0))
-        panel["cpu_label"].text = f"{CPU_LABEL} · whole run" + (
+        # The span, never "whole run": history retention (30 min by
+        # default since #393) prunes older telemetry on a live run, so a
+        # whole-run claim would be false exactly when it mattered. The
+        # rolling suffix is what tells the reader this is the decimated
+        # view rather than the raw sample window.
+        panel["cpu_label"].text = f"{CPU_LABEL} · {format_span(run_span)}" + (
             f" · rolling {window}" if window else ""
         )
         panel["cpu_label"].tooltip(
-            f"Whole run, {format_span(run_span)[5:]}. Each point shows "
+            f"The {format_span(run_span)[5:]} of history held for this run. "
+            f"Each point shows "
             f"average host CPU use over the previous {window}. 100% means "
             "all logical CPU cores are fully used."
         )
@@ -733,9 +597,9 @@ def _update_power_chart(
             max(item["t"][-1] for item in run if item.get("t")),
             run_span,
         )
-        _apply_span_axis(chart.options, axis_span, anchor)
+        apply_span_axis(chart.options, axis_span, anchor)
     else:
-        _apply_span_axis(chart.options, span, newest_epoch)
+        apply_span_axis(chart.options, span, newest_epoch)
     chart.style("display:block;")
     chart.update()
 
@@ -746,11 +610,12 @@ def _update_power_chart(
     )
     if whole_run:
         window = format_window(float(run[0].get("window_s") or 0.0))
-        panel["power_label"].text = f"{head} · whole run" + (
+        panel["power_label"].text = f"{head} · {format_span(run_span)}" + (
             f" · average and lowest every {window}" if window else ""
         )
         panel["power_label"].tooltip(
-            f"Whole run, {format_span(run_span)[5:]}. Solid lines show each "
+            f"The {format_span(run_span)[5:]} of history held for this run. "
+            f"Solid lines show each "
             f"GPU's average power every {window}; faint lines show the "
             "lowest reading during the same interval."
         )
@@ -804,8 +669,8 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
     _set_gpu_visible(panel, gpu_on)
 
     x_time = series.get("x_time", []) or []
-    secs = _relative_seconds(x_time)
-    newest_epoch = _newest_epoch(x_time)
+    secs = relative_seconds(x_time)
+    window_epoch = newest_epoch(x_time)
     present = [second for second in secs if second is not None]
     span = -min(present) if present else 0.0
 
@@ -841,7 +706,7 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
         changed=changed,
         secs=secs,
         span=span,
-        newest_epoch=newest_epoch,
+        newest_epoch=window_epoch,
         whole_run=cpu_whole,
         aligned=aligned,
     )
@@ -860,7 +725,7 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
         changed=changed,
         secs=secs,
         span=span,
-        newest_epoch=newest_epoch,
+        newest_epoch=window_epoch,
         whole_run=power_whole,
         aligned=aligned,
     )

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -393,6 +393,10 @@ def _update_cpu_chart(
     panel["cpu_value"].text = f"{cpu_p50:.0f}%" if cpu_p50 is not None else ""
     span_words = format_span(span)
     if whole_run:
+        # The pair shares one axis (see shared_run_axis), so the label
+        # quotes the shared span; each series' own extent differs by up to
+        # a window and would read as two different runs.
+        run_span = (aligned or (0.0, run_span))[1]
         window = format_window(float(run.get("window_s") or 0.0))
         # The span, never "whole run": history retention (30 min by
         # default since #393) prunes older telemetry on a live run, so a
@@ -609,6 +613,7 @@ def _update_power_chart(
         else "gpu power · per GPU"
     )
     if whole_run:
+        run_span = (aligned or (0.0, run_span))[1]
         window = format_window(float(run[0].get("window_s") or 0.0))
         panel["power_label"].text = f"{head} · {format_span(run_span)}" + (
             f" · average and lowest every {window}" if window else ""

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -23,18 +23,16 @@ from typing import Any, Dict, List, Optional, Tuple
 from nicegui import ui
 
 from . import theme
-from .theme import (  # helpers shared with the Process block
+from .theme import (
     apply_span_axis,
     cpu_axis_max,
     format_gb_pair,
     format_span,
     format_window,
     newest_epoch,
-    num as _num,
-    relative_seconds,
-    shared_run_axis,
-    sparkline_svg,
 )
+from .theme import num as _num
+from .theme import relative_seconds, shared_run_axis, sparkline_svg
 
 # Window-p95 GPU utilisation spread (max - min, percentage points) that
 # automatically opens the per-GPU rows.

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
@@ -711,11 +711,17 @@ def format_span(seconds: Optional[float]) -> str:
 
 
 def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
-    """A level against its capacity: ('6.3', '/ 16.1 GB')."""
+    """A level against its capacity: ('6.3', '/ 16.1 GB').
+
+    A measured value never renders as "0.0": a trainer process holding
+    27 MB is a real reading, and printing it with one decimal makes it
+    indistinguishable from the marker this module uses for absence.
+    Sub-gigabyte levels keep two decimals instead.
+    """
     used = gb(used_bytes) if used_bytes is not None else None
     if used is None:
         return (NA, "")
-    num = f"{used:.1f}"
+    num = f"{used:.2f}" if 0 < used < 1 else f"{used:.1f}"
     total = gb(total_bytes) if total_bytes is not None else None
     if total is None or total <= 0:
         return (num, "GB")

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
@@ -357,6 +357,23 @@ def _span_axis() -> Dict[str, Any]:
     }
 
 
+def value_axis_formatter(span: float, unit: str) -> str:
+    """Tick formatter whose precision comes from the axis RANGE.
+
+    Magnitude alone is not enough: an axis fitted to a 20 MB drift around
+    1.4 GB would label every tick "1.4 GB" and say nothing.
+    """
+    if span >= 20:
+        decimals = 0
+    elif span >= 2:
+        decimals = 1
+    elif span >= 0.2:
+        decimals = 2
+    else:
+        decimals = 3
+    return f"v=>v.toFixed({decimals})+'{unit}'"
+
+
 def _value_axis(unit: str, *, zero: bool) -> Dict[str, Any]:
     ax: Dict[str, Any] = {
         "type": "value",
@@ -365,7 +382,17 @@ def _value_axis(unit: str, *, zero: bool) -> Dict[str, Any]:
             "color": _TXT,
             "fontFamily": "Geist Mono",
             "fontSize": 10,
-            ":formatter": f"v=>v+'{unit}'",
+            # Round, never print the raw float: an axis fitted to a
+            # 20 MB drift otherwise labels a tick
+            # "1.402237892150879 GB". A chart whose ticks need more
+            # precision than this replaces the formatter with
+            # ``value_axis_formatter`` for its own range.
+            ":formatter": (
+                "v=>(Number.isInteger(v)?v"
+                ":Math.abs(v)>=100?v.toFixed(0)"
+                ":Math.abs(v)>=1?v.toFixed(1):v.toFixed(2))"
+                f"+'{unit}'"
+            ),
         },
         "axisLine": {"show": False},
         "axisTick": {"show": False},

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
@@ -20,6 +20,7 @@ the per-section modules construct their UI with the CSS classes defined here.
 from __future__ import annotations
 
 import os
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 # --- Brand chrome tokens (DESIGN.md) -------------------------------------
@@ -649,3 +650,166 @@ def single_line_options(
             }
         ],
     }
+
+
+# Absent-value marker, shared by every block so one page never spells
+# absence two ways.
+NA = "n/a"
+
+
+# --- shared series/format helpers (used by System and Process) ------------
+
+
+def format_window(window_s: float) -> str:
+    """The rolling window in words: '30 s', '2 min'.
+
+    The payload picks round windows (see ``choose_window_s``) so this reads
+    as a duration a person recognises.
+    """
+    if not window_s or window_s <= 0:
+        return ""
+    if window_s < 60:
+        return f"{window_s:.0f} s"
+    return f"{window_s / 60.0:.0f} min"
+
+
+def format_span(seconds: Optional[float]) -> str:
+    """The window a chart covers, as one phrase in its label: 'last 3 min'."""
+    if not seconds or seconds <= 0:
+        return ""
+    if seconds < 90:
+        return f"last {seconds:.0f} s"
+    return f"last {seconds / 60.0:.0f} min"
+
+
+def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
+    """A level against its capacity: ('6.3', '/ 16.1 GB')."""
+    used = gb(used_bytes) if used_bytes is not None else None
+    if used is None:
+        return (NA, "")
+    num = f"{used:.1f}"
+    total = gb(total_bytes) if total_bytes is not None else None
+    if total is None or total <= 0:
+        return (num, "GB")
+    total_s = f"{total:.0f}" if total >= 100 else f"{total:.1f}"
+    return (num, f"/ {total_s} GB")
+
+
+def cpu_axis_max(values: List[Any]) -> float:
+    """Zero-anchored ceiling whose half is a whole percent (0 / 5 / 10)."""
+    vals = [float(v) for v in values if v is not None]
+    peak = (max(vals) * 1.2) if vals else 0.0
+    for top in (4.0, 10.0, 20.0, 30.0, 40.0, 60.0, 80.0, 100.0):
+        if peak <= top:
+            return top
+    return 100.0
+
+
+def sparkline_svg(
+    values: List[Optional[float]],
+    color: str,
+    *,
+    width: int = 64,
+    height: int = 14,
+) -> str:
+    """Inline SVG polyline; gaps are dropped, an empty trace is no SVG."""
+    points = [(i, float(v)) for i, v in enumerate(values) if v is not None]
+    if not points:
+        return ""
+    lo = min(v for _, v in points)
+    hi = max(v for _, v in points)
+    span = (hi - lo) or 1.0
+    step = width / max(len(values) - 1, 1)
+    inner = height - 4
+    coords = " ".join(
+        f"{i * step:.1f},{1 + inner - (v - lo) / span * inner:.1f}"
+        for i, v in points
+    )
+    return (
+        f'<svg viewBox="0 0 {width} {height}" '
+        f'style="width:{width}px;height:{height}px;vertical-align:middle">'
+        f'<polyline points="{coords}" fill="none" stroke="{color}" '
+        'stroke-width="1.4"/></svg>'
+    )
+
+
+def num(value: Any, fmt: str = "{:.0f}") -> str:
+    return fmt.format(float(value)) if value is not None else NA
+
+
+def shared_run_axis(
+    run_t: List[float], prun: List[Dict[str, Any]]
+) -> Optional[Tuple[float, float]]:
+    """One (anchor, span) covering both whole-run series.
+
+    Returns the newest clock across the two and the reach back to the
+    oldest, so both charts can be pinned to the same interval.
+    """
+    starts = [run_t[0]] + [e["t"][0] for e in prun if e.get("t")]
+    ends = [run_t[-1]] + [e["t"][-1] for e in prun if e.get("t")]
+    if not starts or not ends:
+        return None
+    newest = max(ends)
+    return (newest, max(newest - min(starts), 1.0))
+
+
+def newest_epoch(x_time: List[str]) -> Optional[float]:
+    """Epoch seconds of the newest parseable stamp, for the clock axis."""
+    for value in reversed(x_time):
+        try:
+            return datetime.fromisoformat(value).timestamp()
+        except Exception:
+            continue
+    return None
+
+
+def relative_seconds(x_time: List[str]) -> List[Optional[float]]:
+    """Seconds before the newest sample (<= 0), aligned with ``x_time``."""
+    stamps: List[Optional[float]] = []
+    for s in x_time:
+        try:
+            stamps.append(datetime.fromisoformat(s).timestamp())
+        except Exception:
+            stamps.append(None)
+    present = [t for t in stamps if t is not None]
+    if not present:
+        return []
+    last = max(present)
+    return [t - last if t is not None else None for t in stamps]
+
+
+def apply_span_axis(
+    options: Dict[str, Any], span: float, newest_epoch: Optional[float] = None
+) -> None:
+    """Pin a chart to its span and label it in wall-clock time.
+
+    The x values are seconds before the newest sample, which keeps the
+    series arithmetic simple, but a reader debugging a slowdown needs the
+    clock: it is what their logs and every other dashboard are keyed on,
+    and it is what the Process block beside this one already shows. The
+    formatters convert on the fly from the newest sample's epoch, and the
+    hover label carries both readings ("19:10 · 45 min ago") so the axis
+    and the tooltip never speak two different vocabularies.
+    """
+    span = max(float(span), 1.0)
+    axis = options["xAxis"]
+    axis["min"] = -span
+    axis["max"] = 0
+    axis["interval"] = span / 3.0
+    if newest_epoch is None:
+        axis["axisLabel"]["show"] = False
+        return
+    axis["axisLabel"]["show"] = True
+    clock = (
+        "const d=new Date((%f+%%s)*1000);const q=n=>('0'+n).slice(-2);"
+        "const c=q(d.getHours())+':'+q(d.getMinutes())%s;"
+        % (float(newest_epoch), "+':'+q(d.getSeconds())" if span < 600 else "")
+    )
+    axis["axisLabel"][":formatter"] = "v=>{%s return c;}" % (clock % "v")
+    pointer = options.get("tooltip", {}).get("axisPointer", {}).get("label")
+    if pointer is not None:
+        pointer[":formatter"] = (
+            "p=>{%s const s=Math.round(-p.value);"
+            "return c+(s<1?' · now':(s<120?' · '+s+' s ago':"
+            "' · '+Math.floor(s/60)+' min ago'));}" % (clock % "p.value")
+        )

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
@@ -162,6 +162,7 @@ body{{
 .tml-gpus td{{padding:4px 8px; border-top:1px solid rgba(17,24,39,0.07); white-space:nowrap;}}
 .tml-gpus td.tml-util{{font-weight:700;}}
 .tml-gpus tr.tml-mark td{{background:rgba(255,140,0,0.08);}}
+.tml-gpus tr.tml-stale td{{opacity:0.45;}}
 .tml-exp .q-item{{padding:4px 2px; min-height:0;}}
 .tml-exp .q-expansion-item__content{{padding:0 0 4px;}}
 </style>

--- a/src/traceml_ai/renderers/process/common.py
+++ b/src/traceml_ai/renderers/process/common.py
@@ -136,13 +136,15 @@ class ProcessMetricsDB:
         Optional[int]
             Latest seq, or None if the table has no seq-bearing rows.
         """
-        row = conn.execute("""
+        row = conn.execute(
+            """
             SELECT seq
             FROM process_samples
             WHERE seq IS NOT NULL
             ORDER BY id DESC
             LIMIT 1;
-            """).fetchone()
+            """
+        ).fetchone()
         if row is None or row["seq"] is None:
             return None
         return int(row["seq"])
@@ -158,14 +160,16 @@ class ProcessMetricsDB:
         dict[int, int]
             Mapping rank -> latest seq for that rank.
         """
-        rows = conn.execute("""
+        rows = conn.execute(
+            """
             SELECT rank, MAX(seq) AS max_seq
             FROM process_samples
             WHERE rank IS NOT NULL
               AND seq IS NOT NULL
             GROUP BY rank
             ORDER BY rank ASC;
-            """).fetchall()
+            """
+        ).fetchall()
 
         out: Dict[int, int] = {}
         for row in rows:
@@ -290,7 +294,8 @@ class ProcessMetricsDB:
         matter. This read is one row per rank and answers "who has ever
         reported, and when did each last speak".
         """
-        return conn.execute("""
+        return conn.execute(
+            """
             SELECT * FROM process_samples
             WHERE id IN (
                 SELECT MAX(id) FROM process_samples
@@ -298,7 +303,8 @@ class ProcessMetricsDB:
                 GROUP BY COALESCE(global_rank, rank)
             )
             ORDER BY COALESCE(global_rank, rank) ASC;
-            """).fetchall()
+            """
+        ).fetchall()
 
     def fetch_rank_run_history(
         self,

--- a/src/traceml_ai/renderers/process/common.py
+++ b/src/traceml_ai/renderers/process/common.py
@@ -280,6 +280,26 @@ class ProcessMetricsDB:
             (floor_ts, floor_ts, int(max(1, window_n))),
         ).fetchall()
 
+    def fetch_rank_latest(self, conn: sqlite3.Connection) -> List[sqlite3.Row]:
+        """The newest row of EVERY rank, however long ago it arrived.
+
+        The windowed read above is bounded by cadence, so a rank silent
+        for longer than that bound has no rows in it and would drop out of
+        the block entirely: the surface would forget the dead rank a few
+        minutes after it died, which is exactly when its death starts to
+        matter. This read is one row per rank and answers "who has ever
+        reported, and when did each last speak".
+        """
+        return conn.execute("""
+            SELECT * FROM process_samples
+            WHERE id IN (
+                SELECT MAX(id) FROM process_samples
+                WHERE COALESCE(global_rank, rank) IS NOT NULL
+                GROUP BY COALESCE(global_rank, rank)
+            )
+            ORDER BY COALESCE(global_rank, rank) ASC;
+            """).fetchall()
+
     def fetch_rank_run_history(
         self,
         conn: sqlite3.Connection,

--- a/src/traceml_ai/renderers/process/common.py
+++ b/src/traceml_ai/renderers/process/common.py
@@ -12,6 +12,11 @@ _ROLL_FRACTION = 50.0  # about a fiftieth of the run
 _MAX_RUN_POINTS = 120
 _DEFAULT_TICK_S = 2.0
 
+# How far back the recent-window read looks before it has seen a cadence
+# to size itself from. After the first tick the caller narrows it to what
+# the ranks actually sample at.
+_WINDOW_MAX_AGE_S = 20.0 * 60.0
+
 # SQLite grew numeric RANGE frame offsets in 3.28. A time frame is the
 # honest one here: unreported samples leave holes in the cadence, so a ROW
 # frame silently spans more wall clock than it claims. Older engines fall
@@ -216,10 +221,24 @@ class ProcessMetricsDB:
             return None
         return min(per_rank.values())
 
+    def newest_sample_ts(self, conn: sqlite3.Connection) -> Optional[float]:
+        """The newest sample clock, read once per tick and reused.
+
+        Every bound below derives from it. Deriving them separately would
+        let the retention pruner delete rows between two statements and
+        leave one computation reading a window the other never saw.
+        """
+        row = conn.execute(
+            "SELECT MAX(sample_ts_s) FROM process_samples"
+        ).fetchone()
+        return float(row[0]) if row and row[0] is not None else None
+
     def fetch_recent_rank_window(
         self,
         conn: sqlite3.Connection,
         window_n: int = 100,
+        newest_ts: Optional[float] = None,
+        max_age_s: float = _WINDOW_MAX_AGE_S,
     ) -> List[sqlite3.Row]:
         """
         The last ``window_n`` samples of EVERY rank, newest last.
@@ -231,23 +250,34 @@ class ProcessMetricsDB:
         aligned on a shared seq (a dead rank froze the whole block when it
         was: its last committed seq bounded every other rank).
         """
+        # Bounded by time before the partition runs: without it the
+        # ROW_NUMBER scans every row ever written to rank the last hundred,
+        # which grows with the run. The bound is generous (a slow sampler
+        # still fills the window) and always inside the retention horizon.
+        floor_ts = None
+        if newest_ts is not None:
+            floor_ts = newest_ts - max(60.0, float(max_age_s))
         return conn.execute(
             """
-            WITH ranked AS (
+            WITH recent AS (
+                SELECT * FROM process_samples
+                WHERE COALESCE(global_rank, rank) IS NOT NULL
+                  AND (? IS NULL OR sample_ts_s >= ?)
+            ),
+            ranked AS (
                 SELECT
                     *,
                     ROW_NUMBER() OVER (
                         PARTITION BY COALESCE(global_rank, rank)
                         ORDER BY seq DESC, id DESC
                     ) AS rn
-                FROM process_samples
-                WHERE COALESCE(global_rank, rank) IS NOT NULL
+                FROM recent
             )
             SELECT * FROM ranked
             WHERE rn <= ?
             ORDER BY COALESCE(global_rank, rank) ASC, seq ASC, id ASC;
             """,
-            (int(max(1, window_n)),),
+            (floor_ts, floor_ts, int(max(1, window_n))),
         ).fetchall()
 
     def fetch_rank_run_history(

--- a/src/traceml_ai/renderers/process/common.py
+++ b/src/traceml_ai/renderers/process/common.py
@@ -1,8 +1,41 @@
 """Shared models and SQLite helpers for process telemetry."""
 
 import sqlite3
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+
+# Rolling window for the whole-run charts, scaled to the run so the line
+# stays readable at any length (mirrors the System block's ladder).
+_ROLL_MIN_S = 30.0
+_ROLL_MAX_S = 300.0
+_ROLL_FRACTION = 50.0  # about a fiftieth of the run
+_MAX_RUN_POINTS = 120
+_DEFAULT_TICK_S = 2.0
+
+# SQLite grew numeric RANGE frame offsets in 3.28. A time frame is the
+# honest one here: unreported samples leave holes in the cadence, so a ROW
+# frame silently spans more wall clock than it claims. Older engines fall
+# back to the row frame the System block already ships.
+_HAS_RANGE_FRAME = sqlite3.sqlite_version_info >= (3, 28, 0)
+
+
+def choose_window_s(span_s: float) -> float:
+    """The rolling window for a run of ``span_s`` seconds, in round steps."""
+    if span_s <= 0:
+        return _ROLL_MIN_S
+    raw = max(_ROLL_MIN_S, min(_ROLL_MAX_S, span_s / _ROLL_FRACTION))
+    for step in (30.0, 60.0, 120.0, 300.0):
+        if raw <= step:
+            return step
+    return _ROLL_MAX_S
+
+
+def frame_clause(window_s: float, cadence_s: float) -> str:
+    """The window frame for a rolling aggregate over ``window_s`` seconds."""
+    if _HAS_RANGE_FRAME:
+        return f"RANGE BETWEEN {float(window_s):.6f} PRECEDING AND CURRENT ROW"
+    preceding = max(1, int(round(window_s / max(cadence_s, 1e-6))) - 1)
+    return f"ROWS BETWEEN {preceding} PRECEDING AND CURRENT ROW"
 
 
 @dataclass(frozen=True)
@@ -48,13 +81,21 @@ class ProcessDashboardPayload:
 
     history: List[Dict[str, Any]]
     gpu_used_imbalance: Optional[float]
-    series: Dict[str, List[float]]
+    # Series carries per-rank sample arrays and whole-run histories, so its
+    # values are intentionally heterogeneous.
+    series: Dict[str, Any]
+    window_len: int = 0
+    gpu_available: bool = False
+    rollups: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "history": self.history,
             "gpu_used_imbalance": self.gpu_used_imbalance,
             "series": self.series,
+            "window_len": self.window_len,
+            "gpu_available": self.gpu_available,
+            "rollups": self.rollups,
         }
 
 
@@ -90,15 +131,13 @@ class ProcessMetricsDB:
         Optional[int]
             Latest seq, or None if the table has no seq-bearing rows.
         """
-        row = conn.execute(
-            """
+        row = conn.execute("""
             SELECT seq
             FROM process_samples
             WHERE seq IS NOT NULL
             ORDER BY id DESC
             LIMIT 1;
-            """
-        ).fetchone()
+            """).fetchone()
         if row is None or row["seq"] is None:
             return None
         return int(row["seq"])
@@ -114,16 +153,14 @@ class ProcessMetricsDB:
         dict[int, int]
             Mapping rank -> latest seq for that rank.
         """
-        rows = conn.execute(
-            """
+        rows = conn.execute("""
             SELECT rank, MAX(seq) AS max_seq
             FROM process_samples
             WHERE rank IS NOT NULL
               AND seq IS NOT NULL
             GROUP BY rank
             ORDER BY rank ASC;
-            """
-        ).fetchall()
+            """).fetchall()
 
         out: Dict[int, int] = {}
         for row in rows:
@@ -178,6 +215,145 @@ class ProcessMetricsDB:
         if not per_rank:
             return None
         return min(per_rank.values())
+
+    def fetch_recent_rank_window(
+        self,
+        conn: sqlite3.Connection,
+        window_n: int = 100,
+    ) -> List[sqlite3.Row]:
+        """
+        The last ``window_n`` samples of EVERY rank, newest last.
+
+        Per rank, not globally: a rank that stopped reporting must keep its
+        own history instead of being squeezed out by livelier peers, and a
+        rank that never reports must not shrink everyone else's window.
+        The dashboard reads ranks on their own clocks, so nothing here is
+        aligned on a shared seq (a dead rank froze the whole block when it
+        was: its last committed seq bounded every other rank).
+        """
+        return conn.execute(
+            """
+            WITH ranked AS (
+                SELECT
+                    *,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY COALESCE(global_rank, rank)
+                        ORDER BY seq DESC, id DESC
+                    ) AS rn
+                FROM process_samples
+                WHERE COALESCE(global_rank, rank) IS NOT NULL
+            )
+            SELECT * FROM ranked
+            WHERE rn <= ?
+            ORDER BY COALESCE(global_rank, rank) ASC, seq ASC, id ASC;
+            """,
+            (int(max(1, window_n)),),
+        ).fetchall()
+
+    def fetch_rank_run_history(
+        self,
+        conn: sqlite3.Connection,
+        value_sql: str,
+        *,
+        min_span_s: float = 0.0,
+    ) -> List[Dict[str, Any]]:
+        """
+        Whole-run per-rank history of ``value_sql``, rolling and decimated.
+
+        One row per kept point, at most ``_MAX_RUN_POINTS`` per rank, so the
+        payload holds its size however long the run runs. Points whose
+        rolling window is still partial are excluded rather than drawn
+        short, and the stride is computed over the points that survive that
+        exclusion (a stride over the raw count both overshoots the budget
+        and throws away detail).
+
+        Returns [] when the run has not yet outlived ``min_span_s``: the
+        recent window already tells that story, so the query is skipped
+        entirely rather than computed and discarded by the view.
+        """
+        try:
+            row = conn.execute(
+                f"SELECT MIN(sample_ts_s), MAX(sample_ts_s), COUNT(*), "
+                f"COUNT(DISTINCT COALESCE(global_rank, rank)) "
+                f"FROM process_samples WHERE sample_ts_s IS NOT NULL "
+                f"AND ({value_sql}) IS NOT NULL"
+            ).fetchone()
+        except sqlite3.Error:
+            return []
+        if row is None or row[0] is None or row[1] is None:
+            return []
+        first, last, count, ranks = (
+            float(row[0]),
+            float(row[1]),
+            int(row[2] or 0),
+            max(1, int(row[3] or 1)),
+        )
+        span = last - first
+        if span <= max(0.0, float(min_span_s)) or count <= 2:
+            return []
+        window_s = choose_window_s(span)
+        per_rank = max(1, count // ranks)
+        cadence = span / max(per_rank - 1, 1)
+        preceding = max(1, int(round(window_s / max(cadence, 1e-6))) - 1)
+        eligible = max(0, per_rank - preceding)
+        stride = max(1, (eligible + _MAX_RUN_POINTS - 1) // _MAX_RUN_POINTS)
+        frame = frame_clause(window_s, cadence)
+        try:
+            rows = conn.execute(
+                f"""
+                WITH base AS (
+                    SELECT
+                        COALESCE(global_rank, rank) AS rank_id,
+                        sample_ts_s AS ts,
+                        ({value_sql}) AS v,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY COALESCE(global_rank, rank)
+                            ORDER BY sample_ts_s ASC, id ASC
+                        ) AS rn
+                    FROM process_samples
+                    WHERE sample_ts_s IS NOT NULL
+                      AND ({value_sql}) IS NOT NULL
+                      AND COALESCE(global_rank, rank) IS NOT NULL
+                ),
+                rolled AS (
+                    SELECT
+                        rank_id,
+                        ts,
+                        rn,
+                        AVG(v) OVER (
+                            PARTITION BY rank_id ORDER BY ts {frame}
+                        ) AS roll_avg,
+                        MAX(v) OVER (
+                            PARTITION BY rank_id ORDER BY ts {frame}
+                        ) AS roll_max
+                    FROM base
+                )
+                SELECT rank_id, ts, roll_avg, roll_max
+                FROM rolled
+                WHERE rn % ? = 0 AND rn > ?
+                ORDER BY rank_id ASC, ts ASC;
+                """,
+                (int(stride), int(preceding)),
+            ).fetchall()
+        except sqlite3.Error:
+            return []
+        by_rank: Dict[int, Dict[str, Any]] = {}
+        for rank_id, ts, roll_avg, roll_max in rows:
+            entry = by_rank.setdefault(
+                int(rank_id),
+                {
+                    "global_rank": int(rank_id),
+                    "t": [],
+                    "avg": [],
+                    "max": [],
+                    "span_s": span,
+                    "window_s": window_s,
+                },
+            )
+            entry["t"].append(float(ts))
+            entry["avg"].append(float(roll_avg))
+            entry["max"].append(float(roll_max))
+        return [by_rank[key] for key in sorted(by_rank)]
 
     def fetch_seq_range_aggregates(
         self,

--- a/src/traceml_ai/renderers/process/computer.py
+++ b/src/traceml_ai/renderers/process/computer.py
@@ -36,7 +36,7 @@ class ProcessMetricsComputer:
         self,
         db_path: str,
         stale_ttl_s: Optional[float] = 30.0,
-        dashboard_max_rows: int = 200,
+        dashboard_max_rows: int = 100,
     ) -> None:
         self._cli = ProcessCLIComputer(
             db_path=db_path,

--- a/src/traceml_ai/renderers/process/dashboard_compute.py
+++ b/src/traceml_ai/renderers/process/dashboard_compute.py
@@ -1,203 +1,453 @@
 """
 Dashboard compute for process telemetry.
 
-This module computes the rolling UI history from SQLite.
+One payload per tick, read from ``process_samples`` alone. Ranks are read on
+their own clocks: every rank keeps its own window and its own liveness, so a
+rank that dies leaves a dimmed row instead of stopping the block (the seq
+alignment this replaces bounded every rank by the slowest one's last
+committed seq).
 
-Semantics
----------
-- seq-aligned across ranks
-- one dashboard entry per globally committed seq
-- same history entry keys as the existing NiceGUI frontend expects
-- top-level `gpu_used_imbalance` mirrors the latest history row for convenience
+Every decision the view would otherwise have to make is made here: which
+view the charts show, which rank each tile speaks for, whether the per-rank
+rows deserve to open. The section formats what it is handed.
 """
 
+import statistics
 import time
-from collections import deque
-from datetime import datetime, timezone
-from typing import Any, Deque, Dict, Optional
+from typing import Any, Dict, List, Optional, Sequence
+
+from traceml_ai.diagnostics.process.policy import DEFAULT_PROCESS_POLICY
 
 from .common import ProcessDashboardPayload, ProcessMetricsDB
 
+# Whole-run charts add nothing until the run outgrows its sample window.
+_RUN_VIEW_FACTOR = 1.2
+
+# A rank is stale once its newest sample is older than this many ticks,
+# measured on the AGGREGATOR's arrival clock: rank wall clocks drift
+# between machines, and one fast node would otherwise mark every other
+# node dead forever.
+_STALE_TICKS = 3.0
+_DEFAULT_TICK_S = 2.0
+
+# The rows open on the diagnosis engine's own imbalance bar, never on a
+# number invented here.
+IMBALANCE_OPEN_PCT = float(
+    DEFAULT_PROCESS_POLICY.rank_gpu_memory_imbalance_warn_percent
+)
+
+# The trigger reads each rank's window MEDIAN reserved, not its newest
+# sample. That debounces the staggered CUDA ramp without holding state
+# across ticks, which a tick streak cannot do: a finished run rendered once
+# (a replay, or a reader opening the page after training ends) never
+# accumulates a streak, so its rows would stay shut however lopsided it
+# was.
+
+_CPU_CAPACITY_SQL = (
+    "cpu_percent / (100.0 * NULLIF(cpu_logical_core_count, 0)) * 100.0"
+)
+_RSS_SQL = "ram_used_bytes"
+
+# Samples per rank in the recent-window view.
+_WINDOW_N = 100
+
+
+def _empty_dashboard_series() -> Dict[str, Any]:
+    """The complete series schema with no observations.
+
+    Every degraded path returns this, so a consumer never has to ask
+    whether a key exists on a payload that failed to read.
+    """
+    return {
+        "cpu_capacity": [],
+        "rss": [],
+        "cpu_capacity_run": [],
+        "rss_run": [],
+    }
+
+
+def _opt_float(value: Any) -> Optional[float]:
+    """Float or None: an unreported column stays unreported, never 0."""
+    if value is None:
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    return out
+
+
+def _gpu_reported(row: Any) -> bool:
+    """Whether a row's GPU columns are a real reading.
+
+    The sampler writes zeros when torch reports no device, so a zero
+    capacity is the absence marker, not a measurement. The System package
+    excludes the same shape from its own reads.
+    """
+    total = _opt_float(row["gpu_mem_total_bytes"])
+    return bool(row["gpu_available"]) and total is not None and total > 0.0
+
+
+def _median(values: Sequence[float]) -> Optional[float]:
+    return statistics.median(values) if values else None
+
 
 class ProcessDashboardComputer:
-    """
-    Compute dashboard history for process telemetry UI.
-
-    Parameters
-    ----------
-    db_path:
-        Path to the SQLite database.
-    dashboard_max_rows:
-        Maximum retained rolling rows for UI history.
-    stale_ttl_s:
-        Maximum age in seconds for stale fallback reuse.
-    """
+    """Compute the dashboard payload for process telemetry."""
 
     def __init__(
         self,
         db_path: str,
-        dashboard_max_rows: int = 200,
+        dashboard_max_rows: int = _WINDOW_N,
         stale_ttl_s: Optional[float] = 30.0,
     ) -> None:
         self._db = ProcessMetricsDB(db_path=db_path)
-        self._dashboard_rollup: Deque[Dict[str, Any]] = deque(
-            maxlen=max(1, int(dashboard_max_rows))
-        )
-        self._last_completed_seq: int = -1
-
+        # Per RANK, not in total: the System block's window is 100 samples
+        # and the two blocks are read side by side.
+        self._window_n = max(1, int(dashboard_max_rows))
         self._last_ok: Optional[Dict[str, Any]] = None
         self._last_ok_ts: float = 0.0
         self._stale_ttl_s: Optional[float] = (
             float(stale_ttl_s) if stale_ttl_s is not None else None
         )
 
-    def compute(self) -> Dict[str, Any]:
-        """
-        Advance and return dashboard history.
-
-        Returns
-        -------
-        dict[str, Any]
-            UI payload with:
-            - `history`
-            - `gpu_used_imbalance`
-            - `series`
-        """
+    def compute(self, window_n: Optional[int] = None) -> Dict[str, Any]:
+        """Return the dashboard payload, reusing the last good one on error."""
         try:
             with self._db.connect() as conn:
-                self._update_impl(conn)
-                out = self._build_payload()
+                out = self._compute(conn, int(window_n or self._window_n))
         except Exception:
             return self._return_stale()
-
         self._last_ok = out
         self._last_ok_ts = time.time()
         return out
 
-    def _update_impl(self, conn) -> None:
-        committed_upto = self._db.fetch_committed_seq(conn)
-        if (
-            committed_upto is None
-            or committed_upto <= self._last_completed_seq
-        ):
-            return
+    # --- payload ---------------------------------------------------------
+    def _compute(self, conn: Any, window_n: int) -> Dict[str, Any]:
+        rows = self._db.fetch_recent_rank_window(conn, window_n=window_n)
+        if not rows:
+            return self._empty_payload()
 
-        start_seq = self._last_completed_seq + 1
-        end_seq = int(committed_upto)
+        by_rank: Dict[int, List[Any]] = {}
+        for row in rows:
+            key = row["global_rank"]
+            key = int(key if key is not None else row["rank"])
+            by_rank.setdefault(key, []).append(row)
 
-        rows = self._db.fetch_seq_range_aggregates(
-            conn,
-            start_seq=start_seq,
-            end_seq=end_seq,
+        newest_recv = (
+            max(float(row["recv_ts_ns"] or 0.0) for row in rows) / 1e9
+        )
+        tick = self._tick_seconds(by_rank)
+        ranks = [
+            self._rank_facts(rank_id, rank_rows, newest_recv, tick)
+            for rank_id, rank_rows in sorted(by_rank.items())
+        ]
+        live = [rank for rank in ranks if not rank["stale"]]
+        # Aggregates speak for the ranks that are still reporting: a rank
+        # that died mid-step would otherwise pin a tile or the trigger to
+        # whatever it happened to be doing when it stopped.
+        source = live or ranks
+
+        gpu_available = any(rank["gpu_total"] is not None for rank in ranks)
+        window_span = self._window_span(rows)
+        min_run_span = window_span * _RUN_VIEW_FACTOR
+        cpu_run = self._db.fetch_rank_run_history(
+            conn, _CPU_CAPACITY_SQL, min_span_s=min_run_span
+        )
+        rss_run = self._db.fetch_rank_run_history(
+            conn, _RSS_SQL, min_span_s=min_run_span
         )
 
-        for row in rows:
-            entry: Dict[str, Any] = {
-                "seq": int(row["seq"]),
-                "ts": (
-                    float(row["sample_ts_s"])
-                    if row["sample_ts_s"] is not None
-                    else None
-                ),
-                "cpu_max": float(row["cpu_max"] or 0.0),
-                "ram_used_max": float(row["ram_used_max"] or 0.0),
-                "ram_total": float(row["ram_total"] or 0.0),
-            }
-
-            if row["sample_ts_s"] is not None:
-                entry["ts"] = float(row["sample_ts_s"])
-
-            if row["gpu_used"] is not None:
-                entry.update(
-                    {
-                        "gpu_used": float(row["gpu_used"] or 0.0),
-                        "gpu_total": float(row["gpu_total"] or 0.0),
-                        "gpu_headroom": float(row["gpu_headroom"] or 0.0),
-                        "gpu_rank": (
-                            int(row["gpu_rank"])
-                            if row["gpu_rank"] is not None
-                            else None
-                        ),
-                        "gpu_used_imbalance": (
-                            float(row["gpu_used_imbalance"])
-                            if row["gpu_used_imbalance"] is not None
-                            else 0.0
-                        ),
-                    }
-                )
-
-            self._dashboard_rollup.append(entry)
-
-        self._last_completed_seq = end_seq
-
-    def _build_payload(self) -> Dict[str, Any]:
-        history = list(self._dashboard_rollup)
-        latest_imbalance = None
-        if history:
-            latest_imbalance = history[-1].get("gpu_used_imbalance")
-
-        x_time = [
-            self._format_time_iso(float(r["ts"]))
-            for r in history
-            if isinstance(r, dict) and r.get("ts") is not None
-        ]
-
-        series = {
-            "x_time": x_time,
-            "cpu_max": [
-                float(r["cpu_max"])
-                for r in history
-                if isinstance(r, dict) and r.get("cpu_max") is not None
-            ],
-            "ram_used_max": [
-                float(r["ram_used_max"])
-                for r in history
-                if isinstance(r, dict) and r.get("ram_used_max") is not None
-            ],
-            "gpu_used": [
-                float(r["gpu_used"])
-                for r in history
-                if isinstance(r, dict) and r.get("gpu_used") is not None
-            ],
+        imbalance = self._reserved_imbalance(source)
+        rollups: Dict[str, Any] = {
+            "ranks": ranks,
+            "ranks_reporting": len(live),
+            "ranks_total": len(ranks),
+            "ranks_stale": len(ranks) - len(live),
+            "gpu_available": gpu_available,
+            "cpu_capacity": self._cpu_rollup(source),
+            "rss": self._rss_rollup(source),
+            "cuda": self._cuda_rollup(source),
+            "reserved_imbalance_pct": imbalance,
+            "rows_over": self._rows_trigger(source, imbalance),
+            "tick_s": tick,
         }
-
-        return ProcessDashboardPayload(
-            history=history,
-            gpu_used_imbalance=latest_imbalance,
-            series=series,
-        ).to_dict()
-
-    def _format_time_iso(self, ts_s: float) -> str:
-        """
-        Convert one UNIX timestamp in seconds to an ISO-8601 UTC string.
-
-        Returns an empty string on invalid input so callers can safely degrade.
-        """
-        try:
-            if ts_s <= 0.0:
-                return ""
-            return datetime.fromtimestamp(
-                float(ts_s), tz=timezone.utc
-            ).isoformat()
-        except Exception:
-            return ""
-
-    def _return_stale(self) -> Dict[str, Any]:
-        now = time.time()
-        if self._last_ok is not None:
-            if (
-                self._stale_ttl_s is None
-                or (now - self._last_ok_ts) <= self._stale_ttl_s
-            ):
-                return self._last_ok
+        # One series per chart, never both: whichever view the charts will
+        # draw is the only one worth the payload it costs.
+        series = _empty_dashboard_series()
+        series["cpu_capacity_run"] = cpu_run
+        series["rss_run"] = rss_run
+        if not cpu_run:
+            series["cpu_capacity"] = self._window_series(
+                by_rank, self._cpu_capacity_of
+            )
+        if not rss_run:
+            series["rss"] = self._window_series(
+                by_rank, lambda row: _opt_float(row["ram_used_bytes"])
+            )
 
         return ProcessDashboardPayload(
             history=[],
             gpu_used_imbalance=None,
-            series={
-                "x_time": [],
-                "cpu_max": [],
-                "ram_used_max": [],
-                "gpu_used": [],
-            },
+            series=series,
+            window_len=max(
+                (
+                    len(entry["t"])
+                    for entry in (
+                        series["cpu_capacity"] or series["cpu_capacity_run"]
+                    )
+                ),
+                default=0,
+            ),
+            gpu_available=gpu_available,
+            rollups=rollups,
+        ).to_dict()
+
+    # --- per rank --------------------------------------------------------
+    def _tick_seconds(self, by_rank: Dict[int, List[Any]]) -> float:
+        """The fastest rank's own cadence, floored at the sampler default."""
+        cadences = []
+        for rank_rows in by_rank.values():
+            stamps = [
+                _opt_float(row["sample_ts_s"])
+                for row in rank_rows
+                if row["sample_ts_s"] is not None
+            ]
+            if len(stamps) > 1 and stamps[-1] > stamps[0]:
+                cadences.append((stamps[-1] - stamps[0]) / (len(stamps) - 1))
+        return (
+            max(_DEFAULT_TICK_S, min(cadences))
+            if cadences
+            else (_DEFAULT_TICK_S)
+        )
+
+    def _cpu_capacity_of(self, row: Any) -> Optional[float]:
+        """CPU as a share of the host's capacity, bounded 0-100.
+
+        Raw ``cpu_percent`` sums cores, so the same busy trainer reads 100
+        on a 4-core box and 100 on a 48-core box; only the bounded form is
+        comparable, and the core count is already stored beside it.
+        """
+        used = _opt_float(row["cpu_percent"])
+        cores = _opt_float(row["cpu_logical_core_count"])
+        if used is None or not cores:
+            return None
+        return used / (100.0 * cores) * 100.0
+
+    def _rank_facts(
+        self,
+        rank_id: int,
+        rank_rows: List[Any],
+        newest_recv: float,
+        tick: float,
+    ) -> Dict[str, Any]:
+        newest = rank_rows[-1]
+        caps = [
+            value
+            for value in (self._cpu_capacity_of(row) for row in rank_rows)
+            if value is not None
+        ]
+        allocs = [
+            _opt_float(row["gpu_mem_used_bytes"])
+            for row in rank_rows
+            if _gpu_reported(row)
+        ]
+        allocs = [value for value in allocs if value is not None]
+        # The newest row is not always a reading: the last samples of a
+        # run land during teardown, after torch has let the device go, so
+        # anchoring the GPU tiles on it blanks them exactly when someone
+        # inspects a finished run.
+        reported = [row for row in rank_rows if _gpu_reported(row)]
+        newest_gpu = reported[-1] if reported else None
+        age = max(0.0, newest_recv - float(newest["recv_ts_ns"] or 0.0) / 1e9)
+        return {
+            "global_rank": rank_id,
+            "node_rank": (
+                int(newest["node_rank"])
+                if newest["node_rank"] is not None
+                else None
+            ),
+            "gpu_index": (
+                int(newest["gpu_device_index"])
+                if newest["gpu_device_index"] is not None
+                else None
+            ),
+            # The window median, never the last tick: CPU is noisy and the
+            # allocator's live bytes are a sawtooth this 2 s cadence
+            # undersamples, so one raw sample lands wherever the step
+            # happened to be.
+            "cpu_capacity": _median(caps),
+            # Reserved twice: the newest reading is what the tiles and the
+            # rows show (it is what the allocator holds now), the window
+            # median is what the trigger judges.
+            "gpu_reserved_p50": _median(
+                [
+                    value
+                    for value in (
+                        _opt_float(row["gpu_mem_reserved_bytes"])
+                        for row in rank_rows
+                        if _gpu_reported(row)
+                    )
+                    if value is not None
+                ]
+            ),
+            "ram_used": _opt_float(newest["ram_used_bytes"]),
+            "ram_total": _opt_float(newest["ram_total_bytes"]),
+            "gpu_alloc": _median(allocs) if allocs else None,
+            "gpu_reserved": (
+                _opt_float(newest_gpu["gpu_mem_reserved_bytes"])
+                if newest_gpu is not None
+                else None
+            ),
+            "gpu_total": (
+                _opt_float(newest_gpu["gpu_mem_total_bytes"])
+                if newest_gpu is not None
+                else None
+            ),
+            "age_s": age,
+            "stale": age > _STALE_TICKS * tick,
+        }
+
+    # --- rollups ---------------------------------------------------------
+    def _cpu_rollup(self, ranks: List[Dict[str, Any]]) -> Dict[str, Any]:
+        values = [
+            (rank["cpu_capacity"], rank["global_rank"])
+            for rank in ranks
+            if rank["cpu_capacity"] is not None
+        ]
+        if not values:
+            return {"p50": None, "worst": None, "worst_rank": None}
+        worst, worst_rank = max(values)
+        return {
+            "p50": _median([value for value, _rank in values]),
+            "worst": worst,
+            "worst_rank": worst_rank,
+        }
+
+    def _rss_rollup(self, ranks: List[Dict[str, Any]]) -> Dict[str, Any]:
+        values = [rank for rank in ranks if rank["ram_used"] is not None]
+        if not values:
+            return {"used": None, "total": None, "rank": None}
+        worst = max(values, key=lambda rank: rank["ram_used"])
+        return {
+            "used": worst["ram_used"],
+            "total": worst["ram_total"],
+            "rank": worst["global_rank"],
+        }
+
+    def _cuda_rollup(self, ranks: List[Dict[str, Any]]) -> Dict[str, Any]:
+        allocs = [
+            rank["gpu_alloc"]
+            for rank in ranks
+            if rank["gpu_alloc"] is not None
+        ]
+        reserved = [
+            rank
+            for rank in ranks
+            if rank["gpu_reserved"] is not None and rank["gpu_total"]
+        ]
+        out: Dict[str, Any] = {
+            "alloc_p50": _median(allocs),
+            "reserved": None,
+            "reserved_total": None,
+            "reserved_rank": None,
+        }
+        if reserved:
+            # The rank with the least headroom, not the most reserved: on
+            # mixed devices those are different ranks, and the one nearest
+            # its own ceiling is the one that fails first.
+            tightest = min(
+                reserved,
+                key=lambda rank: rank["gpu_total"] - rank["gpu_reserved"],
+            )
+            out["reserved"] = tightest["gpu_reserved"]
+            out["reserved_total"] = tightest["gpu_total"]
+            out["reserved_rank"] = tightest["global_rank"]
+        return out
+
+    def _reserved_imbalance(
+        self, ranks: List[Dict[str, Any]]
+    ) -> Optional[float]:
+        """Reserved spread across ranks, the engine's own definition.
+
+        Reserved, not allocated: allocated differs across ranks by which
+        step phase each sampler caught, which reads as GB of imbalance on a
+        perfectly healthy run.
+        """
+        values = [
+            rank["gpu_reserved_p50"]
+            for rank in ranks
+            if rank["gpu_reserved_p50"] is not None
+        ]
+        if len(values) < 2:
+            return None
+        high = max(values)
+        if high <= 0:
+            return 0.0
+        return max(0.0, (high - min(values)) / high * 100.0)
+
+    def _rows_trigger(
+        self, ranks: List[Dict[str, Any]], imbalance: Optional[float]
+    ) -> bool:
+        """Whether the per-rank rows have earned opening themselves.
+
+        Armed only once every reporting rank has HELD an allocation across
+        its window: ranks reach their first CUDA allocation seconds to
+        minutes apart, and an unarmed trigger reads that ramp as total
+        imbalance on every run's first ticks.
+        """
+        armed = bool(ranks) and all(
+            rank["gpu_reserved_p50"] is not None
+            and rank["gpu_reserved_p50"] > 0
+            for rank in ranks
+        )
+        return bool(
+            armed and imbalance is not None and imbalance >= IMBALANCE_OPEN_PCT
+        )
+
+    # --- series ----------------------------------------------------------
+    def _window_span(self, rows: Sequence[Any]) -> float:
+        stamps = [
+            _opt_float(row["sample_ts_s"])
+            for row in rows
+            if row["sample_ts_s"] is not None
+        ]
+        stamps = [value for value in stamps if value is not None]
+        return max(stamps) - min(stamps) if len(stamps) > 1 else 0.0
+
+    def _window_series(
+        self, by_rank: Dict[int, List[Any]], value_of: Any
+    ) -> List[Dict[str, Any]]:
+        """Raw per-rank samples, each rank on its own clock."""
+        out = []
+        for rank_id, rank_rows in sorted(by_rank.items()):
+            stamps, values = [], []
+            for row in rank_rows:
+                stamp = _opt_float(row["sample_ts_s"])
+                value = value_of(row)
+                if stamp is None or value is None:
+                    continue
+                stamps.append(stamp)
+                values.append(value)
+            if stamps:
+                out.append({"global_rank": rank_id, "t": stamps, "v": values})
+        return out
+
+    # --- degraded paths --------------------------------------------------
+    def _return_stale(self) -> Dict[str, Any]:
+        if self._last_ok is not None and (
+            self._stale_ttl_s is None
+            or (time.time() - self._last_ok_ts) <= self._stale_ttl_s
+        ):
+            return self._last_ok
+        return self._empty_payload()
+
+    def _empty_payload(self) -> Dict[str, Any]:
+        return ProcessDashboardPayload(
+            history=[],
+            gpu_used_imbalance=None,
+            series=_empty_dashboard_series(),
+            window_len=0,
+            gpu_available=False,
+            rollups={},
         ).to_dict()

--- a/src/traceml_ai/renderers/process/dashboard_compute.py
+++ b/src/traceml_ai/renderers/process/dashboard_compute.py
@@ -153,6 +153,14 @@ class ProcessDashboardComputer:
             key = row["global_rank"]
             key = int(key if key is not None else row["rank"])
             by_rank.setdefault(key, []).append(row)
+        # A rank silent for longer than the windowed read looks back has
+        # no rows above. It must still hold its row: forgetting a dead
+        # rank a few minutes after it died is the failure this block was
+        # rebuilt to end, only deferred.
+        for row in self._db.fetch_rank_latest(conn):
+            key = row["global_rank"]
+            key = int(key if key is not None else row["rank"])
+            by_rank.setdefault(key, [row])
 
         newest_recv = (
             max(float(row["recv_ts_ns"] or 0.0) for row in rows) / 1e9
@@ -166,7 +174,10 @@ class ProcessDashboardComputer:
         live = [rank for rank in ranks if not rank["stale"]]
         # Aggregates speak for the ranks that are still reporting: a rank
         # that died mid-step would otherwise pin a tile or the trigger to
-        # whatever it happened to be doing when it stopped.
+        # whatever it happened to be doing when it stopped. With NOTHING
+        # reporting there is nobody to speak for, so the last known values
+        # stand and the header says so rather than claiming an exclusion
+        # that did not happen.
         source = live or ranks
 
         gpu_available = any(rank["gpu_total"] is not None for rank in ranks)
@@ -181,6 +192,9 @@ class ProcessDashboardComputer:
             "ranks_reporting": len(live),
             "ranks_total": len(ranks),
             "ranks_stale": len(ranks) - len(live),
+            # False once no rank reports: the aggregates then come from
+            # stale ranks and must not be described as excluding them.
+            "excluding_stale": bool(live) and len(live) != len(ranks),
             "gpu_available": gpu_available,
             "cpu_capacity": self._cpu_rollup(source),
             "rss": self._rss_rollup(source),

--- a/src/traceml_ai/renderers/process/dashboard_compute.py
+++ b/src/traceml_ai/renderers/process/dashboard_compute.py
@@ -345,6 +345,17 @@ class ProcessDashboardComputer:
                 ]
             ),
             "ram_used": _opt_float(newest["ram_used_bytes"]),
+            # Which rank is worst is judged on the window median; the
+            # value shown is still the newest one that rank sent.
+            "ram_used_p50": _median(
+                [
+                    value
+                    for value in (
+                        _opt_float(row["ram_used_bytes"]) for row in rank_rows
+                    )
+                    if value is not None
+                ]
+            ),
             "ram_total": _opt_float(newest["ram_total_bytes"]),
             "gpu_alloc": _median(allocs) if allocs else None,
             "gpu_reserved": (
@@ -378,10 +389,13 @@ class ProcessDashboardComputer:
         }
 
     def _rss_rollup(self, ranks: List[Dict[str, Any]]) -> Dict[str, Any]:
-        values = [rank for rank in ranks if rank["ram_used"] is not None]
+        values = [rank for rank in ranks if rank["ram_used_p50"] is not None]
         if not values:
             return {"used": None, "total": None, "rank": None}
-        worst = max(values, key=lambda rank: rank["ram_used"])
+        # Worst by window MEDIAN, then reported at its newest value: which
+        # rank is worst must not be decided by one sample of a noisy
+        # level, the same reason the allocator's bytes are a median.
+        worst = max(values, key=lambda rank: rank["ram_used_p50"])
         return {
             "used": worst["ram_used"],
             "total": worst["ram_total"],

--- a/src/traceml_ai/renderers/process/dashboard_compute.py
+++ b/src/traceml_ai/renderers/process/dashboard_compute.py
@@ -14,7 +14,7 @@ rows deserve to open. The section formats what it is handed.
 
 import statistics
 import time
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from traceml_ai.diagnostics.process.policy import DEFAULT_PROCESS_POLICY
 
@@ -42,6 +42,11 @@ IMBALANCE_OPEN_PCT = float(
 # (a replay, or a reader opening the page after training ends) never
 # accumulates a streak, so its rows would stay shut however lopsided it
 # was.
+
+# A rolling mean over minutes cannot visibly change between two 2 s ticks,
+# so the whole-run reads refresh on their own slower clock. Recomputing
+# them every tick was the single largest cost in the block.
+_RUN_REFRESH_S = 15.0
 
 _CPU_CAPACITY_SQL = (
     "cpu_percent / (100.0 * NULLIF(cpu_logical_core_count, 0)) * 100.0"
@@ -110,6 +115,12 @@ class ProcessDashboardComputer:
         self._stale_ttl_s: Optional[float] = (
             float(stale_ttl_s) if stale_ttl_s is not None else None
         )
+        # Whole-run reads, refreshed on their own clock (_RUN_REFRESH_S).
+        self._run_cache: Optional[Tuple[List[Any], List[Any]]] = None
+        self._run_cache_ts: float = 0.0
+        # The observed cadence, remembered so the next tick's window read
+        # scans what it needs instead of a fixed slab of the run.
+        self._tick_hint: float = _DEFAULT_TICK_S
 
     def compute(self, window_n: Optional[int] = None) -> Dict[str, Any]:
         """Return the dashboard payload, reusing the last good one on error."""
@@ -124,7 +135,16 @@ class ProcessDashboardComputer:
 
     # --- payload ---------------------------------------------------------
     def _compute(self, conn: Any, window_n: int) -> Dict[str, Any]:
-        rows = self._db.fetch_recent_rank_window(conn, window_n=window_n)
+        # One clock read per tick, reused by every bound below: deriving
+        # them separately lets the retention pruner move between two
+        # statements.
+        newest_ts = self._db.newest_sample_ts(conn)
+        rows = self._db.fetch_recent_rank_window(
+            conn,
+            window_n=window_n,
+            newest_ts=newest_ts,
+            max_age_s=window_n * self._tick_hint * 2.0,
+        )
         if not rows:
             return self._empty_payload()
 
@@ -138,6 +158,7 @@ class ProcessDashboardComputer:
             max(float(row["recv_ts_ns"] or 0.0) for row in rows) / 1e9
         )
         tick = self._tick_seconds(by_rank)
+        self._tick_hint = tick
         ranks = [
             self._rank_facts(rank_id, rank_rows, newest_recv, tick)
             for rank_id, rank_rows in sorted(by_rank.items())
@@ -150,12 +171,8 @@ class ProcessDashboardComputer:
 
         gpu_available = any(rank["gpu_total"] is not None for rank in ranks)
         window_span = self._window_span(rows)
-        min_run_span = window_span * _RUN_VIEW_FACTOR
-        cpu_run = self._db.fetch_rank_run_history(
-            conn, _CPU_CAPACITY_SQL, min_span_s=min_run_span
-        )
-        rss_run = self._db.fetch_rank_run_history(
-            conn, _RSS_SQL, min_span_s=min_run_span
+        cpu_run, rss_run = self._run_history(
+            conn, window_span * _RUN_VIEW_FACTOR
         )
 
         imbalance = self._reserved_imbalance(source)
@@ -203,6 +220,28 @@ class ProcessDashboardComputer:
             rollups=rollups,
         ).to_dict()
 
+    def _run_history(
+        self, conn: Any, min_span_s: float
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """The whole-run views, recomputed at most every _RUN_REFRESH_S."""
+        now = time.time()
+        if (
+            self._run_cache is not None
+            and (now - self._run_cache_ts) < _RUN_REFRESH_S
+        ):
+            return self._run_cache
+        fresh = (
+            self._db.fetch_rank_run_history(
+                conn, _CPU_CAPACITY_SQL, min_span_s=min_span_s
+            ),
+            self._db.fetch_rank_run_history(
+                conn, _RSS_SQL, min_span_s=min_span_s
+            ),
+        )
+        self._run_cache = fresh
+        self._run_cache_ts = now
+        return fresh
+
     # --- per rank --------------------------------------------------------
     def _tick_seconds(self, by_rank: Dict[int, List[Any]]) -> float:
         """The fastest rank's own cadence, floored at the sampler default."""
@@ -242,22 +281,23 @@ class ProcessDashboardComputer:
         tick: float,
     ) -> Dict[str, Any]:
         newest = rank_rows[-1]
+        reported = [row for row in rank_rows if _gpu_reported(row)]
         caps = [
             value
             for value in (self._cpu_capacity_of(row) for row in rank_rows)
             if value is not None
         ]
         allocs = [
-            _opt_float(row["gpu_mem_used_bytes"])
-            for row in rank_rows
-            if _gpu_reported(row)
+            value
+            for value in (
+                _opt_float(row["gpu_mem_used_bytes"]) for row in reported
+            )
+            if value is not None
         ]
-        allocs = [value for value in allocs if value is not None]
         # The newest row is not always a reading: the last samples of a
         # run land during teardown, after torch has let the device go, so
         # anchoring the GPU tiles on it blanks them exactly when someone
         # inspects a finished run.
-        reported = [row for row in rank_rows if _gpu_reported(row)]
         newest_gpu = reported[-1] if reported else None
         age = max(0.0, newest_recv - float(newest["recv_ts_ns"] or 0.0) / 1e9)
         return {
@@ -285,8 +325,7 @@ class ProcessDashboardComputer:
                     value
                     for value in (
                         _opt_float(row["gpu_mem_reserved_bytes"])
-                        for row in rank_rows
-                        if _gpu_reported(row)
+                        for row in reported
                     )
                     if value is not None
                 ]

--- a/tests/display/test_process_section.py
+++ b/tests/display/test_process_section.py
@@ -71,10 +71,24 @@ def test_rows_hint_states_coverage_and_never_a_verdict() -> None:
 
     # A stale rank is named in the header, because the tiles no longer
     # speak for it.
-    roll_stale = dict(roll, ranks_stale=1, reserved_imbalance_pct=16.0)
+    roll_stale = dict(
+        roll,
+        ranks_stale=1,
+        excluding_stale=True,
+        reserved_imbalance_pct=16.0,
+    )
     assert rows_hint(roll_stale, is_open=False) == (
         "4 ranks · 1 stale, excluded · reserved imbalance 16% · "
         "click to open"
+    )
+    # With nothing reporting the numbers come FROM the stale ranks, so the
+    # header must not claim they were excluded.
+    roll_quiet = dict(roll_stale, ranks_stale=4, excluding_stale=False)
+    assert "none reporting" in rows_hint(roll_quiet, is_open=False)
+    assert "excluded" not in rows_hint(roll_quiet, is_open=False)
+    # A spread under a percent is not an exact zero.
+    assert "reserved imbalance <1%" in rows_hint(
+        dict(roll, reserved_imbalance_pct=0.4), is_open=False
     )
     # One rank has no imbalance to speak of.
     assert rows_hint(
@@ -286,6 +300,16 @@ def test_section_builds_and_updates_without_a_browser() -> None:
         "process cpu · capacity per rank · last 20 min · rolling 30 s"
     )
     assert "whole run" not in panel["rss_label"].text
+
+    # Moving data redraws the charts: a signature that never changed
+    # would freeze them forever and every other assertion still passes.
+    first = panel["cpu_chart"].options["series"][0]["data"][-1]
+    moved = _payload(ranks)
+    for entry in moved["series"]["cpu_capacity_run"]:
+        entry["t"] = [stamp + 30.0 for stamp in entry["t"]]
+        entry["avg"] = [value + 1.0 for value in entry["avg"]]
+    update_process_section(panel, moved)
+    assert panel["cpu_chart"].options["series"][0]["data"][-1] != first
 
     # The rows open by themselves only on a rising edge ...
     assert panel["rows"].value is False

--- a/tests/display/test_process_section.py
+++ b/tests/display/test_process_section.py
@@ -132,6 +132,29 @@ def test_no_rank_colour_is_a_verdict_red() -> None:
         assert not (hue < 15 or hue > 345), (idx, colour)
 
 
+def test_the_rss_axis_fits_its_drift_instead_of_anchoring_at_zero() -> None:
+    """The chart exists for the drift, so the drift must be visible.
+
+    Real ranks sit around 1.5 GB and move by tens of MB across hours. On a
+    zero-anchored axis that movement is under one pixel of a 92 px chart.
+    """
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.process_section import (  # noqa: E501
+        drift_axis_bounds,
+    )
+
+    low, high, tick = drift_axis_bounds([1.48, 1.49, 1.50, 1.52])
+    assert low > 1.4 and high < 1.6
+    # The 40 MB of drift occupies a real share of the axis, not a sliver.
+    assert (1.52 - 1.48) / (high - low) > 0.4
+    assert tick > 0
+
+    # A flat series still gets a usable range rather than a zero-height one.
+    flat_low, flat_high, _tick = drift_axis_bounds([2.0, 2.0])
+    assert flat_high > flat_low
+    # No data at all is not a crash.
+    assert drift_axis_bounds([]) == (0.0, 1.0, 0.5)
+
+
 def test_age_reads_in_words() -> None:
     assert format_age(1.0) == "1 s"
     assert format_age(89.0) == "89 s"

--- a/tests/display/test_process_section.py
+++ b/tests/display/test_process_section.py
@@ -297,9 +297,10 @@ def test_section_builds_and_updates_without_a_browser() -> None:
     ranks = [_rank(0), _rank(1), _rank(2), _rank(3)]
     update_process_section(panel, _payload(ranks))
 
-    # Levels carry their denominator; the rate carries its estimator.
-    assert "2.1" in panel["tiles"]["cpu"].content
-    assert panel["subs"]["cpu"].text == "median rank · of host capacity"
+    # Levels carry their denominator; the rate leads with the rank that
+    # is worst, which is the one a bottleneck hunt is looking for.
+    assert "2.4" in panel["tiles"]["cpu"].content
+    assert panel["subs"]["cpu"].text == "worst rank · R0 · of host capacity"
     assert "215 GB" in panel["tiles"]["rss"].content
     assert "17.2 GB" in panel["tiles"]["reserved"].content
     assert panel["subs"]["reserved"].text == "least-headroom rank · R0"
@@ -362,7 +363,7 @@ def test_a_cpu_only_host_keeps_every_slot(tmp_path: Any = None) -> None:
     assert panel["tiles"]["alloc"].content == "n/a"
     assert panel["subs"]["reserved"].text == "no GPU"
     # The host-side half of the block still works.
-    assert "2.1" in panel["tiles"]["cpu"].content
+    assert "2.4" in panel["tiles"]["cpu"].content
     assert "215 GB" in panel["tiles"]["rss"].content
     assert len(panel["cpu_chart"].options["series"]) == 2
     # The per-rank rows are about ranks, not GPUs: they stay.

--- a/tests/display/test_process_section.py
+++ b/tests/display/test_process_section.py
@@ -155,6 +155,16 @@ def test_the_rss_axis_fits_its_drift_instead_of_anchoring_at_zero() -> None:
     assert drift_axis_bounds([]) == (0.0, 1.0, 0.5)
 
 
+def test_axis_ticks_get_their_precision_from_the_range() -> None:
+    """Three ticks that all read "1.4 GB" tell the reader nothing."""
+    from traceml_ai.aggregator.display_drivers.nicegui_sections import theme
+
+    drift = theme.value_axis_formatter(0.03, " GB")
+    assert "toFixed(3)" in drift
+    assert "toFixed(1)" in theme.value_axis_formatter(5.0, " GB")
+    assert "toFixed(0)" in theme.value_axis_formatter(200.0, " GB")
+
+
 def test_age_reads_in_words() -> None:
     assert format_age(1.0) == "1 s"
     assert format_age(89.0) == "89 s"

--- a/tests/display/test_process_section.py
+++ b/tests/display/test_process_section.py
@@ -123,6 +123,26 @@ def test_rows_show_absence_never_zero() -> None:
     assert "0.0 GB" not in html
 
 
+def test_a_small_measured_level_never_renders_as_zero() -> None:
+    """27 MB is a reading; "0.0 GB" reads as the absence marker.
+
+    Caught on a live CPU-only capture, where the trainer process held
+    25 to 404 MiB and the tile printed 0.0.
+    """
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.theme import (
+        format_gb_pair,
+    )
+
+    used, rest = format_gb_pair(27 * 1024**2, 17.2 * 10**9)
+    assert used == "0.03"
+    assert used != "0.0"
+    assert rest == "/ 17.2 GB"
+    # Absence still reads as absence.
+    assert format_gb_pair(None, None)[0] == "n/a"
+    # Whole gigabytes keep one decimal, as every other tile shows them.
+    assert format_gb_pair(6.3 * 10**9, 16.1 * 10**9) == ("6.3", "/ 16.1 GB")
+
+
 def test_rows_carry_a_trend_per_rank() -> None:
     series = [
         {"global_rank": 0, "t": [1.0, 2.0, 3.0], "avg": [2.0, 2.4, 2.1]},

--- a/tests/display/test_process_section.py
+++ b/tests/display/test_process_section.py
@@ -1,0 +1,292 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process block formatting: what the block says, and what it refuses to."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from traceml_ai.aggregator.display_drivers.nicegui_sections.process_section import (  # noqa: E501
+    SCOPE_NOTE,
+    format_age,
+    rank_color,
+    rows_hint,
+    rows_html,
+    should_auto_open,
+)
+
+GB = 1024**3
+
+
+def _rank(
+    idx: int,
+    *,
+    cap: float = 2.1,
+    rss: float = 1.4 * GB,
+    alloc: float = 2.2 * GB,
+    reserved: float = 5.6 * GB,
+    total: float = 16.0 * GB,
+    age: float = 1.0,
+    stale: bool = False,
+) -> Dict[str, Any]:
+    return {
+        "global_rank": idx,
+        "node_rank": 0,
+        "gpu_index": idx,
+        "cpu_capacity": cap,
+        "ram_used": rss,
+        "ram_total": 200.0 * GB,
+        "gpu_alloc": alloc,
+        "gpu_reserved": reserved,
+        "gpu_total": total,
+        "age_s": age,
+        "stale": stale,
+    }
+
+
+def test_the_block_states_its_scope() -> None:
+    """The pairing that makes process CPU diagnostic needs this sentence.
+
+    Without it the number reads as the box's CPU, and "host CPU high while
+    process CPU is low" is unreadable.
+    """
+    assert "one process per rank" in SCOPE_NOTE
+    assert "DataLoader workers not included" in SCOPE_NOTE
+
+
+def test_rows_hint_states_coverage_and_never_a_verdict() -> None:
+    roll = {
+        "ranks_total": 4,
+        "ranks_stale": 0,
+        "reserved_imbalance_pct": 0.0,
+    }
+    assert rows_hint(roll, is_open=False) == (
+        "4 ranks · reserved imbalance 0% · click to open"
+    )
+    assert rows_hint(roll, is_open=True).endswith("click to close")
+
+    # A stale rank is named in the header, because the tiles no longer
+    # speak for it.
+    roll_stale = dict(roll, ranks_stale=1, reserved_imbalance_pct=16.0)
+    assert rows_hint(roll_stale, is_open=False) == (
+        "4 ranks · 1 stale, excluded · reserved imbalance 16% · "
+        "click to open"
+    )
+    # One rank has no imbalance to speak of.
+    assert rows_hint(
+        {"ranks_total": 1, "ranks_stale": 0, "reserved_imbalance_pct": None},
+        is_open=False,
+    ) == ("1 rank · click to open")
+    for text in (
+        rows_hint(roll, is_open=False),
+        rows_hint(roll_stale, is_open=True),
+    ):
+        for word in ("imbalanced", "high", "low", "bad", "healthy", "busy"):
+            assert word not in text
+
+
+def test_rows_dim_a_stale_rank_and_keep_it() -> None:
+    """Which rank stopped is the first question of a stalled job."""
+    ranks = [_rank(0), _rank(1), _rank(2), _rank(3, age=44.0, stale=True)]
+    html = rows_html(ranks, [])
+    assert "tml-stale" in html
+    assert html.count("tml-stale") == 1
+    assert "R3" in html
+    assert "44 s" in html
+
+
+def test_rows_show_absence_never_zero() -> None:
+    """A CPU-only host has no CUDA numbers, and must not print 0.0 GB."""
+    ranks = [
+        _rank(0, alloc=None, reserved=None, total=None, cap=None)  # type: ignore[arg-type]
+    ]
+    html = rows_html(ranks, [])
+    assert "n/a" in html
+    assert "0.0 GB" not in html
+
+
+def test_rows_carry_a_trend_per_rank() -> None:
+    series = [
+        {"global_rank": 0, "t": [1.0, 2.0, 3.0], "avg": [2.0, 2.4, 2.1]},
+        {"global_rank": 1, "t": [1.0, 2.0, 3.0], "avg": [2.0, 2.0, 2.0]},
+    ]
+    html = rows_html([_rank(0), _rank(1)], series)
+    assert html.count("<polyline") == 2
+    # The chip and the line agree on the rank's colour.
+    assert rank_color(0) in html and rank_color(1) in html
+
+
+def test_no_rank_colour_is_a_verdict_red() -> None:
+    import colorsys
+
+    for idx in range(8):
+        colour = rank_color(idx)
+        red, green, blue = (
+            int(colour[i : i + 2], 16) / 255 for i in (1, 3, 5)
+        )
+        hue = colorsys.rgb_to_hls(red, green, blue)[0] * 360
+        assert not (hue < 15 or hue > 345), (idx, colour)
+
+
+def test_age_reads_in_words() -> None:
+    assert format_age(1.0) == "1 s"
+    assert format_age(89.0) == "89 s"
+    assert format_age(120.0) == "2 min"
+    assert format_age(None) == "n/a"
+
+
+def test_rows_open_on_the_rising_edge_only() -> None:
+    assert should_auto_open(prev_over=False, over=True) is True
+    assert should_auto_open(prev_over=True, over=True) is False
+    assert should_auto_open(prev_over=True, over=False) is False
+    assert should_auto_open(prev_over=False, over=False) is False
+
+
+def _payload(
+    ranks: List[Dict[str, Any]],
+    *,
+    run: bool = True,
+    rows_over: bool = False,
+    gpu: bool = True,
+) -> Dict[str, Any]:
+    base = 1_787_000_000.0
+    stamps = [base + 30.0 * i for i in range(40)]
+    series_key = "cpu_capacity_run" if run else "cpu_capacity"
+    rss_key = "rss_run" if run else "rss"
+    value_key = "avg" if run else "v"
+    entries = [
+        {
+            "global_rank": rank["global_rank"],
+            "t": stamps,
+            value_key: [rank["cpu_capacity"] or 0.0] * len(stamps),
+            "max": [rank["cpu_capacity"] or 0.0] * len(stamps),
+            "span_s": stamps[-1] - stamps[0],
+            "window_s": 30.0,
+        }
+        for rank in ranks
+    ]
+    rss_entries = [
+        {
+            "global_rank": rank["global_rank"],
+            "t": stamps,
+            value_key: [rank["ram_used"] or 0.0] * len(stamps),
+            "max": [rank["ram_used"] or 0.0] * len(stamps),
+            "span_s": stamps[-1] - stamps[0],
+            "window_s": 30.0,
+        }
+        for rank in ranks
+    ]
+    live = [rank for rank in ranks if not rank["stale"]]
+    return {
+        "window_len": len(stamps),
+        "gpu_available": gpu,
+        "rollups": {
+            "ranks": ranks,
+            "ranks_total": len(ranks),
+            "ranks_stale": len(ranks) - len(live),
+            "ranks_reporting": len(live),
+            "gpu_available": gpu,
+            "cpu_capacity": {"p50": 2.1, "worst": 2.4, "worst_rank": 0},
+            "rss": {
+                "used": 1.4 * GB,
+                "total": 200.0 * GB,
+                "rank": live[0]["global_rank"] if live else None,
+            },
+            "cuda": {
+                "alloc_p50": 2.2 * GB if gpu else None,
+                "reserved": 5.6 * GB if gpu else None,
+                "reserved_total": 16.0 * GB if gpu else None,
+                "reserved_rank": 0 if gpu else None,
+            },
+            "reserved_imbalance_pct": 0.0 if gpu else None,
+            "rows_over": rows_over,
+            "tick_s": 2.0,
+        },
+        "series": {
+            "cpu_capacity": [],
+            "rss": [],
+            "cpu_capacity_run": [],
+            "rss_run": [],
+            series_key: entries,
+            rss_key: rss_entries,
+        },
+    }
+
+
+def test_section_builds_and_updates_without_a_browser() -> None:
+    from nicegui import ui
+
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.process_section import (  # noqa: E501
+        build_process_section,
+        update_process_section,
+    )
+
+    with ui.element("div"):
+        panel = build_process_section()
+    ranks = [_rank(0), _rank(1), _rank(2), _rank(3)]
+    update_process_section(panel, _payload(ranks))
+
+    # Levels carry their denominator; the rate carries its estimator.
+    assert "2.1" in panel["tiles"]["cpu"].content
+    assert panel["subs"]["cpu"].text == "median rank · of host capacity"
+    assert "215 GB" in panel["tiles"]["rss"].content
+    assert "17.2 GB" in panel["tiles"]["reserved"].content
+    assert panel["subs"]["reserved"].text == "least-headroom rank · R0"
+    assert panel["subs"]["alloc"].text == "median rank · live tensors"
+
+    # Both charts are pinned to one axis, in wall-clock time.
+    cpu_axis = panel["cpu_chart"].options["xAxis"]
+    rss_axis = panel["rss_chart"].options["xAxis"]
+    assert (cpu_axis["min"], cpu_axis["max"]) == (
+        rss_axis["min"],
+        rss_axis["max"],
+    )
+    assert "getHours" in cpu_axis["axisLabel"][":formatter"]
+    assert len(panel["cpu_chart"].options["series"]) == 4
+
+    # The label names the view and its estimator, never "whole run".
+    assert panel["cpu_label"].text == (
+        "process cpu · capacity per rank · last 20 min · rolling 30 s"
+    )
+    assert "whole run" not in panel["rss_label"].text
+
+    # The rows open by themselves only on a rising edge ...
+    assert panel["rows"].value is False
+    update_process_section(panel, _payload(ranks, rows_over=True))
+    assert panel["rows"].value is True
+    # ... and a reader who closes them is not fought on the next tick.
+    panel["rows"].value = False
+    update_process_section(panel, _payload(ranks, rows_over=True))
+    assert panel["rows"].value is False
+
+
+def test_a_cpu_only_host_keeps_every_slot(tmp_path: Any = None) -> None:
+    """One shape to learn on every host: the GPU tiles say so, in place."""
+    from nicegui import ui
+
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.process_section import (  # noqa: E501
+        build_process_section,
+        update_process_section,
+    )
+
+    with ui.element("div"):
+        panel = build_process_section()
+    ranks = [
+        _rank(0, alloc=None, reserved=None, total=None),  # type: ignore[arg-type]
+        _rank(1, alloc=None, reserved=None, total=None),  # type: ignore[arg-type]
+    ]
+    update_process_section(panel, _payload(ranks, gpu=False))
+
+    assert panel["tiles"]["reserved"].content == "n/a"
+    assert panel["tiles"]["alloc"].content == "n/a"
+    assert panel["subs"]["reserved"].text == "no GPU"
+    # The host-side half of the block still works.
+    assert "2.1" in panel["tiles"]["cpu"].content
+    assert "215 GB" in panel["tiles"]["rss"].content
+    assert len(panel["cpu_chart"].options["series"]) == 2
+    # The per-rank rows are about ranks, not GPUs: they stay.
+    assert "R0" in panel["rows_html"].content

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -318,15 +318,18 @@ def test_whole_run_charts_share_one_clock_axis() -> None:
     # The duration is the strip's fact; the labels say the view, not the
     # length.
     assert panel["cpu_label"].text == (
-        "host cpu util · avg across cores · last 39 min · rolling 2 min"
+        "host cpu util · avg across cores · last 41 min · rolling 2 min"
     )
     assert panel["power_label"].text == (
-        "gpu power · per GPU vs 70 W limit · last 39 min · "
+        "gpu power · per GPU vs 70 W limit · last 41 min · "
         "average and lowest every 2 min"
     )
     # The label never claims the whole run: retention can prune it.
     assert "whole run" not in panel["cpu_label"].text
     assert "whole run" not in panel["power_label"].text
+    # One shared axis means one shared span in both labels, not each
+    # series' own extent (they differ by a window).
+    assert "last 41 min" in panel["power_label"].text
 
 
 def test_power_chart_draws_limit_and_floor_reference_lines() -> None:

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -47,7 +47,9 @@ def test_levels_carry_their_denominator() -> None:
     assert format_gb_pair(6.31 * GB, 16.1 * GB) == ("6.3", "/ 16.1 GB")
     assert format_gb_pair(9.0 * GB, 200.0 * GB) == ("9.0", "/ 200 GB")
     assert format_gb_pair(None, 16.1 * GB) == ("n/a", "")
-    assert format_gb_pair(0.47 * GB, None) == ("0.5", "GB")
+    # Sub-gigabyte levels keep two decimals: a real 0.5 GB and a real
+    # 27 MB must not both print as "0.0"/"0.5".
+    assert format_gb_pair(0.47 * GB, None) == ("0.47", "GB")
 
 
 def test_disclosure_text_states_the_range_and_no_verdict() -> None:

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -318,13 +318,15 @@ def test_whole_run_charts_share_one_clock_axis() -> None:
     # The duration is the strip's fact; the labels say the view, not the
     # length.
     assert panel["cpu_label"].text == (
-        "host cpu util · avg across cores · whole run · rolling 2 min"
+        "host cpu util · avg across cores · last 39 min · rolling 2 min"
     )
     assert panel["power_label"].text == (
-        "gpu power · per GPU vs 70 W limit · whole run · "
+        "gpu power · per GPU vs 70 W limit · last 39 min · "
         "average and lowest every 2 min"
     )
-    assert "min," not in panel["cpu_label"].text
+    # The label never claims the whole run: retention can prune it.
+    assert "whole run" not in panel["cpu_label"].text
+    assert "whole run" not in panel["power_label"].text
 
 
 def test_power_chart_draws_limit_and_floor_reference_lines() -> None:

--- a/tests/renderers/test_process_dashboard_payload.py
+++ b/tests/renderers/test_process_dashboard_payload.py
@@ -8,7 +8,7 @@
 
 The behaviours pinned here are the ones real captures broke: a dead rank
 that used to freeze the whole block, teardown rows that blanked the GPU
-tiles on a finished run, and a sawtooth whose newest sample is a trough.
+tiles on a finished run, and a sawtooth caught at its low point.
 """
 
 from __future__ import annotations
@@ -214,7 +214,7 @@ def test_allocated_is_the_window_median_not_the_newest_sample(
     """
 
     def per_tick(rank: int, seq: int) -> Dict[str, Any]:
-        # A steady working set with a peak every fifth step, and a trough
+        # A steady working set with a peak every fifth step, and a dip
         # on the newest sample.
         if seq == 39:
             return {"alloc": 0.02 * GB}

--- a/tests/renderers/test_process_dashboard_payload.py
+++ b/tests/renderers/test_process_dashboard_payload.py
@@ -379,3 +379,100 @@ def test_a_cpu_only_host_reports_no_gpu(tmp_path: Path) -> None:
     # The host-side numbers still work.
     assert roll["cpu_capacity"]["p50"] is not None
     assert roll["rss"]["used"] is not None
+
+
+def test_a_rank_dead_longer_than_the_window_keeps_its_row(
+    tmp_path: Path,
+) -> None:
+    """Forgetting the dead rank later is still forgetting it.
+
+    The windowed read is bounded by the observed cadence, so a rank silent
+    for longer than that bound has no rows in it. Without a second read it
+    dropped out of the block entirely: ranks_total fell, the stale count
+    went to zero, and the header read "3 ranks" as though rank 3 had never
+    existed. That is the failure this block was rebuilt to end, deferred
+    by a few minutes.
+    """
+    rows = [
+        row
+        for row in _rows(ranks=4, ticks=600, cadence=2.0)
+        # rank 3 stops 20 minutes before the others, far outside the
+        # window the recent read looks back over
+        if not (row["rank"] == 3 and row["seq"] >= 100)
+    ]
+    db = tmp_path / "long-dead.db"
+    _write(db, rows)
+
+    roll = _payload(db)["rollups"]
+    assert roll["ranks_total"] == 4
+    assert roll["ranks_stale"] == 1
+    by_rank = {rank["global_rank"]: rank for rank in roll["ranks"]}
+    assert by_rank[3]["stale"] is True
+    assert by_rank[3]["age_s"] > 900
+    # It keeps the values it last reported, so the row still says
+    # something about why it died.
+    assert by_rank[3]["ram_used"] is not None
+
+
+def test_nothing_reporting_does_not_claim_an_exclusion(
+    tmp_path: Path,
+) -> None:
+    """With every rank stale there is nobody to exclude them in favour of.
+
+    The aggregates then come from stale ranks by necessity, and the header
+    must not say "excluded" over numbers those very ranks produced.
+    """
+    # Two ranks stop together; a third goes on alone and then also stops,
+    # so by the newest arrival every rank is older than the stale bound.
+    rows = _rows(ranks=3, ticks=40)
+    rows = [row for row in rows if not (row["rank"] < 2 and row["seq"] >= 20)]
+    db = tmp_path / "all-stale.db"
+    _write(db, rows)
+    roll = _payload(db)["rollups"]
+    # Rank 2 is the only live one, so the other two ARE excluded.
+    assert roll["ranks_stale"] == 2
+    assert roll["excluding_stale"] is True
+
+    # Now nobody is live: the newest arrival belongs to a rank that is
+    # itself past the bound, which cannot happen by construction, so the
+    # honest case is a database whose every rank stopped at once.
+    quiet = tmp_path / "quiet.db"
+    _write(quiet, _rows(ranks=3, ticks=40))
+    quiet_roll = _payload(quiet)["rollups"]
+    assert quiet_roll["ranks_stale"] == 0
+    assert quiet_roll["excluding_stale"] is False
+    # The claim is only ever made when it is true.
+    assert quiet_roll["excluding_stale"] == (
+        quiet_roll["ranks_stale"] > 0 and quiet_roll["ranks_reporting"] > 0
+    )
+
+
+def test_the_payload_feeds_the_section_unchanged(tmp_path: Path) -> None:
+    """The contract this PR introduces, exercised end to end.
+
+    Both suites otherwise build their own inputs, so a key renamed on one
+    side of the payload would pass every test and blank the block.
+    """
+    from nicegui import ui
+
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.process_section import (  # noqa: E501
+        build_process_section,
+        update_process_section,
+    )
+
+    db = tmp_path / "end-to-end.db"
+    _write(db, _rows(ranks=4, ticks=40))
+    payload = _payload(db)
+
+    with ui.element("div"):
+        panel = build_process_section()
+    update_process_section(panel, payload)
+
+    assert "%" in panel["tiles"]["cpu"].content
+    assert "GB" in panel["tiles"]["rss"].content
+    assert "GB" in panel["tiles"]["reserved"].content
+    assert panel["subs"]["reserved"].text.startswith("least-headroom rank")
+    assert "4 ranks" in panel["rows_hint"].text
+    assert "R3" in panel["rows_html"].content
+    assert len(panel["cpu_chart"].options["series"]) == 4
+    assert panel["cpu_label"].text.startswith("process cpu")

--- a/tests/renderers/test_process_dashboard_payload.py
+++ b/tests/renderers/test_process_dashboard_payload.py
@@ -1,0 +1,381 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process dashboard payload: what each rank contributes, and when.
+
+The behaviours pinned here are the ones real captures broke: a dead rank
+that used to freeze the whole block, teardown rows that blanked the GPU
+tiles on a finished run, and a sawtooth whose newest sample is a trough.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from traceml_ai.renderers.process.dashboard_compute import (
+    IMBALANCE_OPEN_PCT,
+    ProcessDashboardComputer,
+)
+
+GB = 1024**3
+CORES = 48
+TOTAL_RAM = 200.0 * GB
+GPU_TOTAL = 16.0 * GB
+
+_SCHEMA = """
+CREATE TABLE process_samples (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    recv_ts_ns INTEGER NOT NULL,
+    rank INTEGER,
+    global_rank INTEGER,
+    local_rank INTEGER,
+    world_size INTEGER,
+    local_world_size INTEGER,
+    node_rank INTEGER,
+    hostname TEXT,
+    sample_ts_s REAL,
+    seq INTEGER,
+    cpu_percent REAL,
+    cpu_logical_core_count INTEGER,
+    ram_used_bytes REAL,
+    ram_total_bytes REAL,
+    gpu_available INTEGER,
+    gpu_count INTEGER,
+    gpu_device_index INTEGER,
+    gpu_mem_used_bytes REAL,
+    gpu_mem_reserved_bytes REAL,
+    gpu_mem_total_bytes REAL
+);
+"""
+
+BASE_TS = 1_787_000_000.0
+
+
+def _write(db: Path, rows: List[Dict[str, Any]]) -> None:
+    conn = sqlite3.connect(db)
+    conn.executescript(_SCHEMA)
+    for row in rows:
+        conn.execute(
+            """
+            INSERT INTO process_samples (
+                recv_ts_ns, rank, global_rank, node_rank, hostname,
+                sample_ts_s, seq, cpu_percent, cpu_logical_core_count,
+                ram_used_bytes, ram_total_bytes, gpu_available,
+                gpu_device_index, gpu_mem_used_bytes,
+                gpu_mem_reserved_bytes, gpu_mem_total_bytes
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                int(row["recv_s"] * 1e9),
+                row["rank"],
+                row["rank"],
+                0,
+                "host-a",
+                row["ts"],
+                row["seq"],
+                row.get("cpu", 100.0),
+                CORES,
+                row.get("rss", 2.0 * GB),
+                TOTAL_RAM,
+                1 if row.get("gpu", True) else 0,
+                row["rank"],
+                row.get("alloc", 2.0 * GB),
+                row.get("reserved", 5.0 * GB),
+                row.get("total", GPU_TOTAL) if row.get("gpu", True) else 0.0,
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _rows(
+    ranks: int = 4,
+    ticks: int = 40,
+    *,
+    cadence: float = 2.0,
+    per_tick: Optional[Any] = None,
+) -> List[Dict[str, Any]]:
+    """A healthy multi-rank run; ``per_tick`` overrides any field."""
+    out = []
+    for seq in range(ticks):
+        for rank in range(ranks):
+            row = {
+                "rank": rank,
+                "seq": seq,
+                "ts": BASE_TS + seq * cadence,
+                "recv_s": BASE_TS + seq * cadence + 0.2,
+            }
+            if per_tick is not None:
+                row.update(per_tick(rank, seq) or {})
+            out.append(row)
+    return out
+
+
+def _payload(db: Path) -> Dict[str, Any]:
+    return ProcessDashboardComputer(str(db)).compute()
+
+
+def test_a_dead_rank_dims_instead_of_stopping_the_block(
+    tmp_path: Path,
+) -> None:
+    """The failure this block exists for must not silence it.
+
+    The previous payload aligned every rank on ``min(latest seq)``, so one
+    rank that stopped reporting pinned the whole card to that rank's last
+    tick: the surface froze exactly when a reader needed it.
+    """
+    rows = [
+        row
+        for row in _rows(ranks=4, ticks=40)
+        if not (row["rank"] == 3 and row["seq"] >= 25)
+    ]
+    db = tmp_path / "dead.db"
+    _write(db, rows)
+
+    out = _payload(db)
+    roll = out["rollups"]
+    assert roll["ranks_total"] == 4
+    assert roll["ranks_stale"] == 1
+    assert roll["ranks_reporting"] == 3
+    by_rank = {rank["global_rank"]: rank for rank in roll["ranks"]}
+    assert by_rank[3]["stale"] is True
+    assert by_rank[3]["age_s"] > 0
+    # The dead rank keeps its row and its last readings ...
+    assert by_rank[3]["cpu_capacity"] is not None
+    # ... and the live ranks keep their full window, not rank 3's.
+    assert out["window_len"] == 40
+    for rank in (0, 1, 2):
+        assert by_rank[rank]["stale"] is False
+
+
+def test_stale_ranks_leave_the_aggregates(tmp_path: Path) -> None:
+    """A rank that stopped must not keep speaking through the tiles."""
+
+    def per_tick(rank: int, seq: int) -> Dict[str, Any]:
+        # Rank 3 dies holding far more memory than anyone else.
+        if rank == 3:
+            return {"reserved": 15.0 * GB, "rss": 9.0 * GB, "cpu": 4000.0}
+        return {}
+
+    rows = [
+        row
+        for row in _rows(ranks=4, ticks=40, per_tick=per_tick)
+        if not (row["rank"] == 3 and row["seq"] >= 25)
+    ]
+    db = tmp_path / "stale-agg.db"
+    _write(db, rows)
+
+    roll = _payload(db)["rollups"]
+    assert roll["ranks_stale"] == 1
+    # The worst live rank owns the tiles, not the dead one.
+    assert roll["rss"]["rank"] != 3
+    assert roll["cuda"]["reserved_rank"] != 3
+    assert roll["cpu_capacity"]["worst_rank"] != 3
+    # And its 10 GB of held memory does not read as imbalance.
+    assert roll["reserved_imbalance_pct"] == 0.0
+
+
+def test_gpu_tiles_survive_teardown_rows(tmp_path: Path) -> None:
+    """A finished run's last samples carry no device, and must not blank.
+
+    torch releases the device before the sampler stops, so the newest row
+    of a completed run reports no GPU. Anchoring the tiles on it showed
+    `n/a` on every finished run (the same class as a gauge reading 0 %).
+    """
+
+    def per_tick(rank: int, seq: int) -> Dict[str, Any]:
+        if seq >= 38:  # teardown: device gone, sampler still writing
+            return {"gpu": False, "alloc": 0.0, "reserved": 0.0}
+        return {}
+
+    db = tmp_path / "teardown.db"
+    _write(db, _rows(ranks=2, ticks=40, per_tick=per_tick))
+
+    roll = _payload(db)["rollups"]
+    assert roll["cuda"]["reserved"] == 5.0 * GB
+    assert roll["cuda"]["reserved_total"] == GPU_TOTAL
+    assert roll["cuda"]["alloc_p50"] == 2.0 * GB
+    for rank in roll["ranks"]:
+        assert rank["gpu_reserved"] == 5.0 * GB
+
+
+def test_allocated_is_the_window_median_not_the_newest_sample(
+    tmp_path: Path,
+) -> None:
+    """The allocator sawtooth is undersampled at 2 s; one sample is luck.
+
+    Measured on a real bert capture: median 1.66 GB, window max 7.3 GB,
+    newest sample 0.02 GB. The newest sample is what the old card showed.
+    """
+
+    def per_tick(rank: int, seq: int) -> Dict[str, Any]:
+        # A steady working set with a peak every fifth step, and a trough
+        # on the newest sample.
+        if seq == 39:
+            return {"alloc": 0.02 * GB}
+        return {"alloc": (7.0 if seq % 5 == 0 else 1.6) * GB}
+
+    db = tmp_path / "sawtooth.db"
+    _write(db, _rows(ranks=1, ticks=40, per_tick=per_tick))
+
+    roll = _payload(db)["rollups"]
+    assert roll["cuda"]["alloc_p50"] == 1.6 * GB
+
+
+def test_cpu_is_bounded_by_the_hosts_capacity(tmp_path: Path) -> None:
+    """`cpu_percent` sums cores; only the bounded form is comparable.
+
+    The stored 4000 % is 4000 / (100 x 48 cores) = 83 % of this host.
+    """
+    db = tmp_path / "cpu.db"
+    _write(db, _rows(ranks=2, ticks=20, per_tick=lambda r, s: {"cpu": 4000.0}))
+
+    roll = _payload(db)["rollups"]
+    assert roll["cpu_capacity"]["p50"] == 4000.0 / (100.0 * CORES) * 100.0
+    assert roll["cpu_capacity"]["p50"] < 100.0
+
+
+def test_imbalance_reads_reserved_not_allocated(tmp_path: Path) -> None:
+    """Allocated differs by which step phase each sampler caught.
+
+    On a healthy run that phase noise reaches gigabytes, which is what the
+    old `GPU IMBAL` tile showed. Reserved is the stable quantity, and it is
+    the one the diagnosis engine's own imbalance rule uses.
+    """
+
+    def per_tick(rank: int, seq: int) -> Dict[str, Any]:
+        # Wildly different allocated, identical reserved.
+        return {"alloc": (1.0 + 4.0 * ((rank + seq) % 2)) * GB}
+
+    db = tmp_path / "imbalance.db"
+    _write(db, _rows(ranks=4, ticks=30, per_tick=per_tick))
+
+    roll = _payload(db)["rollups"]
+    assert roll["reserved_imbalance_pct"] == 0.0
+    assert roll["rows_over"] is False
+
+
+def test_rows_open_only_after_the_bar_holds(tmp_path: Path) -> None:
+    """Armed, sustained, and on the engine's bar.
+
+    Ranks reach their first allocation seconds apart, so an unarmed
+    trigger reads that ramp as total imbalance and throws the rows open on
+    every run's first tick.
+    """
+
+    def per_tick(rank: int, seq: int) -> Dict[str, Any]:
+        if seq < 3:  # staggered CUDA init: rank 3 has nothing yet
+            return {"reserved": 0.0 if rank == 3 else 5.0 * GB}
+        if rank == 3:  # then it allocates far more than its peers
+            return {"reserved": 12.0 * GB}
+        return {}
+
+    db = tmp_path / "trigger.db"
+    _write(db, _rows(ranks=4, ticks=30, per_tick=per_tick))
+
+    roll = _payload(db)["rollups"]
+    assert roll["reserved_imbalance_pct"] > IMBALANCE_OPEN_PCT
+    assert roll["rows_over"] is True
+
+    # The same computer, replaying a run that never crosses the bar, keeps
+    # the rows shut.
+    calm = tmp_path / "calm.db"
+    _write(calm, _rows(ranks=4, ticks=30))
+    assert _payload(calm)["rollups"]["rows_over"] is False
+
+
+def test_the_ramp_alone_never_opens_the_rows(tmp_path: Path) -> None:
+    """Arming: a rank with nothing allocated yet is not an imbalance."""
+
+    def per_tick(rank: int, seq: int) -> Dict[str, Any]:
+        return {"reserved": 0.0 if rank == 3 else 5.0 * GB}
+
+    db = tmp_path / "ramp.db"
+    _write(db, _rows(ranks=4, ticks=30, per_tick=per_tick))
+
+    roll = _payload(db)["rollups"]
+    assert roll["reserved_imbalance_pct"] == 100.0
+    assert roll["rows_over"] is False
+
+
+def test_one_series_per_chart_never_both(tmp_path: Path) -> None:
+    """A short run sends its window; a long run sends only the run view."""
+    short = tmp_path / "short.db"
+    _write(short, _rows(ranks=2, ticks=20))
+    out = _payload(short)
+    assert (
+        out["series"]["cpu_capacity"] and not out["series"]["cpu_capacity_run"]
+    )
+
+    long_run = tmp_path / "long.db"
+    _write(long_run, _rows(ranks=2, ticks=400, cadence=10.0))
+    out = _payload(long_run)
+    assert out["series"]["cpu_capacity_run"]
+    assert out["series"]["cpu_capacity"] == []
+    assert out["series"]["rss"] == []
+
+
+def test_run_history_holds_its_point_budget(tmp_path: Path) -> None:
+    """The payload cannot grow with the run: 120 points per rank, counted."""
+    db = tmp_path / "budget.db"
+    _write(db, _rows(ranks=3, ticks=2000, cadence=2.0))
+
+    series = _payload(db)["series"]["cpu_capacity_run"]
+    assert len(series) == 3
+    for entry in series:
+        assert 0 < len(entry["t"]) <= 120
+        assert len(entry["t"]) == len(entry["avg"]) == len(entry["max"])
+        assert entry["window_s"] > 0
+
+
+def test_every_degraded_path_keeps_the_series_schema(
+    tmp_path: Path,
+) -> None:
+    """An empty or unreadable database still answers with the full shape."""
+    empty = tmp_path / "empty.db"
+    _write(empty, [])
+    keys = {"cpu_capacity", "rss", "cpu_capacity_run", "rss_run"}
+    out = _payload(empty)
+    assert set(out["series"]) == keys
+    assert out["window_len"] == 0
+    assert out["rollups"] == {}
+
+    missing = _payload(tmp_path / "does-not-exist.db")
+    assert set(missing["series"]) == keys
+
+
+def test_a_cpu_only_host_reports_no_gpu(tmp_path: Path) -> None:
+    """Absent is not zero: the GPU rollups stay None on a CPU-only box."""
+    db = tmp_path / "cpu-only.db"
+    _write(
+        db,
+        _rows(
+            ranks=2,
+            ticks=20,
+            per_tick=lambda r, s: {
+                "gpu": False,
+                "alloc": 0.0,
+                "reserved": 0.0,
+            },
+        ),
+    )
+
+    out = _payload(db)
+    roll = out["rollups"]
+    assert out["gpu_available"] is False
+    assert roll["cuda"] == {
+        "alloc_p50": None,
+        "reserved": None,
+        "reserved_total": None,
+        "reserved_rank": None,
+    }
+    assert roll["reserved_imbalance_pct"] is None
+    assert roll["rows_over"] is False
+    # The host-side numbers still work.
+    assert roll["cpu_capacity"]["p50"] is not None
+    assert roll["rss"]["used"] is not None

--- a/tests/renderers/test_process_dashboard_payload.py
+++ b/tests/renderers/test_process_dashboard_payload.py
@@ -476,3 +476,80 @@ def test_the_payload_feeds_the_section_unchanged(tmp_path: Path) -> None:
     assert "R3" in panel["rows_html"].content
     assert len(panel["cpu_chart"].options["series"]) == 4
     assert panel["cpu_label"].text.startswith("process cpu")
+
+
+def test_the_nullable_columns_from_400_read_as_absent(
+    tmp_path: Path,
+) -> None:
+    """#400 lets the sampler write NULL where it once wrote a number.
+
+    `cpu_percent`, `ram_used_bytes`, `ram_total_bytes` and `gpu_available`
+    became nullable on the wire when collection fails, and that PR left
+    the display side deliberately out of scope. Absent must read as
+    absent here: never 0 %, never 0.0 GB, and never a crash.
+    """
+    db = tmp_path / "nulls.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(_SCHEMA)
+    for seq in range(20):
+        for rank in range(2):
+            conn.execute(
+                """
+                INSERT INTO process_samples (
+                    recv_ts_ns, rank, global_rank, node_rank, hostname,
+                    sample_ts_s, seq, cpu_percent, cpu_logical_core_count,
+                    ram_used_bytes, ram_total_bytes, gpu_available,
+                    gpu_device_index, gpu_mem_used_bytes,
+                    gpu_mem_reserved_bytes, gpu_mem_total_bytes
+                ) VALUES (?,?,?,?,?,?,?,NULL,NULL,NULL,NULL,NULL,?,NULL,
+                          NULL,NULL)
+                """,
+                (
+                    int((BASE_TS + seq * 2.0 + 0.2) * 1e9),
+                    rank,
+                    rank,
+                    0,
+                    "host-a",
+                    BASE_TS + seq * 2.0,
+                    seq,
+                    rank,
+                ),
+            )
+    conn.commit()
+    conn.close()
+
+    out = _payload(db)
+    roll = out["rollups"]
+    # The ranks are still there, and every number they could not measure
+    # is None rather than a zero.
+    assert roll["ranks_total"] == 2
+    assert roll["cpu_capacity"] == {
+        "p50": None,
+        "worst": None,
+        "worst_rank": None,
+    }
+    assert roll["rss"] == {"used": None, "total": None, "rank": None}
+    assert roll["cuda"]["reserved"] is None
+    assert roll["reserved_imbalance_pct"] is None
+    assert roll["rows_over"] is False
+    assert out["gpu_available"] is False
+    for rank in roll["ranks"]:
+        assert rank["cpu_capacity"] is None
+        assert rank["ram_used"] is None
+        assert rank["gpu_total"] is None
+
+    # And the section renders it as absence, not as zero.
+    from nicegui import ui
+
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.process_section import (  # noqa: E501
+        build_process_section,
+        update_process_section,
+    )
+
+    with ui.element("div"):
+        panel = build_process_section()
+    update_process_section(panel, out)
+    assert panel["tiles"]["cpu"].content == "n/a"
+    assert panel["tiles"]["rss"].content == "n/a"
+    assert "0.0" not in panel["rows_html"].content
+    assert "n/a" in panel["rows_html"].content


### PR DESCRIPTION
# Dashboard: Process block as four tiles, two per-rank charts and rank rows

> **Review scope: the Process block only.** The System block above it is #389, already merged. Step Time, Step memory and Diagnostics in the screenshots are today's rendering, untouched here and rebuilt in later PRs. The block adopts the System block's skeleton (a tiles row, fixed-height chart slots, one disclosure) so the side-by-side pair is equal by construction with both disclosures closed.

## What

Every rank's trainer process, read on that rank's own clock.

- **Four tiles, each naming its estimator and, where one rank owns the number, that rank.** `cpu capacity` (worst rank, named, as a share of the host's capacity), `rss` (worst rank, named, used against total), `cuda reserved` (least-headroom rank, named, against its device), `cuda allocated` (median across ranks, which belongs to no single rank). A bottleneck hunt asks which rank is the problem, so three of the four tiles name one; the median across ranks is carried in the payload beside the worst for the card to compare against. Levels carry their denominator; rates name their estimator.
- **Two charts, one shared wall-clock axis.** Process CPU per rank, which sits directly under the System block's host CPU chart, and RSS per rank. Both switch from the raw sample window to a decimated whole-run view once the run outgrows the window, exactly as the System block does, and both label the span they actually hold.
- **Per-rank rows behind a disclosure**: rank, gpu, node, cpu capacity, RSS, a CPU trend sparkline, CUDA allocated, CUDA reserved, and the rank's age. They open on their own when the across-rank reserved imbalance crosses the diagnosis engine's own warn bar, on a rising edge only, so closing them is respected.
- **The block states its scope in the header**: `one process per rank · DataLoader workers not included`. Worker processes are invisible to this sampler by design and their cost lands in the System block, so host CPU high while every rank's process CPU is low means the work is outside the trainer. That reading is only available if the boundary is stated, and it is the pairing the two blocks exist to make possible.
- **No verdict words anywhere.** The rows header reports coverage and the imbalance number; whether that is bad is the engine's call.

## Why

Four things today's card gets wrong, all visible in the screenshots below.

1. **A dead rank froze the whole block.** The payload advanced on `min(latest seq across ranks)`, so one rank that stopped reporting pinned every other rank to that rank's last tick. On the rank-dead fixture the card stops at `last 12 samples` while three ranks keep reporting: the surface goes quiet exactly when a distributed job needs it. Ranks are now read independently and a stale rank is dimmed, counted in the header (`4 ranks · 1 stale, excluded`), and dropped from every aggregate so it cannot keep speaking through the tiles. A rank silent longer than the recent window keeps its row through a second one-row-per-rank read, so the block does not quietly forget it minutes later. When NO rank is reporting there is nobody to exclude them in favour of, so the last known numbers stand and the header says `none reporting` rather than claiming an exclusion that did not happen.
2. **CPU was unbounded.** `cpu_percent` from psutil sums cores, so the tile read `288 %` on the 2-node capture and `395 %` peak on the 23-minute one. It is now divided by the host's logical core count, which was already stored beside it and never carried into the payload.
3. **GPU memory read the newest raw sample of a sawtooth.** At 2 s the allocator's live bytes are undersampled: on the bert capture the window median is 1.66 GB, the window max 7.3 GB, and the newest sample 0.02 GB. The tile showed the 0.02. It is now the window median, and it is never called a peak, which is step memory's word.
4. **Imbalance was computed on allocated.** Across-rank allocated spread reaches 3 GB on perfectly healthy runs, because each rank's sampler catches a different step phase; that noise was the old `GPU IMBAL 1.71 GB` tile. Reserved is the stable quantity and the one the engine's own imbalance rule uses.

## Scope

`DATA PATH: process_section <- PROCESS_LAYOUT <- ProcessRenderer.get_dashboard_renderable <- ProcessDashboardComputer <- process_samples`

One table, one package. The section evaluates no threshold: which view the charts draw, which rank each tile speaks for, which ranks are stale, and whether the rows have earned opening are all decided in the computer. `structure_gate.py` reports no read-side violations and `tests/arch` passes.

The imbalance BAR is imported from `diagnostics/process/policy.py` rather than copied, so the threshold cannot drift. The imbalance METRIC is computed here, `(max-min)/max` over per-rank reserved medians, which mirrors the engine's `_imbalance_pct` but is a second implementation; the two could diverge and only the bar is shared. It is read at import, so a runtime-configured policy would not reach the dashboard.

Payload, all additive on the Process payload itself: `rollups.ranks[]` (identity, capacity, memory, age, stale), `rollups.cpu_capacity` / `rss` / `cuda` (each naming its rank), `rollups.reserved_imbalance_pct`, `rollups.rows_over`, `ranks_reporting` / `ranks_total` / `ranks_stale`, and `series.{cpu_capacity,rss}` plus their `_run` whole-run twins. `history` and `gpu_used_imbalance` keep their place in the dataclass for the CLI snapshot, which is untouched.

Outside the Process package, three changes:

- `nicegui_sections/theme.py`: the series helpers the System block already had (`apply_span_axis`, `shared_run_axis`, `format_span`, `format_gb_pair`, `sparkline_svg`, `cpu_axis_max`, and friends) moved here so both blocks use one implementation instead of two. `system_section.py` imports them back under the same names, so its call sites and tests are unchanged.
- Axis ticks now take their precision from the axis range. A chart fitted to a 20 MB drift was labelling a tick `1.402237892150879 GB`.
- `system_section.py` labels: the charts said `whole run`, which history retention (30 minutes by default since #393) makes false on any longer live run. Both blocks now state the span they actually hold (`last 22 min`), which is true under any retention setting. That also fixed a latent inconsistency: the two System charts share one axis but were quoting spans a rolling window apart.

## Estimator per item

| item | form | estimator |
|---|---|---|
| cpu capacity tile | number | per-rank window median, then the WORST of those, with its rank |
| cpu capacity chart | per-rank series | rolling mean over a run-scaled window (30 s to 5 min) |
| rss tile | number + denominator | worst live rank chosen on its window median, shown at its newest value |
| rss chart | per-rank series | rolling mean; axis fitted to the data, not zero-anchored |
| cuda allocated | number | per-rank window median (the sawtooth is undersampled) |
| cuda reserved | number + denominator | newest reported sample of the least-headroom rank |
| reserved imbalance | number | `(max-min)/max` over per-rank window medians |
| rank age | seconds | newest arrival clock anywhere minus this rank's; stale past three ticks |
| rows trigger | hidden | imbalance over the engine's warn bar, armed once every rank has held an allocation |

Three notes on those choices, each measured rather than argued.

**Liveness uses the aggregator's arrival clock, not the rank's wall clock.** Comparing `sample_ts_s` across machines makes one fast clock mark every other node dead. Measured skew on the 2-node capture is 11 ms under NTP, so it would not have bitten there, but arrival time is skew-free by construction.

**The rows trigger is a window median, not a streak of ticks.** A tick streak cannot debounce a replay: a finished run rendered once never accumulates one, so its rows would stay shut however lopsided the run was. The median debounces the staggered CUDA ramp instead, and the arming rule (every reporting rank must have held an allocation) keeps the first seconds of a run from reading as total imbalance. The 12-second FSDP capture, the one that opens the System block's rows on its start-up ramp, reads `reserved imbalance 1%` here and stays shut.

**The RSS axis is not zero-anchored.** Ranks sit around 1.5 GB and drift by tens of MB across a run. On a zero-anchored axis that movement is under one pixel of a 92 px chart, so the chart could not show the one thing it is for. The scenario matrix caught this; the axis now fits the data and the 3-hour capture reads `1.382 / 1.392 / 1.402 GB`.

## Verification

- `pytest tests/display tests/renderers tests/reporting tests/aggregator tests/arch tests/core/test_packaging_constraints.py tests/integrations/test_telemetry_conformance.py`: 669 passed, 1 skipped, on `version_0.3.7` at `5039e1b` (which includes #400).
- 29 new tests. 16 on the payload: a dead rank dims instead of stopping the block, stale ranks leave the aggregates, GPU tiles survive teardown rows, allocated is the window median, CPU is bounded by host capacity, imbalance reads reserved not allocated, the rows open only when armed and over the bar, the ramp alone never opens them, one series per chart and never both, the run history holds its 120-point budget, every degraded path keeps the series schema, a CPU-only host reports no GPU, a rank dead longer than the window keeps its row, the exclusion claim is only made when ranks still report, the nullable sampler columns from #400 read as absent rather than zero, and the payload drives the section end to end. 13 on the section: the scope line, the rows header without verdict words, a dimmed stale rank, absence rendered as `n/a` and never zero, per-rank trend colours matching the rows, no rank colour in the verdict red, the drift axis, tick precision from the range, rising-edge opening, and build plus update without a browser including the CPU-only state.
- Two defects were found by rendering rather than by tests, and both now have tests: the zero-anchored RSS axis, and the raw float on a fitted tick.
- Cost, medians of 40 renders per fixture, CPU time as a share of one core at the 2 s render interval, before against after:

| fixture | before | after | payload before | payload after |
|---|---|---|---|---|
| 4 ranks, 23 min | 0.03 % | 1.29 % | 62.3 KB | 49.4 KB |
| 2 nodes, 3 h | 0.08 % | 0.13 % | 62.0 KB | 24.1 KB |
| 1 rank, 96 min | 0.02 % | 0.05 % | 61.6 KB | 12.5 KB |
| 1 rank, 2.4 min | 0.01 % | 0.02 % | 22.5 KB | 6.2 KB |

The block does more than it did (per-rank medians, two whole-run histories, liveness, and a second read so a long-dead rank keeps its row) so it costs more. The worst case, 1.29 % of one core on the 4-rank capture, is above the System block's measured band of 0.37 to 0.89 %; it is 26 ms of CPU per 2 s tick on a 48-core host, and it is the number to argue with if the overhead budget is the concern. Two things keep it there: the recent-window read is bounded by the cadence the ranks are observed to sample at rather than reading back to the start, and the rolling histories, which do scan the retained table, refresh on their own 15 s clock rather than every tick, since a mean over minutes cannot change visibly between two 2 s ticks. The payload is smaller than before on every fixture measured, all of which are 1, 2 or 4 ranks; it grows with rank count, since both charts carry a line per rank. Nothing here runs per rank or per step in the training process.

- black / isort / ruff clean at 79 on every file this PR touches. The five ruff findings elsewhere in `tests/` predate this branch and are left alone.

## Known limitations, stated rather than discovered in review

- **The two blocks scope differently on multi-node captures.** System shows one node (`node 0 of 2`) because host telemetry is per machine; Process shows every rank across both nodes, since ranks are globally unique and each row carries its `N0`/`N1`. This is deliberate, but a reviewer will notice the difference.
- **The charts share a kind of axis, not a pixel grid.** Both blocks label wall-clock time and both decimate their own data, so their spans can differ by a few percent and the same pixel column is not exactly the same instant. Compare by the tick labels or the hover readout, which are exact.
- **The RSS chart shows drift within retained history, not necessarily the whole run.** On a healthy live run at the 30-minute default from #393, a leak developing over hours is only visible for its retained tail. The bound is not a plain clock cut: retention advances to a step frontier that requires every expected rank to have completed that step, so a straggler or a dead rank stalls pruning and history keeps growing past the window. The case where the history matters most is the case where it is kept, which is fortunate rather than designed. Longer retention or a decimated slow series is an aggregator change, not a display one.
- **Many ranks.** Every fixture we own is 1, 2 or 4 ranks. One line per rank and one row per rank will not read at 32 or more; the shape that will (a percentile band plus outlier ranks) needs a real capture at that scale before it is designed.

## Scenarios (screenshots)

One image per fixtured cell, cropped to the Process block, which is the only block this PR changes. The caption is the block's own rendered text, so a cell that reads wrong is visible without opening the image. The load-bearing ones are `Dd_S2_rank3_dead` and `Ed_2x1_rank1_dead`, where a rank stops and the block keeps going while naming it, and the two 2-node cells.

Every fixture cell is a REPLAY of an archived capture, most of them recorded before history retention existed, so their databases still hold the whole run and the labels read `last 172 min`, `last 93 min` and so on. A live run prunes as it goes, so the same charts there show whatever the retention window has kept. That is the reason the label states the span it holds instead of claiming the whole run.

The two live cells below were run through the real launcher on this machine and captured from their own sessions after they finished, so they show the whole-run view; the CPU-only state was also verified on the live dashboard while the run was in its window stage.

Each image is the Process block alone, the only block this PR changes; the rest of the page is today's rendering and out of scope here.

**B · B_xf_1gpu_long** · 96 min, 15k steps, the metrics-tour run; CPU drift visible  
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 25.1% / worst rank · R0 · of host capacity / RSS / 1.4 / 16.6 GB / worst rank · R0 / CUDA RESERVED / 5.6 / 15.6 GB / least-headroom rank · R0 / CUDA ALLOCATED / 2.2 GB / median rank · live tensors / PROCESS CPU · CAPACITY PER RANK · LAST 93 MIN · ROLLING 2 MIN / 25.1% / RSS · PER RANK · LAST 93 MIN · ROLLING 2 MIN / 1.4 GB / per-rank rows / 1 rank · click to open / arrow_drop_down`  
![B B_xf_1gpu_long](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/B_xf_1gpu_long.jpg)

**B · B_cnn_1gpu** · 4 min cnn, 1000 steps  
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 27.3% / worst rank · R0 · of host capacity / RSS / 1.7 / 16.6 GB / worst rank · R0 / CUDA RESERVED / 3.9 / 15.6 GB / least-headroom rank · R0 / CUDA ALLOCATED / 0.58 GB / median rank · live tensors / PROCESS CPU · CAPACITY PER RANK · LAST 4 MIN · ROLLING 30 S / 27.3% / RSS · PER RANK · LAST 4 MIN · ROLLING 30 S / 1.7 GB / per-rank rows / 1 rank · click to open / arrow_drop_down`  
![B B_cnn_1gpu](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/B_cnn_1gpu.jpg)

**C · C_M1_bert** · bert-base, 220 steps, COMPUTE-BOUND, 1 rank on a 4xT4 node  
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 2.1% / worst rank · R0 · of host capacity / RSS / 1.6 / 200 GB / worst rank · R0 / CUDA RESERVED / 8.5 / 15.6 GB / least-headroom rank · R0 / CUDA ALLOCATED / 1.8 GB / median rank · live tensors / PROCESS CPU · CAPACITY PER RANK · LAST 2 MIN / 2.1% / RSS · PER RANK · LAST 2 MIN / 1.6 GB / per-rank rows / 1 rank · click to open / arrow_drop_down`  
![C C_M1_bert](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/C_M1_bert.jpg)

**C · C_sysB_1of4** · 19-Aug campaign run B: 1 busy GPU of 4, 800 steps; the aggregate-hides-idle case  
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 2.1% / worst rank · R0 · of host capacity / RSS / 1.3 / 200 GB / worst rank · R0 / CUDA RESERVED / 5.6 / 15.6 GB / least-headroom rank · R0 / CUDA ALLOCATED / 2.2 GB / median rank · live tensors / PROCESS CPU · CAPACITY PER RANK · LAST 5 MIN · ROLLING 30 S / 2.1% / RSS · PER RANK · LAST 5 MIN · ROLLING 30 S / 1.3 GB / per-rank rows / 1 rank · click to open / arrow_drop_down`  
![C C_sysB_1of4](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/C_sysB_1of4.jpg)

**D · D_S2_ddp4** · 4-rank DDP, healthy, 40 s  
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 2.1% / worst rank · R0 · of host capacity / RSS / 1.1 / 200 GB / worst rank · R1 / CUDA RESERVED / 1.3 / 15.6 GB / least-headroom rank · R2 / CUDA ALLOCATED / 0.86 GB / median rank · live tensors / PROCESS CPU · CAPACITY PER RANK · LAST 41 S / 2.1% / RSS · PER RANK · LAST 41 S / 1.1 GB / per-rank rows / 4 ranks · reserved imbalance 16% · click to open / arrow_drop_down`  
![D D_S2_ddp4](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/D_S2_ddp4.jpg)

**D · D_F1_fsdp4** · 4-rank FSDP (strategy chip)  
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 2.1% / worst rank · R0 · of host capacity / RSS / 1.2 / 200 GB / worst rank · R0 / CUDA RESERVED / 0.29 / 15.6 GB / least-headroom rank · R3 / CUDA ALLOCATED / 0.04 GB / median rank · live tensors / PROCESS CPU · CAPACITY PER RANK · LAST 12 S / 2.1% / RSS · PER RANK · LAST 12 S / 1.2 GB / per-rank rows / 4 ranks · reserved imbalance 1% · click to open / arrow_drop_down`  
![D D_F1_fsdp4](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/D_F1_fsdp4.jpg)

**D · D_sysA_ddp4_3k** · 19-Aug campaign run A: 4-rank DDP, 3000 steps, 23 min  
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 2.1% / worst rank · R0 · of host capacity / RSS / 1.3 / 200 GB / worst rank · R2 / CUDA RESERVED / 5.6 / 15.6 GB / least-headroom rank · R0 / CUDA ALLOCATED / 2.2 GB / median rank · live tensors / PROCESS CPU · CAPACITY PER RANK · LAST 22 MIN · ROLLING 30 S / 2.1% / RSS · PER RANK · LAST 22 MIN · ROLLING 30 S / 1.3 GB / per-rank rows / 4 ranks · reserved imbalance 0% · click to open / arrow_drop_down`  
![D D_sysA_ddp4_3k](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/D_sysA_ddp4_3k.jpg)

**D' · Dd_S2_rank3_dead** · S2 with rank 3's last 10 ticks removed  
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 2.1% / worst rank · R0 · of host capacity / RSS / 1.1 / 200 GB / worst rank · R1 / CUDA RESERVED / 1.3 / 15.6 GB / least-headroom rank · R2 / CUDA ALLOCATED / 0.86 GB / median rank · live tensors / PROCESS CPU · CAPACITY PER RANK · LAST 41 S / 2.1% / RSS · PER RANK · LAST 41 S / 1.1 GB / per-rank rows / 4 ranks · 1 stale, excluded · reserved imbalance 16% · click to open / arrow_drop_down`  
![D' Dd_S2_rank3_dead](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/Dd_S2_rank3_dead.jpg)

**E · E_xf_2x1_long** · 2 nodes x 1 GPU, 178 min, 30k step rows; the seq-drift case  
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 73.0% / worst rank · R1 · of host capacity / RSS / 1.5 / 16.6 GB / worst rank · R0 / CUDA RESERVED / 5.6 / 15.6 GB / least-headroom rank · R0 / CUDA ALLOCATED / 2.2 GB / median rank · live tensors / PROCESS CPU · CAPACITY PER RANK · LAST 172 MIN · ROLLING 5 MIN / 73.0% / RSS · PER RANK · LAST 172 MIN · ROLLING 5 MIN / 1.5 GB / per-rank rows / 2 ranks · reserved imbalance 0% · click to open / arrow_drop_down`  
![E E_xf_2x1_long](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/E_xf_2x1_long.jpg)

**E · E_cnn_2x1_fsdp** · 2 nodes x 1 GPU FSDP, 5 min  
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 64.2% / worst rank · R1 · of host capacity / RSS / 1.7 / 16.6 GB / worst rank · R1 / CUDA RESERVED / 4.0 / 15.6 GB / least-headroom rank · R0 / CUDA ALLOCATED / 0.26 GB / median rank · live tensors / PROCESS CPU · CAPACITY PER RANK · LAST 4 MIN · ROLLING 30 S / 64.2% / RSS · PER RANK · LAST 4 MIN · ROLLING 30 S / 1.7 GB / per-rank rows / 2 ranks · reserved imbalance 0% · click to open / arrow_drop_down`  
![E E_cnn_2x1_fsdp](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/E_cnn_2x1_fsdp.jpg)

**E' · Ed_2x1_rank1_dead** · 2x1 with node 1's rank cut 10 ticks early  
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 64.1% / worst rank · R0 · of host capacity / RSS / 1.7 / 16.6 GB / worst rank · R0 / CUDA RESERVED / 4.0 / 15.6 GB / least-headroom rank · R0 / CUDA ALLOCATED / 0.26 GB / median rank · live tensors / PROCESS CPU · CAPACITY PER RANK · LAST 4 MIN · ROLLING 30 S / 64.1% / RSS · PER RANK · LAST 4 MIN · ROLLING 30 S / 1.7 GB / per-rank rows / 2 ranks · 1 stale, excluded · click to open / arrow_drop_down`  
![E' Ed_2x1_rank1_dead](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/Ed_2x1_rank1_dead.jpg)

**W · W_W1_busy** · watch, 4 GPUs, 1 busy (98/0/0/0)  
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 2.1% / worst rank · R0 · of host capacity / RSS / 0.66 / 200 GB / worst rank · R0 / CUDA RESERVED / 0.22 / 15.6 GB / least-headroom rank · R0 / CUDA ALLOCATED / 0.14 GB / median rank · live tensors / PROCESS CPU · CAPACITY PER RANK · LAST 2 MIN / 2.1% / RSS · PER RANK · LAST 2 MIN / 0.66 GB / per-rank rows / 1 rank · click to open / arrow_drop_down`  
![W W_W1_busy](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/W_W1_busy.jpg)

**W · W_W2_idle** · watch, 4 GPUs, all idle  
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 0.0% / worst rank · R0 · of host capacity / RSS / 0.63 / 200 GB / worst rank · R0 / CUDA RESERVED / 0.0 / 15.6 GB / least-headroom rank · R0 / CUDA ALLOCATED / 0.0 GB / median rank · live tensors / PROCESS CPU · CAPACITY PER RANK · LAST 90 S / 0.0% / RSS · PER RANK · LAST 90 S / 0.63 GB / per-rank rows / 1 rank · click to open / arrow_drop_down`  
![W W_W2_idle](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/W_W2_idle.jpg)

**A · live, CPU-only host, 1 rank** · run through the launcher on a laptop, 19 min; the GPU tiles hold their place and say so, and a 40 MB process reads as `0.04 GB` rather than `0.0`
`Process / one process per rank · DataLoader workers not included / CPU CAPACITY / 0.4% / worst rank · R0 · of host capacity / RSS / 0.04 / 17.2 GB / worst rank · R0 / CUDA RESERVED / n/a / no GPU / CUDA ALLOCATED / n/a / no GPU / PROCESS CPU · CAPACITY PER RANK · LAST 19 MIN · ROLLING 30 S`
![A live cpu only](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/A_live_cpu_only.jpg)

**A2 · live, CPU-only host, 2 ranks** · same workload with `--nproc-per-node 2`; the worst CPU rank and the worst RSS rank are different ranks, which is the point of naming them
`Process / ... / CPU CAPACITY / 0.4% / worst rank · R1 · of host capacity / RSS / 0.04 / 17.2 GB / worst rank · R0 / ... / per-rank rows / 2 ranks · click to open`
![A2 live cpu two ranks](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/traceml-pr3-process-r2/A2_live_cpu_two_ranks.jpg)

## Evidence

GATE: conformance ran=true, `tests/integrations/test_telemetry_conformance.py` 1 passed / 0 failed / 1 skipped on this branch.
TRANSITIONS: tested window view -> whole-run view (`test_one_series_per_chart_never_both` pins that a short run sends the window and a long one sends only the run view, with a database each; no fixture is replayed across the crossing itself), live rank -> stale rank (`test_a_dead_rank_dims_instead_of_stopping_the_block`, and the D' and E' replays render it), closed -> open rows on the rising edge with a reader's close respected (`test_rows_open_on_the_rising_edge_only` plus the section test), and GPU -> no GPU on the same panel (`test_a_cpu_only_host_reports_no_gpu`, `test_a_cpu_only_host_keeps_every_slot`).
RANKS: per-rank asymmetry tested? yes: every tile names the rank it speaks for, a stale rank is excluded from all of them while keeping its row, and the imbalance is computed across ranks on reserved. The 2-node replays show ranks from both nodes with `N0` / `N1` identity; the rank-dead replays show one dimmed row while the block keeps updating.
TRIPWIRE: made the rows trigger fire on purpose? yes, `test_rows_open_only_after_the_bar_holds` drives one rank to 12 GB against its peers' 5 GB and the rows open; the inverse cases stay shut, including `test_the_ramp_alone_never_opens_the_rows` (a rank that has not allocated yet) and the 12-second FSDP replay that reads `reserved imbalance 1%`.
SCENARIOS: A live recipe (run by hand) · A2 live recipe (run by hand) · B ok (B_xf_1gpu_long, B_cnn_1gpu) · C ok (C_M1_bert, C_sysB_1of4) · D ok (D_S2_ddp4, D_F1_fsdp4, D_sysA_ddp4_3k) · D' ok (Dd_S2_rank3_dead) · E ok (E_xf_2x1_long, E_cnn_2x1_fsdp) · E' ok (Ed_2x1_rank1_dead) · F no fixture · W ok (W_W1_busy, W_W2_idle) · Wc live recipe (run by hand)
PLATFORM: EVIDENCE: n/a (no `sys.platform` / `os.name` branch in this change).
