### PR TITLE
Process dashboard: per-rank facts, freshness, normalized CPU rollups, and whole-run series

### DIFF
--- a/src/traceml_ai/renderers/process/dashboard_compute.py
+++ b/src/traceml_ai/renderers/process/dashboard_compute.py
@@ -26,7 +26,19 @@ from __future__ import annotations
 
 import time
 from collections import deque
-from typing import Any, Deque, List, Optional, Sequence, Tuple
+from dataclasses import replace
+from typing import Any, Deque, Dict, List, Optional, Sequence, Tuple
+
+from traceml_ai.renderers.shared.freshness import (
+    CachedPayloadTTL,
+    FreshnessPolicy,
+)
+from traceml_ai.renderers.shared.run_series import (
+    DEFAULT_RUN_SERIES_POLICY,
+    RunSeriesPolicy,
+    finite,
+    plan_run_series,
+)
 
 from .dashboard_models import (
     ChartSeries,
@@ -35,12 +47,25 @@ from .dashboard_models import (
     MetricRollup,
     ProcessDashboardPayload,
     ProcessHistoryEntry,
+    RankChart,
+    RankCoverage,
+    RankSnapshot,
+    RankTrace,
 )
 from .repository import ProcessRepository
 
 # How many committed steps the card describes. Kept at the value the
 # section applied to its own history slice on 0.3.7.
 DASHBOARD_WINDOW = 100
+
+# Samples per rank in the recent-window view.
+RANK_WINDOW_N = 100
+
+# A rolling mean over minutes cannot visibly change between two ticks, so
+# the whole-run reads refresh on their own slower clock. Recomputing them
+# every tick was the single largest cost measured in this block, which is
+# the demonstrated need this cache exists for.
+RUN_REFRESH_S = 15.0
 
 
 def percentile(values: Sequence[Optional[float]], p: float) -> float:
@@ -58,6 +83,56 @@ def percentile(values: Sequence[Optional[float]], p: float) -> float:
     if low == high:
         return float(clean[low])
     return float(clean[low] * (high - k) + clean[high] * (k - low))
+
+
+def _opt_float(value: Any) -> Optional[float]:
+    """A usable number from a database cell, or ``None``."""
+    if value is None:
+        return None
+    try:
+        return finite(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _median(values: Sequence[float]) -> Optional[float]:
+    """The middle value, or ``None`` when there is nothing to take."""
+    clean = sorted(v for v in values if v is not None)
+    if not clean:
+        return None
+    middle = len(clean) // 2
+    if len(clean) % 2:
+        return float(clean[middle])
+    return float((clean[middle - 1] + clean[middle]) / 2.0)
+
+
+def _gpu_reported(row: Any) -> bool:
+    """Whether one row carries a usable GPU reading.
+
+    ``gpu_available`` alone is not enough: a rank reports it as true while
+    torch is still coming up, before any capacity is known.
+    """
+    try:
+        if not row["gpu_available"]:
+            return False
+        total = _opt_float(row["gpu_mem_total_bytes"])
+        return total is not None and total > 0
+    except (KeyError, IndexError, TypeError):
+        return False
+
+
+def _cpu_capacity_of(row: Any) -> Optional[float]:
+    """CPU as a share of the host's cores, not a sum across them.
+
+    ``psutil`` reports process CPU summed over cores, so a healthy
+    four-core rank reads 291%. Divided by the core count the number is
+    bounded and comparable between ranks on different machines.
+    """
+    used = _opt_float(row["cpu_percent"])
+    cores = _opt_float(row["cpu_logical_core_count"])
+    if used is None or cores is None or cores <= 0:
+        return None
+    return used / cores
 
 
 class ProcessDashboardComputer:
@@ -80,8 +155,17 @@ class ProcessDashboardComputer:
         db_path: str,
         dashboard_max_rows: int = 200,
         stale_ttl_s: Optional[float] = 30.0,
+        sampler_interval_s: Optional[float] = None,
+        run_series_policy: RunSeriesPolicy = DEFAULT_RUN_SERIES_POLICY,
     ) -> None:
         self._db = ProcessRepository(db_path=db_path)
+        # The configured cadence, used only until the ranks show their
+        # real one. Freshness is then judged on what arrived.
+        self._configured_interval_s = sampler_interval_s
+        self._run_policy = run_series_policy
+        self._cache_ttl = CachedPayloadTTL(ttl_s=stale_ttl_s)
+        self._run_cache: Optional[Tuple[RankChart, RankChart]] = None
+        self._run_cache_at: float = 0.0
         self._dashboard_rollup: Deque[ProcessHistoryEntry] = deque(
             maxlen=max(1, int(dashboard_max_rows))
         )
@@ -98,7 +182,10 @@ class ProcessDashboardComputer:
         try:
             with self._db.connect() as conn:
                 self._advance(conn)
-                out = self._build_payload()
+                newest_ts = self._db.newest_sample_ts(conn)
+                ranks, _policy = self._rank_snapshots(conn, newest_ts)
+                out = self._build_payload(ranks)
+                out = self._with_charts(conn, out)
         except Exception:
             return self._return_stale()
 
@@ -125,11 +212,196 @@ class ProcessDashboardComputer:
 
         self._last_completed_seq = end_seq
 
+    # --- per-rank facts --------------------------------------------------
+    def _rank_snapshots(
+        self,
+        conn: Any,
+        newest_ts: Optional[float],
+    ) -> Tuple[Tuple[RankSnapshot, ...], FreshnessPolicy]:
+        """Every rank's own state, read on its own clock.
+
+        Two reads, on purpose. The windowed one carries each rank's recent
+        history; the latest-row one carries every rank that has EVER
+        reported, so a rank silent for longer than the window still appears
+        with its true age instead of vanishing from the block.
+        """
+        window_rows = self._db.fetch_recent_rank_window(
+            conn, window_n=RANK_WINDOW_N, newest_ts=newest_ts
+        )
+        latest_rows = self._db.fetch_rank_latest(conn)
+
+        by_rank: Dict[int, List[Any]] = {}
+        for row in window_rows:
+            rank_id = row["global_rank"]
+            if rank_id is None:
+                rank_id = row["rank"]
+            if rank_id is None:
+                continue
+            by_rank.setdefault(int(rank_id), []).append(row)
+
+        newest_by_rank: Dict[int, Any] = {}
+        for row in latest_rows:
+            rank_id = row["global_rank"]
+            if rank_id is None:
+                rank_id = row["rank"]
+            if rank_id is not None:
+                newest_by_rank[int(rank_id)] = row
+
+        policy = FreshnessPolicy.from_observed_cadence(
+            self._observed_cadence(by_rank),
+            configured_s=self._configured_interval_s,
+        )
+        now_s = self._newest_recv(list(newest_by_rank.values()))
+
+        snapshots = [
+            self._snapshot_for(
+                rank_id,
+                by_rank.get(rank_id, []),
+                newest_by_rank[rank_id],
+                policy=policy,
+                now_s=now_s,
+            )
+            for rank_id in sorted(newest_by_rank)
+        ]
+        return tuple(snapshots), policy
+
+    def _observed_cadence(
+        self, by_rank: Dict[int, List[Any]]
+    ) -> Optional[float]:
+        """The gap the ranks actually sample at, from the busiest rank."""
+        best: Optional[float] = None
+        for rows in by_rank.values():
+            stamps = [
+                value
+                for value in (_opt_float(r["sample_ts_s"]) for r in rows)
+                if value is not None
+            ]
+            if len(stamps) < 2:
+                continue
+            span = max(stamps) - min(stamps)
+            cadence = finite(span / float(len(stamps) - 1))
+            if cadence and cadence > 0:
+                best = cadence if best is None else min(best, cadence)
+        return best
+
+    def _newest_recv(self, rows: Sequence[Any]) -> float:
+        """The aggregator's newest arrival clock, the reference for age."""
+        stamps = [
+            value / 1e9
+            for value in (_opt_float(r["recv_ts_ns"]) for r in rows)
+            if value is not None
+        ]
+        return max(stamps) if stamps else 0.0
+
+    def _snapshot_for(
+        self,
+        rank_id: int,
+        rows: List[Any],
+        newest_row: Any,
+        *,
+        policy: FreshnessPolicy,
+        now_s: float,
+    ) -> RankSnapshot:
+        reported = [row for row in rows if _gpu_reported(row)]
+        # The newest row is not always a reading: the last samples of a run
+        # land during teardown, after torch has released the device, so
+        # anchoring the GPU facts on it blanks them exactly when someone
+        # inspects a finished run.
+        newest_gpu = reported[-1] if reported else None
+
+        recv = _opt_float(newest_row["recv_ts_ns"])
+        age = policy.age_of(
+            recv / 1e9 if recv is not None else None, now_s=now_s
+        )
+
+        return RankSnapshot(
+            global_rank=rank_id,
+            node_rank=_optional_int(newest_row["node_rank"]),
+            gpu_index=_optional_int(newest_row["gpu_device_index"]),
+            cpu_capacity_percent=_median(
+                [
+                    value
+                    for value in (_cpu_capacity_of(r) for r in rows)
+                    if value is not None
+                ]
+            ),
+            ram_used_bytes=_opt_float(newest_row["ram_used_bytes"]),
+            ram_used_p50_bytes=_median(
+                [
+                    value
+                    for value in (
+                        _opt_float(r["ram_used_bytes"]) for r in rows
+                    )
+                    if value is not None
+                ]
+            ),
+            ram_total_bytes=_opt_float(newest_row["ram_total_bytes"]),
+            gpu_allocated_p50_bytes=_median(
+                [
+                    value
+                    for value in (
+                        _opt_float(r["gpu_mem_used_bytes"]) for r in reported
+                    )
+                    if value is not None
+                ]
+            ),
+            gpu_reserved_bytes=(
+                _opt_float(newest_gpu["gpu_mem_reserved_bytes"])
+                if newest_gpu is not None
+                else None
+            ),
+            gpu_reserved_p50_bytes=_median(
+                [
+                    value
+                    for value in (
+                        _opt_float(r["gpu_mem_reserved_bytes"])
+                        for r in reported
+                    )
+                    if value is not None
+                ]
+            ),
+            gpu_total_bytes=(
+                _opt_float(newest_gpu["gpu_mem_total_bytes"])
+                if newest_gpu is not None
+                else None
+            ),
+            age_s=age,
+            freshness=policy.state_of(age),
+        )
+
     # --- describing ------------------------------------------------------
-    def _build_payload(self) -> ProcessDashboardPayload:
+    def _build_payload(
+        self, ranks: Tuple[RankSnapshot, ...] = ()
+    ) -> ProcessDashboardPayload:
+        live = tuple(r for r in ranks if r.freshness == "fresh")
+        stale = tuple(r for r in ranks if r.freshness == "stale")
+        # Aggregates describe the ranks that are still reporting; a rank
+        # that stopped is kept in `ranks` with its age so the card can say
+        # it stopped, but it does not drag a headline with it. A rank whose
+        # age is unknown stays in the aggregate: a missing timestamp is not
+        # evidence that it died, and dropping it would discard a real
+        # reading on the strength of a clock problem.
+        reporting = tuple(r for r in ranks if r.freshness != "stale")
+        aggregate_over = reporting or ranks
+        coverage = RankCoverage(
+            total=len(ranks),
+            live=len(live),
+            stale=len(stale),
+            unknown=len(ranks) - len(live) - len(stale),
+        )
+
         history = tuple(self._dashboard_rollup)
         if not history:
-            return ProcessDashboardPayload()
+            return ProcessDashboardPayload(
+                ranks=ranks,
+                coverage=coverage,
+                cpu_capacity=self._cpu_rollup(aggregate_over),
+                rss_worst=self._rss_rollup(aggregate_over),
+                gpu_reserved=self._cuda_rollup(aggregate_over),
+                reserved_imbalance_percent=self._reserved_imbalance(
+                    aggregate_over
+                ),
+            )
 
         window = history[-DASHBOARD_WINDOW:]
         latest = window[-1]
@@ -170,9 +442,209 @@ class ProcessDashboardComputer:
                 else None
             ),
             chart=_build_chart(window),
