### PR TITLE
Process dashboard presentation: four tiles, per-rank charts and rows

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/charting.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/charting.py
@@ -1,0 +1,200 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shaping a chart: axes, ranges, per-rank series, sparklines.
+
+``theme`` owns the look (palette, fonts, the base ECharts option dicts).
+This module owns the arithmetic of fitting a chart to its data: what the
+y range should be for a given kind of signal, how a time axis is pinned and
+labelled, and how one series per rank is built.
+
+The split matters because the two change for different reasons. A palette
+change is a brand decision; an axis-range change is a decision about what a
+metric's information IS. Keeping them in one file meant every axis fix
+touched the module that defines the brand.
+
+No function here reads a payload or decides severity. They take numbers and
+return option fragments.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+# One colour per rank, shared by the charts and the rows' chips so a line
+# and a row are recognisably the same rank. Red is not among them: on this
+# page red reads as a verdict, and a rank identifier is not a verdict.
+RANK_COLORS: Tuple[str, ...] = (
+    "#f97316",
+    "#3b82f6",
+    "#0d9488",
+    "#a855f7",
+    "#0ea5e9",
+    "#eab308",
+    "#ec4899",
+    "#10b981",
+)
+
+
+def rank_color(rank: int) -> str:
+    """The colour that identifies one rank, stable across every surface."""
+    return RANK_COLORS[int(rank) % len(RANK_COLORS)]
+
+
+def capacity_axis_max(values: Sequence[Any]) -> float:
+    """Zero-anchored ceiling whose half is a whole percent (0 / 5 / 10).
+
+    Right for a share of a capacity: the distance from zero is the reading,
+    so zero must be on the axis.
+    """
+    numbers = [float(v) for v in values if v is not None]
+    peak = (max(numbers) * 1.2) if numbers else 0.0
+    for top in (4.0, 10.0, 20.0, 30.0, 40.0, 60.0, 80.0, 100.0):
+        if peak <= top:
+            return top
+    return 100.0
+
+
+def drift_axis_bounds(
+    values: Sequence[Any],
+) -> Tuple[float, float, float]:
+    """A y range fitted to the data, for a series whose signal is DRIFT.
+
+    RSS is a level a few GB high that moves by tens of MB across a run.
+    Zero-anchoring it, which is right for a share of capacity, puts that
+    whole movement inside one pixel: on the three-hour capture the ranks
+    sit at 1.48 to 1.50 GB on an axis that would run to 5. The leak this
+    chart exists to show would be invisible.
+    """
+    numbers = [float(value) for value in values if value is not None]
+    if not numbers:
+        return (0.0, 1.0, 0.5)
+    low, high = min(numbers), max(numbers)
+    if high <= low:
+        high = low + max(abs(low) * 0.01, 0.01)
+    pad = (high - low) * 0.25
+    low, high = max(0.0, low - pad), high + pad
+    return (low, high, (high - low) / 2.0)
+
+
+def value_axis_formatter(span: float, unit: str) -> str:
+    """Tick formatter whose precision comes from the axis RANGE.
+
+    Magnitude alone is not enough: an axis fitted to a 20 MB drift around
+    1.4 GB would label every tick "1.4 GB" and say nothing.
+    """
+    if span >= 20:
+        decimals = 0
+    elif span >= 2:
+        decimals = 1
+    elif span >= 0.2:
+        decimals = 2
+    else:
+        decimals = 3
+    return f"v=>v.toFixed({decimals})+'{unit}'"
+
+
+def apply_span_axis(
+    options: Dict[str, Any],
+    span: float,
+    newest_epoch: Optional[float] = None,
+) -> None:
+    """Pin a chart to its span and label it in wall-clock time.
+
+    The x values are seconds before the newest sample, which keeps the
+    series arithmetic simple, but a reader debugging a slowdown needs the
+    clock: it is what their logs are keyed on. The formatters convert on
+    the fly from the newest sample's epoch, and the hover label carries
+    both readings ("19:10 · 45 min ago") so the axis and the tooltip never
+    speak two different vocabularies.
+    """
+    span = max(float(span), 1.0)
+    axis = options["xAxis"]
+    axis["min"] = -span
+    axis["max"] = 0
+    axis["interval"] = span / 3.0
+    if newest_epoch is None:
+        axis["axisLabel"]["show"] = False
+        return
+    axis["axisLabel"]["show"] = True
+    clock = (
+        "const d=new Date((%f+%%s)*1000);const q=n=>('0'+n).slice(-2);"
+        "const c=q(d.getHours())+':'+q(d.getMinutes())%s;"
+        % (float(newest_epoch), "+':'+q(d.getSeconds())" if span < 600 else "")
+    )
+    axis["axisLabel"][":formatter"] = "v=>{%s return c;}" % (clock % "v")
+    pointer = options.get("tooltip", {}).get("axisPointer", {}).get("label")
+    if pointer is not None:
+        pointer[":formatter"] = (
+            "p=>{%s const s=Math.round(-p.value);"
+            "return c+(s<1?' · now':(s<120?' · '+s+' s ago':"
+            "' · '+Math.floor(s/60)+' min ago'));}" % (clock % "p.value")
+        )
+
+
+def sparkline_svg(
+    values: Sequence[Optional[float]],
+    color: str,
+    *,
+    width: int = 64,
+    height: int = 14,
+) -> str:
+    """Inline SVG polyline; gaps are dropped, an empty trace is no SVG."""
+    points = [(i, float(v)) for i, v in enumerate(values) if v is not None]
+    if not points:
+        return ""
+    low = min(value for _i, value in points)
+    high = max(value for _i, value in points)
+    span = (high - low) or 1.0
+    step = width / max(len(values) - 1, 1)
+    inner = height - 4
+    coords = " ".join(
+        f"{i * step:.1f},{1 + inner - (value - low) / span * inner:.1f}"
+        for i, value in points
+    )
+    return (
+        f'<svg viewBox="0 0 {width} {height}" '
+        f'style="width:{width}px;height:{height}px;vertical-align:middle">'
+        f'<polyline points="{coords}" fill="none" stroke="{color}" '
+        'stroke-width="1.4"/></svg>'
+    )
+
+
+def shared_span(*traces: Sequence[Any]) -> Optional[Tuple[float, float]]:
+    """One anchor and span covering every trace given.
+
+    Both Process charts are pinned to it so a vertical read across the pair
+    lands on the same moment. Each trace is expected to expose a
+    ``timestamps`` sequence.
+    """
+    starts: List[float] = []
+    ends: List[float] = []
+    for group in traces:
+        for trace in group or ():
+            stamps = [
+                float(value)
+                for value in getattr(trace, "timestamps", ()) or ()
+                if value is not None
+            ]
+            if stamps:
+                starts.append(stamps[0])
+                ends.append(stamps[-1])
+    if not ends:
+        return None
+    newest = max(ends)
+    return (newest, max(newest - min(starts), 1.0))
+
+
+__all__ = [
+    "RANK_COLORS",
+    "apply_span_axis",
+    "capacity_axis_max",
+    "drift_axis_bounds",
+    "rank_color",
+    "shared_span",
+    "sparkline_svg",
+    "value_axis_formatter",
+]

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/formatting.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/formatting.py
@@ -1,0 +1,132 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Numbers as the words a card prints.
+
+Separate from ``theme`` on purpose. ``theme`` owns colours, fonts and CSS;
+this module owns the far smaller question of how one already-decided value
+is written down. The two were one module and the boundary blurred: chart
+builders and value formatters accumulated beside the palette until a change
+to how a byte count reads meant editing the file that also defines the
+brand.
+
+Nothing here decides what a number MEANS. That is settled in
+``renderers/<domain>/`` before the payload is built. These functions only
+choose decimals, units and phrasing.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Tuple
+
+NA = "n/a"
+
+_BYTES_PER_GB = float(1024**3)
+
+
+def gb(value: Any) -> Optional[float]:
+    """Bytes as gigabytes, or ``None`` when the value is not a number."""
+    if value is None:
+        return None
+    try:
+        return float(value) / _BYTES_PER_GB
+    except (TypeError, ValueError):
+        return None
+
+
+def num(value: Any, fmt: str = "{:.0f}") -> str:
+    """One number in the given format, or the absence marker."""
+    if value is None:
+        return NA
+    try:
+        return fmt.format(float(value))
+    except (TypeError, ValueError):
+        return NA
+
+
+def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
+    """A level against its capacity: ``('6.3', '/ 16.1 GB')``.
+
+    A measured value never renders as "0.0": a trainer process holding
+    27 MB is a real reading, and printing it with one decimal makes it
+    indistinguishable from the marker this module uses for absence.
+    Sub-gigabyte levels keep two decimals instead.
+    """
+    used = gb(used_bytes)
+    if used is None:
+        return (NA, "")
+    shown = f"{used:.2f}" if 0 < used < 1 else f"{used:.1f}"
+    total = gb(total_bytes)
+    if total is None or total <= 0:
+        return (shown, "GB")
+    total_s = f"{total:.0f}" if total >= 100 else f"{total:.1f}"
+    return (shown, f"/ {total_s} GB")
+
+
+def format_span(seconds: Optional[float]) -> str:
+    """The window a chart covers, as one phrase: ``'last 3 min'``."""
+    if not seconds or seconds <= 0:
+        return ""
+    if seconds < 90:
+        return f"last {seconds:.0f} s"
+    return f"last {seconds / 60.0:.0f} min"
+
+
+def format_window(window_s: Optional[float]) -> str:
+    """The rolling window in words: ``'30 s'``, ``'2 min'``.
+
+    The compute layer picks round windows, so this reads as a duration a
+    person recognises rather than an arbitrary number of seconds.
+    """
+    if not window_s or window_s <= 0:
+        return ""
+    if window_s < 60:
+        return f"{window_s:.0f} s"
+    return f"{window_s / 60.0:.0f} min"
+
+
+def format_age(seconds: Any) -> str:
+    """How long ago a rank last reported, in the strip's vocabulary."""
+    if seconds is None:
+        return NA
+    try:
+        value = float(seconds)
+    except (TypeError, ValueError):
+        return NA
+    if value < 90:
+        return f"{value:.0f} s"
+    if value < 90 * 60:
+        return f"{value / 60.0:.0f} min"
+    return f"{value / 3600.0:.1f} h"
+
+
+def format_percent(value: Optional[float], fmt: str = "{:.0f}") -> str:
+    """A percentage, with a floor so a real small share is not lost.
+
+    A reserved-memory spread of 0.4% is a genuine reading. Rounded to a
+    whole percent it prints "0", which reads as balanced.
+    """
+    if value is None:
+        return NA
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return NA
+    if 0 < number < 1:
+        return "<1"
+    return fmt.format(number)
+
+
+__all__ = [
+    "NA",
+    "format_age",
+    "format_gb_pair",
+    "format_percent",
+    "format_span",
+    "format_window",
+    "gb",
+    "num",
+]

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/formatting.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/formatting.py
@@ -67,10 +67,16 @@ def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
 
 
 def format_span(seconds: Optional[float]) -> str:
-    """The window a chart covers, as one phrase: ``'last 3 min'``."""
+    """The window a chart covers, as one phrase: ``'last 3 min'``.
+
+    Seconds until a full two minutes. Switching at ninety and rounding to
+    whole minutes announced a 105 second window as "last 2 min", which
+    overstates what the chart shows by 14% in the label a reader uses to
+    place it in time.
+    """
     if not seconds or seconds <= 0:
         return ""
