### PR TITLE
native logger used instead of forced logging

### DIFF
--- a/src/traceml_ai/runtime/executor.py
+++ b/src/traceml_ai/runtime/executor.py
@@ -4,7 +4,11 @@
 # you may not use this file except in compliance with the License.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Execute a user script inside the TraceML runtime."""
+"""Run a user script with a best-effort TraceML runtime around it.
+
+The executor is intentionally transparent to user failures: Python and
+torchrun remain responsible for exception reporting and process exit status.
+"""
 
 import os
 import runpy
@@ -12,7 +16,7 @@ import sys
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 from traceml_ai.runtime.launch_context import (
     LaunchContext,
@@ -33,7 +37,6 @@ from traceml_ai.telemetry.retention import (
     parse_history_retention,
 )
 
-INTERRUPTED_EXIT_CODE = 130
 DEFAULT_LOGS_DIR = "./logs"
 DEFAULT_AGGREGATOR_HOST = "127.0.0.1"
 DEFAULT_AGGREGATOR_BIND_HOST = "127.0.0.1"
@@ -119,11 +122,12 @@ def write_user_error_log(
     error: Optional[BaseException] = None,
 ) -> None:
     """
-    Append a user-script crash or exit report to torchrun_error.log.
+    Append an ordinary user-script exception to torchrun_error.log.
 
-    This log is reserved for failures originating from the executed user
-    script, including unhandled exceptions, KeyboardInterrupt, and nonzero
-    SystemExit outcomes.
+    This is a compatibility bridge until launcher-owned stderr persistence is
+    available for every display mode. It must never replace or alter native
+    exception propagation, and it can be removed once the launcher output is
+    the canonical durable record.
     """
     _append_error_log(
         cfg=cfg,
@@ -351,105 +355,59 @@ def run_user_script(script_path: str, script_args: list[str]) -> None:
         runpy.run_path(resolved_script_path, run_name="__main__")
 
 
-def report_crash(cfg: Dict[str, Any], error: BaseException) -> None:
-    """
-    Persist an enriched user-script crash report.
+def _execute_with_runtime() -> None:
+    """Execute the user script while owning one TraceML runtime lifecycle.
 
-    The crash report is written to torchrun_error.log.
-
-    This function intentionally does not print large tracebacks to the terminal,
-    because the aggregator may own the terminal UI and overwrite them.
-    """
-    write_user_error_log(
-        cfg,
-        header="Unhandled exception in user script",
-        error=error,
-    )
-
-
-def _coerce_exit_code(code: Any) -> int:
-    """
-    Normalize SystemExit.code into a process exit code.
-
-    Rules
-    -----
-    - None -> 0
-    - int -> int
-    - anything else -> 1
-    """
-    if code is None:
-        return 0
-    if isinstance(code, int):
-        return code
-    return 1
-
-
-def main() -> None:
-    """
-    TraceML executor entrypoint.
-
-    Execution flow
-    --------------
-    1. Read TraceML configuration from environment variables
-    2. Start the TraceML runtime
-    3. Execute the user script in-process
-    4. Stop the runtime
-    5. Persist enriched crash context if needed
-    6. Exit with the user script's resulting exit code
-
-    Error handling policy
-    ---------------------
-    - User script failures are written to torchrun_error.log
-    - TraceML internal failures are written to runtime_error.log
-    - Large error reports are not printed to the terminal because the
-      aggregator may control the terminal UI
+    User exceptions are logged best effort for compatibility and then
+    re-raised unchanged. The ``finally`` block guarantees Python-level cleanup
+    without converting ``SystemExit``, ``KeyboardInterrupt``, or ordinary
+    exceptions into TraceML-specific failures.
     """
     cfg = read_traceml_env()
-    script_args = extract_script_args()
-
     runtime = start_runtime(cfg)
 
-    exit_code = 0
-    error: Optional[BaseException] = None
-
     try:
-        run_user_script(str(cfg["script_path"]), script_args)
-
-    except KeyboardInterrupt as interrupt_error:
+        run_user_script(
+            str(cfg["script_path"]),
+            extract_script_args(),
+        )
+    except Exception as error:
         write_user_error_log(
             cfg,
-            header="KeyboardInterrupt (Ctrl+C)",
-            error=interrupt_error,
+            header="Unhandled exception in user script",
+            error=error,
         )
-        exit_code = INTERRUPTED_EXIT_CODE
-        error = None
-
-    except SystemExit as system_exit:
-        exit_code = _coerce_exit_code(system_exit.code)
-
-        if exit_code != 0:
-            write_user_error_log(
-                cfg,
-                header=(
-                    "User script exited via SystemExit " f"(code={exit_code})"
-                ),
-                error=system_exit,
-            )
-
-        error = None
-
-    except Exception as unhandled_error:
-        error = unhandled_error
-        exit_code = 1
-
+        raise
     finally:
         stop_runtime(runtime, cfg)
 
-    if error is not None:
-        report_crash(cfg, error)
-        raise SystemExit(1)
 
-    raise SystemExit(exit_code)
+def _run_with_torchelastic_record(
+    entrypoint: Callable[[], None],
+) -> None:
+    """Use torchrun's native error recorder when torchrun configured one.
+
+    The import remains lazy so torch-free execution paths do not acquire a
+    PyTorch dependency. Older or incomplete PyTorch installations fall back to
+    normal Python propagation rather than preventing the user script from
+    running.
+    """
+    if not os.environ.get("TORCHELASTIC_ERROR_FILE"):
+        entrypoint()
+        return
+
+    try:
+        from torch.distributed.elastic.multiprocessing.errors import record
+    except ImportError:
+        entrypoint()
+        return
+
+    record(entrypoint)()
+
+
+def main() -> None:
+    """Run the transparent executor, using torchrun error recording if set."""
+    _run_with_torchelastic_record(_execute_with_runtime)
 
 
 if __name__ == "__main__":

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -1,7 +1,11 @@
 import json
+import os
+import subprocess
 import sys
 import types
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
@@ -30,6 +34,7 @@ sys.modules.setdefault(
     ),
 )
 
+import traceml_ai.runtime.executor as executor  # noqa: E402
 from traceml_ai.runtime.executor import (  # noqa: E402
     build_runtime_settings,
     extract_script_args,
@@ -202,3 +207,102 @@ def test_write_user_error_log_records_error(tmp_path):
     )
     assert "User script failed" in log_text
     assert "RuntimeError: boom" in log_text
+
+
+@pytest.mark.parametrize(
+    "user_exit",
+    [SystemExit(7), KeyboardInterrupt()],
+)
+def test_execute_with_runtime_preserves_base_exceptions_without_user_log(
+    monkeypatch,
+    user_exit,
+):
+    cfg = {"script_path": "train.py"}
+    events = []
+
+    monkeypatch.setattr(executor, "read_traceml_env", lambda: cfg)
+    monkeypatch.setattr(executor, "start_runtime", lambda value: object())
+    monkeypatch.setattr(executor, "extract_script_args", lambda: [])
+
+    def exit_user_script(*_args):
+        raise user_exit
+
+    monkeypatch.setattr(executor, "run_user_script", exit_user_script)
+    monkeypatch.setattr(
+        executor,
+        "write_user_error_log",
+        lambda *_args, **_kwargs: events.append("logged"),
+    )
+    monkeypatch.setattr(
+        executor,
+        "stop_runtime",
+        lambda *_args: events.append("stopped"),
+    )
+
+    with pytest.raises(type(user_exit)) as exc_info:
+        executor._execute_with_runtime()
+
+    assert exc_info.value is user_exit
+    assert events == ["stopped"]
+
+
+def test_torchelastic_record_wraps_entrypoint_when_configured(monkeypatch):
+    calls = []
+
+    def fake_record(entrypoint):
+        def wrapped():
+            calls.append("record")
+            return entrypoint()
+
+        return wrapped
+
+    monkeypatch.setenv("TORCHELASTIC_ERROR_FILE", "error.json")
+    monkeypatch.setitem(
+        sys.modules,
+        "torch.distributed.elastic.multiprocessing.errors",
+        types.SimpleNamespace(record=fake_record),
+    )
+
+    executor._run_with_torchelastic_record(lambda: calls.append("entrypoint"))
+
+    assert calls == ["record", "entrypoint"]
+
+
+def test_executor_subprocess_preserves_native_traceback_and_compatibility_log(
+    tmp_path,
+):
+    script_path = tmp_path / "raise_error.py"
+    script_path.write_text(
+        "raise RuntimeError('subprocess boom')\n",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.pop("TORCHELASTIC_ERROR_FILE", None)
+    env.update(
+        {
+            "PYTHONPATH": str(SRC),
+            "TRACEML_SCRIPT_PATH": str(script_path),
+            "TRACEML_DISABLED": "1",
+            "TRACEML_LOGS_DIR": str(tmp_path / "logs"),
+            "TRACEML_SESSION_ID": "executor-test",
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "traceml_ai.runtime.executor"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+    assert result.returncode == 1
+    assert "Traceback (most recent call last)" in result.stderr
+    assert "RuntimeError: subprocess boom" in result.stderr
+    compatibility_log = (
+        tmp_path / "logs" / "executor-test" / "torchrun_error.log"
+    )
+    assert compatibility_log.is_file()
+    assert "RuntimeError: subprocess boom" in compatibility_log.read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
Why
TraceML was converting user failures into its own exit behavior, which could hide native Python tracebacks and interfere with torchrun error reporting.

What changed
- Re-raise user exceptions unchanged so Python displays the original traceback.
- Preserve native SystemExit and KeyboardInterrupt behavior.
- Use TorchElastic’s error recorder when launched through torchrun.
- Keep the existing error log as a temporary compatibility fallback.
- Ensure TraceML cleanup remains best-effort and cannot mask user failures.

Testing
- Verified native traceback and exit-code propagation.
- Verified SystemExit, KeyboardInterrupt, and TorchElastic integration.
- 14 passed.