+            ranks=ranks,
+            coverage=coverage,
+            reserved_imbalance_percent=self._reserved_imbalance(
+                aggregate_over
+            ),
+            cpu_capacity=self._cpu_rollup(aggregate_over),
+            rss_worst=self._rss_rollup(aggregate_over),
+            gpu_reserved=self._cuda_rollup(aggregate_over),
+        )
+
+    # --- rollups ---------------------------------------------------------
+    def _cpu_rollup(
+        self, ranks: Sequence[RankSnapshot]
+    ) -> Optional[MetricRollup]:
+        """CPU led by the WORST rank, named.
+
+        A bottleneck finder has to answer "which rank", so the headline is
+        the worst one rather than the cohort median, and the median rides
+        alongside as the context that says whether it is an outlier.
+        """
+        pairs = [
+            (r.global_rank, r.cpu_capacity_percent)
+            for r in ranks
+            if r.cpu_capacity_percent is not None
+        ]
+        if not pairs:
+            return None
+        worst_rank, worst = max(pairs, key=lambda item: item[1])
+        return MetricRollup(
+            now=float(worst),
+            p95=float(worst),
+            p50=_median([value for _r, value in pairs]),
+            worst_rank=int(worst_rank),
+        )
+
+    def _rss_rollup(
+        self, ranks: Sequence[RankSnapshot]
+    ) -> Optional[MetricRollup]:
+        """RSS of the worst rank, chosen on its median, shown at its newest.
+
+        Which rank is worst is a judgement about its typical state, so it
+        is made on the window median; the number displayed is still the
+        newest value that rank actually sent.
+        """
+        pairs = [
+            (r, r.ram_used_p50_bytes)
+            for r in ranks
+            if r.ram_used_p50_bytes is not None
+        ]
+        if not pairs:
+            return None
+        worst, _p50 = max(pairs, key=lambda item: item[1])
+        shown = worst.ram_used_bytes
+        if shown is None:
+            shown = worst.ram_used_p50_bytes or 0.0
+        return MetricRollup(
+            now=float(shown),
+            p95=float(shown),
+            p50=_median([value for _r, value in pairs]),
+            total=worst.ram_total_bytes,
+            worst_rank=worst.global_rank,
+        )
+
+    def _cuda_rollup(
+        self, ranks: Sequence[RankSnapshot]
+    ) -> Optional[MetricRollup]:
+        """Reserved memory on the rank with the least headroom.
+
+        Not the largest user: the process at risk is the one closest to
+        filling its card.
+        """
+        candidates = [
+            r
+            for r in ranks
+            if r.gpu_reserved_bytes is not None
+            and r.gpu_total_bytes is not None
+            and r.gpu_total_bytes > 0
+        ]
+        if not candidates:
+            return None
+        worst = min(
+            candidates,
+            key=lambda r: (r.gpu_total_bytes or 0.0)
+            - (r.gpu_reserved_bytes or 0.0),
+        )
+        return MetricRollup(
+            now=float(worst.gpu_reserved_bytes or 0.0),
+            p95=float(worst.gpu_reserved_bytes or 0.0),
+            total=worst.gpu_total_bytes,
+            worst_rank=worst.global_rank,
+        )
+
+    def _reserved_imbalance(
+        self, ranks: Sequence[RankSnapshot]
+    ) -> Optional[float]:
+        """Spread of RESERVED memory across ranks, as a percentage.
+
+        Reserved rather than allocated: the allocator's live bytes are a
+        sawtooth this cadence undersamples, so their across-rank spread is
+        phase noise on a healthy run. Reserved is what the process holds.
+        Computed on window medians for the same reason.
+        """
+        values = [
+            r.gpu_reserved_p50_bytes
+            for r in ranks
+            if r.gpu_reserved_p50_bytes is not None
+            and r.gpu_reserved_p50_bytes > 0
+        ]
+        if len(values) < 2:
+            return None
+        low, high = min(values), max(values)
+        if high <= 0:
+            return None
+        return float((high - low) / high * 100.0)
+
+    # --- whole-run series ------------------------------------------------
+    def _rank_charts(
+        self, conn: Any, window_span_s: float
+    ) -> Tuple[RankChart, RankChart]:
+        """Per-rank CPU and RSS, over the window or over the whole run.
+
+        The mode is decided here and stated on the payload. A rolling mean
+        over minutes cannot visibly change between two ticks, so the
+        whole-run reads are refreshed on their own slower clock; that cache
+        exists because recomputing them every tick was the largest cost
+        measured in this block.
+        """
+        now = time.time()
+        if (
+            self._run_cache is not None
+            and (now - self._run_cache_at) < RUN_REFRESH_S
+        ):
+            return self._run_cache
+
+        charts = (
+            self._one_chart(conn, "cpu", window_span_s),
+            self._one_chart(conn, "rss", window_span_s),
+        )
+        self._run_cache = charts
+        self._run_cache_at = now
+        return charts
+
+    def _one_chart(
+        self, conn: Any, metric: str, window_span_s: float
+    ) -> RankChart:
+        stats = (
+            self._db.cpu_capacity_run_stats(conn)
+            if metric == "cpu"
+            else self._db.rss_run_stats(conn)
+        )
+        if stats is None:
+            return RankChart(mode="recent")
+
+        mode = self._run_policy.mode_for(stats.span_s, window_span_s)
+        if mode != "retained":
+            return RankChart(mode="recent", span_s=stats.span_s)
+
+        plan = plan_run_series(
+            span_s=stats.span_s,
+            sample_count=stats.samples_per_rank,
+            policy=self._run_policy,
+        )
+        if plan is None:
+            return RankChart(mode="recent", span_s=stats.span_s)
+
+        rows = (
+            self._db.fetch_cpu_capacity_run(conn, plan)
+            if metric == "cpu"
+            else self._db.fetch_rss_run(conn, plan)
+        )
+        by_rank: Dict[int, Tuple[List[float], List[float], List[float]]] = {}
+        for rank_id, ts, roll_avg, roll_max in rows:
+            stamps, values, peaks = by_rank.setdefault(rank_id, ([], [], []))
+            stamps.append(ts)
+            values.append(roll_avg)
+            peaks.append(roll_max)
+
+        return RankChart(
+            mode="retained",
+            window_s=plan.window_s,
+            span_s=stats.span_s,
+            traces=tuple(
+                RankTrace(
+                    global_rank=rank_id,
+                    timestamps=tuple(by_rank[rank_id][0]),
+                    values=tuple(by_rank[rank_id][1]),
+                    peaks=tuple(by_rank[rank_id][2]),
+                )
+                for rank_id in sorted(by_rank)
+            ),
         )
 
     # --- degraded reads --------------------------------------------------
+    def _with_charts(
+        self, conn: Any, payload: ProcessDashboardPayload
+    ) -> ProcessDashboardPayload:
+        """Attach the per-rank charts, in whichever mode the run warrants."""
+        window_span = _window_span(payload.history)
+        cpu_chart, rss_chart = self._rank_charts(conn, window_span)
+        return replace(
+            payload, cpu_capacity_chart=cpu_chart, rss_chart=rss_chart
+        )
+
     def _return_stale(self) -> ProcessDashboardPayload:
         """Reuse the last good payload while a read keeps failing.
 
@@ -180,13 +652,18 @@ class ProcessDashboardComputer:
         not be queried just now, never that the ranks are still healthy.
         """
         now = time.time()