-    if seconds < 90:
+    if seconds < 120:
         return f"last {seconds:.0f} s"
     return f"last {seconds / 60.0:.0f} min"
 

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
@@ -192,6 +192,10 @@ def rows_html(
 
     A rank that stopped is dimmed and kept. Dropping it would hide the one
     fact worth having when a job stalls, which is WHICH rank stopped.
+
+    Each row's CUDA columns come from that rank's least-headroom sample in
+    the recent window. Keeping allocated and reserved on the paired sample
+    makes the selected headline row directly verifiable in this table.
     """
     trend = {
         trace.global_rank: trace.values
@@ -219,10 +223,15 @@ def rows_html(
             ),
             rank.ram_total_bytes,
         )
+        cuda = rank.cuda_least_headroom_sample
         reserved, reserved_rest = format_gb_pair(
-            rank.gpu_reserved_bytes, rank.gpu_total_bytes
+            cuda.reserved_bytes if cuda is not None else None,
+            cuda.total_bytes if cuda is not None else None,
         )
-        alloc, alloc_rest = format_gb_pair(rank.gpu_allocated_p50_bytes, None)
+        alloc, alloc_rest = format_gb_pair(
+            cuda.allocated_bytes if cuda is not None else None,
+            cuda.total_bytes if cuda is not None else None,
+        )
         capacity = rank.cpu_capacity_percent
         row = '<tr class="tml-stale">' if rank.freshness == "stale" else "<tr>"
         gpu_cell = (

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
@@ -92,7 +92,7 @@ def build_process_section() -> Dict[str, Any]:
 
         with ui.element("div").classes("tilerow").style("margin-bottom:10px;"):
             for key, label, accent in (
-                ("cpu", "cpu capacity", theme.C_CPU),
+                ("cpu", "cpu", theme.C_CPU),
                 ("rss", "rss", theme.C_CPU),
                 ("reserved", "cuda reserved", theme.C_GPU),
                 ("alloc", "cuda allocated", theme.C_GPU),

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
@@ -379,7 +379,12 @@ def update_process_section(panel: Dict[str, Any], data: Any) -> None:
                 else "reserved / total"
             ),
         )
-        _tile_gb(panel, "alloc", data.gpu, "median rank · live tensors")
+        _tile_gb(
+            panel,
+            "alloc",
+            data.gpu_allocated,
+            "median rank · live tensors",
+        )
     else:
         seen = bool(data.window_len or data.ranks)
         for key in ("reserved", "alloc"):

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
@@ -52,6 +52,11 @@ _MONO = "font-family:var(--mono);"
 # diagnostic is invisible.
 SCOPE_NOTE = "one process per rank · DataLoader workers not included"
 
+# The span the tiles summarise, stated on the card. It is a duration
+# rather than a sample count so it means the same thing at every
+# sampling rate.
+SECTION_TITLE = "Process resources · recent 60s"
+
 _CPU_TOOLTIP = (
     "Each rank's trainer process, as a share of the host's total CPU "
     "capacity: 100% means every logical core busy. DataLoader workers are "
@@ -81,7 +86,7 @@ def build_process_section() -> Dict[str, Any]:
             .classes("w-full items-center")
             .style("margin-bottom:10px; gap:12px;")
         ):
-            ui.label("Process").classes("ctitle")
+            ui.label(SECTION_TITLE).classes("ctitle")
             ui.element("div").style("flex:1;")
             panel["note"] = ui.label(SCOPE_NOTE).classes("cmeta")
 
@@ -243,6 +248,22 @@ def _rank_series(
     # sample to join them.
     sparse = any(len(trace.timestamps) < 2 for trace in chart.traces)
     series = []
+    if chart.total is not None and chart.total.timestamps:
+        # Drawn first so the rank lines sit on top of it, and in the ink
+        # colour rather than a rank colour: it is not a rank, and giving it
+        # one would make it look like the fifth GPU.
+        total = theme.line_series(
+            "Total",
+            theme.INK,
+            [
+                [stamp - anchor, value / scale]
+                for stamp, value in zip(
+                    chart.total.timestamps, chart.total.values
+                )
+            ],
+            width=2.2,
+        )
+        series.append(total)
     for trace in chart.traces:
         line = theme.line_series(
             f"R{int(trace.global_rank)}",
@@ -288,7 +309,14 @@ def _draw_chart(
     # nothing draws them; fitting the axis to those put its floor above
     # the drawn line, which clipped the early samples and understated the
     # very drift this chart exists to show.
-    flat = [value / scale for trace in chart.traces for value in trace.values]
+    # Every line that is DRAWN, the total included. It is the sum across
+    # ranks, so it sits above all of them; fitting the axis to the rank
+    # traces alone would put the one line the reader most wants above the
+    # ceiling and clip it.
+    drawn = list(chart.traces)
+    if chart.total is not None and chart.total.timestamps:
+        drawn.append(chart.total)
+    flat = [value / scale for trace in drawn for value in trace.values]
     bounds = bounds_of(flat)
     if isinstance(bounds, tuple):
         low, high, tick = bounds
@@ -330,7 +358,16 @@ def _chart_signature(payload: ProcessDashboardPayload) -> Tuple[Any, ...]:
 def _tile_gb(
     panel: Dict[str, Any], key: str, rollup: Optional[MetricRollup], sub: str
 ) -> None:
-    value, rest = format_gb_pair(rollup.now if rollup else None, None)
+    """A byte level against the capacity it is measured out of.
+
+    Every memory tile carries its denominator. A level without one cannot
+    be read: 14 GB is unremarkable on an 80 GB card and nearly fatal on a
+    16 GB one.
+    """
+    value, rest = format_gb_pair(
+        rollup.now if rollup else None,
+        rollup.total if rollup else None,
+    )
     panel["tiles"][key].content = theme.kval(value, f" {rest}" if rest else "")
     panel["subs"][key].text = sub
 
@@ -347,12 +384,12 @@ def update_process_section(panel: Dict[str, Any], data: Any) -> None:
     worst = capacity.now if capacity else None
     panel["tiles"]["cpu"].content = theme.kval(
         num(worst, "{:.1f}") if worst is not None else NA,
-        "%" if worst is not None else "",
+        "% of host" if worst is not None else "",
     )
     panel["subs"]["cpu"].text = (
-        f"worst rank · R{int(capacity.worst_rank)} · of host capacity"
+        f"highest median · R{int(capacity.worst_rank)}"
         if capacity is not None and capacity.worst_rank is not None
-        else "of host capacity"
+        else "of host"
     )
 
     rss = data.rss_worst
@@ -361,7 +398,7 @@ def update_process_section(panel: Dict[str, Any], data: Any) -> None:
         "rss",
         rss,
         (
-            f"worst rank · R{int(rss.worst_rank)}"
+            f"highest median · R{int(rss.worst_rank)}"
             if rss is not None and rss.worst_rank is not None
             else "used / total"
         ),
@@ -374,16 +411,21 @@ def update_process_section(panel: Dict[str, Any], data: Any) -> None:
             "reserved",
             reserved,
             (
-                f"least-headroom rank · R{int(reserved.worst_rank)}"
+                f"least headroom · R{int(reserved.worst_rank)}"
                 if reserved is not None and reserved.worst_rank is not None
                 else "reserved / total"
             ),
         )
+        allocated = data.gpu_allocated
         _tile_gb(
             panel,
             "alloc",
-            data.gpu_allocated,
-            "median rank · live tensors",
+            allocated,
+            (
+                f"least-headroom rank · R{int(allocated.worst_rank)}"
+                if allocated is not None and allocated.worst_rank is not None
+                else "live tensors"
+            ),
         )
     else:
         seen = bool(data.window_len or data.ranks)

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
@@ -206,8 +206,18 @@ def rows_html(
     for rank in ranks:
         index = int(rank.global_rank)
         colour = charting.rank_color(index)
+        # The median over the window, matching the tile above. Showing the
+        # newest sample here made the card contradict itself: the tile
+        # named R1 at its median while R1's own row showed its post
+        # teardown value, so the number a reader went to the rows to
+        # verify disagreed with the one that sent them there.
         used, used_rest = format_gb_pair(
-            rank.ram_used_bytes, rank.ram_total_bytes
+            (
+                rank.ram_used_p50_bytes
+                if rank.ram_used_p50_bytes is not None
+                else rank.ram_used_bytes
+            ),
+            rank.ram_total_bytes,
         )
         reserved, reserved_rest = format_gb_pair(
             rank.gpu_reserved_bytes, rank.gpu_total_bytes

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/process_section.py
@@ -1,154 +1,434 @@
-"""Process metrics card: RAM and GPU-memory over time, plus four tiles.
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
 
-Presentation only. Every number here arrives on a
-``ProcessDashboardPayload`` already decided: the percentiles, the window
-bound and the share-of-capacity arithmetic moved to
-``renderers/process/dashboard_compute.py``, which is where what a metric
-MEANS is settled. What is left in this module is layout, units, colours
-and chart options.
+"""Process block: the trainer process on every rank.
 
-Whether the run has a GPU is read from ``payload.gpu_available``, not
-inferred from which keys happen to be present.
+Four tiles, two per-rank charts and a per-rank table. Scope is stated on
+the block because it is the block's most useful fact: one process per rank,
+its own PID only. DataLoader workers are separate processes, so their CPU
+lands in the System block and never here. Reading the two together is what
+the page is for: host CPU high while every rank's process CPU is low means
+the work is outside the trainer.
+
+Presentation only. Every number arrives on a ``ProcessDashboardPayload``
+already decided: which rank is worst, what the spread is, which history a
+chart is made of, and whether the rows have earned opening. This module
+chooses layout, colour, units and wording, and nothing else. In particular
+it never compares a value to a threshold, because that is a severity
+judgement and the diagnosis engine owns those.
 """
 
 from __future__ import annotations
 
-from math import isfinite
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from nicegui import ui
 
 from traceml_ai.renderers.process.dashboard_models import (
-    ChartTrace,
+    MetricRollup,
     ProcessDashboardPayload,
+    RankChart,
+    RankSnapshot,
 )
 
-from . import theme
+from . import charting, theme
+from .formatting import (
+    NA,
+    format_age,
+    format_gb_pair,
+    format_percent,
+    format_span,
+    format_window,
+    num,
+)
 
-NA_GPU = "N/A"
-DASH = "—"
+_MONO = "font-family:var(--mono);"
+
+# The block's scope, on screen rather than in a tooltip: without it the CPU
+# numbers read as the whole box's, and the pairing that makes them
+# diagnostic is invisible.
+SCOPE_NOTE = "one process per rank · DataLoader workers not included"
+
+_CPU_TOOLTIP = (
+    "Each rank's trainer process, as a share of the host's total CPU "
+    "capacity: 100% means every logical core busy. DataLoader workers are "
+    "separate processes and are not included, so host CPU high with these "
+    "low means the work is outside the trainer. On a hyperthreaded host, "
+    "logical capacity is reached before the cores saturate."
+)
+_RSS_TOOLTIP = (
+    "Host memory held by each rank's trainer process. The shape is the "
+    "point: steady growth across the run is the signature of a leak, which "
+    "ends with the OS killing one rank. It covers the history retained for "
+    "this run, not necessarily the whole run."
+)
 
 
 def build_process_section() -> Dict[str, Any]:
-    kpis: Dict[str, Any] = {}
+    """Build the block once; ``update_process_section`` fills it per tick."""
+    panel: Dict[str, Any] = {"tiles": {}, "subs": {}}
     card = ui.element("div").classes("glass reveal")
     card.style(
-        "padding:18px 20px; width:100%; height:100%; "
-        "display:flex; flex-direction:column; overflow:hidden;"
+        "padding:18px 20px; width:100%; display:flex; "
+        "flex-direction:column; overflow:hidden;"
     )
     with card:
         with (
             ui.row()
             .classes("w-full items-center")
-            .style("margin-bottom:8px; gap:12px;")
+            .style("margin-bottom:10px; gap:12px;")
         ):
             ui.label("Process").classes("ctitle")
-            for nm, col in [("RAM", theme.C_CPU), ("GPU mem", theme.C_GPU)]:
-                with ui.element("div").classes("legchip"):
-                    ui.element("div").classes("legdot").style(
-                        f"background:{col};"
-                    )
-                    ui.label(nm)
             ui.element("div").style("flex:1;")
-            win = ui.label("waiting for data").classes("cmeta")
-        chart = ui.echart(theme.dual_line_options("RAM", "GPU mem")).style(
-            "height:200px; width:100%; flex:1; min-height:160px;"
-        )
-        with (
-            ui.row()
-            .classes("w-full")
-            .style("gap:8px; margin-top:12px; flex-wrap:nowrap;")
-        ):
-            for key, lab, acc, qual in [
-                ("cpu", "CPU", theme.C_CPU, "max · rank"),
-                ("ram", "RAM", theme.C_CPU, "max · rank"),
-                ("gmem", "GPU MEM", theme.C_GPU, "worst rank"),
-                ("gimb", "GPU IMBAL", theme.C_GPU, "spread"),
-            ]:
+            panel["note"] = ui.label(SCOPE_NOTE).classes("cmeta")
+
+        with ui.element("div").classes("tilerow").style("margin-bottom:10px;"):
+            for key, label, accent in (
+                ("cpu", "cpu capacity", theme.C_CPU),
+                ("rss", "rss", theme.C_CPU),
+                ("reserved", "cuda reserved", theme.C_GPU),
+                ("alloc", "cuda allocated", theme.C_GPU),
+            ):
                 with (
                     ui.element("div")
                     .classes("kpi")
-                    .style(f"--acc:{acc}; flex:1 1 0; min-width:0;")
+                    .style(f"--acc:{accent}; min-width:0;")
                 ):
-                    ui.html(
-                        f"{lab} <span class='kq'>{qual}</span>",
-                        sanitize=False,
-                    ).classes("klab")
-                    kpis[key] = ui.html(DASH, sanitize=False).classes("kval")
-    return {"chart": chart, "win": win, "kpis": kpis}
+                    ui.label(label).classes("klab")
+                    panel["tiles"][key] = ui.html(NA, sanitize=False).classes(
+                        "kval"
+                    )
+                    panel["subs"][key] = ui.label("").classes("ksub")
 
+        for chart_key, label_key, value_key, head, unit, margin in (
+            ("cpu_chart", "cpu_label", "cpu_value", "process cpu", "%", "2px"),
+            ("rss_chart", "rss_label", "rss_value", "rss", " GB", "8px"),
+        ):
+            with (
+                ui.row()
+                .classes("w-full items-baseline")
+                .style(f"gap:8px; margin:{margin} 0 2px;")
+            ):
+                panel[label_key] = ui.label(head).classes("estlabel")
+                ui.element("div").style("flex:1;")
+                panel[value_key] = ui.label("").style(
+                    f"{_MONO} font-size:14px; font-weight:600;"
+                )
+            panel[chart_key] = ui.echart(theme.multi_line_options(unit)).style(
+                "height:92px; width:100%;"
+            )
 
-def to_ms(seconds: Optional[float]) -> Optional[int]:
-    """A sample time as ECharts wants it, or ``None`` when unusable."""
-    if seconds is None:
-        return None
-    try:
-        value = float(seconds)
-    except (TypeError, ValueError):
-        return None
-    if not isfinite(value) or value <= 0.0:
-        return None
-    return int(value * 1000.0)
-
-
-def gb_value(value: Optional[float]) -> str:
-    """Bytes as gigabytes, or a dash when the number does not exist."""
-    number = theme.gb(value) if value is not None else None
-    return f"{number:.2f}" if number is not None else DASH
-
-
-def trace_points(trace: Optional[ChartTrace]) -> List[List[Any]]:
-    """One trace as [time, value] pairs, dropping unplottable samples."""
-    if trace is None:
-        return []
-    return [
-        [ms, value]
-        for ms, value in zip(
-            (to_ms(t) for t in trace.timestamps), trace.values
+        expansion = (
+            ui.expansion()
+            .classes("w-full tml-exp")
+            .props("dense dense-toggle expand-icon-toggle")
+            .style("margin-top:6px;")
         )
-        if ms is not None
-    ]
+        with expansion.add_slot("header"):
+            with (
+                ui.row()
+                .classes("w-full items-center")
+                .style("gap:10px; min-width:0;")
+            ):
+                ui.label("per-rank rows").style(
+                    f"{_MONO} font-size:12px; font-weight:700;"
+                )
+                panel["rows_hint"] = ui.label("").classes("cmeta")
+        with expansion:
+            panel["rows_html"] = ui.html("", sanitize=False).classes("w-full")
+        panel["rows"] = expansion
+        panel["_was_open"] = False
+        panel["_signature"] = None
+    panel["card"] = card
+    return panel
 
 
-def window_text(payload: ProcessDashboardPayload) -> str:
-    return f"last {payload.window_len} samples"
+def should_auto_open(*, prev_over: bool, over: bool) -> bool:
+    """Open on the rising edge only.
+
+    A reader who closes the rows must not be fought every tick while the
+    condition that opened them persists.
+    """
+    return bool(over and not prev_over)
+
+
+def rows_hint(payload: ProcessDashboardPayload, *, is_open: bool) -> str:
+    """Header of the per-rank rows: coverage, spread, and nothing else.
+
+    It states what was observed. Whether that is bad is the engine's call,
+    so no word here classifies it.
+    """
+    coverage = payload.coverage
+    if not coverage.total:
+        return ""
+    parts = [f"{coverage.total} rank{'s' if coverage.total != 1 else ''}"]
+    if coverage.stale and coverage.excluding_stale:
+        parts.append(f"{coverage.stale} stale, excluded")
+    elif coverage.stale:
+        # Nothing is reporting, so nothing was excluded: the numbers above
+        # are the last ones these ranks sent.
+        parts.append("none reporting")
+    if coverage.unknown:
+        parts.append(f"{coverage.unknown} without a clock")
+    if payload.reserved_imbalance_percent is not None:
+        shown = format_percent(payload.reserved_imbalance_percent)
+        parts.append(f"reserved imbalance {shown}%")
+    parts.append("click to close" if is_open else "click to open")
+    return " · ".join(parts)
+
+
+def rows_html(
+    ranks: Sequence[RankSnapshot], chart: Optional[RankChart]
+) -> str:
+    """Per-rank table: identity, capacity, memory, and how fresh it is.
+
+    A rank that stopped is dimmed and kept. Dropping it would hide the one
+    fact worth having when a job stalls, which is WHICH rank stopped.
+    """
+    trend = {
+        trace.global_rank: trace.values
+        for trace in (chart.traces if chart else ())
+    }
+    head = (
+        "<tr><th>rank</th><th>gpu</th><th>node</th><th>cpu cap</th>"
+        "<th>rss</th><th>cpu trend</th><th>cuda allocated</th>"
+        "<th>cuda reserved</th><th>age</th></tr>"
+    )
+    body = ""
+    for rank in ranks:
+        index = int(rank.global_rank)
+        colour = charting.rank_color(index)
+        used, used_rest = format_gb_pair(
+            rank.ram_used_bytes, rank.ram_total_bytes
+        )
+        reserved, reserved_rest = format_gb_pair(
+            rank.gpu_reserved_bytes, rank.gpu_total_bytes
+        )
+        alloc, alloc_rest = format_gb_pair(rank.gpu_allocated_p50_bytes, None)
+        capacity = rank.cpu_capacity_percent
+        row = '<tr class="tml-stale">' if rank.freshness == "stale" else "<tr>"
+        gpu_cell = (
+            f"G{int(rank.gpu_index)}" if rank.gpu_index is not None else NA
+        )
+        node_cell = (
+            f"N{int(rank.node_rank)}" if rank.node_rank is not None else NA
+        )
+        capacity_cell = (
+            f"{num(capacity, '{:.1f}')} %" if capacity is not None else NA
+        )
+        body += (
+            row + f'<td><span style="color:{colour}">■</span> R{index}</td>'
+            f"<td>{gpu_cell}</td>"
+            f"<td>{node_cell}</td>"
+            f"<td>{capacity_cell}</td>"
+            f"<td>{used} {used_rest}</td>"
+            f"<td>{charting.sparkline_svg(trend.get(index, ()), colour)}</td>"
+            f"<td>{alloc} {alloc_rest}</td>"
+            f"<td>{reserved} {reserved_rest}</td>"
+            f"<td>{format_age(rank.age_s)}</td>"
+            "</tr>"
+        )
+    return f'<table class="tml-gpus">{head}{body}</table>'
+
+
+def _rank_series(
+    chart: RankChart, anchor: float, scale: float
+) -> List[Dict[str, Any]]:
+    """One line per rank, x in seconds before the shared anchor."""
+    # A line through one point draws nothing, and the first ticks of every
+    # run are exactly that. Show the markers until there is a second
+    # sample to join them.
+    sparse = any(len(trace.timestamps) < 2 for trace in chart.traces)
+    series = []
+    for trace in chart.traces:
+        line = theme.line_series(
+            f"R{int(trace.global_rank)}",
+            charting.rank_color(int(trace.global_rank)),
+            [
+                [stamp - anchor, value / scale]
+                for stamp, value in zip(trace.timestamps, trace.values)
+            ],
+        )
+        if sparse:
+            line["showSymbol"] = True
+            line["symbolSize"] = 4
+        series.append(line)
+    return series
+
+
+def _draw_chart(
+    panel: Dict[str, Any],
+    *,
+    chart_key: str,
+    label_key: str,
+    head: str,
+    chart: Optional[RankChart],
+    aligned: Optional[Tuple[float, float]],
+    scale: float,
+    bounds_of: Any,
+    tooltip: str,
+    unit: str = "",
+) -> None:
+    """Draw whichever history the payload carried, and name it."""
+    element = panel[chart_key]
+    if chart is None or not chart.traces or aligned is None:
+        element.options["series"] = []
+        element.update()
+        panel[label_key].text = head
+        return
+
+    anchor, span = aligned
+    element.options["series"] = _rank_series(chart, anchor, scale)
+    charting.apply_span_axis(element.options, span, anchor)
+
+    # The values, never the peaks. `peaks` are the rolling maxima and
+    # nothing draws them; fitting the axis to those put its floor above
+    # the drawn line, which clipped the early samples and understated the
+    # very drift this chart exists to show.
+    flat = [value / scale for trace in chart.traces for value in trace.values]
+    bounds = bounds_of(flat)
+    if isinstance(bounds, tuple):
+        low, high, tick = bounds
+        element.options["yAxis"]["min"] = low
+        element.options["yAxis"]["max"] = high
+        element.options["yAxis"]["interval"] = tick
+        element.options["yAxis"]["axisLabel"][":formatter"] = (
+            charting.value_axis_formatter(high - low, unit)
+        )
+    else:
+        element.options["yAxis"]["max"] = bounds
+    element.update()
+
+    words = format_window(chart.window_s) if chart.is_retained else ""
+    panel[label_key].text = f"{head} · {format_span(span)}" + (
+        f" · rolling {words}" if words else ""
+    )
+    panel[label_key].tooltip(tooltip)
+
+
+def _chart_signature(payload: ProcessDashboardPayload) -> Tuple[Any, ...]:
+    """What must change before the charts are worth re-sending.
+
+    The UI timer ticks faster than telemetry arrives, and a full options
+    dict per tick is pure websocket traffic.
+    """
+    chart = payload.cpu_capacity_chart
+    return (
+        payload.window_len,
+        payload.coverage.total,
+        payload.coverage.stale,
+        tuple(
+            trace.timestamps[-1] if trace.timestamps else None
+            for trace in (chart.traces if chart else ())
+        ),
+    )
+
+
+def _tile_gb(
+    panel: Dict[str, Any], key: str, rollup: Optional[MetricRollup], sub: str
+) -> None:
+    value, rest = format_gb_pair(rollup.now if rollup else None, None)
+    panel["tiles"][key].content = theme.kval(value, f" {rest}" if rest else "")
+    panel["subs"][key].text = sub
 
 
 def update_process_section(panel: Dict[str, Any], data: Any) -> None:
-    if not isinstance(data, ProcessDashboardPayload) or not data.has_data:
+    """Fill the block from one Process payload."""
+    if not isinstance(data, ProcessDashboardPayload):
         return
 
-    chart = panel["chart"]
-    ram_points = trace_points(data.chart.ram_percent if data.chart else None)
-    gpu_points = trace_points(data.chart.gpu_percent if data.chart else None)
-    chart.options["series"][0]["data"] = ram_points
-    chart.options["series"][1]["data"] = gpu_points
+    changed = _chart_signature(data) != panel.get("_signature")
+    panel["_signature"] = _chart_signature(data)
 
-    ymax = theme.nice_ymax(
-        [v for _t, v in ram_points] + [v for _t, v in gpu_points]
+    capacity = data.cpu_capacity
+    worst = capacity.now if capacity else None
+    panel["tiles"]["cpu"].content = theme.kval(
+        num(worst, "{:.1f}") if worst is not None else NA,
+        "%" if worst is not None else "",
     )
-    chart.options["yAxis"][0]["max"] = ymax
-    chart.options["yAxis"][1]["max"] = ymax
-    chart.update()
-
-    panel["win"].text = window_text(data)
-    kpis = panel["kpis"]
-    kpis["cpu"].content = theme.kval(
-        f"{data.cpu.now:.0f}" if data.cpu else DASH, "%"
-    )
-    kpis["ram"].content = theme.kval(
-        gb_value(data.ram.now if data.ram else None), "GB"
+    panel["subs"]["cpu"].text = (
+        f"worst rank · R{int(capacity.worst_rank)} · of host capacity"
+        if capacity is not None and capacity.worst_rank is not None
+        else "of host capacity"
     )
 
-    if not data.gpu_available:
-        kpis["gmem"].content = NA_GPU
-        kpis["gimb"].content = DASH
-        return
+    rss = data.rss_worst
+    _tile_gb(
+        panel,
+        "rss",
+        rss,
+        (
+            f"worst rank · R{int(rss.worst_rank)}"
+            if rss is not None and rss.worst_rank is not None
+            else "used / total"
+        ),
+    )
 
-    kpis["gmem"].content = theme.kval(
-        gb_value(data.gpu.now if data.gpu else None), "GB"
+    if data.gpu_available:
+        reserved = data.gpu_reserved
+        _tile_gb(
+            panel,
+            "reserved",
+            reserved,
+            (
+                f"least-headroom rank · R{int(reserved.worst_rank)}"
+                if reserved is not None and reserved.worst_rank is not None
+                else "reserved / total"
+            ),
+        )
+        _tile_gb(panel, "alloc", data.gpu, "median rank · live tensors")
+    else:
+        seen = bool(data.window_len or data.ranks)
+        for key in ("reserved", "alloc"):
+            panel["tiles"][key].content = NA
+            panel["subs"][key].text = "no GPU" if seen else ""
+
+    aligned = charting.shared_span(
+        data.cpu_capacity_chart.traces if data.cpu_capacity_chart else (),
+        data.rss_chart.traces if data.rss_chart else (),
     )
-    imbalance = gb_value(data.gpu_used_imbalance_bytes)
-    kpis["gimb"].content = theme.kval(
-        imbalance, "GB" if imbalance != DASH else ""
+    if changed:
+        _draw_chart(
+            panel,
+            chart_key="cpu_chart",
+            label_key="cpu_label",
+            head="process cpu · capacity per rank",
+            chart=data.cpu_capacity_chart,
+            aligned=aligned,
+            scale=1.0,
+            bounds_of=charting.capacity_axis_max,
+            tooltip=_CPU_TOOLTIP,
+        )
+        _draw_chart(
+            panel,
+            chart_key="rss_chart",
+            label_key="rss_label",
+            head="rss · per rank",
+            chart=data.rss_chart,
+            aligned=aligned,
+            scale=float(1024**3),
+            bounds_of=charting.drift_axis_bounds,
+            unit=" GB",
+            tooltip=_RSS_TOOLTIP,
+        )
+
+    panel["cpu_value"].text = (
+        f"{float(worst):.1f}%" if worst is not None else ""
     )
+    rss_value, rss_rest = format_gb_pair(rss.now if rss else None, None)
+    panel["rss_value"].text = (
+        f"{rss_value} {rss_rest}".strip() if rss is not None else ""
+    )
+
+    if should_auto_open(
+        prev_over=bool(panel.get("_was_open")), over=data.rows_open
+    ):
+        panel["rows"].value = True
+    panel["_was_open"] = data.rows_open
+    panel["rows_hint"].text = rows_hint(
+        data, is_open=bool(panel["rows"].value)
+    )
+    panel["rows_html"].content = rows_html(data.ranks, data.cpu_capacity_chart)

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/theme.py
@@ -161,6 +161,8 @@ body{{
 .tml-gpus td{{padding:4px 8px; border-top:1px solid rgba(17,24,39,0.07); white-space:nowrap;}}
 .tml-gpus td.tml-util{{font-weight:700;}}
 .tml-gpus tr.tml-mark td{{background:rgba(255,140,0,0.08);}}
+/* A rank that stopped reporting: kept in the table, dimmed, never coloured as a verdict. */
+.tml-gpus tr.tml-stale td{{color:var(--muted); opacity:.72;}}
 .tml-exp .q-item{{padding:4px 2px; min-height:0;}}
 .tml-exp .q-expansion-item__content{{padding:0 0 4px;}}
 </style>

--- a/src/traceml_ai/renderers/process/dashboard_compute.py
+++ b/src/traceml_ai/renderers/process/dashboard_compute.py
@@ -59,11 +59,11 @@ from .repository import ProcessRepository
 # section applied to its own history slice on 0.3.7.
 DASHBOARD_WINDOW = 100
 
-# Samples per rank in the recent-window view.
 # The recent window the tiles describe, as a DURATION. A sample count
 # means a different span at every sampling rate, so two runs sampling at
 # different cadences could not be compared and the card could not say what
-# period it was summarising.
+# period it was summarising. The same duration drives both the repository
+# read and the recent-to-retained chart transition.
 RECENT_WINDOW_S = 60.0
 
 # A rolling mean over minutes cannot visibly change between two ticks, so
@@ -709,13 +709,13 @@ class ProcessDashboardComputer:
     def _rank_charts(
         self,
         conn: Any,
-        window_span_s: float,
+        recent_window_s: float,
         by_rank: Dict[int, List[Any]],
     ) -> Tuple[RankChart, RankChart]:
         """Per-rank CPU and RSS, over the window or over the whole run."""
         return (
-            self._one_chart(conn, "cpu", window_span_s, by_rank),
-            self._one_chart(conn, "rss", window_span_s, by_rank),
+            self._one_chart(conn, "cpu", recent_window_s, by_rank),
+            self._one_chart(conn, "rss", recent_window_s, by_rank),
         )
 
     def _recent_chart(
@@ -765,7 +765,7 @@ class ProcessDashboardComputer:
         self,
         conn: Any,
         metric: str,
-        window_span_s: float,
+        recent_window_s: float,
         by_rank: Dict[int, List[Any]],
     ) -> RankChart:
         """One chart, in whichever mode the run has earned.
@@ -784,7 +784,7 @@ class ProcessDashboardComputer:
         if stats is None:
             return self._recent_chart(metric, by_rank, None)
 
-        mode = self._run_policy.mode_for(stats.span_s, window_span_s)
+        mode = self._run_policy.mode_for(stats.span_s, recent_window_s)
         if mode != "retained":
             return self._recent_chart(metric, by_rank, stats.span_s)
 
@@ -844,8 +844,9 @@ class ProcessDashboardComputer:
         by_rank: Dict[int, List[Any]],
     ) -> ProcessDashboardPayload:
         """Attach the per-rank charts, in whichever mode the run warrants."""
-        window_span = _window_span(payload.history)
-        cpu_chart, rss_chart = self._rank_charts(conn, window_span, by_rank)
+        cpu_chart, rss_chart = self._rank_charts(
+            conn, RECENT_WINDOW_S, by_rank
+        )
         return replace(
             payload, cpu_capacity_chart=cpu_chart, rss_chart=rss_chart
         )
@@ -905,14 +906,6 @@ def _entry_from_row(row: Any) -> ProcessHistoryEntry:
         ram_total_bytes=float(row["ram_total"] or 0.0),
         gpu=gpu,
     )
-
-
-def _window_span(window: Sequence[ProcessHistoryEntry]) -> float:
-    """Wall-clock seconds the recent window covers."""
-    stamps = [e.ts for e in window if e.ts is not None]
-    if len(stamps) < 2:
-        return 0.0
-    return max(0.0, max(stamps) - min(stamps))
 
 
 def _build_chart(window: Sequence[ProcessHistoryEntry]) -> ChartSeries:

--- a/src/traceml_ai/renderers/process/dashboard_compute.py
+++ b/src/traceml_ai/renderers/process/dashboard_compute.py
@@ -67,6 +67,11 @@ RANK_WINDOW_N = 100
 # the demonstrated need this cache exists for.
 RUN_REFRESH_S = 15.0
 
+# Reserved-memory spread at which the per-rank rows have earned opening
+# themselves. Below this the rows are a detail; at or above it, WHICH rank
+# is holding more is the question the reader now has.
+IMBALANCE_OPEN_PCT = 15.0
+
 
 def percentile(values: Sequence[Optional[float]], p: float) -> float:
     """Linear-interpolated percentile over the values that exist.
@@ -402,6 +407,7 @@ class ProcessDashboardComputer:
         )
 
         imbalance = self._reserved_imbalance(aggregate_over)
+        rows_open = self._rows_trigger(aggregate_over, imbalance)
 
         history = tuple(self._dashboard_rollup)
         if not history:
@@ -412,6 +418,7 @@ class ProcessDashboardComputer:
                 rss_worst=self._rss_rollup(aggregate_over),
                 gpu_reserved=self._cuda_rollup(aggregate_over),
                 reserved_imbalance_percent=imbalance,
+                rows_open=rows_open,
             )
 
         window = history[-DASHBOARD_WINDOW:]
@@ -456,6 +463,7 @@ class ProcessDashboardComputer:
             ranks=ranks,
             coverage=coverage,
             reserved_imbalance_percent=imbalance,
+            rows_open=rows_open,
             cpu_capacity=self._cpu_rollup(aggregate_over),
             rss_worst=self._rss_rollup(aggregate_over),
             gpu_reserved=self._cuda_rollup(aggregate_over),
@@ -562,6 +570,33 @@ class ProcessDashboardComputer:
         if high <= 0:
             return None
         return float((high - low) / high * 100.0)
+
+    def _rows_trigger(
+        self,
+        ranks: Sequence[RankSnapshot],
+        imbalance: Optional[float],
+    ) -> bool:
+        """Whether the per-rank rows have earned opening themselves.
+
+        Armed only once every reporting rank has HELD an allocation across
+        its window. Ranks reach their first CUDA allocation seconds to
+        minutes apart, and an unarmed trigger reads that ordinary ramp as
+        total imbalance on every run's first ticks, so the rows would fly
+        open on a healthy start.
+
+        This is a judgement about the telemetry, which is why it is decided
+        here and shipped as a fact. A view that compared the imbalance to a
+        number of its own would be making a severity call in the layer that
+        is only allowed to draw one.
+        """
+        armed = bool(ranks) and all(
+            rank.gpu_reserved_p50_bytes is not None
+            and rank.gpu_reserved_p50_bytes > 0
+            for rank in ranks
+        )
+        if not armed or imbalance is None:
+            return False
+        return float(imbalance) >= IMBALANCE_OPEN_PCT
 
     # --- whole-run series ------------------------------------------------
     def _rank_charts(

--- a/src/traceml_ai/renderers/process/dashboard_compute.py
+++ b/src/traceml_ai/renderers/process/dashboard_compute.py
@@ -417,6 +417,7 @@ class ProcessDashboardComputer:
                 cpu_capacity=self._cpu_rollup(aggregate_over),
                 rss_worst=self._rss_rollup(aggregate_over),
                 gpu_reserved=self._cuda_rollup(aggregate_over),
+                gpu_allocated=self._alloc_rollup(aggregate_over),
                 reserved_imbalance_percent=imbalance,
                 rows_open=rows_open,
             )
@@ -467,6 +468,7 @@ class ProcessDashboardComputer:
             cpu_capacity=self._cpu_rollup(aggregate_over),
             rss_worst=self._rss_rollup(aggregate_over),
             gpu_reserved=self._cuda_rollup(aggregate_over),
+            gpu_allocated=self._alloc_rollup(aggregate_over),
         )
 
     # --- rollups ---------------------------------------------------------
@@ -547,6 +549,30 @@ class ProcessDashboardComputer:
             total=worst.gpu_total_bytes,
             worst_rank=worst.global_rank,
         )
+
+    def _alloc_rollup(
+        self, ranks: Sequence[RankSnapshot]
+    ) -> Optional[MetricRollup]:
+        """Live tensors on the median rank.
+
+        The median rather than the worst, because allocated bytes are the
+        model's shape rather than a risk: on a healthy synchronous run
+        every rank holds much the same, and the median says what that is
+        while the reserved tile beside it names the rank at risk.
+
+        Read from the ranks, not from the aggregated step history. The
+        history's newest step carries no GPU snapshot once a run tears
+        down, which left this tile reading "n/a" directly above rows that
+        listed each rank's allocated bytes.
+        """
+        values = [
+            r.gpu_allocated_p50_bytes
+            for r in ranks
+            if r.gpu_allocated_p50_bytes is not None
+        ]
+        if not values:
+            return None
+        return MetricRollup(now=float(_median(values) or 0.0))
 
     def _reserved_imbalance(
         self, ranks: Sequence[RankSnapshot]

--- a/src/traceml_ai/renderers/process/dashboard_compute.py
+++ b/src/traceml_ai/renderers/process/dashboard_compute.py
@@ -59,7 +59,11 @@ from .repository import ProcessRepository
 DASHBOARD_WINDOW = 100
 
 # Samples per rank in the recent-window view.
-RANK_WINDOW_N = 100
+# The recent window the tiles describe, as a DURATION. A sample count
+# means a different span at every sampling rate, so two runs sampling at
+# different cadences could not be compared and the card could not say what
+# period it was summarising.
+RECENT_WINDOW_S = 60.0
 
 # A rolling mean over minutes cannot visibly change between two ticks, so
 # the whole-run reads refresh on their own slower clock. Recomputing them
@@ -138,6 +142,45 @@ def _cpu_capacity_of(row: Any) -> Optional[float]:
     if used is None or cores is None or cores <= 0:
         return None
     return used / cores
+
+
+def _total_trace(traces: Sequence[RankTrace]) -> Optional[RankTrace]:
+    """Every rank summed, on the union of their sample times.
+
+    Ranks sample on their own clocks, so adding the series index by index
+    would add readings taken at different moments. Each rank's last known
+    value is carried forward to every timestamp instead, which is what a
+    step function does between samples, and the sum is taken there.
+
+    A rank that has not reported yet contributes nothing rather than a
+    zero, so the total does not dip while ranks are still starting.
+    """
+    usable = [t for t in traces if t.timestamps]
+    if len(usable) < 2:
+        return None
+    stamps = sorted({float(s) for t in usable for s in t.timestamps})
+    if not stamps:
+        return None
+
+    cursors = [0] * len(usable)
+    last: List[Optional[float]] = [None] * len(usable)
+    values: List[float] = []
+    for stamp in stamps:
+        for i, trace in enumerate(usable):
+            while (
+                cursors[i] < len(trace.timestamps)
+                and float(trace.timestamps[cursors[i]]) <= stamp
+            ):
+                last[i] = float(trace.values[cursors[i]])
+                cursors[i] += 1
+        seen = [v for v in last if v is not None]
+        values.append(sum(seen) if seen else 0.0)
+
+    return RankTrace(
+        global_rank=-1,
+        timestamps=tuple(stamps),
+        values=tuple(values),
+    )
 
 
 class ProcessDashboardComputer:
@@ -237,7 +280,7 @@ class ProcessDashboardComputer:
         with its true age instead of vanishing from the block.
         """
         window_rows = self._db.fetch_recent_rank_window(
-            conn, window_n=RANK_WINDOW_N, newest_ts=newest_ts
+            conn, window_s=RECENT_WINDOW_S, newest_ts=newest_ts
         )
         latest_rows = self._db.fetch_rank_latest(conn)
 
@@ -376,6 +419,17 @@ class ProcessDashboardComputer:
                     if value is not None
                 ]
             ),
+            gpu_reserved_peak_bytes=max(
+                (
+                    value
+                    for value in (
+                        _opt_float(r["gpu_mem_reserved_bytes"])
+                        for r in reported
+                    )
+                    if value is not None
+                ),
+                default=None,
+            ),
             gpu_total_bytes=(
                 _opt_float(newest_gpu["gpu_mem_total_bytes"])
                 if newest_gpu is not None
@@ -511,12 +565,14 @@ class ProcessDashboardComputer:
         ]
         if not pairs:
             return None
-        worst, _p50 = max(pairs, key=lambda item: item[1])
-        shown = worst.ram_used_bytes
-        if shown is None:
-            shown = worst.ram_used_p50_bytes or 0.0
+        worst, worst_p50 = max(pairs, key=lambda item: item[1])
+        # The median, not the newest sample. The newest reading of a
+        # finished run lands after teardown, so the tile used to show a
+        # collapsed value beside a chart still drawn at the run's real
+        # level. One rule for the whole section: each rank's median over
+        # the recent window, then the highest of those.
         return MetricRollup(
-            now=float(shown),
+            now=float(worst_p50),
             p50=_median([value for _r, value in pairs]),
             total=worst.ram_total_bytes,
             worst_rank=worst.global_rank,
@@ -533,19 +589,23 @@ class ProcessDashboardComputer:
         candidates = [
             r
             for r in ranks
-            if r.gpu_reserved_bytes is not None
+            if r.gpu_reserved_peak_bytes is not None
             and r.gpu_total_bytes is not None
             and r.gpu_total_bytes > 0
         ]
         if not candidates:
             return None
+        # Each rank's PEAK reserved over the window, then the rank with the
+        # least headroom against that peak. Peak rather than newest because
+        # the question this tile answers is which rank comes closest to
+        # filling its card, and that is a high-water mark.
         worst = min(
             candidates,
             key=lambda r: (r.gpu_total_bytes or 0.0)
-            - (r.gpu_reserved_bytes or 0.0),
+            - (r.gpu_reserved_peak_bytes or 0.0),
         )
         return MetricRollup(
-            now=float(worst.gpu_reserved_bytes or 0.0),
+            now=float(worst.gpu_reserved_peak_bytes or 0.0),
             total=worst.gpu_total_bytes,
             worst_rank=worst.global_rank,
         )
@@ -553,26 +613,32 @@ class ProcessDashboardComputer:
     def _alloc_rollup(
         self, ranks: Sequence[RankSnapshot]
     ) -> Optional[MetricRollup]:
-        """Live tensors on the median rank.
+        """Live tensors on the rank the reserved tile chose.
 
-        The median rather than the worst, because allocated bytes are the
-        model's shape rather than a risk: on a healthy synchronous run
-        every rank holds much the same, and the median says what that is
-        while the reserved tile beside it names the rank at risk.
+        The SAME rank, so the two GPU tiles describe one device rather than
+        two. Read side by side they answer "how close is the tightest rank
+        to filling its card, and how much of what it holds is live tensors"
+        rather than mixing a worst case with a cohort median.
 
         Read from the ranks, not from the aggregated step history. The
         history's newest step carries no GPU snapshot once a run tears
         down, which left this tile reading "n/a" directly above rows that
         listed each rank's allocated bytes.
         """
-        values = [
-            r.gpu_allocated_p50_bytes
-            for r in ranks
-            if r.gpu_allocated_p50_bytes is not None
-        ]
-        if not values:
+        reserved = self._cuda_rollup(ranks)
+        if reserved is None or reserved.worst_rank is None:
             return None
-        return MetricRollup(now=float(_median(values) or 0.0))
+        chosen = next(
+            (r for r in ranks if r.global_rank == reserved.worst_rank),
+            None,
+        )
+        if chosen is None or chosen.gpu_allocated_p50_bytes is None:
+            return None
+        return MetricRollup(
+            now=float(chosen.gpu_allocated_p50_bytes),
+            total=chosen.gpu_total_bytes,
+            worst_rank=chosen.global_rank,
+        )
 
     def _reserved_imbalance(
         self, ranks: Sequence[RankSnapshot]
@@ -672,7 +738,13 @@ class ProcessDashboardComputer:
                         values=tuple(values),
                     )
                 )
-        return RankChart(mode="recent", span_s=span_s, traces=tuple(traces))
+        built = tuple(traces)
+        return RankChart(
+            mode="recent",
+            span_s=span_s,
+            traces=built,
+            total=_total_trace(built),
+        )
 
     def _one_chart(
         self,
@@ -729,19 +801,21 @@ class ProcessDashboardComputer:
             values.append(roll_avg)
             peaks.append(roll_max)
 
+        built = tuple(
+            RankTrace(
+                global_rank=rank_id,
+                timestamps=tuple(rolled[rank_id][0]),
+                values=tuple(rolled[rank_id][1]),
+                peaks=tuple(rolled[rank_id][2]),
+            )
+            for rank_id in sorted(rolled)
+        )
         chart = RankChart(
             mode="retained",
             window_s=plan.window_s,
             span_s=stats.span_s,
-            traces=tuple(
-                RankTrace(
-                    global_rank=rank_id,
-                    timestamps=tuple(rolled[rank_id][0]),
-                    values=tuple(rolled[rank_id][1]),
-                    peaks=tuple(rolled[rank_id][2]),
-                )
-                for rank_id in sorted(rolled)
-            ),
+            traces=built,
+            total=_total_trace(built),
         )
         self._run_cache[metric] = chart
         self._run_cache_at[metric] = now

--- a/src/traceml_ai/renderers/process/dashboard_compute.py
+++ b/src/traceml_ai/renderers/process/dashboard_compute.py
@@ -43,6 +43,7 @@ from traceml_ai.renderers.shared.run_series import (
 from .dashboard_models import (
     ChartSeries,
     ChartTrace,
+    CudaHeadroomSample,
     GpuSnapshot,
     MetricRollup,
     ProcessDashboardPayload,
@@ -128,6 +129,47 @@ def _gpu_reported(row: Any) -> bool:
         return total is not None and total > 0
     except (KeyError, IndexError, TypeError):
         return False
+
+
+def _least_headroom_sample(
+    rows: Sequence[Any],
+) -> Optional[CudaHeadroomSample]:
+    """The least-headroom row, kept whole so CUDA tile values stay paired.
+
+    Equal-headroom samples resolve to the newest usable row. This makes the
+    result deterministic while preferring the most recent view of live
+    allocations when reserved capacity is unchanged.
+    """
+    candidates = []
+    for row in rows:
+        reserved = _opt_float(row["gpu_mem_reserved_bytes"])
+        total = _opt_float(row["gpu_mem_total_bytes"])
+        if reserved is None or total is None or total <= 0:
+            continue
+        stamp = _opt_float(row["sample_ts_s"])
+        seq = _opt_float(row["seq"])
+        row_id = _opt_float(row["id"])
+        candidates.append(
+            (
+                row,
+                total - reserved,
+                stamp if stamp is not None else float("-inf"),
+                seq if seq is not None else float("-inf"),
+                row_id if row_id is not None else float("-inf"),
+            )
+        )
+    if not candidates:
+        return None
+
+    chosen, _headroom, _stamp, _seq, _row_id = min(
+        candidates,
+        key=lambda item: (item[1], -item[2], -item[3], -item[4]),
+    )
+    return CudaHeadroomSample(
+        allocated_bytes=_opt_float(chosen["gpu_mem_used_bytes"]),
+        reserved_bytes=float(chosen["gpu_mem_reserved_bytes"]),
+        total_bytes=float(chosen["gpu_mem_total_bytes"]),
+    )
 
 
 def _cpu_capacity_of(row: Any) -> Optional[float]:
@@ -395,20 +437,6 @@ class ProcessDashboardComputer:
                 ]
             ),
             ram_total_bytes=_opt_float(newest_row["ram_total_bytes"]),
-            gpu_allocated_p50_bytes=_median(
-                [
-                    value
-                    for value in (
-                        _opt_float(r["gpu_mem_used_bytes"]) for r in reported
-                    )
-                    if value is not None
-                ]
-            ),
-            gpu_reserved_bytes=(
-                _opt_float(newest_gpu["gpu_mem_reserved_bytes"])
-                if newest_gpu is not None
-                else None
-            ),
             gpu_reserved_p50_bytes=_median(
                 [
                     value
@@ -419,17 +447,7 @@ class ProcessDashboardComputer:
                     if value is not None
                 ]
             ),
-            gpu_reserved_peak_bytes=max(
-                (
-                    value
-                    for value in (
-                        _opt_float(r["gpu_mem_reserved_bytes"])
-                        for r in reported
-                    )
-                    if value is not None
-                ),
-                default=None,
-            ),
+            cuda_least_headroom_sample=_least_headroom_sample(reported),
             gpu_total_bytes=(
                 _opt_float(newest_gpu["gpu_mem_total_bytes"])
                 if newest_gpu is not None
@@ -581,33 +599,30 @@ class ProcessDashboardComputer:
     def _cuda_rollup(
         self, ranks: Sequence[RankSnapshot]
     ) -> Optional[MetricRollup]:
-        """Reserved memory on the rank with the least headroom.
+        """Reserved memory from the window's least-headroom rank and row."""
+        worst = self._least_headroom_rank(ranks)
+        if worst is None or worst.cuda_least_headroom_sample is None:
+            return None
+        sample = worst.cuda_least_headroom_sample
+        return MetricRollup(
+            now=sample.reserved_bytes,
+            total=sample.total_bytes,
+            worst_rank=worst.global_rank,
+        )
 
-        Not the largest user: the process at risk is the one closest to
-        filling its card.
-        """
+    @staticmethod
+    def _least_headroom_rank(
+        ranks: Sequence[RankSnapshot],
+    ) -> Optional[RankSnapshot]:
+        """Select across each rank's least-headroom sample."""
         candidates = [
-            r
-            for r in ranks
-            if r.gpu_reserved_peak_bytes is not None
-            and r.gpu_total_bytes is not None
-            and r.gpu_total_bytes > 0
+            r for r in ranks if r.cuda_least_headroom_sample is not None
         ]
         if not candidates:
             return None
-        # Each rank's PEAK reserved over the window, then the rank with the
-        # least headroom against that peak. Peak rather than newest because
-        # the question this tile answers is which rank comes closest to
-        # filling its card, and that is a high-water mark.
-        worst = min(
+        return min(
             candidates,
-            key=lambda r: (r.gpu_total_bytes or 0.0)
-            - (r.gpu_reserved_peak_bytes or 0.0),
-        )
-        return MetricRollup(
-            now=float(worst.gpu_reserved_peak_bytes or 0.0),
-            total=worst.gpu_total_bytes,
-            worst_rank=worst.global_rank,
+            key=lambda rank: rank.cuda_least_headroom_sample.headroom_bytes,
         )
 
     def _alloc_rollup(
@@ -625,18 +640,18 @@ class ProcessDashboardComputer:
         down, which left this tile reading "n/a" directly above rows that
         listed each rank's allocated bytes.
         """
-        reserved = self._cuda_rollup(ranks)
-        if reserved is None or reserved.worst_rank is None:
+        chosen = self._least_headroom_rank(ranks)
+        if chosen is None or chosen.cuda_least_headroom_sample is None:
             return None
-        chosen = next(
-            (r for r in ranks if r.global_rank == reserved.worst_rank),
-            None,
-        )
-        if chosen is None or chosen.gpu_allocated_p50_bytes is None:
+        # Reserved and allocated deliberately come from this exact rank and
+        # row. Pairing the rank's reserved peak with its allocated median
+        # would describe two different moments as though they were one.
+        sample = chosen.cuda_least_headroom_sample
+        if sample.allocated_bytes is None:
             return None
         return MetricRollup(
-            now=float(chosen.gpu_allocated_p50_bytes),
-            total=chosen.gpu_total_bytes,
+            now=sample.allocated_bytes,
+            total=sample.total_bytes,
             worst_rank=chosen.global_rank,
         )
 

--- a/src/traceml_ai/renderers/process/dashboard_models.py
+++ b/src/traceml_ai/renderers/process/dashboard_models.py
@@ -222,6 +222,7 @@ class ProcessDashboardPayload:
     cpu_capacity: Optional[MetricRollup] = None
     rss_worst: Optional[MetricRollup] = None
     gpu_reserved: Optional[MetricRollup] = None
+    gpu_allocated: Optional[MetricRollup] = None
     reserved_imbalance_percent: Optional[float] = None
     cpu_capacity_chart: Optional[RankChart] = None
     rss_chart: Optional[RankChart] = None

--- a/src/traceml_ai/renderers/process/dashboard_models.py
+++ b/src/traceml_ai/renderers/process/dashboard_models.py
@@ -42,6 +42,25 @@ class GpuSnapshot:
 
 
 @dataclass(frozen=True)
+class CudaHeadroomSample:
+    """One rank's least-headroom CUDA sample in the recent window.
+
+    Allocated, reserved and total bytes stay together because the two CUDA
+    tiles must describe the same rank at the same sample, not statistics
+    independently selected from different moments.
+    """
+
+    allocated_bytes: Optional[float]
+    reserved_bytes: float
+    total_bytes: float
+
+    @property
+    def headroom_bytes(self) -> float:
+        """Device bytes not reserved at this sample."""
+        return self.total_bytes - self.reserved_bytes
+
+
+@dataclass(frozen=True)
 class ProcessHistoryEntry:
     """One globally committed step, aggregated across ranks.
 
@@ -66,12 +85,10 @@ class RankSnapshot:
     squeezed out by livelier peers, and a rank that never reports must not
     shrink everyone else's window.
 
-    The levels here are deliberately not all "the newest sample". CPU and
-    the allocator's live bytes are sampled far slower than they move, so a
-    single reading lands wherever the sawtooth happened to be; those carry
-    a window median. Reserved memory and RSS carry both, because which rank
-    is WORST is a judgement about its typical state while the number SHOWN
-    should be what that rank last actually sent.
+    The levels here are deliberately not all "the newest sample". CPU, RSS
+    and the allocator's live bytes carry window summaries where needed.
+    CUDA also carries the complete least-headroom sample so allocated and
+    reserved can never be paired across different moments.
     """
 
     global_rank: int
@@ -83,10 +100,8 @@ class RankSnapshot:
     ram_used_p50_bytes: Optional[float] = None
     ram_total_bytes: Optional[float] = None
 
-    gpu_allocated_p50_bytes: Optional[float] = None
-    gpu_reserved_bytes: Optional[float] = None
     gpu_reserved_p50_bytes: Optional[float] = None
-    gpu_reserved_peak_bytes: Optional[float] = None
+    cuda_least_headroom_sample: Optional[CudaHeadroomSample] = None
     gpu_total_bytes: Optional[float] = None
 
     age_s: Optional[float] = None
@@ -275,6 +290,7 @@ class ProcessDashboardPayload:
 __all__ = [
     "ChartSeries",
     "ChartTrace",
+    "CudaHeadroomSample",
     "GpuSnapshot",
     "MetricRollup",
     "ProcessDashboardPayload",

--- a/src/traceml_ai/renderers/process/dashboard_models.py
+++ b/src/traceml_ai/renderers/process/dashboard_models.py
@@ -86,6 +86,7 @@ class RankSnapshot:
     gpu_allocated_p50_bytes: Optional[float] = None
     gpu_reserved_bytes: Optional[float] = None
     gpu_reserved_p50_bytes: Optional[float] = None
+    gpu_reserved_peak_bytes: Optional[float] = None
     gpu_total_bytes: Optional[float] = None
 
     age_s: Optional[float] = None
@@ -180,6 +181,11 @@ class RankChart:
     window_s: Optional[float] = None
     span_s: Optional[float] = None
     traces: Tuple[RankTrace, ...] = ()
+    # Every rank added together, on the union of their sample times. The
+    # per-rank lines answer "which rank", the total answers "how much of
+    # the host is this job using", and neither can be read off the other
+    # when ranks sample on their own clocks.
+    total: Optional[RankTrace] = None
 
     @property
     def is_retained(self) -> bool:

--- a/src/traceml_ai/renderers/process/dashboard_models.py
+++ b/src/traceml_ai/renderers/process/dashboard_models.py
@@ -225,6 +225,7 @@ class ProcessDashboardPayload:
     reserved_imbalance_percent: Optional[float] = None
     cpu_capacity_chart: Optional[RankChart] = None
     rss_chart: Optional[RankChart] = None
+    rows_open: bool = False
 
     @property
     def has_data(self) -> bool:

--- a/src/traceml_ai/renderers/process/repository.py
+++ b/src/traceml_ai/renderers/process/repository.py
@@ -310,23 +310,28 @@ class ProcessRepository:
     def fetch_recent_rank_window(
         self,
         conn: sqlite3.Connection,
-        window_n: int = 100,
+        window_s: float = 60.0,
         newest_ts: Optional[float] = None,
-        max_age_s: float = 20.0 * 60.0,
+        max_rows_per_rank: int = 2000,
     ) -> List[sqlite3.Row]:
-        """The last ``window_n`` samples of EVERY rank, newest last.
+        """Every rank's samples from the last ``window_s`` seconds.
 
-        Per rank, not globally. A rank that stopped reporting keeps its own
-        history instead of being squeezed out by livelier peers, and a rank
-        that never reports does not shrink everyone else's window.
+        A DURATION, not a sample count. The two are the same thing only at
+        one sampling rate: at the default two-second cadence a hundred
+        samples is a little over three minutes, at a half-second cadence it
+        is under one, so a card labelled "last 100 samples" describes a
+        different span on every run and two runs cannot be compared.
 
-        Bounded by time before the partition runs: without it the
-        ROW_NUMBER scans every row ever written in order to rank the last
-        hundred, and that scan grows with the run.
+        Per rank rather than globally. A rank that stopped reporting keeps
+        its own history instead of being squeezed out by livelier peers.
+
+        ``max_rows_per_rank`` is a backstop, not the window: a pathological
+        sampler cannot make one tick's read unbounded. It sits far above
+        any real cadence, so under normal operation the duration decides.
         """
         floor_ts = None
         if newest_ts is not None:
-            floor_ts = newest_ts - max(60.0, float(max_age_s))
+            floor_ts = float(newest_ts) - max(0.0, float(window_s))
         return conn.execute(
             """
             WITH recent AS (
@@ -347,7 +352,7 @@ class ProcessRepository:
             WHERE rn <= ?
             ORDER BY COALESCE(global_rank, rank) ASC, seq ASC, id ASC;
             """,
-            (floor_ts, floor_ts, int(max(1, window_n))),
+            (floor_ts, floor_ts, int(max(1, max_rows_per_rank))),
         ).fetchall()
 
     def fetch_rank_latest(self, conn: sqlite3.Connection) -> List[sqlite3.Row]:

--- a/tests/display/test_charting_and_formatting.py
+++ b/tests/display/test_charting_and_formatting.py
@@ -1,0 +1,161 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The two presentation helper modules, on their own.
+
+Neither imports NiceGUI, so these run without a display stack and a failure
+points at the arithmetic rather than at a card.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from traceml_ai.aggregator.display_drivers.nicegui_sections import (
+    charting,
+    formatting,
+)
+
+GIB = float(1024**3)
+
+
+# --- formatting ----------------------------------------------------------
+def test_a_measured_value_never_prints_as_zero():
+    """27 MB is a reading. Printed with one decimal it reads as absent."""
+    value, rest = formatting.format_gb_pair(27 * 1024 * 1024, None)
+    assert value == "0.03"
+    assert rest == "GB"
+
+
+def test_a_level_carries_its_denominator():
+    value, rest = formatting.format_gb_pair(6.3 * GIB, 16.1 * GIB)
+    assert (value, rest) == ("6.3", "/ 16.1 GB")
+
+
+def test_absence_is_a_marker_not_a_number():
+    assert formatting.format_gb_pair(None, 16.0 * GIB) == ("n/a", "")
+    assert formatting.num(None) == "n/a"
+    assert formatting.format_age(None) == "n/a"
+
+
+def test_a_garbled_value_does_not_raise():
+    assert formatting.num("not a number") == "n/a"
+    assert formatting.format_age("later") == "n/a"
+    assert formatting.gb("many") is None
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [(45.0, "45 s"), (300.0, "5 min"), (7200.0, "2.0 h")],
+)
+def test_an_age_is_written_in_the_unit_that_fits_it(seconds, expected):
+    assert formatting.format_age(seconds) == expected
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [(0.0, ""), (None, ""), (45.0, "last 45 s"), (600.0, "last 10 min")],
+)
+def test_a_span_is_one_phrase_or_nothing(seconds, expected):
+    assert formatting.format_span(seconds) == expected
+
+
+def test_a_real_but_small_percentage_is_not_rounded_to_zero():
+    assert formatting.format_percent(0.4) == "<1"
+    assert formatting.format_percent(22.0) == "22"
+    assert formatting.format_percent(None) == "n/a"
+
+
+# --- charting ------------------------------------------------------------
+def test_a_rank_keeps_the_same_colour_everywhere():
+    assert charting.rank_color(1) == charting.rank_color(1)
+    assert charting.rank_color(0) != charting.rank_color(1)
+
+
+def test_rank_colours_wrap_rather_than_run_out():
+    count = len(charting.RANK_COLORS)
+    assert charting.rank_color(count) == charting.rank_color(0)
+
+
+def test_no_rank_colour_reads_as_a_verdict():
+    """Red is a severity word on this page, and a rank id is not one."""
+    for colour in charting.RANK_COLORS:
+        assert colour.lower() not in ("#ff0000", "#f00", "red")
+
+
+def test_a_capacity_axis_is_anchored_at_zero():
+    top = charting.capacity_axis_max([12.0, 18.0])
+    assert top >= 18.0
+    assert top in (20.0, 30.0, 40.0, 60.0, 80.0, 100.0)
+
+
+def test_a_drift_axis_fits_the_data_instead_of_the_origin():
+    """The RSS case: a 20 MB movement on a 1.5 GB level.
+
+    Zero-anchoring would put the whole movement inside one pixel, which is
+    the leak this chart exists to show.
+    """
+    low, high, tick = charting.drift_axis_bounds([1.48, 1.49, 1.50])
+    assert low > 1.0
+    assert high < 2.0
+    assert tick > 0
+
+
+def test_a_flat_series_still_gets_a_range():
+    low, high, _tick = charting.drift_axis_bounds([2.0, 2.0, 2.0])
+    assert high > low
+
+
+def test_an_empty_series_does_not_raise():
+    assert charting.drift_axis_bounds([]) == (0.0, 1.0, 0.5)
+    assert charting.capacity_axis_max([]) == 4.0
+
+
+@pytest.mark.parametrize(
+    "span,decimals",
+    [
+        (50.0, "toFixed(0)"),
+        (5.0, "toFixed(1)"),
+        (0.5, "toFixed(2)"),
+        (0.05, "toFixed(3)"),
+    ],
+)
+def test_tick_precision_comes_from_the_range_not_the_magnitude(span, decimals):
+    assert decimals in charting.value_axis_formatter(span, " GB")
+
+
+def test_a_sparkline_of_nothing_is_nothing():
+    assert charting.sparkline_svg([], "#fff") == ""
+    assert charting.sparkline_svg([None, None], "#fff") == ""
+
+
+def test_a_sparkline_drops_gaps_rather_than_drawing_them_at_zero():
+    svg = charting.sparkline_svg([1.0, None, 3.0], "#fff")
+    assert svg.count(",") == 2
+    assert "polyline" in svg
+
+
+class _Trace:
+    def __init__(self, stamps):
+        self.timestamps = stamps
+
+
+def test_the_shared_span_covers_every_trace_given():
+    anchor, span = charting.shared_span(
+        [_Trace((100.0, 110.0))], [_Trace((90.0, 105.0))]
+    )
+    assert anchor == 110.0
+    assert span == pytest.approx(20.0)
+
+
+def test_a_span_of_no_traces_is_none():
+    assert charting.shared_span([], []) is None
+    assert charting.shared_span([_Trace(())]) is None
+
+
+def test_a_span_never_collapses_to_zero():
+    _anchor, span = charting.shared_span([_Trace((100.0,))])
+    assert span >= 1.0

--- a/tests/display/test_charting_and_formatting.py
+++ b/tests/display/test_charting_and_formatting.py
@@ -57,7 +57,14 @@ def test_an_age_is_written_in_the_unit_that_fits_it(seconds, expected):
 
 @pytest.mark.parametrize(
     "seconds,expected",
-    [(0.0, ""), (None, ""), (45.0, "last 45 s"), (600.0, "last 10 min")],
+    [
+        (0.0, ""),
+        (None, ""),
+        (45.0, "last 45 s"),
+        # 105 s used to read "last 2 min", overstating the window by 14%.
+        (105.0, "last 105 s"),
+        (600.0, "last 10 min"),
+    ],
 )
 def test_a_span_is_one_phrase_or_nothing(seconds, expected):
     assert formatting.format_span(seconds) == expected

--- a/tests/display/test_process_section.py
+++ b/tests/display/test_process_section.py
@@ -15,10 +15,9 @@ things now. The two differences worth naming:
   reserved`` pair. One tile could not say which of the two it held, and the
   two numbers answer different questions: allocated is what the tensors
   need, reserved is what the process is holding from the device.
-* The ``CPU`` and ``RAM`` tiles become ``cpu capacity`` and ``rss``, which
-  are the per-rank, denominator-carrying versions of the same quantities.
-  A raw 700% CPU reading is not comparable between hosts; 87.5% of the
-  host's capacity is.
+* The ``CPU`` and ``RAM`` tiles become ``cpu`` and ``rss``. CPU keeps its
+  meaning in the value: a raw 700% process reading is not comparable between
+  hosts, while 87.5% of the host is.
 
 ``test_the_card_renders_the_same_from_a_real_database`` closes the loop
 from database through compute to screen, and states both new meanings as

--- a/tests/display/test_process_section.py
+++ b/tests/display/test_process_section.py
@@ -196,6 +196,7 @@ def _payload(
             else None
         ),
         gpu=(MetricRollup(now=6.0 * GIB, p95=6.0 * GIB) if gpu else None),
+        gpu_allocated=(MetricRollup(now=6.0 * GIB) if gpu else None),
         reserved_imbalance_percent=imbalance,
         rows_open=rows_open,
         cpu_capacity_chart=_chart(*ranks),
@@ -229,6 +230,10 @@ def test_allocated_and_reserved_are_two_tiles_not_one():
     process_section.update_process_section(panel, _payload())
     assert "7.0" in panel["tiles"]["reserved"].content
     assert "6.0" in panel["tiles"]["alloc"].content
+    # Read from the per-rank rollup, not the aggregated step history: the
+    # history's newest step has no GPU snapshot once a run tears down,
+    # which left this tile "n/a" above rows listing each rank's bytes.
+    assert panel["tiles"]["alloc"].content != "n/a"
     assert panel["subs"]["reserved"].text == "least-headroom rank · R1"
     assert panel["subs"]["alloc"].text == "median rank · live tensors"
 
@@ -566,3 +571,38 @@ def test_a_single_sample_is_visible_rather_than_an_empty_plot():
     series = panel["cpu_chart"].options["series"][0]
     assert series["data"], "the point must reach the chart"
     assert series["showSymbol"] is True, "one point needs a marker"
+
+
+def test_the_allocated_tile_survives_a_teardown_step():
+    """It reads the ranks, so it does not blank when history loses the GPU.
+
+    The tile said "median rank · live tensors" while being fed the newest
+    committed step's aggregate, which is None after teardown. It read
+    "n/a" directly above rows listing each rank's allocated bytes.
+    """
+    from traceml_ai.renderers.process.dashboard_models import (
+        ProcessHistoryEntry,
+    )
+
+    payload = ProcessDashboardPayload(
+        history=(
+            ProcessHistoryEntry(
+                seq=1,
+                ts=1_700_000_001.0,
+                cpu_percent_max=10.0,
+                ram_used_bytes_max=1.0 * GIB,
+                ram_total_bytes=64.0 * GIB,
+                gpu=None,
+            ),
+        ),
+        ranks=(_rank(0), _rank(1)),
+        coverage=RankCoverage(total=2, live=2),
+        gpu=None,
+        gpu_allocated=MetricRollup(now=4.0 * GIB),
+        gpu_reserved=MetricRollup(now=6.0 * GIB, worst_rank=0),
+        cpu_capacity_chart=_chart(0, 1),
+        rss_chart=_chart(0, 1),
+    )
+    panel = _panel()
+    process_section.update_process_section(panel, payload)
+    assert "4.0" in panel["tiles"]["alloc"].content

--- a/tests/display/test_process_section.py
+++ b/tests/display/test_process_section.py
@@ -196,7 +196,9 @@ def _payload(
             else None
         ),
         gpu=(MetricRollup(now=6.0 * GIB, p95=6.0 * GIB) if gpu else None),
-        gpu_allocated=(MetricRollup(now=6.0 * GIB) if gpu else None),
+        gpu_allocated=(
+            MetricRollup(now=6.0 * GIB, worst_rank=1) if gpu else None
+        ),
         reserved_imbalance_percent=imbalance,
         rows_open=rows_open,
         cpu_capacity_chart=_chart(*ranks),
@@ -205,18 +207,20 @@ def _payload(
 
 
 # --- the four tiles ------------------------------------------------------
-def test_the_cpu_tile_leads_with_the_worst_rank_and_names_it():
+def test_the_cpu_tile_leads_with_the_highest_median_and_names_it():
+    """One rule for the section: per-rank median, then the highest."""
     panel = _panel()
     process_section.update_process_section(panel, _payload())
     assert "87.5" in panel["tiles"]["cpu"].content
-    assert panel["subs"]["cpu"].text == ("worst rank · R1 · of host capacity")
+    assert "of host" in panel["tiles"]["cpu"].content
+    assert panel["subs"]["cpu"].text == "highest median · R1"
 
 
-def test_the_rss_tile_names_its_worst_rank():
+def test_the_rss_tile_names_the_rank_with_the_highest_median():
     panel = _panel()
     process_section.update_process_section(panel, _payload())
     assert "2.5" in panel["tiles"]["rss"].content
-    assert panel["subs"]["rss"].text == "worst rank · R0"
+    assert panel["subs"]["rss"].text == "highest median · R0"
 
 
 def test_allocated_and_reserved_are_two_tiles_not_one():
@@ -234,8 +238,9 @@ def test_allocated_and_reserved_are_two_tiles_not_one():
     # history's newest step has no GPU snapshot once a run tears down,
     # which left this tile "n/a" above rows listing each rank's bytes.
     assert panel["tiles"]["alloc"].content != "n/a"
-    assert panel["subs"]["reserved"].text == "least-headroom rank · R1"
-    assert panel["subs"]["alloc"].text == "median rank · live tensors"
+    assert panel["subs"]["reserved"].text == "least headroom · R1"
+    # Both GPU tiles describe ONE device, so they can be read together.
+    assert panel["subs"]["alloc"].text == "least-headroom rank · R1"
 
 
 def test_a_cpu_only_run_marks_both_gpu_tiles_absent():
@@ -606,3 +611,50 @@ def test_the_allocated_tile_survives_a_teardown_step():
     panel = _panel()
     process_section.update_process_section(panel, payload)
     assert "4.0" in panel["tiles"]["alloc"].content
+
+
+def test_the_total_line_is_drawn_and_fits_inside_the_axis():
+    """The total is the sum across ranks, so it is the highest line.
+
+    Fitting the axis to the per-rank traces alone would clip exactly the
+    line a reader looks at first. This is the same defect that clipped the
+    RSS chart when the axis was fitted to the peaks.
+    """
+    chart = RankChart(
+        mode="recent",
+        traces=(
+            RankTrace(
+                global_rank=0,
+                timestamps=(1.0, 2.0, 3.0),
+                values=(10.0, 11.0, 12.0),
+            ),
+            RankTrace(
+                global_rank=1,
+                timestamps=(1.0, 2.0, 3.0),
+                values=(10.0, 11.0, 12.0),
+            ),
+        ),
+        total=RankTrace(
+            global_rank=-1,
+            timestamps=(1.0, 2.0, 3.0),
+            values=(20.0, 22.0, 24.0),
+        ),
+    )
+    payload = ProcessDashboardPayload(
+        window_len=3,
+        ranks=(_rank(0), _rank(1)),
+        coverage=RankCoverage(total=2, live=2),
+        cpu_capacity=MetricRollup(now=12.0, worst_rank=0),
+        cpu_capacity_chart=chart,
+        rss_chart=chart,
+    )
+    panel = _panel()
+    process_section.update_process_section(panel, payload)
+
+    series = panel["cpu_chart"].options["series"]
+    assert len(series) == 3, "two ranks plus the total"
+    assert series[0]["name"] == "Total"
+
+    drawn = [v for s in series for _t, v in s["data"]]
+    top = panel["cpu_chart"].options["yAxis"]["max"]
+    assert top >= max(drawn), "the total must not be clipped"

--- a/tests/display/test_process_section.py
+++ b/tests/display/test_process_section.py
@@ -40,6 +40,7 @@ from traceml_ai.renderers.process.dashboard_compute import (  # noqa: E402
     ProcessDashboardComputer,
 )
 from traceml_ai.renderers.process.dashboard_models import (  # noqa: E402
+    CudaHeadroomSample,
     MetricRollup,
     ProcessDashboardPayload,
     RankChart,
@@ -123,9 +124,12 @@ def _rank(
         ram_used_bytes=rss,
         ram_used_p50_bytes=rss,
         ram_total_bytes=64.0 * GIB,
-        gpu_allocated_p50_bytes=allocated,
-        gpu_reserved_bytes=reserved,
         gpu_reserved_p50_bytes=reserved,
+        cuda_least_headroom_sample=CudaHeadroomSample(
+            allocated_bytes=allocated,
+            reserved_bytes=reserved,
+            total_bytes=40.0 * GIB,
+        ),
         gpu_total_bytes=40.0 * GIB,
         age_s=age_s,
         freshness=freshness,
@@ -319,6 +323,24 @@ def test_every_rank_is_a_row_with_its_identity_and_its_memory():
     assert "R0" in html and "R1" in html
     assert "G0" in html and "N0" in html
     assert "cuda allocated" in html and "cuda reserved" in html
+
+
+def test_each_row_pairs_cuda_values_from_its_least_headroom_sample():
+    """The row and selected CUDA tiles share one per-rank sample basis."""
+    rank = RankSnapshot(
+        global_rank=0,
+        gpu_reserved_p50_bytes=5.0 * GIB,
+        cuda_least_headroom_sample=CudaHeadroomSample(
+            allocated_bytes=22.0 * GIB,
+            reserved_bytes=30.0 * GIB,
+            total_bytes=40.0 * GIB,
+        ),
+    )
+
+    html = process_section.rows_html((rank,), None)
+
+    assert "22.0 / 40.0 GB" in html
+    assert "30.0 / 40.0 GB" in html
 
 
 def test_a_stale_rank_is_dimmed_and_kept():

--- a/tests/display/test_process_section.py
+++ b/tests/display/test_process_section.py
@@ -6,18 +6,28 @@
 
 """What the Process card puts on screen for a given payload.
 
-Every on-screen assertion here is the one that was pinned against
-version_0.3.7 rendering; only the payload handed to the card changed shape.
-The percentile and rollup tests that used to live in this file moved to
-``tests/renderers/process/test_process_dashboard_payload.py``, because the
-arithmetic they cover moved to the compute layer. That relocation is the
-whole point of the change, so the tests follow the code.
+The card this file describes is the one this PR builds: four tiles, two
+per-rank charts and a per-rank table. The previous card's assertions are
+NOT carried over unchanged, because the card deliberately says different
+things now. The two differences worth naming:
 
-``test_the_card_renders_the_same_from_a_real_database`` closes the loop end
-to end: database, compute, card, screen.
+* The single ``GPU MEM`` tile becomes the ``cuda allocated`` and ``cuda
+  reserved`` pair. One tile could not say which of the two it held, and the
+  two numbers answer different questions: allocated is what the tensors
+  need, reserved is what the process is holding from the device.
+* The ``CPU`` and ``RAM`` tiles become ``cpu capacity`` and ``rss``, which
+  are the per-rank, denominator-carrying versions of the same quantities.
+  A raw 700% CPU reading is not comparable between hosts; 87.5% of the
+  host's capacity is.
+
+``test_the_card_renders_the_same_from_a_real_database`` closes the loop
+from database through compute to screen, and states both new meanings as
+explicit numbers so the change is visible rather than implied.
 """
 
 from __future__ import annotations
+
+import re
 
 import pytest
 
@@ -30,15 +40,16 @@ from traceml_ai.renderers.process.dashboard_compute import (  # noqa: E402
     ProcessDashboardComputer,
 )
 from traceml_ai.renderers.process.dashboard_models import (  # noqa: E402
-    ChartSeries,
-    ChartTrace,
-    GpuSnapshot,
     MetricRollup,
     ProcessDashboardPayload,
-    ProcessHistoryEntry,
+    RankChart,
+    RankCoverage,
+    RankSnapshot,
+    RankTrace,
 )
 
 GB = 1_000_000_000.0
+GIB = float(1024**3)
 
 
 class _Html:
@@ -49,13 +60,24 @@ class _Html:
 class _Text:
     def __init__(self) -> None:
         self.text = ""
+        self.tooltips: list = []
+
+    def tooltip(self, text: str) -> None:
+        self.tooltips.append(text)
+
+
+class _Expansion:
+    def __init__(self) -> None:
+        self.value = False
 
 
 class _Chart:
     def __init__(self) -> None:
         self.options = {
-            "series": [{"data": []}, {"data": []}],
-            "yAxis": [{}, {}],
+            "series": [],
+            "xAxis": {"axisLabel": {}},
+            "yAxis": {"axisLabel": {}},
+            "tooltip": {"axisPointer": {"label": {}}},
         }
         self.updates = 0
 
@@ -64,174 +86,312 @@ class _Chart:
 
 
 def _panel() -> dict:
+    keys = ("cpu", "rss", "reserved", "alloc")
     return {
-        "chart": _Chart(),
-        "win": _Text(),
-        "kpis": {k: _Html() for k in ("cpu", "ram", "gmem", "gimb")},
+        "tiles": {k: _Html() for k in keys},
+        "subs": {k: _Text() for k in keys},
+        "note": _Text(),
+        "cpu_chart": _Chart(),
+        "rss_chart": _Chart(),
+        "cpu_label": _Text(),
+        "rss_label": _Text(),
+        "cpu_value": _Text(),
+        "rss_value": _Text(),
+        "rows": _Expansion(),
+        "rows_hint": _Text(),
+        "rows_html": _Html(),
+        "_was_open": False,
+        "_signature": None,
     }
+
+
+def _rank(
+    index: int,
+    *,
+    capacity: float = 25.0,
+    rss: float = 2.0 * GIB,
+    reserved: float = 6.0 * GIB,
+    allocated: float = 4.0 * GIB,
+    freshness: str = "fresh",
+    age_s: float = 2.0,
+) -> RankSnapshot:
+    return RankSnapshot(
+        global_rank=index,
+        node_rank=0,
+        gpu_index=index,
+        cpu_capacity_percent=capacity,
+        ram_used_bytes=rss,
+        ram_used_p50_bytes=rss,
+        ram_total_bytes=64.0 * GIB,
+        gpu_allocated_p50_bytes=allocated,
+        gpu_reserved_bytes=reserved,
+        gpu_reserved_p50_bytes=reserved,
+        gpu_total_bytes=40.0 * GIB,
+        age_s=age_s,
+        freshness=freshness,
+    )
+
+
+def _chart(*ranks: int, mode: str = "recent") -> RankChart:
+    stamps = (1_700_000_000.0, 1_700_000_002.0, 1_700_000_004.0)
+    return RankChart(
+        mode=mode,
+        window_s=120.0 if mode == "retained" else None,
+        traces=tuple(
+            RankTrace(
+                global_rank=index,
+                timestamps=stamps,
+                values=(20.0 + index, 21.0 + index, 22.0 + index),
+            )
+            for index in ranks
+        ),
+    )
 
 
 def _payload(
     *,
-    n: int = 1,
-    cpu: float = 10.0,
-    ram: float = 2.0 * GB,
-    ram_total: float = 16.0 * GB,
-    gpu_used: float = None,
-    gpu_total: float = 16.0 * GB,
-    imbalance: float = None,
+    ranks=(0, 1),
+    gpu: bool = True,
+    imbalance=None,
+    rows_open: bool = False,
+    stale: int = 0,
+    unknown: int = 0,
 ) -> ProcessDashboardPayload:
-    stamps = tuple(1_700_000_000.0 + i for i in range(n))
-    gpu_block = (
-        None
-        if gpu_used is None
-        else GpuSnapshot(
-            used_bytes=gpu_used,
-            total_bytes=gpu_total,
-            headroom_bytes=gpu_total - gpu_used,
-            rank=0,
-            used_imbalance_bytes=imbalance or 0.0,
+    snapshots = tuple(
+        _rank(
+            i,
+            reserved=(6.0 * GIB if gpu else None),
+            allocated=(4.0 * GIB if gpu else None),
         )
+        for i in ranks
     )
-    history = tuple(
-        ProcessHistoryEntry(
-            seq=i,
-            ts=stamps[i],
-            cpu_percent_max=cpu,
-            ram_used_bytes_max=ram,
-            ram_total_bytes=ram_total,
-            gpu=gpu_block,
+    if not gpu:
+        snapshots = tuple(
+            RankSnapshot(
+                global_rank=r.global_rank,
+                node_rank=r.node_rank,
+                cpu_capacity_percent=r.cpu_capacity_percent,
+                ram_used_bytes=r.ram_used_bytes,
+                ram_used_p50_bytes=r.ram_used_p50_bytes,
+                ram_total_bytes=r.ram_total_bytes,
+                age_s=r.age_s,
+                freshness=r.freshness,
+            )
+            for r in snapshots
         )
-        for i in range(n)
-    )
     return ProcessDashboardPayload(
-        history=history,
-        window_len=n,
-        cpu=MetricRollup(now=cpu, p95=cpu, p50=cpu),
-        ram=MetricRollup(now=ram, p95=ram, total=ram_total),
-        gpu=(
-            None
-            if gpu_used is None
-            else MetricRollup(now=gpu_used, p95=gpu_used, total=gpu_total)
+        window_len=3,
+        ranks=snapshots,
+        coverage=RankCoverage(
+            total=len(snapshots),
+            live=len(snapshots) - stale - unknown,
+            stale=stale,
+            unknown=unknown,
         ),
-        gpu_used_imbalance_bytes=imbalance,
-        chart=ChartSeries(
-            ram_percent=ChartTrace(
-                label="RAM",
-                timestamps=stamps,
-                values=tuple((ram / ram_total) * 100.0 for _ in range(n)),
-            ),
-            gpu_percent=(
-                None
-                if gpu_used is None
-                else ChartTrace(
-                    label="GPU mem",
-                    timestamps=stamps,
-                    values=tuple(
-                        (gpu_used / gpu_total) * 100.0 for _ in range(n)
-                    ),
-                )
-            ),
+        cpu_capacity=MetricRollup(now=87.5, p95=87.5, p50=25.0, worst_rank=1),
+        rss_worst=MetricRollup(now=2.5 * GIB, p95=2.5 * GIB, worst_rank=0),
+        gpu_reserved=(
+            MetricRollup(now=7.0 * GIB, p95=7.0 * GIB, worst_rank=1)
+            if gpu
+            else None
         ),
+        gpu=(MetricRollup(now=6.0 * GIB, p95=6.0 * GIB) if gpu else None),
+        reserved_imbalance_percent=imbalance,
+        rows_open=rows_open,
+        cpu_capacity_chart=_chart(*ranks),
+        rss_chart=_chart(*ranks),
     )
 
 
-# --- what lands on screen ------------------------------------------------
-def test_a_cpu_only_payload_renders_cpu_and_ram_and_marks_gpu_absent():
+# --- the four tiles ------------------------------------------------------
+def test_the_cpu_tile_leads_with_the_worst_rank_and_names_it():
     panel = _panel()
-    process_section.update_process_section(
-        panel, _payload(n=2, cpu=50.0, ram=4.0 * GB)
-    )
-    assert "50" in panel["kpis"]["cpu"].content
-    assert "4.00" in panel["kpis"]["ram"].content
-    assert panel["kpis"]["gmem"].content == "N/A"
-    assert panel["kpis"]["gimb"].content == "—"
-    assert panel["win"].text == "last 2 samples"
+    process_section.update_process_section(panel, _payload())
+    assert "87.5" in panel["tiles"]["cpu"].content
+    assert panel["subs"]["cpu"].text == ("worst rank · R1 · of host capacity")
 
 
-def test_a_gpu_payload_renders_memory_and_imbalance():
+def test_the_rss_tile_names_its_worst_rank():
     panel = _panel()
-    process_section.update_process_section(
-        panel, _payload(n=2, gpu_used=6.0 * GB, imbalance=1.5 * GB)
-    )
-    assert "6.00" in panel["kpis"]["gmem"].content
-    assert "1.50" in panel["kpis"]["gimb"].content
+    process_section.update_process_section(panel, _payload())
+    assert "2.5" in panel["tiles"]["rss"].content
+    assert panel["subs"]["rss"].text == "worst rank · R0"
 
 
-def test_an_unavailable_imbalance_renders_a_dash_not_a_zero():
+def test_allocated_and_reserved_are_two_tiles_not_one():
+    """The split that #399 settled the wording for.
+
+    A single tile could not say which of the two numbers it held. They are
+    different quantities: 6 GiB of live tensors inside 7 GiB the process is
+    holding from the device.
+    """
     panel = _panel()
-    process_section.update_process_section(
-        panel, _payload(gpu_used=6.0 * GB, imbalance=None)
-    )
-    assert "—" in panel["kpis"]["gimb"].content
+    process_section.update_process_section(panel, _payload())
+    assert "7.0" in panel["tiles"]["reserved"].content
+    assert "6.0" in panel["tiles"]["alloc"].content
+    assert panel["subs"]["reserved"].text == "least-headroom rank · R1"
+    assert panel["subs"]["alloc"].text == "median rank · live tensors"
 
 
-def test_the_chart_plots_ram_as_a_percentage_of_its_total():
+def test_a_cpu_only_run_marks_both_gpu_tiles_absent():
     panel = _panel()
-    process_section.update_process_section(
-        panel, _payload(ram=4.0 * GB, ram_total=16.0 * GB)
-    )
-    ram_series = panel["chart"].options["series"][0]["data"]
-    assert len(ram_series) == 1
-    assert ram_series[0][1] == pytest.approx(25.0)
-
-
-def test_the_chart_plots_gpu_memory_as_a_percentage_of_its_total():
-    panel = _panel()
-    process_section.update_process_section(
-        panel, _payload(gpu_used=4.0 * GB, gpu_total=16.0 * GB)
-    )
-    gpu_series = panel["chart"].options["series"][1]["data"]
-    assert gpu_series[0][1] == pytest.approx(25.0)
-
-
-def test_both_axes_share_one_ceiling():
-    panel = _panel()
-    process_section.update_process_section(
-        panel, _payload(ram=8.0 * GB, ram_total=16.0 * GB)
-    )
-    options = panel["chart"].options
-    assert options["yAxis"][0]["max"] == options["yAxis"][1]["max"]
-
-
-def test_the_window_length_is_stated_by_the_payload():
-    panel = _panel()
-    process_section.update_process_section(panel, _payload(n=100))
-    assert panel["win"].text == "last 100 samples"
-
-
-def test_an_empty_payload_leaves_the_card_untouched():
-    panel = _panel()
-    process_section.update_process_section(panel, ProcessDashboardPayload())
-    assert panel["win"].text == ""
-    assert panel["chart"].updates == 0
+    process_section.update_process_section(panel, _payload(gpu=False))
+    assert panel["tiles"]["reserved"].content == "n/a"
+    assert panel["tiles"]["alloc"].content == "n/a"
+    assert panel["subs"]["reserved"].text == "no GPU"
 
 
 def test_a_payload_of_the_wrong_type_is_ignored():
     panel = _panel()
     process_section.update_process_section(panel, None)
-    process_section.update_process_section(panel, {"history": []})
-    assert panel["win"].text == ""
+    process_section.update_process_section(panel, {"ranks": []})
+    assert panel["tiles"]["cpu"].content == ""
 
 
-def test_a_sample_without_a_usable_time_is_not_plotted():
-    """A zero timestamp cannot be placed on a time axis, so it is dropped
-    rather than drawn at the epoch."""
-    payload = _payload(n=1)
-    payload = ProcessDashboardPayload(
-        history=payload.history,
-        window_len=payload.window_len,
-        cpu=payload.cpu,
-        ram=payload.ram,
-        chart=ChartSeries(
-            ram_percent=ChartTrace(
-                label="RAM", timestamps=(0.0,), values=(25.0,)
-            )
-        ),
-    )
+# --- the two charts ------------------------------------------------------
+def test_each_rank_is_its_own_line_on_both_charts():
     panel = _panel()
+    process_section.update_process_section(panel, _payload(ranks=(0, 1, 2)))
+    assert len(panel["cpu_chart"].options["series"]) == 3
+    assert len(panel["rss_chart"].options["series"]) == 3
+
+
+def test_both_charts_share_one_time_axis():
+    """A vertical read across the pair has to land on the same moment."""
+    panel = _panel()
+    process_section.update_process_section(panel, _payload())
+    cpu_axis = panel["cpu_chart"].options["xAxis"]
+    rss_axis = panel["rss_chart"].options["xAxis"]
+    assert (cpu_axis["min"], cpu_axis["max"]) == (
+        rss_axis["min"],
+        rss_axis["max"],
+    )
+
+
+def test_the_capacity_chart_is_zero_anchored_and_rss_is_not():
+    """Different signals, so deliberately different y ranges.
+
+    CPU capacity is a share, so the distance from zero is the reading. RSS
+    is a level that drifts, and zero-anchoring it puts the drift inside one
+    pixel.
+    """
+    panel = _panel()
+    process_section.update_process_section(panel, _payload())
+    assert "min" not in panel["cpu_chart"].options["yAxis"]
+    assert panel["rss_chart"].options["yAxis"]["min"] > 0
+
+
+def test_a_retained_chart_says_it_is_rolling():
+    panel = _panel()
+    payload = _payload()
+    payload = ProcessDashboardPayload(
+        **{
+            **payload.__dict__,
+            "cpu_capacity_chart": _chart(0, 1, mode="retained"),
+        }
+    )
     process_section.update_process_section(panel, payload)
-    assert panel["chart"].options["series"][0]["data"] == []
+    assert "rolling 2 min" in panel["cpu_label"].text
+
+
+def test_an_empty_chart_leaves_the_label_bare():
+    panel = _panel()
+    process_section.update_process_section(panel, ProcessDashboardPayload())
+    assert panel["cpu_label"].text == "process cpu · capacity per rank"
+    assert panel["cpu_chart"].options["series"] == []
+
+
+# --- the per-rank rows ---------------------------------------------------
+def test_every_rank_is_a_row_with_its_identity_and_its_memory():
+    panel = _panel()
+    process_section.update_process_section(panel, _payload(ranks=(0, 1)))
+    html = panel["rows_html"].content
+    assert "R0" in html and "R1" in html
+    assert "G0" in html and "N0" in html
+    assert "cuda allocated" in html and "cuda reserved" in html
+
+
+def test_a_stale_rank_is_dimmed_and_kept():
+    """Dropping it hides the one fact worth having when a job stalls."""
+    panel = _panel()
+    payload = _payload()
+    payload = ProcessDashboardPayload(
+        **{
+            **payload.__dict__,
+            "ranks": (
+                _rank(0),
+                _rank(1, freshness="stale", age_s=900.0),
+            ),
+        }
+    )
+    process_section.update_process_section(panel, payload)
+    html = panel["rows_html"].content
+    assert 'class="tml-stale"' in html
+    assert "R1" in html
+    assert "15 min" in html
+
+
+def test_the_hint_states_coverage_without_classifying_it():
+    panel = _panel()
+    process_section.update_process_section(
+        panel, _payload(ranks=(0, 1), stale=1, imbalance=22.0)
+    )
+    hint = panel["rows_hint"].text
+    assert "2 ranks" in hint
+    assert "1 stale, excluded" in hint
+    assert "reserved imbalance 22%" in hint
+    for verdict in ("bad", "high", "warning", "critical", "unhealthy"):
+        assert verdict not in hint.lower()
+
+
+def test_a_rank_without_a_clock_is_named_in_the_hint():
+    panel = _panel()
+    process_section.update_process_section(
+        panel, _payload(ranks=(0, 1), unknown=1)
+    )
+    assert "1 without a clock" in panel["rows_hint"].text
+
+
+def test_a_small_spread_is_not_rounded_away_to_zero():
+    """0.4% is a real reading; printing "0%" would say balanced."""
+    panel = _panel()
+    process_section.update_process_section(panel, _payload(imbalance=0.4))
+    assert "reserved imbalance <1%" in panel["rows_hint"].text
+
+
+# --- the auto-open trigger ----------------------------------------------
+def test_the_rows_open_when_the_engine_says_so():
+    panel = _panel()
+    process_section.update_process_section(panel, _payload(rows_open=True))
+    assert panel["rows"].value is True
+
+
+def test_the_rows_do_not_reopen_after_the_reader_closes_them():
+    """Rising edge only, or a reader is fought on every tick."""
+    panel = _panel()
+    process_section.update_process_section(panel, _payload(rows_open=True))
+    panel["rows"].value = False
+    process_section.update_process_section(panel, _payload(rows_open=True))
+    assert panel["rows"].value is False
+
+
+def test_the_rows_stay_shut_when_the_engine_is_silent():
+    panel = _panel()
+    process_section.update_process_section(panel, _payload(rows_open=False))
+    assert panel["rows"].value is False
+
+
+def test_the_card_never_decides_the_threshold_itself():
+    """The view holds no number it compares an imbalance against.
+
+    A severity call in the view is the one thing this layer may not do, so
+    a large spread with the engine silent must leave the rows shut.
+    """
+    panel = _panel()
+    process_section.update_process_section(
+        panel, _payload(imbalance=99.0, rows_open=False)
+    )
+    assert panel["rows"].value is False
 
 
 # --- the whole path ------------------------------------------------------
@@ -241,6 +401,12 @@ def test_the_card_renders_the_same_from_a_real_database(tmp_path):
     The unit tests above hand the card a constructed payload; this one
     proves the layer that builds it agrees, so a boundary change cannot
     pass both halves while breaking the join between them.
+
+    The numbers assert the two deliberate meaning changes. The row holds
+    6 GiB allocated inside 7 GiB reserved, and those are now two tiles
+    reading 6.0 and 7.0 rather than one tile reading 6.0. CPU is 200% of a
+    process on an 8-core host, which is 25% of the host's capacity, and the
+    tile shows the capacity share rather than the raw number.
     """
     import sqlite3
 
@@ -251,22 +417,25 @@ def test_the_card_renders_the_same_from_a_real_database(tmp_path):
     init_schema(conn)
     for seq in (1, 2):
         conn.execute(
-            "INSERT INTO process_samples (recv_ts_ns, rank, seq, "
-            "sample_ts_s, cpu_percent, ram_used_bytes, ram_total_bytes, "
-            "gpu_available, gpu_mem_used_bytes, gpu_mem_reserved_bytes, "
-            "gpu_mem_total_bytes) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            "INSERT INTO process_samples (recv_ts_ns, rank, global_rank, "
+            "seq, sample_ts_s, cpu_percent, cpu_logical_core_count, "
+            "ram_used_bytes, ram_total_bytes, gpu_available, "
+            "gpu_mem_used_bytes, gpu_mem_reserved_bytes, "
+            "gpu_mem_total_bytes) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
             (
+                int((1_700_000_000 + seq) * 1e9),
                 0,
                 0,
                 seq,
                 1_700_000_000.0 + seq,
-                50.0,
-                4.0 * GB,
-                16.0 * GB,
+                200.0,
+                8,
+                4.0 * GIB,
+                16.0 * GIB,
                 1,
-                6.0 * GB,
-                7.0 * GB,
-                16.0 * GB,
+                6.0 * GIB,
+                7.0 * GIB,
+                16.0 * GIB,
             ),
         )
     conn.commit()
@@ -276,55 +445,124 @@ def test_the_card_renders_the_same_from_a_real_database(tmp_path):
     panel = _panel()
     process_section.update_process_section(panel, payload)
 
-    assert panel["win"].text == "last 2 samples"
-    assert "50" in panel["kpis"]["cpu"].content
-    assert "4.00" in panel["kpis"]["ram"].content
-    assert "6.00" in panel["kpis"]["gmem"].content
-    ram_series = panel["chart"].options["series"][0]["data"]
-    assert ram_series[0][1] == pytest.approx(25.0)
-    gpu_series = panel["chart"].options["series"][1]["data"]
-    assert gpu_series[0][1] == pytest.approx(37.5)
+    assert "25.0" in panel["tiles"]["cpu"].content
+    assert "4.0" in panel["tiles"]["rss"].content
+    assert "7.0" in panel["tiles"]["reserved"].content
+    assert "6.0" in panel["tiles"]["alloc"].content
+    assert "R0" in panel["rows_html"].content
 
 
-def test_a_gap_in_the_timestamps_drops_only_that_sample():
-    """The one place this refactor does NOT preserve 0.3.7 behavior.
+def test_every_class_the_card_emits_has_a_rule_behind_it():
+    """The stale marker shipped once with no CSS rule to render it.
 
-    On 0.3.7 the card zipped a timestamp list that had already had its gaps
-    filtered out against an unfiltered window, guarded by a length check.
-    Both branches were wrong. With few samples the check failed and the
-    chart drew NOTHING: measured 0 points where 2 were plottable. With
-    enough samples the check passed and the two lists were zipped anyway,
-    so every value landed on someone else's moment: measured on a 150-step
-    history with 5 gaps, the first plotted RAM value belonged to step 51
-    and was drawn at step 46.
-
-    Points now carry their own timestamp, so a gap removes one sample and
-    nothing else. This is deliberate and is the only behavior change in
-    this PR; reproducing a silent misalignment to preserve it would be the
-    worse choice.
+    The row carried `class="tml-stale"`, the stylesheet defined nothing for
+    it, and a dead rank drew identically to a live one. Nothing in the
+    markup or the payload could catch that, so the check is here: any class
+    this module puts on screen must exist in the stylesheet.
     """
+    from traceml_ai.aggregator.display_drivers.nicegui_sections import theme
+
+    css = theme.head_html()
+    ranks = (_rank(0), _rank(1, freshness="stale", age_s=900.0))
+    html = process_section.rows_html(ranks, _chart(0, 1))
+
+    emitted = set(re.findall(r'class="([^"]+)"', html))
+    for group in emitted:
+        for name in group.split():
+            assert f".{name}" in css, f"{name} has no CSS rule"
+
+
+def test_a_teardown_step_does_not_turn_a_gpu_run_cpu_only():
+    """The last samples of every run land after torch releases the device.
+
+    Asking the newest committed step whether there is a GPU therefore
+    answers "no" on every finished run, which blanked both CUDA tiles and
+    printed "no GPU" on a card that was simultaneously showing a reserved
+    spread derived from CUDA bytes.
+    """
+    from traceml_ai.renderers.process.dashboard_models import (
+        ProcessHistoryEntry,
+    )
+
     payload = ProcessDashboardPayload(
         history=(
             ProcessHistoryEntry(
                 seq=1,
                 ts=1_700_000_001.0,
-                cpu_percent_max=50.0,
-                ram_used_bytes_max=4.0 * GB,
-                ram_total_bytes=16.0 * GB,
+                cpu_percent_max=10.0,
+                ram_used_bytes_max=1.0 * GIB,
+                ram_total_bytes=64.0 * GIB,
+                gpu=None,
             ),
         ),
-        window_len=3,
-        cpu=MetricRollup(now=50.0, p95=50.0),
-        ram=MetricRollup(now=4.0 * GB, p95=4.0 * GB, total=16.0 * GB),
-        chart=ChartSeries(
-            ram_percent=ChartTrace(
-                label="RAM",
-                timestamps=(1_700_000_001.0, None, 1_700_000_003.0),
-                values=(25.0, 25.0, 25.0),
-            )
+        ranks=(_rank(0), _rank(1)),
+        gpu_reserved=MetricRollup(now=7.0 * GIB, p95=7.0 * GIB, worst_rank=1),
+        gpu=MetricRollup(now=6.0 * GIB, p95=6.0 * GIB),
+        coverage=RankCoverage(total=2, live=2),
+        cpu_capacity_chart=_chart(0, 1),
+        rss_chart=_chart(0, 1),
+    )
+    assert payload.gpu_available is True
+
+    panel = _panel()
+    process_section.update_process_section(panel, payload)
+    assert panel["tiles"]["reserved"].content != "n/a"
+    assert panel["subs"]["reserved"].text != "no GPU"
+
+
+def test_the_axis_fits_the_line_that_is_drawn_not_the_peaks():
+    """Peaks are rolling maxima and nothing plots them.
+
+    Fitting the axis to peaks put its floor above the drawn line, so the
+    early samples were clipped and the drift the chart exists to show was
+    understated.
+    """
+    chart = RankChart(
+        mode="retained",
+        window_s=120.0,
+        traces=(
+            RankTrace(
+                global_rank=0,
+                timestamps=(1.0, 2.0, 3.0),
+                values=(8.0 * GIB, 10.0 * GIB, 10.5 * GIB),
+                peaks=(10.6 * GIB, 10.7 * GIB, 10.8 * GIB),
+            ),
         ),
+    )
+    payload = ProcessDashboardPayload(
+        window_len=3,
+        ranks=(_rank(0),),
+        coverage=RankCoverage(total=1, live=1),
+        rss_worst=MetricRollup(now=10.5 * GIB, p95=10.5 * GIB, worst_rank=0),
+        cpu_capacity=MetricRollup(now=25.0, p95=25.0, worst_rank=0),
+        rss_chart=chart,
+        cpu_capacity_chart=chart,
     )
     panel = _panel()
     process_section.update_process_section(panel, payload)
-    points = panel["chart"].options["series"][0]["data"]
-    assert [ms for ms, _v in points] == [1_700_000_001_000, 1_700_000_003_000]
+
+    axis = panel["rss_chart"].options["yAxis"]
+    drawn = [v for _t, v in panel["rss_chart"].options["series"][0]["data"]]
+    assert axis["min"] <= min(drawn), "the floor clips the drawn line"
+    assert axis["max"] >= max(drawn)
+
+
+def test_a_single_sample_is_visible_rather_than_an_empty_plot():
+    """A line through one point draws nothing, which is every run's start."""
+    one = RankChart(
+        mode="recent",
+        traces=(RankTrace(global_rank=0, timestamps=(1.0,), values=(1.7,)),),
+    )
+    payload = ProcessDashboardPayload(
+        window_len=1,
+        ranks=(_rank(0),),
+        coverage=RankCoverage(total=1, live=1),
+        cpu_capacity=MetricRollup(now=1.7, p95=1.7, worst_rank=0),
+        cpu_capacity_chart=one,
+        rss_chart=one,
+    )
+    panel = _panel()
+    process_section.update_process_section(panel, payload)
+    series = panel["cpu_chart"].options["series"][0]
+    assert series["data"], "the point must reach the chart"
+    assert series["showSymbol"] is True, "one point needs a marker"

--- a/tests/display/test_process_section.py
+++ b/tests/display/test_process_section.py
@@ -658,3 +658,24 @@ def test_the_total_line_is_drawn_and_fits_inside_the_axis():
     drawn = [v for s in series for _t, v in s["data"]]
     top = panel["cpu_chart"].options["yAxis"]["max"]
     assert top >= max(drawn), "the total must not be clipped"
+
+
+def test_the_rss_row_shows_the_same_basis_as_the_rss_tile():
+    """A reader who checks the tile against the rows must find it there.
+
+    The tile names a rank at its median. The row used to show that rank's
+    newest sample, so on a finished run the tile said 2.1 GB and the row
+    it pointed at said 1.0 GB.
+    """
+    ranks = (
+        RankSnapshot(
+            global_rank=0,
+            ram_used_bytes=1.0 * GIB,
+            ram_used_p50_bytes=2.1 * GIB,
+            ram_total_bytes=187.0 * GIB,
+            freshness="fresh",
+        ),
+    )
+    html = process_section.rows_html(ranks, None)
+    assert "2.1" in html
+    assert "1.0 /" not in html

--- a/tests/renderers/process/test_process_rank_features.py
+++ b/tests/renderers/process/test_process_rank_features.py
@@ -351,3 +351,183 @@ def test_an_even_run_leaves_the_rows_shut(process_db):
     out = payload(process_db, sampler_interval_s=2.0)
     assert out.reserved_imbalance_percent == pytest.approx(0.0)
     assert out.rows_open is False
+
+
+# --- the one rule the section follows (review of #417) -------------------
+def test_the_recent_window_is_a_duration_not_a_sample_count(process_db):
+    """A hundred samples is a different span at every sampling rate.
+
+    At a 2 s cadence it is over three minutes; at 0.5 s it is under one.
+    A card that says "recent 60s" has to mean 60 seconds on both, or two
+    runs cannot be compared and the label is not true of either.
+    """
+    from traceml_ai.renderers.process.dashboard_compute import (
+        RECENT_WINDOW_S,
+    )
+
+    # 200 samples at 0.5 s: 100 s of history, of which 60 s is in window.
+    for seq in range(1, 201):
+        process_db.insert(
+            recv_ts_ns=int((1_700_000_000 + seq * 0.5) * 1e9),
+            rank=0,
+            global_rank=0,
+            node_rank=0,
+            seq=seq,
+            sample_ts_s=1_700_000_000.0 + seq * 0.5,
+            cpu_percent=200.0,
+            cpu_logical_core_count=8,
+            ram_used_bytes=2.0 * GB,
+            ram_total_bytes=64.0 * GB,
+        )
+
+    computer = ProcessDashboardComputer(
+        db_path=process_db.path, sampler_interval_s=0.5
+    )
+    with computer._db.connect() as conn:
+        newest = computer._db.newest_sample_ts(conn)
+        rows = computer._db.fetch_recent_rank_window(
+            conn, window_s=RECENT_WINDOW_S, newest_ts=newest
+        )
+    stamps = [r["sample_ts_s"] for r in rows]
+    span = max(stamps) - min(stamps)
+    assert span <= RECENT_WINDOW_S
+    # A sample-count window would have taken all 200 rows, i.e. 100 s.
+    assert len(rows) < 200
+    assert span > RECENT_WINDOW_S / 2
+
+
+def test_the_rss_tile_shows_the_median_not_the_newest_sample(process_db):
+    """Teardown makes the newest sample unrepresentative.
+
+    The last rows of a finished run land after the process released its
+    memory, so a tile reading the newest value showed a collapsed number
+    beside a chart still drawn at the run's real level.
+    """
+    for seq in range(1, 31):
+        # Steady at 8 GB, then one teardown sample at 1 GB.
+        used = 1.0 * GB if seq == 30 else 8.0 * GB
+        process_db.insert(
+            recv_ts_ns=int((1_700_000_000 + seq * 2) * 1e9),
+            rank=0,
+            global_rank=0,
+            node_rank=0,
+            seq=seq,
+            sample_ts_s=1_700_000_000.0 + seq * 2,
+            cpu_percent=200.0,
+            cpu_logical_core_count=8,
+            ram_used_bytes=used,
+            ram_total_bytes=64.0 * GB,
+        )
+
+    rss = payload(process_db, sampler_interval_s=2.0).rss_worst
+    assert rss is not None
+    assert rss.now == pytest.approx(8.0 * GB)
+
+
+def test_reserved_selects_on_each_rank_s_peak_not_its_newest(process_db):
+    """The tile asks which rank came closest to filling its card.
+
+    That is a high-water mark. Rank 1 peaks higher than rank 0 but ends
+    lower, so selecting on the newest sample would name the wrong rank.
+    """
+    for seq in range(1, 21):
+        for rank, reserved in (
+            (0, 8.0 * GB),
+            (1, 30.0 * GB if seq < 15 else 2.0 * GB),
+        ):
+            process_db.insert(
+                recv_ts_ns=int((1_700_000_000 + seq * 2) * 1e9),
+                rank=rank,
+                global_rank=rank,
+                node_rank=0,
+                seq=seq,
+                sample_ts_s=1_700_000_000.0 + seq * 2,
+                cpu_percent=200.0,
+                cpu_logical_core_count=8,
+                ram_used_bytes=2.0 * GB,
+                ram_total_bytes=64.0 * GB,
+                gpu_available=1,
+                gpu_device_index=rank,
+                gpu_mem_used_bytes=1.0 * GB,
+                gpu_mem_reserved_bytes=reserved,
+                gpu_mem_total_bytes=40.0 * GB,
+            )
+
+    out = payload(process_db, sampler_interval_s=2.0)
+    assert out.gpu_reserved is not None
+    assert out.gpu_reserved.worst_rank == 1
+    assert out.gpu_reserved.now == pytest.approx(30.0 * GB)
+
+
+def test_allocated_describes_the_same_rank_as_reserved(process_db):
+    """Two GPU tiles, one device, so they can be read together."""
+    for seq in range(1, 21):
+        for rank, reserved, alloc in (
+            (0, 5.0 * GB, 1.0 * GB),
+            (1, 30.0 * GB, 22.0 * GB),
+            (2, 6.0 * GB, 2.0 * GB),
+        ):
+            process_db.insert(
+                recv_ts_ns=int((1_700_000_000 + seq * 2) * 1e9),
+                rank=rank,
+                global_rank=rank,
+                node_rank=0,
+                seq=seq,
+                sample_ts_s=1_700_000_000.0 + seq * 2,
+                cpu_percent=200.0,
+                cpu_logical_core_count=8,
+                ram_used_bytes=2.0 * GB,
+                ram_total_bytes=64.0 * GB,
+                gpu_available=1,
+                gpu_device_index=rank,
+                gpu_mem_used_bytes=alloc,
+                gpu_mem_reserved_bytes=reserved,
+                gpu_mem_total_bytes=40.0 * GB,
+            )
+
+    out = payload(process_db, sampler_interval_s=2.0)
+    assert out.gpu_reserved.worst_rank == 1
+    assert out.gpu_allocated is not None
+    assert out.gpu_allocated.worst_rank == 1
+    # The median rank's allocated is 2.0 GB; this must not be that.
+    assert out.gpu_allocated.now == pytest.approx(22.0 * GB)
+
+
+def test_the_total_sums_ranks_on_their_own_clocks(process_db):
+    """Ranks do not share a sample clock, so index-wise addition is wrong.
+
+    Each rank's last known value is carried forward to every timestamp in
+    the union and the sum is taken there, which is what a step function
+    does between samples.
+    """
+    # Two ranks, deliberately offset: rank 1 samples one second later.
+    for seq in range(1, 21):
+        for rank, offset, cpu in ((0, 0.0, 200.0), (1, 1.0, 400.0)):
+            process_db.insert(
+                recv_ts_ns=int((1_700_000_000 + seq * 2 + offset) * 1e9),
+                rank=rank,
+                global_rank=rank,
+                node_rank=0,
+                seq=seq,
+                sample_ts_s=1_700_000_000.0 + seq * 2 + offset,
+                cpu_percent=cpu,
+                cpu_logical_core_count=8,
+                ram_used_bytes=2.0 * GB,
+                ram_total_bytes=64.0 * GB,
+            )
+
+    chart = payload(process_db, sampler_interval_s=2.0).cpu_capacity_chart
+    assert chart.total is not None
+    # The union of two offset clocks has more points than either rank.
+    assert len(chart.total.timestamps) > max(
+        len(t.timestamps) for t in chart.traces
+    )
+    # 200% and 400% of 8 cores is 25% and 50% of the host, so 75% together.
+    assert max(chart.total.values) == pytest.approx(75.0, abs=0.5)
+
+
+def test_a_single_rank_has_no_total(process_db):
+    """A total identical to the only line is noise, not information."""
+    _run(process_db, ranks=1, samples=20)
+    chart = payload(process_db, sampler_interval_s=2.0).cpu_capacity_chart
+    assert chart.total is None

--- a/tests/renderers/process/test_process_rank_features.py
+++ b/tests/renderers/process/test_process_rank_features.py
@@ -28,19 +28,28 @@ def payload(db, **kw):
     return ProcessDashboardComputer(db_path=db.path, **kw).compute()
 
 
-def _run(db, *, ranks=4, samples=120, cores=8, hot_rank=None, dies=None):
+def _run(
+    db,
+    *,
+    ranks=4,
+    samples=120,
+    cadence_s=2.0,
+    cores=8,
+    hot_rank=None,
+    dies=None,
+):
     """A multi-rank run. ``hot_rank`` burns CPU; ``dies`` stops early."""
     for seq in range(1, samples + 1):
         for rank in range(ranks):
             if dies is not None and rank == dies[0] and seq > dies[1]:
                 continue
             db.insert(
-                recv_ts_ns=int((1_700_000_000 + seq * 2) * 1e9),
+                recv_ts_ns=int((1_700_000_000 + seq * cadence_s) * 1e9),
                 rank=rank,
                 global_rank=rank,
                 node_rank=0,
                 seq=seq,
-                sample_ts_s=1_700_000_000.0 + seq * 2,
+                sample_ts_s=1_700_000_000.0 + seq * cadence_s,
                 cpu_percent=(700.0 if rank == hot_rank else 200.0),
                 cpu_logical_core_count=cores,
                 ram_used_bytes=(2.0 + rank * 0.5) * GB,
@@ -215,7 +224,9 @@ def test_the_recent_view_moves_between_ticks(process_db):
         db_path=process_db.path, sampler_interval_s=2.0
     )
     first = computer.compute().rss_chart
-    _run(process_db, ranks=2, samples=40)
+    # Stay below the 60 s recent window plus its transition margin; this
+    # test is about live refresh, not the switch to retained history.
+    _run(process_db, ranks=2, samples=30)
     second = computer.compute().rss_chart
 
     assert first.mode == second.mode == "recent"
@@ -237,6 +248,34 @@ def test_a_long_run_switches_to_the_retained_view(process_db):
     assert chart.is_retained is True
     assert chart.window_s is not None
     assert len(chart.traces) == 2
+
+
+@pytest.mark.parametrize(
+    ("cadence_s", "duration_s", "expected_mode"),
+    (
+        (0.5, 60.0, "recent"),
+        (2.0, 60.0, "recent"),
+        (0.5, 80.0, "retained"),
+        (2.0, 80.0, "retained"),
+    ),
+)
+def test_chart_mode_depends_on_duration_not_sample_count(
+    process_db, cadence_s, duration_s, expected_mode
+):
+    """Equal-duration runs choose one mode at every sampling cadence."""
+    samples = int(duration_s / cadence_s) + 1
+    _run(
+        process_db,
+        ranks=2,
+        samples=samples,
+        cadence_s=cadence_s,
+    )
+
+    chart = payload(
+        process_db, sampler_interval_s=cadence_s
+    ).cpu_capacity_chart
+
+    assert chart.mode == expected_mode
 
 
 def test_the_mode_is_stated_never_inferred_from_an_empty_field(process_db):

--- a/tests/renderers/process/test_process_rank_features.py
+++ b/tests/renderers/process/test_process_rank_features.py
@@ -459,14 +459,22 @@ def test_reserved_selects_on_each_rank_s_peak_not_its_newest(process_db):
     assert out.gpu_reserved.now == pytest.approx(30.0 * GB)
 
 
-def test_allocated_describes_the_same_rank_as_reserved(process_db):
-    """Two GPU tiles, one device, so they can be read together."""
+def test_allocated_and_reserved_come_from_the_same_rank_and_row(process_db):
+    """Two GPU tiles describe one device at one least-headroom sample."""
     for seq in range(1, 21):
-        for rank, reserved, alloc in (
-            (0, 5.0 * GB, 1.0 * GB),
-            (1, 30.0 * GB, 22.0 * GB),
-            (2, 6.0 * GB, 2.0 * GB),
-        ):
+        for rank in range(3):
+            reserved, alloc = {
+                0: (5.0 * GB, 1.0 * GB),
+                1: (
+                    30.0 * GB if seq in (10, 15) else 10.0 * GB,
+                    (
+                        24.0 * GB
+                        if seq == 15
+                        else (22.0 * GB if seq == 10 else 3.0 * GB)
+                    ),
+                ),
+                2: (6.0 * GB, 2.0 * GB),
+            }[rank]
             process_db.insert(
                 recv_ts_ns=int((1_700_000_000 + seq * 2) * 1e9),
                 rank=rank,
@@ -487,10 +495,13 @@ def test_allocated_describes_the_same_rank_as_reserved(process_db):
 
     out = payload(process_db, sampler_interval_s=2.0)
     assert out.gpu_reserved.worst_rank == 1
+    assert out.gpu_reserved.now == pytest.approx(30.0 * GB)
     assert out.gpu_allocated is not None
     assert out.gpu_allocated.worst_rank == 1
-    # The median rank's allocated is 2.0 GB; this must not be that.
-    assert out.gpu_allocated.now == pytest.approx(22.0 * GB)
+    # R1's median allocation is 3 GB. The allocated tile instead uses the
+    # exact row chosen for reserved; of equal peaks, the newest row wins.
+    assert out.gpu_allocated.now == pytest.approx(24.0 * GB)
+    assert out.gpu_allocated.total == out.gpu_reserved.total
 
 
 def test_the_total_sums_ranks_on_their_own_clocks(process_db):

--- a/tests/renderers/process/test_process_rank_features.py
+++ b/tests/renderers/process/test_process_rank_features.py
@@ -280,3 +280,74 @@ def test_the_fields_the_card_already_reads_are_unchanged(process_db):
     assert out.window_len > 0
     assert out.gpu_available is True
     assert out.chart is not None and out.chart.ram_percent.values
+
+
+# --- the rows auto-open trigger -----------------------------------------
+def test_the_trigger_stays_armed_off_until_every_rank_has_allocated(
+    process_db,
+):
+    """Ranks reach their first CUDA allocation seconds to minutes apart.
+
+    An unarmed trigger reads that ordinary ramp as total imbalance, so the
+    rows would fly open on the first ticks of a healthy run.
+    """
+    computer = ProcessDashboardComputer(
+        db_path=process_db.path, sampler_interval_s=2.0
+    )
+    ramping = (
+        RankSnapshot(global_rank=0, gpu_reserved_p50_bytes=8.0 * GB),
+        RankSnapshot(global_rank=1, gpu_reserved_p50_bytes=None),
+    )
+    assert computer._rows_trigger(ramping, 99.0) is False
+
+
+def test_the_trigger_fires_once_a_held_spread_is_large(process_db):
+    computer = ProcessDashboardComputer(
+        db_path=process_db.path, sampler_interval_s=2.0
+    )
+    held = (
+        RankSnapshot(global_rank=0, gpu_reserved_p50_bytes=8.0 * GB),
+        RankSnapshot(global_rank=1, gpu_reserved_p50_bytes=4.0 * GB),
+    )
+    assert computer._rows_trigger(held, 50.0) is True
+    assert computer._rows_trigger(held, 1.0) is False
+    assert computer._rows_trigger(held, None) is False
+
+
+def test_a_spread_run_ships_the_trigger_on(process_db):
+    """End to end. The shared fixture is deliberately uneven.
+
+    Its ranks reserve 6, 8, 10 and 12 GB, a 50% spread, which is the case
+    the rows exist to answer.
+    """
+    _run(process_db, ranks=4, samples=30)
+    out = payload(process_db, sampler_interval_s=2.0)
+    assert out.reserved_imbalance_percent == pytest.approx(50.0)
+    assert out.rows_open is True
+
+
+def test_an_even_run_leaves_the_rows_shut(process_db):
+    """Every rank holding the same reserved bytes has nothing to show."""
+    for seq in range(1, 31):
+        for rank in range(4):
+            process_db.insert(
+                recv_ts_ns=int((1_700_000_000 + seq * 2) * 1e9),
+                rank=rank,
+                global_rank=rank,
+                node_rank=0,
+                seq=seq,
+                sample_ts_s=1_700_000_000.0 + seq * 2,
+                cpu_percent=200.0,
+                cpu_logical_core_count=8,
+                ram_used_bytes=2.0 * GB,
+                ram_total_bytes=64.0 * GB,
+                gpu_available=1,
+                gpu_device_index=rank,
+                gpu_mem_used_bytes=4.0 * GB,
+                gpu_mem_reserved_bytes=6.0 * GB,
+                gpu_mem_total_bytes=40.0 * GB,
+            )
+
+    out = payload(process_db, sampler_interval_s=2.0)
+    assert out.reserved_imbalance_percent == pytest.approx(0.0)
+    assert out.rows_open is False


### PR DESCRIPTION
Closes #407. Part 4 of #403.

Part 3 (#412) is merged, so this branch is rebased straight onto `version_0.3.7` and is no longer
stacked. Review it against the release branch:

```
git diff upstream/version_0.3.7...dev/abhijeet/process-presentation
```

10 files, +1915/-320.

## Review scope

The Process card. This is the first part of the series that changes what is on screen, so the
screenshots below are the reviewable artifact as much as the diff is. The other panes in them are
today's rendering and are rebuilt in later parts.

## What

The #401 UI, reading the typed payload part 3 built instead of a dictionary of loosely named keys.

| before | after | why |
|---|---|---|
| `CPU` (raw process %) | `cpu capacity` (share of the host) | 700% on an 8-core host is not comparable to 700% on a 64-core one. 87.5% of capacity is. |
| `RAM` | `rss`, named for what it is | the tile always held RSS; it now says so |
| `GPU MEM` (one tile) | `cuda allocated` **and** `cuda reserved` | one tile could not say which it held. #399 settled the wording; this is the split it was settling it for |
| `GPU IMBAL` (a tile) | reserved spread, in the rows header | a spread is context for the per-rank view, not a headline number |
| one shared chart | two per-rank charts | a single line across ranks hides which rank is drifting |
| no per-rank view | per-rank table, engine-triggered | when a job stalls, WHICH rank stopped is the whole question |

### One rule for the whole section (review round 2)

Every tile now summarises the last **60 seconds**, and says so in the section title. It was the
last 100 samples, which is a different span at every sampling rate: over three minutes at a two
second cadence, under one at half a second. A card cannot claim a window it does not have, and two
runs sampling differently could not be compared.

| tile | the rule | reads |
|---|---|---|
| cpu capacity | each rank's median, then the highest | `25% of host`, `highest median · R0` |
| rss | each rank's median, then the highest | `1.4 / 16.6 GB`, `highest median · R0` |
| cuda reserved | each rank's PEAK, then the least headroom | `14.0 / 15.6 GB`, `least headroom · R0` |
| cuda allocated | the SAME rank the reserved tile chose | `12.2 / 15.6 GB`, `least-headroom rank · R0` |

Three of those changed what is shown, and each fixes something.

**RSS was showing the newest sample.** The last rows of a finished run land after the process
released its memory, so the tile read a collapsed number beside a chart still drawn at the run's
real level. The median removes that.

**Reserved was selecting on the newest reading.** The tile asks which rank comes closest to
filling its card, which is a high-water mark, so it now selects on each rank's peak across the
window.

**Allocated described a different rank from reserved.** It was the cohort median while its
neighbour was the least-headroom rank, so the two GPU tiles described two devices. They now
describe one, and can be read together.

### A total line on both charts

The per-rank lines answer "which rank", and the total answers "how much of this host is the job
using". Neither can be read off the other.

Ranks do not share a sample clock, so the total is not an index-wise sum: each rank's last known
value is carried forward to every timestamp in the union and summed there, which is what a step
function does between samples. A rank that has not reported yet contributes nothing rather than a
zero, so the total does not dip while ranks are still starting. A single-rank run gets no total,
because a line identical to the only other line is noise.

The total is the sum, so it sits above every rank line. The axis is fitted to the lines that are
DRAWN rather than to the rank traces alone, and a test pins that: fitting to a subset is what
clipped the RSS chart earlier in this PR.

### Two charts, two different y ranges, on purpose

CPU capacity is a share, so its axis is anchored at zero: the distance from zero is the reading.
RSS is a level a few GB high that moves by tens of MB across a run. Zero-anchoring RSS puts that
entire movement inside one pixel, and the movement is the leak the chart exists to show. The two
charts share one time axis so a vertical read across the pair lands on the same moment.

### New modules, and what did not go in `theme.py`

`charting.py` holds axis ranges, the time-axis pinning, per-rank colours and sparklines.
`formatting.py` holds how one already-decided value is written down.

The split is not cosmetic. A palette change is a brand decision and an axis-range change is a
decision about what a metric's information IS, and those change for different reasons. Eight of
the ten helpers this card needs were added to `theme.py` on the closed #401, which is the
`theme.py` +199 you flagged there. None of them go back there. Migrating the chart builders
`theme.py` already holds is part 6 (#409), deliberately not this PR.

`theme.py` does gain one line, and it is a CSS rule: `.tml-gpus tr.tml-stale td`, mirroring the
`.tml-mark` rule directly above it. Colours and CSS are what that module is for, so the rule
belongs there; no logic follows it in. Why it was missing is in the bugs section below.

## Two deliberate exceptions to the stated non-goal

#407 says "no computation changes". This PR makes two, both because a thing the card must say is
a fact about the telemetry rather than a drawing decision, and the view is not allowed to decide
either one.

**The rows auto-open trigger.** The rows open themselves when the reserved spread is worth
looking at. That rule has an arming condition: ranks reach their first CUDA allocation seconds to
minutes apart, so an unarmed trigger reads an ordinary startup ramp as total imbalance and throws
the rows open on every healthy run's first ticks. It fires only once every reporting rank has
HELD an allocation across its window. The alternative was to compare the spread against a number
inside `process_section.py`, which would put a severity call in the one layer that may not make
one. It is `rows_open` on the payload and the view only obeys it; a test asserts the view holds
no threshold of its own, so a 99% spread with the engine silent leaves the rows shut.

**The per-rank allocated rollup.** The `cuda allocated` tile has to name a rank and read that
rank's bytes, which is selection and arithmetic. `_alloc_rollup` does it beside the reserved
rollup whose rank it follows. Why the tile needed a new source at all is in the next section.

## What rendering the matrix found

The 22 fixture cells were read, not just rendered, each card against the payload its own database
produces. That pass found more than the test suite did, and none of it could have failed a unit
test.

**The `cuda allocated` tile showed the wrong quantity.** Its label then read "median rank, live
tensors", but it was wired to the aggregated step history, whose value is the least-headroom
rank's instantaneous device usage. On the 4-rank DDP cell that read 2.8 GB against a true median
of 2.1 GB, a 33% overstatement, above rows that each said 2.1. On single-rank cells it was worse:
a confident number about 99x below the rank's actual allocated bytes. And after teardown the
history has no GPU snapshot at all, so on six cells the tile read "n/a" directly above rows
listing each rank's allocated bytes.

It now reads a per-rank `_alloc_rollup`, which after the review round follows the rank the
reserved tile chose. That is the second compute addition in this PR, for the same reason as the
first: selecting a rank and reading its bytes is arithmetic, and the view may not do arithmetic.

**A stale rank was never actually dimmed.** The row carried `class="tml-stale"` and the
stylesheet defined no rule for it, so the dead rank drew identically to a live one and the single
cue that says WHICH rank stopped was invisible. Nothing in the markup or the payload could catch
that, so the check now lives where it can: a test extracts every class the card emits and asserts
each has a rule in the stylesheet.

**A 105 second window announced itself as "last 2 min".** `format_span` switched to whole minutes
at ninety seconds, overstating the window by 14% in the label a reader uses to place the chart in
time. It now stays in seconds until a full two minutes.

## Five more defects, found the same way, fixed in #412

The same pass surfaced five bugs in part 3: both charts empty on every short run, the GPU column
blank on a 4-GPU run, a finished GPU run rendering as CPU-only, `has_data` answering from the
wrong collection, and the per-rank rollups reporting a `p95` nobody computed. They are
compute-layer defects, so they were fixed in #412 where the code lives rather than carried here.
This PR sits on top of them.

Worth naming the pattern rather than the five instances: every one of them read a value from the
newest committed step instead of the newest REPORTING one, and teardown always empties the
former. A single guard would likely be better than five fixes, but that is a design conversation
for the compute layer, not something to fold into a presentation PR.

## Scope

```
STRUCTURE: chart shaping -> display_drivers/nicegui_sections/charting.py (new, formatting-layer
peer of theme.py); value formatting -> nicegui_sections/formatting.py (new, same peer);
mirrored from theme.py, which is the existing helper module in that unit; boundaries crossed: none
DATA PATH: process_section <- PROCESS_LAYOUT <- ProcessRenderer <- ProcessDashboardComputer
           <- ProcessRepository <- process_samples
SCOPE: declared the Process card + its two new helper modules; the diff's only reach outside
nicegui_sections/ is two compute additions the card's own labels require, the rows trigger and
the per-rank allocated rollup, plus one CSS rule in theme.py; 9 files, all three named above with
reasons -> within, with three stated additions
```

## Verification

```
GATE: pytest tests/ -> 1523 passed, 2 skipped; 175 on the display layer, of which 27 cover this card and 29 the two new helper modules; isort, ruff and black clean at 79 under the repo's pinned pre-commit
TRANSITIONS: recent -> retained chart, and the label says which; rows shut -> opened by the engine -> closed by the reader and NOT reopened while the condition holds; GPU present -> absent; a rank fresh -> stale -> dimmed but kept
RANKS: 1, 2, 3 and 4 ranks, a rank that stopped, and a rank with no usable clock; each rank is its own line on both charts and its own row
TRIPWIRE: a test asserts the view compares nothing to a threshold, so moving the trigger back into the card fails the suite; the end-to-end test states both changed tile meanings as explicit numbers, so a silent revert to the old meanings fails; no rank colour may be red, which on this page reads as a verdict
TWINS: the recent window changed UNIT (a 100-sample count became a 60-second duration), so the search is the concept and its synonyms, not the renamed symbol: `RECENT_WINDOW_S` / `window_s` / `window_n` / `_window_span` / `span` -> 4 consuming sites: repository.fetch_recent_rank_window (the read), dashboard_compute._rank_snapshots (the caller), dashboard_compute._one_chart via mode_for (the recent-to-retained transition), and dashboard_models.RankChart.window_s (the label). The third was MISSED on the first pass: grepping only the retired symbol `RANK_WINDOW_N` found two sites, while `_window_span(payload.history)` computed the same idea under another name and still keyed the chart transition to a 100-step count, so the tiles measured seconds while the charts measured samples with the suite green. Abhinav caught it in 84e883c. `_window_span` is now deleted and one duration drives the read and the transition, asserted by test_chart_mode_depends_on_duration_not_sample_count
SCENARIOS: 22 fixture cells rendered and read, not just rendered, on the merged version_0.3.7: B ok (B_xf_1gpu_long, B_cnn_1gpu) · C ok (C_M1_bert, C_sysB_1of4) · D ok (D_S2_ddp4, D_F1_fsdp4, D_sysA_ddp4_3k) · D' ok (Dd_S2_rank3_dead) · E ok (E_xf_2x1_long, E_cnn_2x1_fsdp) · E' ok (Ed_2x1_rank1_dead) · W ok (W_W1_busy, W_W2_idle) · V ok (V_S2_compute_bound, V_S3_input_straggler, V_S4_straggler, V_S5_input_bound, V_S6_h2d_bound, V_S8_warmup, V_M1_single_compute, V_M2_two_rank, V_F1_residual_fsdp); A, A2 and Wc are live-CPU recipes run by hand; F has no fixture
PLATFORM: macOS 26.1, Python 3.12.13, SQLite 3.51.2
```

## Not in this PR

Part 5 (#408) migrates System onto the shared run-series and freshness infrastructure. Part 6
(#409) moves the chart builders `theme.py` still holds into `charting.py` and the value
formatting into `formatting.py`, leaving `theme.py` as colours, fonts and CSS.
