### PR TITLE
Dev/abhinav/issue394 3

### DIFF
--- a/src/traceml_ai/samplers/schema/step_memory.py
+++ b/src/traceml_ai/samplers/schema/step_memory.py
@@ -74,7 +74,7 @@ class StepMemorySample:
         """
         return StepMemorySample(
             sample_idx=data["seq"],
-            timestamp=float(data.get("ts", 0.0)),
+            timestamp=float(data["ts"]),
             model_id=data.get("model_id"),
             device=data.get("device"),
             step=data.get("step"),

--- a/src/traceml_ai/samplers/step_memory_sampler.py
+++ b/src/traceml_ai/samplers/step_memory_sampler.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import time
-from typing import Any, Optional
-
 from traceml_ai.samplers.base_sampler import BaseSampler
 from traceml_ai.samplers.schema.step_memory import StepMemorySample
 from traceml_ai.samplers.utils import drain_queue_nowait
-from traceml_ai.utils.step_memory import step_memory_queue
+from traceml_ai.utils.step_memory import StepMemoryEvent, step_memory_queue
 
 
 class StepMemorySampler(BaseSampler):
@@ -27,31 +24,20 @@ class StepMemorySampler(BaseSampler):
         """
         for event in drain_queue_nowait(step_memory_queue):
             sample = self._event_to_sample(event)
-            if sample is None:
-                continue
             self._add_record(sample.to_wire())
 
-    def _event_to_sample(self, event: Any) -> Optional[StepMemorySample]:
+    def _event_to_sample(self, event: StepMemoryEvent) -> StepMemorySample:
         """
         Convert a raw queue event to a StepMemorySample.
         """
-        ts = time.time()
-
-        model_id = getattr(event, "model_id", None)
-        device = getattr(event, "device", None)
-        step = getattr(event, "step", None)
-
-        peak_alloc = getattr(event, "peak_allocated", None)
-        peak_resv = getattr(event, "peak_reserved", None)
-
         return StepMemorySample(
             sample_idx=self.sample_idx,
-            timestamp=ts,
-            model_id=model_id,
-            device=device,
-            step=step,
-            peak_allocated=peak_alloc,
-            peak_reserved=peak_resv,
+            timestamp=float(event.timestamp),
+            model_id=event.model_id,
+            device=event.device,
+            step=event.step,
+            peak_allocated=event.peak_allocated,
+            peak_reserved=event.peak_reserved,
         )
 
     def sample(self) -> None:

--- a/src/traceml_ai/utils/step_memory.py
+++ b/src/traceml_ai/utils/step_memory.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 from dataclasses import dataclass
 from queue import Full, Queue
 from typing import Dict, Optional
@@ -27,6 +28,7 @@ class StepMemoryEvent:
     step: int
     model_id: int
     device: str
+    timestamp: float
     peak_allocated: Optional[float]
     peak_reserved: Optional[float]
 
@@ -90,6 +92,8 @@ class StepMemoryTracker:
                 float(peak_reserved) if peak_reserved is not None else None
             ),
             step=-1,  # filled during flush
+            # Capture occurrence time here; queue draining can happen later.
+            timestamp=time.time(),
         )
         _temp_step_memory_buffer[self.model_id] = evt
 

--- a/tests/sdk/test_step_memory_timestamp.py
+++ b/tests/sdk/test_step_memory_timestamp.py
@@ -1,0 +1,58 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import traceml_ai.utils.step_memory as step_memory_module
+from traceml_ai.samplers.schema.step_memory import StepMemorySample
+from traceml_ai.samplers.step_memory_sampler import StepMemorySampler
+from traceml_ai.utils.step_memory import StepMemoryEvent, StepMemoryTracker
+
+
+def test_tracker_captures_timestamp_when_memory_is_measured(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+    monkeypatch.setattr(
+        step_memory_module,
+        "should_record_trace_events",
+        lambda: True,
+    )
+    monkeypatch.setattr(step_memory_module.time, "time", lambda: 12.25)
+
+    tracker = StepMemoryTracker.__new__(StepMemoryTracker)
+    tracker.model_id = 7
+    tracker.device = torch.device("cpu")
+
+    try:
+        tracker.record()
+        event = step_memory_module._temp_step_memory_buffer.pop(7)
+        assert event.timestamp == 12.25
+    finally:
+        step_memory_module._temp_step_memory_buffer.pop(7, None)
+
+
+def test_sampler_preserves_event_timestamp_through_wire_schema() -> None:
+    sampler = StepMemorySampler.__new__(StepMemorySampler)
+    sampler.sample_idx = 3
+    event = StepMemoryEvent(
+        step=7,
+        model_id=1,
+        device="cuda:0",
+        timestamp=12.25,
+        peak_allocated=100.0,
+        peak_reserved=200.0,
+    )
+
+    sample = sampler._event_to_sample(event)
+
+    assert sample.timestamp == 12.25
+    assert StepMemorySample.from_wire(sample.to_wire()) == sample
+
+
+def test_wire_schema_requires_measurement_timestamp() -> None:
+    with pytest.raises(KeyError):
+        StepMemorySample.from_wire({"seq": 1})


### PR DESCRIPTION
## Summary

Capture step-memory timestamps when the memory measurement occurs at step end, rather than later when the sampler drains its queue.

## Why

Step-memory events can remain queued before the sampler processes them. Using the queue-drain time makes the timestamp dependent on sampler scheduling and can misalign memory measurements with their training steps and other telemetry.

The event producer is the authoritative source of measurement time, so the timestamp is now captured there and preserved through sampling and serialization.

## Changes

- Add a required `timestamp` to `StepMemoryEvent`.
- Capture the timestamp when step memory is recorded.
- Preserve the event timestamp when creating `StepMemorySample`.
- Keep the timestamp required throughout the internal schema.
- Remove the fabricated `0.0` fallback when reading wire data without `ts`.
- Add focused tests covering timestamp capture, sampler preservation, and wire round-trip behavior.

## Design

`StepMemoryEvent` is an internal typed contract with a single producer, so the sampler accesses its fields directly. Missing external wire fields are rejected at the wire boundary instead of introducing nullable timestamps throughout downstream logic.

## Scope

This PR changes step-memory timestamp semantics only.

It does not modify:

- Telemetry windowing or aggregation
- SQLite retention
- Dashboard or terminal rendering
- Diagnosis behavior