-        if self._last_ok is not None:
-            if (
-                self._stale_ttl_s is None
-                or (now - self._last_ok_ts) <= self._stale_ttl_s
-            ):
-                return self._last_ok
+        if self._last_ok is not None and self._cache_ttl.may_reuse(
+            now - self._last_ok_ts
+        ):
+            return self._last_ok
         return ProcessDashboardPayload()
+
+
+def _optional_int(value: Any) -> Optional[int]:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
 
 
 def _entry_from_row(row: Any) -> ProcessHistoryEntry:
@@ -223,6 +700,14 @@ def _entry_from_row(row: Any) -> ProcessHistoryEntry:
         ram_total_bytes=float(row["ram_total"] or 0.0),
         gpu=gpu,
     )
+
+
+def _window_span(window: Sequence[ProcessHistoryEntry]) -> float:
+    """Wall-clock seconds the recent window covers."""
+    stamps = [e.ts for e in window if e.ts is not None]
+    if len(stamps) < 2:
+        return 0.0
+    return max(0.0, max(stamps) - min(stamps))
 
 
 def _build_chart(window: Sequence[ProcessHistoryEntry]) -> ChartSeries:

--- a/src/traceml_ai/renderers/process/dashboard_compute.py
+++ b/src/traceml_ai/renderers/process/dashboard_compute.py
@@ -164,8 +164,10 @@ class ProcessDashboardComputer:
         self._configured_interval_s = sampler_interval_s
         self._run_policy = run_series_policy
         self._cache_ttl = CachedPayloadTTL(ttl_s=stale_ttl_s)
-        self._run_cache: Optional[Tuple[RankChart, RankChart]] = None
-        self._run_cache_at: float = 0.0
+        # Per metric, because the two charts can be in different modes:
+        # only a retained chart is worth caching.
+        self._run_cache: Dict[str, RankChart] = {}
+        self._run_cache_at: Dict[str, float] = {}
         self._dashboard_rollup: Deque[ProcessHistoryEntry] = deque(
             maxlen=max(1, int(dashboard_max_rows))
         )
@@ -183,9 +185,9 @@ class ProcessDashboardComputer:
             with self._db.connect() as conn:
                 self._advance(conn)
                 newest_ts = self._db.newest_sample_ts(conn)
-                ranks, _policy = self._rank_snapshots(conn, newest_ts)
+                ranks, _policy, by_rank = self._rank_snapshots(conn, newest_ts)
                 out = self._build_payload(ranks)
-                out = self._with_charts(conn, out)
+                out = self._with_charts(conn, out, by_rank)
         except Exception:
             return self._return_stale()
 
@@ -217,7 +219,11 @@ class ProcessDashboardComputer:
         self,
         conn: Any,
         newest_ts: Optional[float],
-    ) -> Tuple[Tuple[RankSnapshot, ...], FreshnessPolicy]:
+    ) -> Tuple[
+        Tuple[RankSnapshot, ...],
+        FreshnessPolicy,
+        Dict[int, List[Any]],
+    ]:
         """Every rank's own state, read on its own clock.
 
         Two reads, on purpose. The windowed one carries each rank's recent
@@ -263,7 +269,7 @@ class ProcessDashboardComputer:
             )
             for rank_id in sorted(newest_by_rank)
         ]
-        return tuple(snapshots), policy
+        return tuple(snapshots), policy, by_rank
 
     def _observed_cadence(
         self, by_rank: Dict[int, List[Any]]
@@ -317,7 +323,12 @@ class ProcessDashboardComputer:
         return RankSnapshot(
             global_rank=rank_id,
             node_rank=_optional_int(newest_row["node_rank"]),
-            gpu_index=_optional_int(newest_row["gpu_device_index"]),
+            # Same teardown reasoning as the byte fields below: a
+            # rank's last sample lands after torch released the
+            # device, so its device index is NULL there.
+            gpu_index=_optional_int(
+                (newest_gpu or newest_row)["gpu_device_index"]
+            ),
             cpu_capacity_percent=_median(
                 [
                     value
@@ -390,6 +401,8 @@ class ProcessDashboardComputer:
             unknown=len(ranks) - len(live) - len(stale),
         )
 
+        imbalance = self._reserved_imbalance(aggregate_over)
+
         history = tuple(self._dashboard_rollup)
         if not history:
             return ProcessDashboardPayload(
@@ -398,9 +411,7 @@ class ProcessDashboardComputer:
                 cpu_capacity=self._cpu_rollup(aggregate_over),
                 rss_worst=self._rss_rollup(aggregate_over),
                 gpu_reserved=self._cuda_rollup(aggregate_over),
-                reserved_imbalance_percent=self._reserved_imbalance(
-                    aggregate_over
-                ),
+                reserved_imbalance_percent=imbalance,
             )
 
         window = history[-DASHBOARD_WINDOW:]
@@ -444,9 +455,7 @@ class ProcessDashboardComputer:
             chart=_build_chart(window),
             ranks=ranks,
             coverage=coverage,
-            reserved_imbalance_percent=self._reserved_imbalance(
-                aggregate_over
-            ),
+            reserved_imbalance_percent=imbalance,
             cpu_capacity=self._cpu_rollup(aggregate_over),
             rss_worst=self._rss_rollup(aggregate_over),
             gpu_reserved=self._cuda_rollup(aggregate_over),
@@ -472,7 +481,6 @@ class ProcessDashboardComputer:
         worst_rank, worst = max(pairs, key=lambda item: item[1])
         return MetricRollup(
             now=float(worst),
-            p95=float(worst),
             p50=_median([value for _r, value in pairs]),
             worst_rank=int(worst_rank),
         )
@@ -499,7 +507,6 @@ class ProcessDashboardComputer:
             shown = worst.ram_used_p50_bytes or 0.0
         return MetricRollup(
             now=float(shown),
-            p95=float(shown),
             p50=_median([value for _r, value in pairs]),
             total=worst.ram_total_bytes,
             worst_rank=worst.global_rank,
@@ -529,7 +536,6 @@ class ProcessDashboardComputer:
         )
         return MetricRollup(
             now=float(worst.gpu_reserved_bytes or 0.0),
-            p95=float(worst.gpu_reserved_bytes or 0.0),
             total=worst.gpu_total_bytes,
             worst_rank=worst.global_rank,
         )
@@ -559,45 +565,88 @@ class ProcessDashboardComputer:
 
     # --- whole-run series ------------------------------------------------
     def _rank_charts(
-        self, conn: Any, window_span_s: float
+        self,
+        conn: Any,
+        window_span_s: float,
+        by_rank: Dict[int, List[Any]],
     ) -> Tuple[RankChart, RankChart]:
-        """Per-rank CPU and RSS, over the window or over the whole run.
-
-        The mode is decided here and stated on the payload. A rolling mean
-        over minutes cannot visibly change between two ticks, so the
-        whole-run reads are refreshed on their own slower clock; that cache
-        exists because recomputing them every tick was the largest cost
-        measured in this block.
-        """
-        now = time.time()
-        if (
-            self._run_cache is not None
-            and (now - self._run_cache_at) < RUN_REFRESH_S
-        ):
-            return self._run_cache
-
-        charts = (
-            self._one_chart(conn, "cpu", window_span_s),
-            self._one_chart(conn, "rss", window_span_s),
+        """Per-rank CPU and RSS, over the window or over the whole run."""
+        return (
+            self._one_chart(conn, "cpu", window_span_s, by_rank),
+            self._one_chart(conn, "rss", window_span_s, by_rank),
         )
-        self._run_cache = charts
-        self._run_cache_at = now
-        return charts
+
+    def _recent_chart(
+        self,
+        metric: str,
+        by_rank: Dict[int, List[Any]],
+        span_s: Optional[float],
+    ) -> RankChart:
+        """The live view: each rank's own samples, as they were taken.
+
+        Built from the rows the snapshot read already returned rather than
+        from a second query, and rebuilt every tick, because the whole
+        point of the recent view is that it moves.
+        """
+        value_of = (
+            _cpu_capacity_of
+            if metric == "cpu"
+            else (lambda row: _opt_float(row["ram_used_bytes"]))
+        )
+        traces = []
+        for rank_id in sorted(by_rank):
+            stamps, values = [], []
+            for row in by_rank[rank_id]:
+                stamp = _opt_float(row["sample_ts_s"])
+                value = value_of(row)
+                if stamp is None or value is None:
+                    continue
+                stamps.append(stamp)
+                values.append(value)
+            if stamps:
+                traces.append(
+                    RankTrace(
+                        global_rank=rank_id,
+                        timestamps=tuple(stamps),
+                        values=tuple(values),
+                    )
+                )
+        return RankChart(mode="recent", span_s=span_s, traces=tuple(traces))
 
     def _one_chart(
-        self, conn: Any, metric: str, window_span_s: float
+        self,
+        conn: Any,
+        metric: str,
+        window_span_s: float,
+        by_rank: Dict[int, List[Any]],
     ) -> RankChart:
+        """One chart, in whichever mode the run has earned.
+
+        Only the retained branch is cached. A rolling mean over minutes
+        cannot visibly change between two ticks and recomputing it every
+        tick was the largest cost measured in this block, but the recent
+        view is the live one and a cached copy of it would be a chart that
+        stops moving.
+        """
         stats = (
             self._db.cpu_capacity_run_stats(conn)
             if metric == "cpu"
             else self._db.rss_run_stats(conn)
         )
         if stats is None:
-            return RankChart(mode="recent")
+            return self._recent_chart(metric, by_rank, None)
 
         mode = self._run_policy.mode_for(stats.span_s, window_span_s)
         if mode != "retained":
-            return RankChart(mode="recent", span_s=stats.span_s)
+            return self._recent_chart(metric, by_rank, stats.span_s)
+
+        now = time.time()
+        cached = self._run_cache.get(metric)
+        if (
+            cached is not None
+            and (now - self._run_cache_at.get(metric, 0.0)) < RUN_REFRESH_S
+        ):
+            return cached
 
         plan = plan_run_series(
             span_s=stats.span_s,
@@ -605,42 +654,48 @@ class ProcessDashboardComputer:
             policy=self._run_policy,
         )
         if plan is None:
-            return RankChart(mode="recent", span_s=stats.span_s)
+            return self._recent_chart(metric, by_rank, stats.span_s)
 
         rows = (
             self._db.fetch_cpu_capacity_run(conn, plan)
             if metric == "cpu"
             else self._db.fetch_rss_run(conn, plan)
         )
-        by_rank: Dict[int, Tuple[List[float], List[float], List[float]]] = {}
+        rolled: Dict[int, Tuple[List[float], List[float], List[float]]] = {}
         for rank_id, ts, roll_avg, roll_max in rows:
-            stamps, values, peaks = by_rank.setdefault(rank_id, ([], [], []))
+            stamps, values, peaks = rolled.setdefault(rank_id, ([], [], []))
             stamps.append(ts)
             values.append(roll_avg)
             peaks.append(roll_max)
 
-        return RankChart(
+        chart = RankChart(
             mode="retained",
             window_s=plan.window_s,
             span_s=stats.span_s,
             traces=tuple(
                 RankTrace(
                     global_rank=rank_id,
-                    timestamps=tuple(by_rank[rank_id][0]),
-                    values=tuple(by_rank[rank_id][1]),
-                    peaks=tuple(by_rank[rank_id][2]),
+                    timestamps=tuple(rolled[rank_id][0]),
+                    values=tuple(rolled[rank_id][1]),
+                    peaks=tuple(rolled[rank_id][2]),
                 )
-                for rank_id in sorted(by_rank)
+                for rank_id in sorted(rolled)
             ),
         )
+        self._run_cache[metric] = chart
+        self._run_cache_at[metric] = now
+        return chart
 
     # --- degraded reads --------------------------------------------------
     def _with_charts(
-        self, conn: Any, payload: ProcessDashboardPayload
+        self,
+        conn: Any,
+        payload: ProcessDashboardPayload,
+        by_rank: Dict[int, List[Any]],
     ) -> ProcessDashboardPayload:
         """Attach the per-rank charts, in whichever mode the run warrants."""
         window_span = _window_span(payload.history)
-        cpu_chart, rss_chart = self._rank_charts(conn, window_span)
+        cpu_chart, rss_chart = self._rank_charts(conn, window_span, by_rank)
         return replace(
             payload, cpu_capacity_chart=cpu_chart, rss_chart=rss_chart
         )

--- a/src/traceml_ai/renderers/process/dashboard_models.py
+++ b/src/traceml_ai/renderers/process/dashboard_models.py
@@ -126,13 +126,17 @@ class RankCoverage:
 class MetricRollup:
     """Window statistics for one metric.
 
