### PR TITLE
system samplers none removed

### DIFF
--- a/src/traceml_ai/samplers/schema/system.py
+++ b/src/traceml_ai/samplers/schema/system.py
@@ -15,7 +15,7 @@ Design principles
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 # ---------------------------------------------------------------------------
 # GPU metrics
@@ -39,14 +39,14 @@ class GPUMetrics:
     power_limit : watts
     """
 
-    util: float
-    mem_used: float
-    mem_total: float
-    temperature: float
-    power_usage: float
-    power_limit: float
+    util: Optional[float]
+    mem_used: Optional[float]
+    mem_total: Optional[float]
+    temperature: Optional[float]
+    power_usage: Optional[float]
+    power_limit: Optional[float]
 
-    def to_wire(self) -> List[float]:
+    def to_wire(self) -> List[Optional[float]]:
         """
         Convert this GPU metric to a compact wire representation.
 
@@ -62,7 +62,7 @@ class GPUMetrics:
 
         Returns
         -------
-        List[float]
+        List[Optional[float]]
             Compact, allocation-light representation suitable for
             JSON serialization or binary transport.
         """
@@ -76,13 +76,13 @@ class GPUMetrics:
         ]
 
     @staticmethod
-    def from_wire(data: List[float]) -> "GPUMetrics":
+    def from_wire(data: List[Optional[float]]) -> "GPUMetrics":
         """
         Reconstruct GPUMetrics from its wire representation.
 
         Parameters
         ----------
-        data : List[float]
+        data : List[Optional[float]]
             Wire-format list produced by `to_wire()`.
 
         Returns
@@ -123,9 +123,9 @@ class SystemSample:
 
     sample_idx: int
     timestamp: float
-    cpu_percent: float
-    ram_used: float
-    ram_total: float
+    cpu_percent: Optional[float]
+    ram_used: Optional[float]
+    ram_total: Optional[float]
     gpu_available: bool
     gpu_count: int
     gpus: List[GPUMetrics]

--- a/src/traceml_ai/samplers/system_sampler.py
+++ b/src/traceml_ai/samplers/system_sampler.py
@@ -18,7 +18,7 @@ The sampler is designed to be:
 from __future__ import annotations
 
 import time
-from typing import List
+from typing import List, Optional
 
 import psutil
 from pynvml import (
@@ -97,7 +97,7 @@ class SystemSampler(BaseSampler):
 
         Stores total system memory for reuse across samples.
         """
-        self.ram_total_memory = 0.0
+        self.ram_total_memory: Optional[float] = None
         try:
             self.ram_total_memory = float(psutil.virtual_memory().total)
         except Exception as e:
@@ -124,7 +124,7 @@ class SystemSampler(BaseSampler):
                 f"[TraceML] NVML initialization failed (GPU unavailable): {e}"
             )
 
-    def _sample_cpu(self) -> float:
+    def _sample_cpu(self) -> Optional[float]:
         """
         Sample current CPU utilization.
         """
@@ -132,9 +132,9 @@ class SystemSampler(BaseSampler):
             return float(psutil.cpu_percent(interval=None))
         except Exception as e:
             self.logger.error(f"[TraceML] CPU sampling failed: {e}")
-            return 0.0
+            return None
 
-    def _sample_ram(self) -> float:
+    def _sample_ram(self) -> Optional[float]:
         """
         Sample current RAM usage.
         """
@@ -142,14 +142,14 @@ class SystemSampler(BaseSampler):
             return float(psutil.virtual_memory().used)
         except Exception as e:
             self.logger.error(f"[TraceML] RAM sampling failed: {e}")
-            return 0.0
+            return None
 
     def _sample_gpus(self) -> List[GPUMetrics]:
         """
         Sample all available GPUs.
 
-        Failure to sample one GPU does not affect others, and a zeroed
-        placeholder is inserted to preserve index alignment.
+        Failure to sample one GPU does not affect others. An unavailable
+        placeholder preserves index alignment without fabricating zeros.
         """
         if not self.gpu_available:
             return []
@@ -183,14 +183,17 @@ class SystemSampler(BaseSampler):
                 self.logger.error(
                     f"[TraceML] GPU {gpu_id} sampling failed: {e}"
                 )
+                # Preserve GPU index alignment while marking every failed
+                # measurement unavailable. Zeros would look like valid idle
+                # hardware and are therefore incorrect telemetry.
                 gpus.append(
                     GPUMetrics(
-                        util=0.0,
-                        mem_used=0.0,
-                        mem_total=0.0,
-                        temperature=0.0,
-                        power_usage=0.0,
-                        power_limit=0.0,
+                        util=None,
+                        mem_used=None,
+                        mem_total=None,
+                        temperature=None,
+                        power_usage=None,
+                        power_limit=None,
                     )
                 )
 

--- a/tests/samplers/test_system_sampler.py
+++ b/tests/samplers/test_system_sampler.py
@@ -1,0 +1,62 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import traceml_ai.samplers.system_sampler as system_module
+from traceml_ai.samplers.schema.system import GPUMetrics, SystemSample
+from traceml_ai.samplers.system_sampler import SystemSampler
+
+
+class _Logger:
+    def error(self, *args, **kwargs) -> None:
+        return None
+
+
+def _raise_unavailable(*args, **kwargs):
+    raise RuntimeError("unavailable")
+
+
+def test_collection_failures_are_unavailable_not_zero(monkeypatch) -> None:
+    sampler = SystemSampler.__new__(SystemSampler)
+    sampler.logger = _Logger()
+    sampler.gpu_available = True
+    sampler.gpu_count = 1
+
+    monkeypatch.setattr(
+        system_module.psutil,
+        "cpu_percent",
+        _raise_unavailable,
+    )
+    monkeypatch.setattr(
+        system_module.psutil,
+        "virtual_memory",
+        _raise_unavailable,
+    )
+    monkeypatch.setattr(
+        system_module,
+        "nvmlDeviceGetHandleByIndex",
+        _raise_unavailable,
+    )
+
+    sampler._init_ram()
+
+    assert sampler.ram_total_memory is None
+    assert sampler._sample_cpu() is None
+    assert sampler._sample_ram() is None
+    assert sampler._sample_gpus()[0].to_wire() == [None] * 6
+
+
+def test_nullable_system_sample_round_trips_through_wire_schema() -> None:
+    sample = SystemSample(
+        sample_idx=1,
+        timestamp=2.0,
+        cpu_percent=None,
+        ram_used=None,
+        ram_total=None,
+        gpu_available=True,
+        gpu_count=1,
+        gpus=[GPUMetrics(None, None, None, None, None, None)],
+    )
+
+    assert SystemSample.from_wire(sample.to_wire()) == sample


### PR DESCRIPTION
Preserve unavailable System sampler measurements as `None` instead of reporting fabricated zero values.

Part of #394.

Partial implementation of #284.

## Changes

- Return `None` when system CPU or RAM collection fails.
- Keep total RAM unknown when initialization fails.
- Preserve GPU device-index alignment when a GPU read fails, while reporting its unavailable measurements as `None`.
- Update the System sample wire schema to support nullable CPU, RAM, and per-GPU measurements.
- Add focused collection-failure and wire-roundtrip tests.

## Scope

This PR changes upstream periodic System sampler and wire semantics only. SQLite already stores these values as `NULL`.

GPU discovery semantics (`gpu_available` and `gpu_count`), the system manifest, and terminal/dashboard/diagnosis presentation are intentionally unchanged. Those concerns can be handled separately without expanding this PR.