-    ``p50`` is optional because not every metric needs a median to be
-    described; a field that is absent says so rather than carrying a zero
-    that reads like a measurement.
+    ``p50`` and ``p95`` are optional because not every metric needs them to
+    be described; a field that is absent says so rather than carrying a
+    number that reads like a measurement.
+
+    The per-rank rollups leave ``p95`` unset. They used to copy ``now``
+    into it, which produced a statistic nobody computed: on a finished run
+    that reported ``p95`` below ``p50``, a rollup contradicting itself.
     """
 
     now: float
-    p95: float
+    p95: Optional[float] = None
     p50: Optional[float] = None
     total: Optional[float] = None
     worst_rank: Optional[int] = None
@@ -224,17 +228,35 @@ class ProcessDashboardPayload:
 
     @property
     def has_data(self) -> bool:
-        """Whether the card has anything to draw."""
-        return bool(self.history)
+        """Whether the card has anything to draw.
+
+        Ranks count as well as steps. The aggregated history needs a step
+        committed across every rank, and the per-rank reads are populated
+        before that happens, so asking only the history calls a live run
+        empty for its first ticks.
+        """
+        return bool(self.history) or bool(self.ranks)
 
     @property
     def gpu_available(self) -> bool:
-        """Whether the newest step reported a GPU.
+        """Whether this run has a GPU to talk about.
 
-        Follows the newest entry rather than any entry, so a run that loses
-        its GPU reporting stops claiming one.
+        Asked of the ranks first, and of the step history only as a
+        fallback. An earlier version asked the newest committed step, on
+        the reasoning that a run losing its GPU reporting should stop
+        claiming one. Teardown makes that unworkable: the last samples of
+        every run land after torch has released the device, so the newest
+        step carries no GPU snapshot and a finished four-GPU run rendered
+        as CPU-only, blanking two tiles while the same card printed a
+        reserved-memory spread derived from the CUDA bytes it had just
+        denied having.
+
+        A rank's ``gpu_reported`` is read from its newest REPORTING row
+        for that same reason, so it stays true through teardown.
         """
-        return bool(self.history) and self.history[-1].gpu is not None
+        if any(rank.gpu_reported for rank in self.ranks):
+            return True
+        return any(entry.gpu is not None for entry in self.history)
 
     @property
     def live_ranks(self) -> Tuple[RankSnapshot, ...]:

--- a/src/traceml_ai/renderers/process/dashboard_models.py
+++ b/src/traceml_ai/renderers/process/dashboard_models.py
@@ -260,8 +260,8 @@ class ProcessDashboardPayload:
 
     @property
     def live_ranks(self) -> Tuple[RankSnapshot, ...]:
-        """Ranks still reporting, which is what aggregates describe."""
-        return tuple(rank for rank in self.ranks if not rank.stale)
+        """Non-stale ranks, including unknown ages, used by aggregates."""
+        return tuple(rank for rank in self.ranks if rank.freshness != "stale")
 
 
 __all__ = [

--- a/src/traceml_ai/renderers/process/dashboard_models.py
+++ b/src/traceml_ai/renderers/process/dashboard_models.py
@@ -16,8 +16,11 @@ and cannot be answered by accident.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Tuple
+
+from traceml_ai.renderers.shared.freshness import FreshnessState
+from traceml_ai.renderers.shared.run_series import SeriesMode
 
 
 @dataclass(frozen=True)
@@ -55,6 +58,71 @@ class ProcessHistoryEntry:
 
 
 @dataclass(frozen=True)
+class RankSnapshot:
+    """One rank's own state, on its own clock.
+
+    Ranks are read independently rather than aligned on a shared step: a
+    rank that stops reporting must keep its own history instead of being
+    squeezed out by livelier peers, and a rank that never reports must not
+    shrink everyone else's window.
+
+    The levels here are deliberately not all "the newest sample". CPU and
+    the allocator's live bytes are sampled far slower than they move, so a
+    single reading lands wherever the sawtooth happened to be; those carry
+    a window median. Reserved memory and RSS carry both, because which rank
+    is WORST is a judgement about its typical state while the number SHOWN
+    should be what that rank last actually sent.
+    """
+
+    global_rank: int
+    node_rank: Optional[int] = None
+    gpu_index: Optional[int] = None
+
+    cpu_capacity_percent: Optional[float] = None
+    ram_used_bytes: Optional[float] = None
+    ram_used_p50_bytes: Optional[float] = None
+    ram_total_bytes: Optional[float] = None
+
+    gpu_allocated_p50_bytes: Optional[float] = None
+    gpu_reserved_bytes: Optional[float] = None
+    gpu_reserved_p50_bytes: Optional[float] = None
+    gpu_total_bytes: Optional[float] = None
+
+    age_s: Optional[float] = None
+    freshness: FreshnessState = "unknown"
+
+    @property
+    def gpu_reported(self) -> bool:
+        """Whether this rank has ever sent a usable GPU reading."""
+        return self.gpu_total_bytes is not None and self.gpu_total_bytes > 0
+
+
+@dataclass(frozen=True)
+class RankCoverage:
+    """Who is reporting, and who has gone quiet.
+
+    Stated rather than implied. A block that silently drops a dead rank
+    forgets it a few minutes after it died, which is exactly when its
+    death starts to matter.
+
+    A rank sits in exactly one of three buckets. ``unknown`` is the one
+    worth stating: it is a rank that sent data but no usable timestamp,
+    so it is neither proven live nor proven dead. Folding it into either
+    of the other two invents a fact the telemetry did not carry.
+    """
+
+    total: int = 0
+    live: int = 0
+    stale: int = 0
+    unknown: int = 0
+
+    @property
+    def excluding_stale(self) -> bool:
+        """Whether aggregates were computed over a subset of the ranks."""
+        return self.live > 0 and self.stale > 0
+
+
+@dataclass(frozen=True)
 class MetricRollup:
     """Window statistics for one metric.
 
@@ -67,6 +135,7 @@ class MetricRollup:
     p95: float
     p50: Optional[float] = None
     total: Optional[float] = None
+    worst_rank: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -81,6 +150,36 @@ class ChartTrace:
     label: str
     timestamps: Tuple[Optional[float], ...]
     values: Tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class RankTrace:
+    """One rank's own line, over the window or over the whole run."""
+
+    global_rank: int
+    timestamps: Tuple[float, ...] = ()
+    values: Tuple[float, ...] = ()
+    peaks: Tuple[float, ...] = ()
+
+
+@dataclass(frozen=True)
+class RankChart:
+    """A per-rank chart, and which history it is made of.
+
+    ``mode`` is stated, never inferred. The previous payload carried a
+    window series and a whole-run series in two differently named fields
+    and left the view to work out which one to draw from whichever
+    happened to be non-empty, which is a rule no reader can see.
+    """
+
+    mode: SeriesMode = "recent"
+    window_s: Optional[float] = None
+    span_s: Optional[float] = None
+    traces: Tuple[RankTrace, ...] = ()
+
+    @property
+    def is_retained(self) -> bool:
+        return self.mode == "retained"
 
 
 @dataclass(frozen=True)
@@ -107,6 +206,22 @@ class ProcessDashboardPayload:
     gpu_used_imbalance_bytes: Optional[float] = None
     chart: Optional[ChartSeries] = None
 
+    # Per-rank facts. Empty on a payload built before this layer existed,
+    # so a consumer of the older shape keeps working unchanged.
+    ranks: Tuple[RankSnapshot, ...] = ()
+    coverage: RankCoverage = field(default_factory=RankCoverage)
+
+    # The per-rank rollups, as NEW fields. `cpu`, `ram` and `gpu` above
+    # keep the meanings the card already reads: `cpu` is raw psutil
+    # percent, `gpu` is allocated bytes. Repurposing them here would have
+    # changed the card silently, which is PR 4's job to do openly.
+    cpu_capacity: Optional[MetricRollup] = None
+    rss_worst: Optional[MetricRollup] = None
+    gpu_reserved: Optional[MetricRollup] = None
+    reserved_imbalance_percent: Optional[float] = None
+    cpu_capacity_chart: Optional[RankChart] = None
+    rss_chart: Optional[RankChart] = None
+
     @property
     def has_data(self) -> bool:
         """Whether the card has anything to draw."""
@@ -121,6 +236,11 @@ class ProcessDashboardPayload:
         """
         return bool(self.history) and self.history[-1].gpu is not None
 
+    @property
+    def live_ranks(self) -> Tuple[RankSnapshot, ...]:
+        """Ranks still reporting, which is what aggregates describe."""
+        return tuple(rank for rank in self.ranks if not rank.stale)
+
 
 __all__ = [
     "ChartSeries",
@@ -129,4 +249,8 @@ __all__ = [
     "MetricRollup",
     "ProcessDashboardPayload",
     "ProcessHistoryEntry",
+    "RankChart",
+    "RankCoverage",
+    "RankSnapshot",
+    "RankTrace",
 ]

--- a/src/traceml_ai/renderers/process/repository.py
+++ b/src/traceml_ai/renderers/process/repository.py
@@ -11,7 +11,46 @@ the modules above it can be read without SQL in the way.
 """
 
 import sqlite3
-from typing import Dict, List, Optional
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+from traceml_ai.renderers.shared.run_series import RunSeriesPlan
+
+# The two whole-run metrics this table can serve, as SQL the repository
+# owns. They are named constants rather than parameters on a generic
+# method: a reader of this class can see every expression it will ever
+# evaluate, and no caller can hand it one.
+_CPU_CAPACITY_SQL = (
+    "cpu_percent / (100.0 * NULLIF(cpu_logical_core_count, 0)) * 100.0"
+)
+_RSS_SQL = "ram_used_bytes"
+
+
+@dataclass(frozen=True)
+class RunStats:
+    """The shape of one metric's history, for planning a read of it."""
+
+    first_ts: float
+    last_ts: float
+    sample_count: int
+    rank_count: int
+    max_samples_per_rank: int
+
+    @property
+    def span_s(self) -> float:
+        return max(0.0, self.last_ts - self.first_ts)
+
+    @property
+    def samples_per_rank(self) -> int:
+        """The BUSIEST rank's row count, not the average across ranks.
+
+        The stride is applied per rank, so planning it on an average
+        overshoots the point budget on any rank with more rows than the
+        mean. Measured on a four-rank run where one rank died early:
+        planning on the average produced 145 points against a budget of
+        120.
+        """
+        return max(1, self.max_samples_per_rank)
 
 
 class ProcessRepository:
@@ -254,3 +293,196 @@ class ProcessRepository:
             """,
             (int(start_seq), int(end_seq)),
         ).fetchall()
+
+    # --- per-rank reads --------------------------------------------------
+    def newest_sample_ts(self, conn: sqlite3.Connection) -> Optional[float]:
+        """The newest sample clock, read once per tick and reused.
+
+        Every time bound below derives from it. Deriving them separately
+        would let the retention pruner delete rows between two statements
+        and leave one computation reading a window the other never saw.
+        """
+        row = conn.execute(
+            "SELECT MAX(sample_ts_s) FROM process_samples"
+        ).fetchone()
+        return float(row[0]) if row and row[0] is not None else None
+
+    def fetch_recent_rank_window(
+        self,
+        conn: sqlite3.Connection,
+        window_n: int = 100,
+        newest_ts: Optional[float] = None,
+        max_age_s: float = 20.0 * 60.0,
+    ) -> List[sqlite3.Row]:
+        """The last ``window_n`` samples of EVERY rank, newest last.
+
+        Per rank, not globally. A rank that stopped reporting keeps its own
+        history instead of being squeezed out by livelier peers, and a rank
+        that never reports does not shrink everyone else's window.
+
+        Bounded by time before the partition runs: without it the
+        ROW_NUMBER scans every row ever written in order to rank the last
+        hundred, and that scan grows with the run.
+        """
+        floor_ts = None
+        if newest_ts is not None:
+            floor_ts = newest_ts - max(60.0, float(max_age_s))
+        return conn.execute(
+            """
+            WITH recent AS (
+                SELECT * FROM process_samples
+                WHERE COALESCE(global_rank, rank) IS NOT NULL
+                  AND (? IS NULL OR sample_ts_s >= ?)
+            ),
+            ranked AS (
+                SELECT
+                    *,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY COALESCE(global_rank, rank)
+                        ORDER BY seq DESC, id DESC
+                    ) AS rn
+                FROM recent
+            )
+            SELECT * FROM ranked
+            WHERE rn <= ?
+            ORDER BY COALESCE(global_rank, rank) ASC, seq ASC, id ASC;
+            """,
+            (floor_ts, floor_ts, int(max(1, window_n))),
+        ).fetchall()
+
+    def fetch_rank_latest(self, conn: sqlite3.Connection) -> List[sqlite3.Row]:
+        """The newest row of EVERY rank, however long ago it arrived.
+
+        The windowed read above is time-bounded, so a rank silent for
+        longer than that bound has no rows in it and would drop out of the
+        block entirely. The surface would forget a dead rank a few minutes
+        after it died, which is exactly when its death starts to matter.
+        This read answers "who has ever reported, and when did each last
+        speak".
+        """
+        return conn.execute(
+            """
+            SELECT * FROM process_samples
+            WHERE id IN (
+                SELECT MAX(id) FROM process_samples
+                WHERE COALESCE(global_rank, rank) IS NOT NULL
+                GROUP BY COALESCE(global_rank, rank)
+            )
+            ORDER BY COALESCE(global_rank, rank) ASC;
+            """
+        ).fetchall()
+
+    # --- whole-run reads, one explicit method per metric -----------------
+    def cpu_capacity_run_stats(
+        self, conn: sqlite3.Connection
+    ) -> Optional[RunStats]:
+        """The shape of the CPU-capacity history, for planning a read."""
+        return self._run_stats(conn, _CPU_CAPACITY_SQL)
+
+    def rss_run_stats(self, conn: sqlite3.Connection) -> Optional[RunStats]:
+        """The shape of the RSS history, for planning a read."""
+        return self._run_stats(conn, _RSS_SQL)
+
+    def fetch_cpu_capacity_run(
+        self, conn: sqlite3.Connection, plan: RunSeriesPlan
+    ) -> List[Tuple[int, float, float, float]]:
+        """Whole-run CPU capacity per rank, rolled and decimated by ``plan``."""
+        return self._run_history(conn, _CPU_CAPACITY_SQL, plan)
+
+    def fetch_rss_run(
+        self, conn: sqlite3.Connection, plan: RunSeriesPlan
+    ) -> List[Tuple[int, float, float, float]]:
+        """Whole-run RSS per rank, rolled and decimated by ``plan``."""
+        return self._run_history(conn, _RSS_SQL, plan)
+
+    # --- the shared implementation of the two above ----------------------
+    def _run_stats(
+        self, conn: sqlite3.Connection, value_sql: str
+    ) -> Optional[RunStats]:
+        try:
+            row = conn.execute(
+                f"""
+                WITH per_rank AS (
+                    SELECT
+                        COUNT(*) AS n,
+                        MIN(sample_ts_s) AS lo,
+                        MAX(sample_ts_s) AS hi
+                    FROM process_samples
+                    WHERE sample_ts_s IS NOT NULL
+                      AND ({value_sql}) IS NOT NULL
+                      AND COALESCE(global_rank, rank) IS NOT NULL
+                    GROUP BY COALESCE(global_rank, rank)
+                )
+                SELECT MIN(lo), MAX(hi), SUM(n), COUNT(*), MAX(n)
+                FROM per_rank;
+                """
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+        if row is None or row[0] is None or row[1] is None:
+            return None
+        return RunStats(
+            first_ts=float(row[0]),
+            last_ts=float(row[1]),
+            sample_count=int(row[2] or 0),
+            rank_count=max(1, int(row[3] or 1)),
+            max_samples_per_rank=max(1, int(row[4] or 1)),
+        )
+
+    def _run_history(
+        self,
+        conn: sqlite3.Connection,
+        value_sql: str,
+        plan: RunSeriesPlan,
+    ) -> List[Tuple[int, float, float, float]]:
+        """Execute one planned whole-run read.
+
+        Private, and the only place a SQL expression is interpolated. The
+        two public methods above each pass one of this module's own
+        constants, so no expression reaches here from outside the class.
+        """
+        try:
+            return [
+                (int(r[0]), float(r[1]), float(r[2]), float(r[3]))
+                for r in conn.execute(
+                    f"""
+                    WITH base AS (
+                        SELECT
+                            COALESCE(global_rank, rank) AS rank_id,
+                            sample_ts_s AS ts,
+                            ({value_sql}) AS v,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY COALESCE(global_rank, rank)
+                                ORDER BY sample_ts_s ASC, id ASC
+                            ) AS rn
+                        FROM process_samples
+                        WHERE sample_ts_s IS NOT NULL
+                          AND ({value_sql}) IS NOT NULL
+                          AND COALESCE(global_rank, rank) IS NOT NULL
+                    ),
+                    rolled AS (
+                        SELECT
+                            rank_id, ts, rn,
+                            AVG(v) OVER (
+                                PARTITION BY rank_id ORDER BY ts
+                                {plan.frame_clause()}
+                            ) AS roll_avg,
+                            MAX(v) OVER (
+                                PARTITION BY rank_id ORDER BY ts
+                                {plan.frame_clause()}
+                            ) AS roll_max
+                        FROM base
+                    )
+                    SELECT rank_id, ts, roll_avg, roll_max
+                    FROM rolled
+                    WHERE rn % ? = 0 AND rn > ?
+                    ORDER BY rank_id ASC, ts ASC;
+                    """,
+                    (int(plan.stride), int(plan.preceding_rows)),
+                ).fetchall()
+            ]
+        except sqlite3.Error:
+            return []
+
+
+__all__ = ["ProcessRepository", "RunStats"]

--- a/src/traceml_ai/renderers/process/repository.py
+++ b/src/traceml_ai/renderers/process/repository.py
@@ -399,26 +399,23 @@ class ProcessRepository:
     def _run_stats(
         self, conn: sqlite3.Connection, value_sql: str
     ) -> Optional[RunStats]:
-        try:
-            row = conn.execute(
-                f"""
-                WITH per_rank AS (
-                    SELECT
-                        COUNT(*) AS n,
-                        MIN(sample_ts_s) AS lo,
-                        MAX(sample_ts_s) AS hi
-                    FROM process_samples
-                    WHERE sample_ts_s IS NOT NULL
-                      AND ({value_sql}) IS NOT NULL
-                      AND COALESCE(global_rank, rank) IS NOT NULL
-                    GROUP BY COALESCE(global_rank, rank)
-                )
-                SELECT MIN(lo), MAX(hi), SUM(n), COUNT(*), MAX(n)
-                FROM per_rank;
-                """
-            ).fetchone()
-        except sqlite3.Error:
-            return None
+        row = conn.execute(
+            f"""
+            WITH per_rank AS (
+                SELECT
+                    COUNT(*) AS n,
+                    MIN(sample_ts_s) AS lo,
+                    MAX(sample_ts_s) AS hi
+                FROM process_samples
+                WHERE sample_ts_s IS NOT NULL
+                  AND ({value_sql}) IS NOT NULL
+                  AND COALESCE(global_rank, rank) IS NOT NULL
+                GROUP BY COALESCE(global_rank, rank)
+            )
+            SELECT MIN(lo), MAX(hi), SUM(n), COUNT(*), MAX(n)
+            FROM per_rank;
+            """
+        ).fetchone()
         if row is None or row[0] is None or row[1] is None:
             return None
         return RunStats(
@@ -441,48 +438,45 @@ class ProcessRepository:
         two public methods above each pass one of this module's own
         constants, so no expression reaches here from outside the class.
         """
-        try:
-            return [
-                (int(r[0]), float(r[1]), float(r[2]), float(r[3]))
-                for r in conn.execute(
-                    f"""
-                    WITH base AS (
-                        SELECT
-                            COALESCE(global_rank, rank) AS rank_id,
-                            sample_ts_s AS ts,
-                            ({value_sql}) AS v,
-                            ROW_NUMBER() OVER (
-                                PARTITION BY COALESCE(global_rank, rank)
-                                ORDER BY sample_ts_s ASC, id ASC
-                            ) AS rn
-                        FROM process_samples
-                        WHERE sample_ts_s IS NOT NULL
-                          AND ({value_sql}) IS NOT NULL
-                          AND COALESCE(global_rank, rank) IS NOT NULL
-                    ),
-                    rolled AS (
-                        SELECT
-                            rank_id, ts, rn,
-                            AVG(v) OVER (
-                                PARTITION BY rank_id ORDER BY ts
-                                {plan.frame_clause()}
-                            ) AS roll_avg,
-                            MAX(v) OVER (
-                                PARTITION BY rank_id ORDER BY ts
-                                {plan.frame_clause()}
-                            ) AS roll_max
-                        FROM base
-                    )
-                    SELECT rank_id, ts, roll_avg, roll_max
-                    FROM rolled
-                    WHERE rn % ? = 0 AND rn > ?
-                    ORDER BY rank_id ASC, ts ASC;
-                    """,
-                    (int(plan.stride), int(plan.preceding_rows)),
-                ).fetchall()
-            ]
-        except sqlite3.Error:
-            return []
+        return [
+            (int(r[0]), float(r[1]), float(r[2]), float(r[3]))
+            for r in conn.execute(
+                f"""
+                WITH base AS (
+                    SELECT
+                        COALESCE(global_rank, rank) AS rank_id,
+                        sample_ts_s AS ts,
+                        ({value_sql}) AS v,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY COALESCE(global_rank, rank)
+                            ORDER BY sample_ts_s ASC, id ASC
+                        ) AS rn
+                    FROM process_samples
+                    WHERE sample_ts_s IS NOT NULL
+                      AND ({value_sql}) IS NOT NULL
+                      AND COALESCE(global_rank, rank) IS NOT NULL
+                ),
+                rolled AS (
+                    SELECT
+                        rank_id, ts, rn,
+                        AVG(v) OVER (
+                            PARTITION BY rank_id ORDER BY ts
+                            {plan.frame_clause()}
+                        ) AS roll_avg,
+                        MAX(v) OVER (
+                            PARTITION BY rank_id ORDER BY ts
+                            {plan.frame_clause()}
+                        ) AS roll_max
+                    FROM base
+                )
+                SELECT rank_id, ts, roll_avg, roll_max
+                FROM rolled
+                WHERE rn % ? = 0 AND rn > ?
+                ORDER BY rank_id ASC, ts ASC;
+                """,
+                (int(plan.stride), int(plan.preceding_rows)),
+            ).fetchall()
+        ]
 
 
 __all__ = ["ProcessRepository", "RunStats"]

--- a/tests/renderers/process/test_process_rank_features.py
+++ b/tests/renderers/process/test_process_rank_features.py
@@ -18,7 +18,10 @@ from tests.renderers.process.conftest import GB
 from traceml_ai.renderers.process.dashboard_compute import (
     ProcessDashboardComputer,
 )
-from traceml_ai.renderers.process.dashboard_models import RankSnapshot
+from traceml_ai.renderers.process.dashboard_models import (
+    ProcessDashboardPayload,
+    RankSnapshot,
+)
 
 
 def payload(db, **kw):
@@ -106,6 +109,18 @@ def test_an_unknown_age_is_counted_apart_from_live_and_stale(process_db):
     assert (coverage.total, coverage.live, coverage.stale) == (3, 1, 1)
     assert coverage.unknown == 1
     assert coverage.live + coverage.stale + coverage.unknown == coverage.total
+
+
+def test_live_ranks_excludes_only_stale_ranks():
+    out = ProcessDashboardPayload(
+        ranks=(
+            RankSnapshot(global_rank=0, freshness="fresh"),
+            RankSnapshot(global_rank=1, freshness="stale"),
+            RankSnapshot(global_rank=2, freshness="unknown"),
+        )
+    )
+
+    assert [rank.global_rank for rank in out.live_ranks] == [0, 2]
 
 
 def test_coverage_states_who_is_reporting(process_db):

--- a/tests/renderers/process/test_process_rank_features.py
+++ b/tests/renderers/process/test_process_rank_features.py
@@ -168,10 +168,51 @@ def test_aggregates_describe_the_live_ranks(process_db):
 
 # --- the whole-run series ------------------------------------------------
 def test_a_short_run_stays_on_the_recent_view(process_db):
+    """Recent, and carrying data: the live view is the common case.
+
+    A run only outgrows its window after minutes, so nearly every chart a
+    reader sees is this one. An earlier version of this test asserted the
+    recent chart was EMPTY, which described the code rather than the
+    intent and left both charts blank on every short run.
+    """
     _run(process_db, ranks=2, samples=20)
     out = payload(process_db, sampler_interval_s=2.0)
-    assert out.cpu_capacity_chart.mode == "recent"
-    assert out.cpu_capacity_chart.traces == ()
+    chart = out.cpu_capacity_chart
+    assert chart.mode == "recent"
+    assert chart.is_retained is False
+    assert len(chart.traces) == 2
+    assert all(trace.timestamps for trace in chart.traces)
+    assert all(
+        len(trace.timestamps) == len(trace.values) for trace in chart.traces
+    )
+
+
+def test_the_recent_view_moves_between_ticks(process_db):
+    """It must not be served from the whole-run cache.
+
+    The retained chart is a rolling mean over minutes and is cached
+    because rebuilding it every tick was this block's largest cost. The
+    recent chart is the live one, and a cached copy of it is a chart that
+    stops moving.
+    """
+    _run(process_db, ranks=2, samples=20)
+    computer = ProcessDashboardComputer(
+        db_path=process_db.path, sampler_interval_s=2.0
+    )
+    first = computer.compute().rss_chart
+    _run(process_db, ranks=2, samples=40)
+    second = computer.compute().rss_chart
+
+    assert first.mode == second.mode == "recent"
+    longest_before = max(len(t.timestamps) for t in first.traces)
+    longest_after = max(len(t.timestamps) for t in second.traces)
+    assert longest_after > longest_before
+
+
+def test_every_rank_gets_its_own_recent_line(process_db):
+    _run(process_db, ranks=4, samples=20)
+    chart = payload(process_db, sampler_interval_s=2.0).rss_chart
+    assert [t.global_rank for t in chart.traces] == [0, 1, 2, 3]
 
 
 def test_a_long_run_switches_to_the_retained_view(process_db):

--- a/tests/renderers/process/test_process_rank_features.py
+++ b/tests/renderers/process/test_process_rank_features.py
@@ -1,0 +1,226 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-rank facts, rollups, coverage and the whole-run series.
+
+The payload only: nothing here imports NiceGUI, so a failure points at the
+computation rather than at a card.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.renderers.process.conftest import GB
+from traceml_ai.renderers.process.dashboard_compute import (
+    ProcessDashboardComputer,
+)
+from traceml_ai.renderers.process.dashboard_models import RankSnapshot
+
+
+def payload(db, **kw):
+    return ProcessDashboardComputer(db_path=db.path, **kw).compute()
+
+
+def _run(db, *, ranks=4, samples=120, cores=8, hot_rank=None, dies=None):
+    """A multi-rank run. ``hot_rank`` burns CPU; ``dies`` stops early."""
+    for seq in range(1, samples + 1):
+        for rank in range(ranks):
+            if dies is not None and rank == dies[0] and seq > dies[1]:
+                continue
+            db.insert(
+                recv_ts_ns=int((1_700_000_000 + seq * 2) * 1e9),
+                rank=rank,
+                global_rank=rank,
+                node_rank=0,
+                seq=seq,
+                sample_ts_s=1_700_000_000.0 + seq * 2,
+                cpu_percent=(700.0 if rank == hot_rank else 200.0),
+                cpu_logical_core_count=cores,
+                ram_used_bytes=(2.0 + rank * 0.5) * GB,
+                ram_total_bytes=64.0 * GB,
+                gpu_available=1,
+                gpu_device_index=rank,
+                gpu_mem_used_bytes=(4.0 + rank) * GB,
+                gpu_mem_reserved_bytes=(6.0 + rank * 2) * GB,
+                gpu_mem_total_bytes=40.0 * GB,
+            )
+
+
+# --- per-rank history ----------------------------------------------------
+def test_every_rank_appears_with_its_own_facts(process_db):
+    _run(process_db, ranks=4, samples=30)
+    out = payload(process_db, sampler_interval_s=2.0)
+    assert [r.global_rank for r in out.ranks] == [0, 1, 2, 3]
+    assert all(r.cpu_capacity_percent is not None for r in out.ranks)
+
+
+def test_cpu_is_normalized_against_the_core_count(process_db):
+    """psutil sums CPU over cores, so a healthy 8-core rank reads 200%.
+
+    Divided by its cores that is 25% of the host, which is bounded and
+    comparable between ranks on different machines.
+    """
+    _run(process_db, ranks=1, samples=30, cores=8)
+    rank = payload(process_db, sampler_interval_s=2.0).ranks[0]
+    assert rank.cpu_capacity_percent == pytest.approx(25.0)
+
+
+def test_a_rank_that_stopped_is_kept_and_marked_stale(process_db):
+    """Dropping it would forget the dead rank exactly when it matters."""
+    _run(process_db, ranks=4, samples=200, dies=(3, 20))
+    out = payload(process_db, sampler_interval_s=2.0)
+    assert [r.global_rank for r in out.ranks] == [0, 1, 2, 3]
+    dead = next(r for r in out.ranks if r.global_rank == 3)
+    assert dead.freshness == "stale"
+    assert dead.age_s is not None and dead.age_s > 0
+    assert all(r.freshness == "fresh" for r in out.ranks if r.global_rank != 3)
+
+
+def test_an_unknown_age_is_counted_apart_from_live_and_stale(process_db):
+    """The three states stay three; none of them absorbs another.
+
+    `FreshnessPolicy.state_of` answers fresh / stale / unknown, and an
+    unknown age means a rank sent data with no usable arrival clock. Our
+    own writer cannot produce that (`recv_ts_ns` is `INTEGER NOT NULL`),
+    so this is a guard rather than a live path, and it is asserted here
+    rather than through the database for exactly that reason.
+
+    The rank still counts toward the aggregate: a clock problem is not
+    evidence that a rank stopped working. It is counted in its own bucket
+    so that "live" never quietly means "not proven dead".
+    """
+    computer = ProcessDashboardComputer(
+        db_path=process_db.path, sampler_interval_s=2.0
+    )
+    ranks = (
+        RankSnapshot(global_rank=0, freshness="fresh", age_s=1.0),
+        RankSnapshot(global_rank=1, freshness="stale", age_s=900.0),
+        RankSnapshot(global_rank=2, freshness="unknown", age_s=None),
+    )
+
+    coverage = computer._build_payload(ranks).coverage
+    assert (coverage.total, coverage.live, coverage.stale) == (3, 1, 1)
+    assert coverage.unknown == 1
+    assert coverage.live + coverage.stale + coverage.unknown == coverage.total
+
+
+def test_coverage_states_who_is_reporting(process_db):
+    _run(process_db, ranks=4, samples=200, dies=(3, 20))
+    coverage = payload(process_db, sampler_interval_s=2.0).coverage
+    assert (coverage.total, coverage.live, coverage.stale) == (4, 3, 1)
+    assert coverage.unknown == 0
+    assert coverage.excluding_stale is True
+
+
+def test_a_healthy_run_is_not_marked_as_excluding_anything(process_db):
+    _run(process_db, ranks=4, samples=30)
+    assert (
+        payload(process_db, sampler_interval_s=2.0).coverage.excluding_stale
+        is False
+    )
+
+
+# --- rollups -------------------------------------------------------------
+def test_cpu_leads_with_the_worst_rank_and_names_it(process_db):
+    """A bottleneck finder has to answer "which rank"."""
+    _run(process_db, ranks=4, samples=30, hot_rank=2)
+    cpu = payload(process_db, sampler_interval_s=2.0).cpu_capacity
+    assert cpu.worst_rank == 2
+    assert cpu.now == pytest.approx(87.5)
+    assert cpu.p50 == pytest.approx(25.0)
+
+
+def test_cuda_reports_the_least_headroom_rank_not_the_largest_user(
+    process_db,
+):
+    _run(process_db, ranks=4, samples=30)
+    gpu = payload(process_db, sampler_interval_s=2.0).gpu_reserved
+    assert gpu.worst_rank == 3  # reserved 12 GB of 40, least headroom
+    assert gpu.now == pytest.approx(12.0 * GB)
+
+
+def test_reserved_imbalance_is_a_spread_across_ranks(process_db):
+    _run(process_db, ranks=4, samples=30)
+    out = payload(process_db, sampler_interval_s=2.0)
+    # reserved runs 6, 8, 10, 12 GB -> (12-6)/12
+    assert out.reserved_imbalance_percent == pytest.approx(50.0)
+
+
+def test_a_single_rank_has_no_imbalance_to_report(process_db):
+    _run(process_db, ranks=1, samples=30)
+    assert (
+        payload(process_db, sampler_interval_s=2.0).reserved_imbalance_percent
+        is None
+    )
+
+
+def test_aggregates_describe_the_live_ranks(process_db):
+    """A dead rank keeps its row but does not drag a headline."""
+    _run(process_db, ranks=4, samples=200, hot_rank=3, dies=(3, 20))
+    out = payload(process_db, sampler_interval_s=2.0)
+    assert out.cpu_capacity.worst_rank != 3
+    assert any(r.global_rank == 3 for r in out.ranks)
+
+
+# --- the whole-run series ------------------------------------------------
+def test_a_short_run_stays_on_the_recent_view(process_db):
+    _run(process_db, ranks=2, samples=20)
+    out = payload(process_db, sampler_interval_s=2.0)
+    assert out.cpu_capacity_chart.mode == "recent"
+    assert out.cpu_capacity_chart.traces == ()
+
+
+def test_a_long_run_switches_to_the_retained_view(process_db):
+    _run(process_db, ranks=2, samples=300)
+    chart = payload(process_db, sampler_interval_s=2.0).cpu_capacity_chart
+    assert chart.mode == "retained"
+    assert chart.is_retained is True
+    assert chart.window_s is not None
+    assert len(chart.traces) == 2
+
+
+def test_the_mode_is_stated_never_inferred_from_an_empty_field(process_db):
+    """The previous payload left the view to guess from whichever series
+    happened to be populated. The mode is a field now."""
+    _run(process_db, ranks=2, samples=300)
+    out = payload(process_db, sampler_interval_s=2.0)
+    for chart in (out.cpu_capacity_chart, out.rss_chart):
+        assert chart.mode in ("recent", "retained")
+
+
+def test_the_point_budget_holds_for_every_rank(process_db):
+    """The stride is applied per rank, so it must be planned on the
+    BUSIEST rank. Planned on the average, a four-rank run with one early
+    death produced 145 points against a budget of 120."""
+    _run(process_db, ranks=4, samples=300, dies=(3, 100))
+    out = payload(process_db, sampler_interval_s=2.0)
+    for chart in (out.cpu_capacity_chart, out.rss_chart):
+        for trace in chart.traces:
+            assert len(trace.values) <= 120, (
+                chart.mode,
+                trace.global_rank,
+                len(trace.values),
+            )
+
+
+def test_each_retained_trace_carries_its_own_rank_and_peaks(process_db):
+    _run(process_db, ranks=3, samples=300)
+    chart = payload(process_db, sampler_interval_s=2.0).rss_chart
+    assert [t.global_rank for t in chart.traces] == [0, 1, 2]
+    for trace in chart.traces:
+        assert len(trace.timestamps) == len(trace.values) == len(trace.peaks)
+
+
+# --- the older payload keeps working -------------------------------------
+def test_the_fields_the_card_already_reads_are_unchanged(process_db):
+    """PR 4 changes the card; this PR must not."""
+    _run(process_db, ranks=2, samples=30)
+    out = payload(process_db, sampler_interval_s=2.0)
+    assert out.has_data is True
+    assert out.window_len > 0
+    assert out.gpu_available is True
+    assert out.chart is not None and out.chart.ram_percent.values

--- a/tests/renderers/process/test_process_repository.py
+++ b/tests/renderers/process/test_process_repository.py
@@ -20,11 +20,17 @@ import pytest
 
 from tests.renderers.process.conftest import GB
 from traceml_ai.renderers.process.repository import ProcessRepository
+from traceml_ai.renderers.shared.run_series import RunSeriesPlan
 
 
 @pytest.fixture
 def repo(process_db):
     return ProcessRepository(db_path=process_db.path), process_db
+
+
+class _FailingConnection:
+    def execute(self, *_args, **_kwargs):
+        raise sqlite3.OperationalError("query failed")
 
 
 def test_latest_seq_is_the_newest_row_carrying_one(repo):
@@ -217,3 +223,22 @@ def test_connect_yields_named_row_access(repo):
         ).fetchone()
     assert isinstance(row, sqlite3.Row)
     assert row["cpu_percent"] == pytest.approx(42.0)
+
+
+def test_run_stats_sql_errors_propagate(repo):
+    repository, _db = repo
+    with pytest.raises(sqlite3.OperationalError, match="query failed"):
+        repository.cpu_capacity_run_stats(_FailingConnection())
+
+
+def test_run_history_sql_errors_propagate(repo):
+    repository, _db = repo
+    plan = RunSeriesPlan(
+        window_s=30.0,
+        cadence_s=2.0,
+        stride=1,
+        max_points=120,
+        sample_count=100,
+    )
+    with pytest.raises(sqlite3.OperationalError, match="query failed"):
+        repository.fetch_cpu_capacity_run(_FailingConnection(), plan)


### PR DESCRIPTION
Closes #406. Part 3 of #403.

Part 2 (#411) is merged, so this branch is rebased straight onto `version_0.3.7` and is no
longer stacked. Review it against the release branch:

```
git diff upstream/version_0.3.7...dev/abhijeet/process-features
```

4 files, +1079/-12.

## Review scope

The Process compute layer and its payload. **No UI change**: `process_section.py` is untouched
and the card renders exactly what it rendered before this PR. That is asserted, not assumed, and
the assertion is described below.

## What

The data-layer content of the closed #401, rebuilt on part 1's boundaries and part 2's shared
policies.

| added | what it is |
|---|---|
| `RankSnapshot` | one rank's own state, read on its own clock |
| `RankCoverage` | total, live, stale and unknown rank counts |
| `RankChart` / `RankTrace` | per-rank series, with the mode stated |
| `cpu_capacity`, `rss_worst`, `gpu_reserved` | the per-rank rollups, as NEW fields |
| `reserved_imbalance_percent` | spread of reserved memory across ranks |

### Per-rank history, on each rank's own clock

Two reads rather than one. The windowed read carries each rank's recent history; the
latest-row read carries every rank that has ever reported. Without the second, a rank silent for
longer than the window has no rows in the first and drops out of the block entirely, so the
surface forgets a dead rank a few minutes after it dies, which is when its death starts to
matter.

### CPU is normalized

`psutil` reports process CPU summed across cores, so a healthy rank on an 8-core host reads
200%. Divided by its core count that is 25% of the host, which is bounded and comparable
between ranks on different machines.

### The rollups name a rank

The worst CPU rank is named, because a bottleneck finder has to answer "which rank" and a cohort
median cannot. The worst RSS rank is chosen on its window MEDIAN but displayed at its NEWEST
value: which rank is worst is a judgement about its typical state, while the number shown should
be what that rank last actually sent. The CUDA rollup reports the rank with the least headroom
rather than the largest user, because the process at risk is the one closest to filling its card.

Imbalance is computed on RESERVED memory, not allocated. The allocator's live bytes are a
sawtooth that this sampling cadence undersamples, so their across-rank spread is phase noise on a
healthy run; reserved is what the process actually holds.

### The series mode is stated

`RankChart.mode` is `recent` or `retained`, on the payload. The previous shape carried a window
series and a whole-run series in two differently named fields and left the view to work out which
to draw from whichever happened to be non-empty. That is a rule no reader can see.

### Caching, with its reason

`RUN_REFRESH_S` refreshes the whole-run reads on a slower clock than the tick. A rolling mean
over minutes cannot visibly change between two 2 s ticks, and recomputing these reads every tick
was the largest cost measured in this block. That is the demonstrated need; the policy is one
constant with the reason next to it.

## No SQL crosses the boundary

The whole-run reads are `fetch_cpu_capacity_run(plan)` and `fetch_rss_run(plan)`. Interpolation
happens in two private helpers that are only ever handed one of this module's own constants, so
no expression reaches the repository from outside the class. Asserted directly: no public method
on `ProcessRepository` takes a parameter whose name contains `sql`.

The window, cadence, stride and point budget are decided by part 2 and arrive as a
`RunSeriesPlan`; the repository executes, it does not plan.

## The card is unchanged, and that is tested

The new rollups are NEW fields. `cpu`, `ram` and `gpu` keep the meanings the card already reads.
Repurposing them would have changed the card silently, which is part 4's job to do openly.

This matters more than it sounds. Two of them nearly moved:

- the GPU tile went from **allocated** to **reserved**, `6.00 GB` to `7.00 GB`
- the CPU tile would have gone from raw `700%` to normalized `87.5%` on any run reporting a core
  count

Both were caught by `test_the_card_renders_the_same_from_a_real_database`, the end-to-end test
added in part 1, which runs database to compute to card and asserts the on-screen strings. A
screenshot could not have caught either: a tile reading `7.00 GB` looks entirely correct.

## A defect found while re-landing

The whole-run stride was planned on the AVERAGE rows per rank (`count // ranks`) and then applied
PER rank, so any rank with more rows than the mean overshot the point budget. Measured on a
four-rank run where one rank stopped early:

```
    stated cap: 120 points
    rank 0: 145 points   <- over
    rank 1: 145 points   <- over
    rank 2: 145 points   <- over
    rank 3:  45 points
```

Unequal row counts are the ordinary case, not an edge one: a rank that dies, joins late, or
samples slower produces them. The plan is now made on the busiest rank's count, and a test
asserts the budget holds for every rank rather than on average.

This is the same class as the floor-vs-ceiling stride fix on #389. That fix corrected the
divisor; the dividend was wrong too and stayed wrong. Worth naming so the next stride change
checks both.

## Adapting to the review fix on part 2

Part 2 landed with `is_stale() -> bool` replaced by `state_of() -> "fresh" | "stale" | "unknown"`.
This PR is that API's first consumer, so it had to decide what the third state means here.

Collapsing it back to a boolean would have undone the change at the first call site: an unknown
age would have become `stale=False` and a rank with no usable clock would have been counted as
live, which is the ambiguity the new signature exists to remove. So the state is carried through
to the payload. `RankSnapshot.freshness` holds it and `RankCoverage` counts it in its own bucket,
which keeps `live + stale + unknown == total` true by construction.

An unknown age still counts toward the aggregates. A missing timestamp is a clock problem, not
evidence that a rank stopped working, and dropping its reading would discard real data on that
basis.

Worth stating plainly: this state is not reachable from our own writer. `recv_ts_ns` is
`INTEGER NOT NULL` (`aggregator/sqlite_writers/process.py:146`), so the age is always computable
for a row we wrote. It is a guard, not a live path, and the test says so and asserts it against
constructed snapshots rather than pretending a database can produce one.

## Scope

```
STRUCTURE: per-rank facts and whole-run series -> renderers/process (owner of process_samples
and its meaning); shared policy consumed from renderers/shared; boundaries crossed: none
DATA PATH: process_section <- PROCESS_LAYOUT <- ProcessRenderer <- ProcessDashboardComputer
           <- ProcessRepository <- process_samples
           <- renderers/shared/{run_series,freshness} for window and freshness policy
SCOPE: declared renderers/process + its tests; diff against version_0.3.7 touches exactly those 4 files -> within
```

## Verification

```
GATE: pytest tests/ -> 1458 passed, 2 skipped; 57 on the Process renderer, 17 of them new here; isort, ruff and black clean at 79 under the repo's pinned pre-commit; every hook passes
TRANSITIONS: recent -> retained once the run outgrows its window; live -> stale per rank on the observed cadence; populated -> read failure served from the last-good payload -> that payload expiring; a rank present in the window read but absent from it later still appears via the latest-row read
RANKS: 1, 2, 3 and 4 ranks, plus a rank that stops mid-run; aggregates describe the live ranks while the stopped one keeps its row and its age; single-rank runs report no imbalance rather than zero; a rank with no usable arrival clock is counted apart from both
TRIPWIRE: the point budget is asserted per rank, not on average, so the 145-vs-120 defect above fails the suite; a test asserts the card's fields keep their meaning; no public repository method may take a SQL parameter; the payload tests import no NiceGUI
SCENARIOS: no rendering change in this PR, so no new screenshots; the card is proven unchanged by the end-to-end test rather than by a picture
PLATFORM: macOS 26.1, Python 3.12.13, SQLite 3.51.2
```

## Not in this PR

The card. Part 4 (#407) switches the tiles to `cpu_capacity`, `rss_worst` and `gpu_reserved`,
splits the single ambiguous `GPU MEM` tile into the `allocated` and `reserved` pair that #399
settled the wording for, and draws the per-rank charts. Until then those fields are computed,
tested and unread, which is deliberate: a regression in the card then lands in the PR that
causes it.
