### PR TITLE
System dashboard: typed payload, and the card's rules move to compute

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -19,9 +19,17 @@ from __future__ import annotations
 
 import math
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from nicegui import ui
+
+from traceml_ai.renderers.system.dashboard_models import (
+    GpuRow,
+    RunContext,
+    SystemDashboardPayload,
+    SystemRollups,
+    SystemSeries,
+)
 
 from . import theme
 
@@ -86,7 +94,7 @@ def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
 
 def disclosure_text(
     gpus: List[Dict[str, Any]],
-    roll: Dict[str, Any],
+    roll: SystemRollups,
     *,
     is_open: bool,
 ) -> str:
@@ -107,21 +115,21 @@ def disclosure_text(
     tail = " · click to close" if is_open else " · click to open"
     if n == 1:
         return "1 GPU" + tail
-    span = roll.get("util_range")
+    span = roll.util_range
     if not span:
         return f"{n} GPUs" + tail
     low, high = span
     return f"{n} GPUs · util {low:.0f} to {high:.0f}%" + tail
 
 
-def node_scope_text(ctx: Dict[str, Any]) -> str:
+def node_scope_text(ctx: Optional[RunContext]) -> str:
     """'node 0 of 2' when the payload dropped other machines, else ''.
 
     Reads only the System payload's own ``system_node`` (the hosts seen in
     this window); the strip's node count lives on the CONTEXT payload and
     is not this block's to read.
     """
-    node = ctx.get("system_node") if isinstance(ctx, dict) else None
+    node = ctx.system_node if ctx is not None else None
     if not isinstance(node, dict):
         return ""
     in_window = int(node.get("nodes_in_window") or 1)
@@ -201,7 +209,7 @@ def sparkline_svg(
     )
 
 
-def gpus_unreported(gpus: List[Dict[str, Any]]) -> bool:
+def gpus_unreported(gpus: Sequence[GpuRow]) -> bool:
     """Whether every GPU present sent nothing but the zero fallback.
 
     The sampler emits an all-zero row when it cannot read a device, which
@@ -215,10 +223,10 @@ def gpus_unreported(gpus: List[Dict[str, Any]]) -> bool:
     carried a power limit and no memory total. The computer decides what a
     metric means; this asks it.
     """
-    return bool(gpus) and not any(gpu.get("reported") for gpu in gpus)
+    return bool(gpus) and not any(gpu.reported for gpu in gpus)
 
 
-def odd_ones_out(roll: Dict[str, Any]) -> set:
+def odd_ones_out(roll: SystemRollups) -> set:
     """GPU indices the computer marked as the smaller utilisation group.
 
     Read, not derived. The rule splits at the midpoint between the lowest
@@ -227,7 +235,7 @@ def odd_ones_out(roll: Dict[str, Any]) -> set:
     diagnosis rule, so it moved to the compute layer unchanged; this reads
     the answer.
     """
-    return {int(i) for i in (roll.get("odd_gpus") or ())}
+    return {int(i) for i in roll.odd_gpus}
 
 
 # Host CPU is psutil.cpu_percent(): the mean across logical cores, where 100%
@@ -245,9 +253,9 @@ def _num(value: Any, fmt: str = "{:.0f}") -> str:
 
 
 def rows_html(
-    gpus: List[Dict[str, Any]],
+    gpus: Sequence[GpuRow],
     power_series: List[Dict[str, Any]],
-    roll: Dict[str, Any],
+    roll: SystemRollups,
 ) -> str:
     """Build GPU rows and highlight the smaller side of a wide util split.
 
@@ -262,39 +270,39 @@ def rows_html(
         int(p.get("gpu_idx", -1)): p.get("values") or []
         for p in power_series or []
     }
-    marked = odd_ones_out(roll) if roll.get("rows_over") else set()
+    marked = odd_ones_out(roll) if roll.rows_over else set()
     head = (
         "<tr><th>gpu</th><th>util</th><th>power trend</th>"
         "<th>mem GB</th><th>temp °C</th><th>W / limit</th></tr>"
     )
     rows = []
     for g in gpus:
-        idx = int(g.get("gpu_idx", 0))
+        idx = int(g.gpu_idx)
         color = gpu_color(idx)
-        used, total = g.get("mem_used"), g.get("mem_total")
+        used, total = g.mem_used, g.mem_total
         if used is not None and total:
             mem = f"{theme.gb(used):.2f} / {theme.gb(total):.1f}"
         elif used is not None:
             mem = f"{theme.gb(used):.2f}"
         else:
             mem = NA
-        power, limit = g.get("power"), g.get("power_limit")
+        power, limit = g.power, g.power_limit
         if power is not None and limit:
             watts = f"{power:.0f} / {limit:.0f}"
         elif power is not None:
             watts = f"{power:.0f} W"
         else:
             watts = NA
-        util = g.get("util_p50")
+        util = g.util_p50
         if util is None:
-            util = g.get("util_now")
+            util = g.util_now
         cls = ' class="tml-mark"' if idx in marked else ""
         rows.append(
             f"<tr{cls}>"
             f'<td><span style="color:{color}">■</span> gpu{idx}</td>'
             f'<td class="tml-util">{_num(util)}</td>'
             f"<td>{sparkline_svg(series_by_idx.get(idx, []), color)}</td>"
-            f"<td>{mem}</td><td>{_num(g.get('temp'))}</td><td>{watts}</td>"
+            f"<td>{mem}</td><td>{_num(g.temp)}</td><td>{watts}</td>"
             "</tr>"
         )
     return f'<table class="tml-gpus">{head}{"".join(rows)}</table>'
@@ -504,8 +512,8 @@ def _set_gpu_visible(panel: Dict[str, Any], visible: bool) -> None:
 
 def _update_cpu_chart(
     panel: Dict[str, Any],
-    roll: Dict[str, Any],
-    series: Dict[str, Any],
+    roll: SystemRollups,
+    series: SystemSeries,
     *,
     changed: bool,
     secs: List[Optional[float]],
@@ -515,12 +523,12 @@ def _update_cpu_chart(
     aligned: Optional[Tuple[float, float]],
 ) -> None:
     """Update the CPU trace, axis, value and label for the selected view."""
-    cpu = series.get("cpu", []) or []
-    run = series.get("cpu_run") or {}
-    run_t = run.get("t") or []
-    run_avg = run.get("avg") or []
-    run_max = run.get("max") or []
-    run_span = float(run.get("span_s") or 0.0)
+    cpu = list(series.cpu)
+    run = series.cpu_run
+    run_t = list(run.t)
+    run_avg = list(run.avg)
+    run_max = list(run.max)
+    run_span = float(run.span_s)
     chart = panel["cpu_chart"]
 
     if changed and whole_run:
@@ -544,11 +552,11 @@ def _update_cpu_chart(
         chart.options["yAxis"]["interval"] = ymax / 2.0
         chart.update()
 
-    cpu_p50 = (roll.get("cpu", {}) or {}).get("p50")
+    cpu_p50 = roll.cpu.p50 if roll.cpu else None
     panel["cpu_value"].text = f"{cpu_p50:.0f}%" if cpu_p50 is not None else ""
     span_words = format_span(span)
     if whole_run:
-        window = format_window(float(run.get("window_s") or 0.0))
+        window = format_window(run.window_s)
         panel["cpu_label"].text = f"{CPU_LABEL} · whole run" + (
             f" · rolling {window}" if window else ""
         )
@@ -565,19 +573,26 @@ def _update_cpu_chart(
 
 def _update_system_tiles(
     panel: Dict[str, Any],
-    roll: Dict[str, Any],
+    roll: SystemRollups,
     *,
     gpu_on: bool,
     has_data: bool,
 ) -> None:
-    """Update the System header and four resource tiles."""
-    ram = roll.get("ram", {}) or {}
-    num, rest = format_gb_pair(ram.get("now"), ram.get("total"))
+    """Update the System header and four resource tiles.
+
+    Reads the typed rollups. Absence is a ``None`` field rather than a
+    missing key, so a tile that has nothing to say says so instead of
+    asking whether somebody remembered to put the key there.
+    """
+    ram = roll.ram
+    num, rest = format_gb_pair(
+        ram.now if ram else None, ram.total if ram else None
+    )
     panel["tiles"]["ram"].content = theme.kval(num, f" {rest}" if rest else "")
     panel["subs"]["ram"].text = "used / total"
 
     notes = []
-    node_note = node_scope_text(roll.get("ctx", {}) or {})
+    node_note = node_scope_text(roll.ctx)
     if node_note:
         notes.append(node_note)
     if not has_data:
@@ -590,19 +605,18 @@ def _update_system_tiles(
             panel["subs"][key].text = "no GPU" if has_data else ""
         return
 
-    gpus = roll.get("gpus", []) or []
-    ctx = roll.get("ctx", {}) or {}
-    n_gpus = len(gpus) or int(ctx.get("gpu_count", 0))
-    unreported = gpus_unreported(gpus)
+    n_gpus = len(roll.gpus) or (roll.ctx.gpu_count if roll.ctx else 0)
+    unreported = roll.gpus_unreported
 
-    util_p50 = (roll.get("gpu_util", {}) or {}).get("p50")
-    panel["tiles"]["util"].content = theme.kval(_num(util_p50), "%")
+    util = roll.gpu_util
+    panel["tiles"]["util"].content = theme.kval(
+        _num(util.p50 if util else None), "%"
+    )
     one_gpu = n_gpus == 1
     panel["subs"]["util"].text = (
         "1 GPU" if one_gpu else f"avg of {n_gpus} GPUs"
     )
 
-    gpu_mem = roll.get("gpu_mem", {}) or {}
     if unreported:
         panel["tiles"]["mem"].content = NA
         panel["subs"]["mem"].text = "GPU sample unreported"
@@ -610,19 +624,24 @@ def _update_system_tiles(
         panel["subs"]["temp"].text = "GPU sample unreported"
         return
 
-    num, rest = format_gb_pair(gpu_mem.get("now"), gpu_mem.get("total"))
+    mem = roll.gpu_mem
+    num, rest = format_gb_pair(
+        mem.now if mem else None, mem.total if mem else None
+    )
     panel["tiles"]["mem"].content = theme.kval(num, f" {rest}" if rest else "")
     panel["subs"]["mem"].text = "used / total" if one_gpu else "max GPU"
-    temp_now = (roll.get("temp", {}) or {}).get("now")
-    panel["tiles"]["temp"].content = theme.kval(_num(temp_now), " °C")
+    temp = roll.temp
+    panel["tiles"]["temp"].content = theme.kval(
+        _num(temp.now if temp else None), " °C"
+    )
     # A qualifier keeps all four tile heights equal on single-GPU hosts.
     panel["subs"]["temp"].text = "1 GPU" if one_gpu else "max GPU"
 
 
 def _update_power_chart(
     panel: Dict[str, Any],
-    roll: Dict[str, Any],
-    series: Dict[str, Any],
+    roll: SystemRollups,
+    series: SystemSeries,
     *,
     gpu_on: bool,
     has_data: bool,
@@ -641,9 +660,9 @@ def _update_power_chart(
         )
         return
 
-    gpu_power = roll.get("gpu_power", {}) or {}
-    limit = gpu_power.get("limit")
-    pseries = series.get("gpu_power", []) or []
+    gpu_power = roll.gpu_power
+    limit = gpu_power.limit if gpu_power else None
+    pseries = list(series.gpu_power)
     flat = [value for item in pseries for value in (item.get("values") or [])]
     chart = panel["power_chart"]
     if not any(value is not None for value in flat):
@@ -653,7 +672,7 @@ def _update_power_chart(
     if not changed:
         return
 
-    run = series.get("gpu_power_run") or []
+    run = list(series.gpu_power_run)
     run_span = float(run[0].get("span_s") or 0.0) if run else 0.0
     if whole_run:
         # Draw each bucket's mean and minimum. The maximum stays in the payload.
@@ -705,7 +724,7 @@ def _update_power_chart(
                     "insideEndTop",
                 )
             )
-        floor_w = gpu_power.get("floor")
+        floor_w = gpu_power.floor if gpu_power else None
         if floor_w is not None and (
             limit is None or float(floor_w) < float(limit) * 0.9
         ):
@@ -776,8 +795,8 @@ def _update_power_chart(
 
 def _update_gpu_rows(
     panel: Dict[str, Any],
-    roll: Dict[str, Any],
-    series: Dict[str, Any],
+    roll: SystemRollups,
+    series: SystemSeries,
     *,
     gpu_on: bool,
     has_data: bool,
@@ -789,9 +808,9 @@ def _update_gpu_rows(
         )
         return
 
-    gpus = roll.get("gpus", []) or []
-    pseries = series.get("gpu_power", []) or []
-    over = bool(roll.get("rows_over"))
+    gpus = list(roll.gpus)
+    pseries = list(series.gpu_power)
+    over = roll.rows_over
     if should_auto_open(prev_over=panel["_over"], over=over):
         panel["rows"].value = True
     panel["_over"] = over
@@ -801,43 +820,41 @@ def _update_gpu_rows(
     panel["rows_html"].content = rows_html(gpus, pseries, roll)
 
 
-def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
+def update_system_section(panel: Dict[str, Any], data: Any) -> None:
     """Coordinate System presentation updates from one computed payload."""
-    if not isinstance(data, dict):
+    if not isinstance(data, SystemDashboardPayload):
         return
-    roll = data.get("rollups", {}) or {}
-    series = data.get("series", {}) or {}
-    gpu_on = bool(data.get("gpu_available") or roll.get("gpu_available"))
-    has_data = bool(data.get("window_len"))
+    roll = data.rollups
+    series = data.series
+    gpu_on = bool(data.gpu_available or roll.gpu_available)
+    has_data = bool(data.window_len)
     _set_gpu_visible(panel, gpu_on)
 
-    x_time = series.get("x_time", []) or []
+    x_time = list(series.x_time)
     secs = _relative_seconds(x_time)
     newest_epoch = _newest_epoch(x_time)
     present = [second for second in secs if second is not None]
     span = -min(present) if present else 0.0
 
     # The UI timer is faster than sampling; avoid resending unchanged charts.
-    gpu_power = roll.get("gpu_power", {}) or {}
-    pseries = series.get("gpu_power", []) or []
+    pseries = list(series.gpu_power)
     signature = (
         x_time[-1] if x_time else None,
-        data.get("window_len"),
+        data.window_len,
         len(pseries),
-        gpu_power.get("limit"),
+        roll.gpu_power.limit if roll.gpu_power else None,
         gpu_on,
     )
     changed = signature != panel.get("_sig")
     panel["_sig"] = signature
 
-    cpu_run = series.get("cpu_run") or {}
-    cpu_run_t = cpu_run.get("t") or []
-    power_run = series.get("gpu_power_run") or []
+    cpu_run_t = list(series.cpu_run.t)
+    power_run = list(series.gpu_power_run)
     # Read, not decided. The card asked ">2 points" of one series and
     # "non-empty" of the other, so its two charts could disagree about
     # which view they were showing.
-    cpu_whole = bool(series.get("cpu_run_whole"))
-    power_whole = bool(series.get("power_run_whole"))
+    cpu_whole = series.cpu_run_whole
+    power_whole = series.power_run_whole
     # Whole-run charts share one clock so vertical comparisons align.
     aligned = (
         shared_run_axis(cpu_run_t, power_run)

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -833,8 +833,11 @@ def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:
     cpu_run = series.get("cpu_run") or {}
     cpu_run_t = cpu_run.get("t") or []
     power_run = series.get("gpu_power_run") or []
-    cpu_whole = len(cpu_run_t) > 2
-    power_whole = bool(power_run)
+    # Read, not decided. The card asked ">2 points" of one series and
+    # "non-empty" of the other, so its two charts could disagree about
+    # which view they were showing.
+    cpu_whole = bool(series.get("cpu_run_whole"))
+    power_whole = bool(series.get("power_run_whole"))
     # Whole-run charts share one clock so vertical comparisons align.
     aligned = (
         shared_run_axis(cpu_run_t, power_run)

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -809,7 +809,7 @@ def update_system_section(panel: Dict[str, Any], data: Any) -> None:
         return
     roll = data.rollups
     series = data.series
-    gpu_on = bool(data.gpu_available or roll.gpu_available)
+    gpu_on = data.gpu_available
     has_data = bool(data.window_len)
     _set_gpu_visible(panel, gpu_on)
 

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -93,7 +93,7 @@ def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
 
 
 def disclosure_text(
-    gpus: List[Dict[str, Any]],
+    gpus: Sequence[GpuRow],
     roll: SystemRollups,
     *,
     is_open: bool,

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -209,23 +209,6 @@ def sparkline_svg(
     )
 
 
-def gpus_unreported(gpus: Sequence[GpuRow]) -> bool:
-    """Whether every GPU present sent nothing but the zero fallback.
-
-    The sampler emits an all-zero row when it cannot read a device, which
-    is absence rather than a GPU sitting at zero, and the card must not
-    draw it as a measurement.
-
-    Reads the computer's ``reported`` flag rather than re-deriving the
-    answer. The card used to test whether ``mem_total`` and ``power`` were
-    both absent, which is a stricter rule than the computer's (``mem_total``
-    or ``power_limit_w`` present), so the two disagreed about a GPU that
-    carried a power limit and no memory total. The computer decides what a
-    metric means; this asks it.
-    """
-    return bool(gpus) and not any(gpu.reported for gpu in gpus)
-
-
 def odd_ones_out(roll: SystemRollups) -> set:
     """GPU indices the computer marked as the smaller utilisation group.
 

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -11,7 +11,7 @@ The CPU and GPU-power charts initially show recent raw samples. After the run
 outgrows that window, they use bounded whole-run series: rolling CPU values
 and fixed-duration GPU-power buckets. Both charts share a wall-clock axis.
 
-Per-GPU rows open when utilisation spread crosses ``SPREAD_EXPAND_PTS``.
+Per-GPU rows open when the computer says the spread has earned it.
 This section presents measurements and leaves verdicts to diagnostics.
 """
 
@@ -27,7 +27,6 @@ from . import theme
 
 # Window-p95 GPU utilisation spread (max - min, percentage points) that
 # automatically opens the per-GPU rows.
-SPREAD_EXPAND_PTS = 20.0
 
 _GPU_COLORS = (
     "#f97316",
@@ -85,27 +84,34 @@ def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
     return (num, f"/ {total_s} GB")
 
 
-def disclosure_text(gpus: List[Dict[str, Any]], *, is_open: bool) -> str:
+def disclosure_text(
+    gpus: List[Dict[str, Any]],
+    roll: Dict[str, Any],
+    *,
+    is_open: bool,
+) -> str:
     """Header of the per-GPU rows: the utilisation range, and nothing else.
 
-    The text reports the observed range without assigning a verdict. Its tail
-    reflects the disclosure's current state, including user changes.
+    The range is read from the payload rather than recomputed. Computing
+    it here made a SECOND definition of "the spread across GPUs" living
+    beside ``gpu_delta``, and the two could disagree: this is the range of
+    window medians, that is the 95th percentile of per-tick max minus min.
+    Both are legitimate; two unnamed ones on one card were not.
+
+    The text reports the observed range without assigning a verdict. Its
+    tail reflects the disclosure's current state, including user changes.
     """
-    utils = []
-    for g in gpus:
-        u = g.get("util_p50")
-        if u is None:
-            u = g.get("util_now")
-        if u is not None:
-            utils.append(float(u))
-    n = len(utils)
+    n = len(gpus)
     if n == 0:
         return ""
     tail = " · click to close" if is_open else " · click to open"
     if n == 1:
         return "1 GPU" + tail
-    lo, hi = min(utils), max(utils)
-    return f"{n} GPUs · util {lo:.0f} to {hi:.0f}%" + tail
+    span = roll.get("util_range")
+    if not span:
+        return f"{n} GPUs" + tail
+    low, high = span
+    return f"{n} GPUs · util {low:.0f} to {high:.0f}%" + tail
 
 
 def node_scope_text(ctx: Dict[str, Any]) -> str:
@@ -212,29 +218,16 @@ def gpus_unreported(gpus: List[Dict[str, Any]]) -> bool:
     return bool(gpus) and not any(gpu.get("reported") for gpu in gpus)
 
 
-def odd_ones_out(gpus: List[Dict[str, Any]]) -> set:
-    """GPU indices on the smaller side of the utilisation split.
+def odd_ones_out(roll: Dict[str, Any]) -> set:
+    """GPU indices the computer marked as the smaller utilisation group.
 
-    Values split at the midpoint between the lowest and highest per-GPU
-    median. The smaller group is highlighted; ties select the higher group.
+    Read, not derived. The rule splits at the midpoint between the lowest
+    and highest per-GPU median and selects the smaller side, which derives
+    a threshold and then picks entities by it. That is the shape of a
+    diagnosis rule, so it moved to the compute layer unchanged; this reads
+    the answer.
     """
-    utils = []
-    for g in gpus:
-        u = g.get("util_p50")
-        if u is None:
-            u = g.get("util_now")
-        if u is not None:
-            utils.append((int(g.get("gpu_idx", 0)), float(u)))
-    if len(utils) < 2:
-        return set()
-    lo = min(u for _, u in utils)
-    hi = max(u for _, u in utils)
-    if hi <= lo:
-        return set()
-    mid = (hi + lo) / 2.0
-    high = {i for i, u in utils if u > mid}
-    low = {i for i, u in utils if u <= mid}
-    return high if len(high) <= len(low) else low
+    return {int(i) for i in (roll.get("odd_gpus") or ())}
 
 
 # Host CPU is psutil.cpu_percent(): the mean across logical cores, where 100%
@@ -254,10 +247,14 @@ def _num(value: Any, fmt: str = "{:.0f}") -> str:
 def rows_html(
     gpus: List[Dict[str, Any]],
     power_series: List[Dict[str, Any]],
-    *,
-    spread: Optional[float],
+    roll: Dict[str, Any],
 ) -> str:
     """Build GPU rows and highlight the smaller side of a wide util split.
+
+    Both the decision to highlight and the choice of which GPUs arrive on
+    the payload. The card used to hold a threshold of its own and compare
+    the spread against it, which is a severity call in the one layer that
+    may not make one.
 
     Absent values use ``NA`` and are never represented as zero.
     """
@@ -265,8 +262,7 @@ def rows_html(
         int(p.get("gpu_idx", -1)): p.get("values") or []
         for p in power_series or []
     }
-    over = spread is not None and spread > SPREAD_EXPAND_PTS
-    marked = odd_ones_out(gpus) if over else set()
+    marked = odd_ones_out(roll) if roll.get("rows_over") else set()
     head = (
         "<tr><th>gpu</th><th>util</th><th>power trend</th>"
         "<th>mem GB</th><th>temp °C</th><th>W / limit</th></tr>"
@@ -795,15 +791,14 @@ def _update_gpu_rows(
 
     gpus = roll.get("gpus", []) or []
     pseries = series.get("gpu_power", []) or []
-    spread = (roll.get("gpu_delta", {}) or {}).get("p95")
-    over = spread is not None and float(spread) > SPREAD_EXPAND_PTS
+    over = bool(roll.get("rows_over"))
     if should_auto_open(prev_over=panel["_over"], over=over):
         panel["rows"].value = True
     panel["_over"] = over
     panel["rows_hint"].text = disclosure_text(
-        gpus, is_open=bool(panel["rows"].value)
+        gpus, roll, is_open=bool(panel["rows"].value)
     )
-    panel["rows_html"].content = rows_html(gpus, pseries, spread=spread)
+    panel["rows_html"].content = rows_html(gpus, pseries, roll)
 
 
 def update_system_section(panel: Dict[str, Any], data: Dict[str, Any]) -> None:

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -202,16 +202,14 @@ def gpus_unreported(gpus: List[Dict[str, Any]]) -> bool:
     is absence rather than a GPU sitting at zero, and the card must not
     draw it as a measurement.
 
-    Named rather than inlined so the rule can be pinned by a test. Note it
-    is not the same rule the compute layer uses: this asks for mem_total
-    AND power both absent, while the computer asks for mem_total OR
-    power_limit_w present. A GPU reporting one and not the other is
-    "reported" to one of them and "unreported" to the other.
+    Reads the computer's ``reported`` flag rather than re-deriving the
+    answer. The card used to test whether ``mem_total`` and ``power`` were
+    both absent, which is a stricter rule than the computer's (``mem_total``
+    or ``power_limit_w`` present), so the two disagreed about a GPU that
+    carried a power limit and no memory total. The computer decides what a
+    metric means; this asks it.
     """
-    return bool(gpus) and all(
-        gpu.get("mem_total") is None and gpu.get("power") is None
-        for gpu in gpus
-    )
+    return bool(gpus) and not any(gpu.get("reported") for gpu in gpus)
 
 
 def odd_ones_out(gpus: List[Dict[str, Any]]) -> set:

--- a/src/traceml_ai/renderers/system/common.py
+++ b/src/traceml_ai/renderers/system/common.py
@@ -67,23 +67,3 @@ class SystemCLISnapshot:
             "gpu_mem_headroom_min": self.gpu_mem_headroom_min,
             "gpu_mem_headroom_min_idx": self.gpu_mem_headroom_min_idx,
         }
-
-
-@dataclass(frozen=True)
-class SystemDashboardPayload:
-    """Dashboard payload for system telemetry."""
-
-    window_len: int
-    gpu_available: bool
-    rollups: Dict[str, Any]
-    # Series includes both flat sample arrays and structured whole-run
-    # histories, so its values are intentionally heterogeneous.
-    series: Dict[str, Any]
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "window_len": self.window_len,
-            "gpu_available": self.gpu_available,
-            "rollups": self.rollups,
-            "series": self.series,
-        }

--- a/src/traceml_ai/renderers/system/computer.py
+++ b/src/traceml_ai/renderers/system/computer.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, Optional
 
 from .cli_compute import SystemCLIComputer
 from .dashboard_compute import SystemDashboardComputer
+from .dashboard_models import SystemDashboardPayload
 
 
 class SystemMetricsComputer:
@@ -56,7 +57,7 @@ class SystemMetricsComputer:
         """
         return self._cli.compute()
 
-    def compute_dashboard(self, window_n: int = 100) -> Dict[str, Any]:
+    def compute_dashboard(self, window_n: int = 100) -> SystemDashboardPayload:
         """
         Compute dashboard rollups and short history series.
         """

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -70,7 +70,26 @@ def _empty_dashboard_series() -> Dict[str, Any]:
             "window_s": 0.0,
         },
         "gpu_power_run": [],
+        "cpu_run_whole": False,
+        "power_run_whole": False,
     }
+
+
+# A whole-run line needs more than two points to say anything about a
+# trend. One rule, applied to both series: the card used to ask ">2
+# points" of the CPU history and merely "non-empty" of the power history,
+# so its two charts could disagree about which view they were showing.
+_MIN_WHOLE_RUN_POINTS = 2
+
+
+def _has_whole_run(entries: Any) -> bool:
+    """Whether a whole-run series has enough shape to draw."""
+    if isinstance(entries, dict):
+        return len(entries.get("t") or ()) > _MIN_WHOLE_RUN_POINTS
+    longest = 0
+    for entry in entries or ():
+        longest = max(longest, len(entry.get("t") or ()))
+    return longest > _MIN_WHOLE_RUN_POINTS
 
 
 def _gpu_medians(gpus: List[Dict[str, Any]]) -> List[tuple]:
@@ -460,6 +479,12 @@ class SystemDashboardComputer:
                 # the host is doing now, these say what it has done.
                 "cpu_run": cpu_run,
                 "gpu_power_run": power_run if gpu_available else [],
+                # Which view each chart is in, decided once here rather
+                # than twice in the card with two different rules.
+                "cpu_run_whole": _has_whole_run(cpu_run),
+                "power_run_whole": _has_whole_run(
+                    power_run if gpu_available else []
+                ),
             },
         ).to_dict()
 

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -73,6 +73,72 @@ def _empty_dashboard_series() -> Dict[str, Any]:
     }
 
 
+def _gpu_medians(gpus: List[Dict[str, Any]]) -> List[tuple]:
+    """Each GPU's representative utilisation, as (index, value).
+
+    The window median where there is one, else the newest reading. One
+    definition, used by everything that asks about the spread across
+    devices, so two surfaces on the same card cannot answer differently.
+    """
+    out = []
+    for g in gpus:
+        value = g.get("util_p50")
+        if value is None:
+            value = g.get("util_now")
+        if value is not None:
+            out.append((int(g.get("gpu_idx", 0)), float(value)))
+    return out
+
+
+def _odd_gpus(gpus: List[Dict[str, Any]]) -> List[int]:
+    """The GPUs on the smaller side of the utilisation split.
+
+    Values split at the midpoint between the lowest and highest
+    representative utilisation; the smaller group is the one worth
+    pointing at, and a tie goes to the higher group.
+
+    Moved here from the card unchanged. It derives a threshold and then
+    selects entities by it, which is the shape of a diagnosis rule and not
+    of a drawing decision, so it belongs on this side of the boundary. Its
+    behaviour is deliberately preserved, including the consequence that on
+    a two-GPU host the groups always tie and the busier card is the one
+    marked.
+    """
+    pairs = _gpu_medians(gpus)
+    if len(pairs) < 2:
+        return []
+    low_value = min(v for _i, v in pairs)
+    high_value = max(v for _i, v in pairs)
+    if high_value <= low_value:
+        return []
+    mid = (high_value + low_value) / 2.0
+    high = [i for i, v in pairs if v > mid]
+    low = [i for i, v in pairs if v <= mid]
+    return sorted(high if len(high) <= len(low) else low)
+
+
+# Utilisation spread, in percentage points, at which the per-GPU rows
+# have earned opening themselves. A threshold against a measurement is a
+# severity judgement, so it lives here and not in the card.
+SPREAD_EXPAND_PTS = 20.0
+
+
+def _util_range(gpus: List[Dict[str, Any]]) -> Optional[tuple]:
+    """The lowest and highest representative utilisation, or None.
+
+    The card computed this itself for its disclosure header, which made it
+    a SECOND definition of "the spread across GPUs" living beside
+    ``gpu_delta``, and the two could disagree: one is the range of window
+    medians, the other the 95th percentile of per-tick max minus min.
+    Both are legitimate; having two of them unnamed on one card was not.
+    """
+    pairs = _gpu_medians(gpus)
+    if not pairs:
+        return None
+    values = [v for _i, v in pairs]
+    return (min(values), max(values))
+
+
 class SystemDashboardComputer:
     """Compute dashboard rollups and short time-series."""
 
@@ -353,6 +419,14 @@ class SystemDashboardComputer:
                 else []
             ),
         }
+
+        gpu_rows = rollups["gpus"]
+        rollups["odd_gpus"] = _odd_gpus(gpu_rows)
+        rollups["util_range"] = _util_range(gpu_rows)
+        spread = (rollups.get("gpu_delta") or {}).get("p95")
+        rollups["rows_over"] = (
+            spread is not None and float(spread) > SPREAD_EXPAND_PTS
+        )
 
         rollups["ctx"] = {
             "world_size": int(last["world_size"] or 0),

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -411,7 +411,6 @@ class SystemDashboardComputer:
         )
 
         rollups = {
-            "gpu_available": gpu_available,
             "cpu": {
                 "now": float(cpu_hist[-1]),
                 "p50": cpu_p50,

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -442,11 +442,17 @@ class SystemDashboardComputer:
         out: List[Dict[str, Any]] = []
         for idx in sorted(set(util_hist) | set(power_hist)):
             g = latest_rows.get(idx)
-            if g is not None and not _gpu_reported(g):
+            reported = g is not None and _gpu_reported(g)
+            if not reported:
                 g = None  # the sampler's all-zero fallback: unreported
             out.append(
                 {
                     "gpu_idx": idx,
+                    # Stated, not inferred. The card used to work this out
+                    # from which fields were None, with a rule that
+                    # disagreed with this one about a GPU reporting a
+                    # power limit but no memory total.
+                    "reported": reported,
                     "util_now": (
                         _opt_float(g["util"]) if g is not None else None
                     ),

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -9,12 +9,17 @@
 from __future__ import annotations
 
 import time
+from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 import numpy as np
 
-from .common import SystemDashboardPayload
+from .dashboard_models import (
+    SystemDashboardPayload,
+    SystemRollups,
+    SystemSeries,
+)
 from .repository import SystemRepository
 
 # Whole-run charts add value only after the run outgrows the recent window.
@@ -80,6 +85,28 @@ def _empty_dashboard_series() -> Dict[str, Any]:
 # points" of the CPU history and merely "non-empty" of the power history,
 # so its two charts could disagree about which view they were showing.
 _MIN_WHOLE_RUN_POINTS = 2
+
+
+def _typed(
+    *,
+    window_len: int,
+    gpu_available: bool,
+    rollups: Dict[str, Any],
+    series: Dict[str, Any],
+) -> SystemDashboardPayload:
+    """Wrap the compute layer's mappings in the payload's own types.
+
+    The mappings are built as dicts here because that is how the readers
+    and the numpy work naturally produce them; the types are the contract
+    the card reads, and the models own the adaptation so the shape is
+    described in one place.
+    """
+    return SystemDashboardPayload(
+        window_len=window_len,
+        gpu_available=gpu_available,
+        rollups=SystemRollups.from_dict(rollups),
+        series=SystemSeries.from_dict(series),
+    )
 
 
 def _has_whole_run(entries: Any) -> bool:
@@ -188,7 +215,7 @@ class SystemDashboardComputer:
         except Exception as e:
             return self._return_stale(f"STALE (exception: {type(e).__name__})")
 
-        if out.get("window_len", 0) == 0 and self._last_ok is not None:
+        if out.window_len == 0 and self._last_ok is not None:
             return self._return_stale("STALE (empty window)")
 
         self._last_ok = out
@@ -457,7 +484,7 @@ class SystemDashboardComputer:
 
         x_time = [self._format_time_iso(ts) for ts in ts_hist.tolist()]
 
-        return SystemDashboardPayload(
+        return _typed(
             window_len=len(samples),
             gpu_available=gpu_available,
             rollups=rollups,
@@ -486,7 +513,7 @@ class SystemDashboardComputer:
                     power_run if gpu_available else []
                 ),
             },
-        ).to_dict()
+        )
 
     @staticmethod
     def _pick_node(samples: List[Any]) -> Dict[str, Any]:
@@ -600,11 +627,11 @@ class SystemDashboardComputer:
         except Exception:
             return ""
 
-    def _return_stale(self, msg: str) -> Dict[str, Any]:
-        """
-        Return the last known good payload when it is still within TTL.
+    def _return_stale(self, msg: str) -> SystemDashboardPayload:
+        """The last good payload while it is still within TTL.
 
-        Adds a human-readable status string into `rollups["status"]`.
+        Carries a human-readable status so the card can say the numbers
+        are held over rather than drawing them as current.
         """
         now = time.time()
         if self._last_ok is not None:
@@ -613,32 +640,21 @@ class SystemDashboardComputer:
                 or (now - self._last_ok_ts) <= self._stale_ttl_s
             ):
                 cached = self._last_ok
-                rollups = dict(cached.get("rollups", {}))
-                rollups["status"] = msg
-                return {
-                    "window_len": cached.get("window_len", 0),
-                    "gpu_available": cached.get("gpu_available", False),
-                    "rollups": rollups,
-                    "series": cached.get(
-                        "series",
-                        _empty_dashboard_series(),
-                    ),
-                }
+                return replace(
+                    cached,
+                    rollups=replace(cached.rollups, status=msg),
+                )
 
-        return {
-            "window_len": 0,
-            "gpu_available": False,
-            "rollups": {"status": "No fresh system data"},
-            "series": _empty_dashboard_series(),
-        }
-
-    def _empty_payload(self) -> Dict[str, Any]:
-        """
-        Return an empty dashboard payload with the full expected schema.
-        """
         return SystemDashboardPayload(
+            rollups=SystemRollups(status="No fresh system data"),
+            series=SystemSeries.from_dict(_empty_dashboard_series()),
+        )
+
+    def _empty_payload(self) -> SystemDashboardPayload:
+        """An empty payload carrying the full expected schema."""
+        return _typed(
             window_len=0,
             gpu_available=False,
             rollups={},
             series=_empty_dashboard_series(),
-        ).to_dict()
+        )

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -195,13 +195,13 @@ class SystemDashboardComputer:
         stale_ttl_s: Optional[float] = 30.0,
     ) -> None:
         self._db = SystemRepository(db_path=db_path, node_rank=node_rank)
-        self._last_ok: Optional[Dict[str, Any]] = None
+        self._last_ok: Optional[SystemDashboardPayload] = None
         self._last_ok_ts: float = 0.0
         self._stale_ttl_s: Optional[float] = (
             float(stale_ttl_s) if stale_ttl_s is not None else None
         )
 
-    def compute(self, window_n: int = 100) -> Dict[str, Any]:
+    def compute(self, window_n: int = 100) -> SystemDashboardPayload:
         """
         Compute dashboard rollups plus short series over the latest window.
 
@@ -222,7 +222,7 @@ class SystemDashboardComputer:
         self._last_ok_ts = time.time()
         return out
 
-    def _compute_impl(self, conn, window_n: int) -> Dict[str, Any]:
+    def _compute_impl(self, conn, window_n: int) -> SystemDashboardPayload:
         """
         Compute the dashboard payload from recent SQLite rows.
 

--- a/src/traceml_ai/renderers/system/dashboard_models.py
+++ b/src/traceml_ai/renderers/system/dashboard_models.py
@@ -164,7 +164,10 @@ class RunContext:
     world_size: int = 0
     gpu_count: int = 0
     hostname: str = ""
-    system_node: Optional[int] = None
+    # The host this payload describes: which node was picked, how many
+    # were seen in the window, and its name. A mapping rather than an
+    # index because the card needs all three to say "node 0 of 2".
+    system_node: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/src/traceml_ai/renderers/system/dashboard_models.py
+++ b/src/traceml_ai/renderers/system/dashboard_models.py
@@ -223,6 +223,13 @@ class SystemRollups:
     # rather than in the card, which is where a rule that selects entities
     # by a derived threshold belongs.
     odd_gpus: Tuple[int, ...] = ()
+    # The lowest and highest representative utilisation, or None. Named so
+    # there is one definition of "the spread across GPUs" rather than this
+    # one and gpu_delta both living unnamed on the same card.
+    util_range: Optional[Tuple[float, float]] = None
+    # Whether the spread has earned opening the per-GPU rows. A threshold
+    # against a measurement is a severity call, so it is decided here.
+    rows_over: bool = False
 
     @property
     def gpus_unreported(self) -> bool:
@@ -272,11 +279,97 @@ class SystemRollups:
             if value is not None:
                 out[key] = value.to_dict()
         out["gpus"] = [g.to_dict() for g in self.gpus]
+        out["odd_gpus"] = list(self.odd_gpus)
+        out["util_range"] = self.util_range
+        out["rows_over"] = self.rows_over
         if self.ctx is not None:
             out["ctx"] = self.ctx.to_dict()
         if self.status is not None:
             out["status"] = self.status
         return out
+
+    @classmethod
+    def from_dict(cls, raw: Dict[str, Any]) -> "SystemRollups":
+        """Adapt the compute layer's rollup mapping."""
+        if not raw:
+            return cls()
+
+        def stat(key: str) -> Optional[Stat]:
+            block = raw.get(key)
+            if not block:
+                return None
+            return Stat(
+                now=block.get("now"),
+                p50=block.get("p50"),
+                p95=block.get("p95"),
+            )
+
+        ram = raw.get("ram") or None
+        mem = raw.get("gpu_mem") or None
+        temp = raw.get("temp") or None
+        power = raw.get("gpu_power") or None
+        ctx = raw.get("ctx") or None
+        span = raw.get("util_range")
+        return cls(
+            gpu_available=bool(raw.get("gpu_available")),
+            cpu=stat("cpu"),
+            gpu_util=stat("gpu_util"),
+            gpu_delta=stat("gpu_delta"),
+            ram=(
+                RamStat(
+                    now=ram["now"],
+                    p95=ram.get("p95"),
+                    total=ram["total"],
+                    headroom=ram.get("headroom", 0.0),
+                )
+                if ram
+                else None
+            ),
+            gpu_mem=(
+                GpuMemStat(
+                    now=mem["now"],
+                    p95=mem.get("p95"),
+                    headroom=mem.get("headroom", 0.0),
+                    total=mem.get("total"),
+                )
+                if mem
+                else None
+            ),
+            temp=(
+                TempStat(
+                    now=temp.get("now"),
+                    p95=temp.get("p95"),
+                    status=temp.get("status"),
+                )
+                if temp
+                else None
+            ),
+            gpu_power=(
+                PowerStat(
+                    now=power.get("now"),
+                    p50=power.get("p50"),
+                    limit=power.get("limit"),
+                    floor=power.get("floor"),
+                )
+                if power
+                else None
+            ),
+            gpus=gpu_rows_from_dicts(raw.get("gpus") or []),
+            ctx=(
+                RunContext(
+                    world_size=int(ctx.get("world_size") or 0),
+                    gpu_count=int(ctx.get("gpu_count") or 0),
+                    hostname=str(ctx.get("hostname") or ""),
+                    system_node=ctx.get("system_node"),
+                )
+                if ctx
+                else None
+            ),
+            status=raw.get("status"),
+            odd_gpus=tuple(raw.get("odd_gpus") or ()),
+            util_range=(tuple(span) if span else None),
+            rows_over=bool(raw.get("rows_over")),
+        )
 
 
 @dataclass(frozen=True)
@@ -289,6 +382,11 @@ class SystemSeries:
     gpu_power: Tuple[Optional[float], ...] = ()
     cpu_run: CpuRunSeries = field(default_factory=CpuRunSeries)
     gpu_power_run: Tuple[Dict[str, Any], ...] = ()
+    # Which view each chart is in. Both answered by one rule in the
+    # compute layer; the card used to answer them itself with two
+    # different rules and its charts could disagree.
+    cpu_run_whole: bool = False
+    power_run_whole: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -298,7 +396,30 @@ class SystemSeries:
             "gpu_power": list(self.gpu_power),
             "cpu_run": self.cpu_run.to_dict(),
             "gpu_power_run": [dict(b) for b in self.gpu_power_run],
+            "cpu_run_whole": self.cpu_run_whole,
+            "power_run_whole": self.power_run_whole,
         }
+
+    @classmethod
+    def from_dict(cls, raw: Dict[str, Any]) -> "SystemSeries":
+        """Adapt the compute layer's series mapping."""
+        run = raw.get("cpu_run") or {}
+        return cls(
+            x_time=tuple(raw.get("x_time") or ()),
+            cpu=tuple(raw.get("cpu") or ()),
+            gpu_avg=tuple(raw.get("gpu_avg") or ()),
+            gpu_power=tuple(raw.get("gpu_power") or ()),
+            cpu_run=CpuRunSeries(
+                t=tuple(run.get("t") or ()),
+                avg=tuple(run.get("avg") or ()),
+                max=tuple(run.get("max") or ()),
+                span_s=float(run.get("span_s") or 0.0),
+                window_s=float(run.get("window_s") or 0.0),
+            ),
+            gpu_power_run=tuple(raw.get("gpu_power_run") or ()),
+            cpu_run_whole=bool(raw.get("cpu_run_whole")),
+            power_run_whole=bool(raw.get("power_run_whole")),
+        )
 
 
 @dataclass(frozen=True)

--- a/src/traceml_ai/renderers/system/dashboard_models.py
+++ b/src/traceml_ai/renderers/system/dashboard_models.py
@@ -1,0 +1,352 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The contract between System compute and the System card.
+
+The payload was four keys, two of which were `Dict[str, Any]`. Everything
+inside them was reachable only by string, so the card asked questions like
+"is `mem_total` missing?" to work out facts the compute layer already knew,
+and answered some of them differently. Naming the fields is what stops
+that: a question with one answer has one place to ask it.
+
+``to_dict`` reproduces the previous dict exactly, key for key. Two tests
+assert the series by equality on degraded paths, and several more read the
+payload as nested dicts, so the shape is a contract until the card is
+migrated across.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class Stat:
+    """A level with the percentiles that say whether it is typical."""
+
+    now: Optional[float] = None
+    p50: Optional[float] = None
+    p95: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"now": self.now}
+        if self.p50 is not None:
+            out["p50"] = self.p50
+        out["p95"] = self.p95
+        return out
+
+
+@dataclass(frozen=True)
+class RamStat:
+    """Host memory, carrying the capacity that makes the level readable."""
+
+    now: float
+    p95: Optional[float]
+    total: float
+    headroom: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "now": self.now,
+            "p95": self.p95,
+            "total": self.total,
+            "headroom": self.headroom,
+        }
+
+
+@dataclass(frozen=True)
+class GpuMemStat:
+    """Device memory on the GPU holding the most, with its own capacity.
+
+    ``total`` is the capacity of the GPU reported in ``now``, not a sum
+    across devices, so the tile can read "used of total" about one card
+    rather than about an imaginary merged one.
+    """
+
+    now: float
+    p95: Optional[float]
+    headroom: float
+    total: Optional[float]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "now": self.now,
+            "p95": self.p95,
+            "headroom": self.headroom,
+            "total": self.total,
+        }
+
+
+@dataclass(frozen=True)
+class TempStat:
+    """Temperature, and the engine's verdict on it.
+
+    ``status`` is the diagnosis engine's word. The card prints it and does
+    not restate it in its own vocabulary.
+    """
+
+    now: Optional[float] = None
+    p95: Optional[float] = None
+    status: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"now": self.now, "p95": self.p95, "status": self.status}
+
+
+@dataclass(frozen=True)
+class PowerStat:
+    """Board power, always the busiest GPU rather than a sum.
+
+    ``floor`` is the lowest reading over the whole run when that history
+    was aggregated, and over the recent window when it was not.
+    """
+
+    now: Optional[float] = None
+    p50: Optional[float] = None
+    limit: Optional[float] = None
+    floor: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "now": self.now,
+            "p50": self.p50,
+            "limit": self.limit,
+            "floor": self.floor,
+        }
+
+
+@dataclass(frozen=True)
+class GpuRow:
+    """One GPU's newest values, or its slot with nothing in it.
+
+    A GPU that vanishes from the newest tick keeps its row with ``None``
+    values rather than disappearing, so the row count never silently
+    drops.
+
+    ``reported`` is the compute layer's answer to "has this device told us
+    anything", and it is on the row so the card never has to infer it. The
+    card used to infer it, with a different rule, and the two disagreed
+    about a GPU that reported a power limit but no memory total.
+    """
+
+    gpu_idx: int
+    util_now: Optional[float] = None
+    util_p50: Optional[float] = None
+    mem_used: Optional[float] = None
+    mem_total: Optional[float] = None
+    temp: Optional[float] = None
+    power: Optional[float] = None
+    power_limit: Optional[float] = None
+    reported: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "gpu_idx": self.gpu_idx,
+            "util_now": self.util_now,
+            "util_p50": self.util_p50,
+            "mem_used": self.mem_used,
+            "mem_total": self.mem_total,
+            "temp": self.temp,
+            "power": self.power,
+            "power_limit": self.power_limit,
+            "reported": self.reported,
+        }
+
+
+@dataclass(frozen=True)
+class RunContext:
+    """Which machine and which slice of the job this payload describes."""
+
+    world_size: int = 0
+    gpu_count: int = 0
+    hostname: str = ""
+    system_node: Optional[int] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "world_size": self.world_size,
+            "gpu_count": self.gpu_count,
+            "hostname": self.hostname,
+            "system_node": self.system_node,
+        }
+
+
+@dataclass(frozen=True)
+class CpuRunSeries:
+    """Host CPU over the whole run, rolled and decimated to fit a chart."""
+
+    t: Tuple[float, ...] = ()
+    avg: Tuple[float, ...] = ()
+    max: Tuple[float, ...] = ()
+    span_s: float = 0.0
+    window_s: float = 0.0
+
+    @property
+    def is_populated(self) -> bool:
+        """Whether the whole-run view has anything to draw.
+
+        Stated here so the card stops deciding it, which it did with two
+        different rules for its two charts.
+        """
+        return len(self.t) > 2
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "t": list(self.t),
+            "avg": list(self.avg),
+            "max": list(self.max),
+            "span_s": self.span_s,
+            "window_s": self.window_s,
+        }
+
+
+@dataclass(frozen=True)
+class SystemRollups:
+    """Every level the card shows, already decided."""
+
+    gpu_available: bool = False
+    cpu: Optional[Stat] = None
+    ram: Optional[RamStat] = None
+    gpu_util: Optional[Stat] = None
+    gpu_delta: Optional[Stat] = None
+    gpu_mem: Optional[GpuMemStat] = None
+    temp: Optional[TempStat] = None
+    gpu_power: Optional[PowerStat] = None
+    gpus: Tuple[GpuRow, ...] = ()
+    ctx: Optional[RunContext] = None
+    status: Optional[str] = None
+    # GPUs whose utilisation puts them in the smaller group. Decided here
+    # rather than in the card, which is where a rule that selects entities
+    # by a derived threshold belongs.
+    odd_gpus: Tuple[int, ...] = ()
+
+    @property
+    def gpus_unreported(self) -> bool:
+        """Whether every GPU present has told us nothing.
+
+        One rule, answered once. The card asked a different question of
+        the same rows and could disagree with this.
+        """
+        return bool(self.gpus) and not any(g.reported for g in self.gpus)
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether nothing was computed, as opposed to computed as zero."""
+        return (
+            not self.gpus
+            and self.ctx is None
+            and self.status is None
+            and all(
+                v is None
+                for v in (
+                    self.cpu,
+                    self.ram,
+                    self.gpu_util,
+                    self.gpu_delta,
+                    self.gpu_mem,
+                    self.temp,
+                    self.gpu_power,
+                )
+            )
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        # The empty payload carries an empty mapping rather than a shell of
+        # null-valued keys, and two tests assert that by equality.
+        if self.is_empty:
+            return {}
+        out: Dict[str, Any] = {"gpu_available": self.gpu_available}
+        for key, value in (
+            ("cpu", self.cpu),
+            ("ram", self.ram),
+            ("gpu_util", self.gpu_util),
+            ("gpu_delta", self.gpu_delta),
+            ("gpu_mem", self.gpu_mem),
+            ("temp", self.temp),
+            ("gpu_power", self.gpu_power),
+        ):
+            if value is not None:
+                out[key] = value.to_dict()
+        out["gpus"] = [g.to_dict() for g in self.gpus]
+        if self.ctx is not None:
+            out["ctx"] = self.ctx.to_dict()
+        if self.status is not None:
+            out["status"] = self.status
+        return out
+
+
+@dataclass(frozen=True)
+class SystemSeries:
+    """The lines the card draws, over the window and over the run."""
+
+    x_time: Tuple[str, ...] = ()
+    cpu: Tuple[Optional[float], ...] = ()
+    gpu_avg: Tuple[Optional[float], ...] = ()
+    gpu_power: Tuple[Optional[float], ...] = ()
+    cpu_run: CpuRunSeries = field(default_factory=CpuRunSeries)
+    gpu_power_run: Tuple[Dict[str, Any], ...] = ()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "x_time": list(self.x_time),
+            "cpu": list(self.cpu),
+            "gpu_avg": list(self.gpu_avg),
+            "gpu_power": list(self.gpu_power),
+            "cpu_run": self.cpu_run.to_dict(),
+            "gpu_power_run": [dict(b) for b in self.gpu_power_run],
+        }
+
+
+@dataclass(frozen=True)
+class SystemDashboardPayload:
+    """Everything the System card needs, and nothing it has to derive."""
+
+    window_len: int = 0
+    gpu_available: bool = False
+    rollups: SystemRollups = field(default_factory=SystemRollups)
+    series: SystemSeries = field(default_factory=SystemSeries)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "window_len": self.window_len,
+            "gpu_available": self.gpu_available,
+            "rollups": self.rollups.to_dict(),
+            "series": self.series.to_dict(),
+        }
+
+
+__all__ = [
+    "CpuRunSeries",
+    "GpuMemStat",
+    "GpuRow",
+    "PowerStat",
+    "RamStat",
+    "RunContext",
+    "Stat",
+    "SystemDashboardPayload",
+    "SystemRollups",
+    "SystemSeries",
+    "TempStat",
+]
+
+
+def gpu_rows_from_dicts(rows: List[Dict[str, Any]]) -> Tuple[GpuRow, ...]:
+    """Adapt the compute layer's row dicts while it still emits them."""
+    return tuple(
+        GpuRow(
+            gpu_idx=int(r.get("gpu_idx", 0)),
+            util_now=r.get("util_now"),
+            util_p50=r.get("util_p50"),
+            mem_used=r.get("mem_used"),
+            mem_total=r.get("mem_total"),
+            temp=r.get("temp"),
+            power=r.get("power"),
+            power_limit=r.get("power_limit"),
+            reported=bool(r.get("reported", False)),
+        )
+        for r in rows
+    )

--- a/src/traceml_ai/renderers/system/dashboard_models.py
+++ b/src/traceml_ai/renderers/system/dashboard_models.py
@@ -145,7 +145,6 @@ class CpuRunSeries:
 class SystemRollups:
     """Every level the card shows, already decided."""
 
-    gpu_available: bool = False
     cpu: Optional[Stat] = None
     ram: Optional[RamStat] = None
     gpu_util: Optional[Stat] = None
@@ -208,7 +207,6 @@ class SystemRollups:
         ctx = raw.get("ctx") or None
         span = raw.get("util_range")
         return cls(
-            gpu_available=bool(raw.get("gpu_available")),
             cpu=stat("cpu"),
             gpu_util=stat("gpu_util"),
             gpu_delta=stat("gpu_delta"),

--- a/src/traceml_ai/renderers/system/dashboard_models.py
+++ b/src/traceml_ai/renderers/system/dashboard_models.py
@@ -12,10 +12,11 @@ inside them was reachable only by string, so the card asked questions like
 and answered some of them differently. Naming the fields is what stops
 that: a question with one answer has one place to ask it.
 
-``to_dict`` reproduces the previous dict exactly, key for key. Two tests
-assert the series by equality on degraded paths, and several more read the
-payload as nested dicts, so the shape is a contract until the card is
-migrated across.
+These types are the whole contract. There is no ``to_dict`` alongside
+them: a second rendering of the same payload is a second place for the
+shape to drift, and the card, the driver and the tests all read the types.
+``from_dict`` remains because the compute layer still assembles mappings
+internally, and adapting them in one place is what keeps that private.
 """
 
 from __future__ import annotations
@@ -32,13 +33,6 @@ class Stat:
     p50: Optional[float] = None
     p95: Optional[float] = None
 
-    def to_dict(self) -> Dict[str, Any]:
-        out: Dict[str, Any] = {"now": self.now}
-        if self.p50 is not None:
-            out["p50"] = self.p50
-        out["p95"] = self.p95
-        return out
-
 
 @dataclass(frozen=True)
 class RamStat:
@@ -48,14 +42,6 @@ class RamStat:
     p95: Optional[float]
     total: float
     headroom: float
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "now": self.now,
-            "p95": self.p95,
-            "total": self.total,
-            "headroom": self.headroom,
-        }
 
 
 @dataclass(frozen=True)
@@ -72,14 +58,6 @@ class GpuMemStat:
     headroom: float
     total: Optional[float]
 
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "now": self.now,
-            "p95": self.p95,
-            "headroom": self.headroom,
-            "total": self.total,
-        }
-
 
 @dataclass(frozen=True)
 class TempStat:
@@ -92,9 +70,6 @@ class TempStat:
     now: Optional[float] = None
     p95: Optional[float] = None
     status: Optional[str] = None
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {"now": self.now, "p95": self.p95, "status": self.status}
 
 
 @dataclass(frozen=True)
@@ -109,14 +84,6 @@ class PowerStat:
     p50: Optional[float] = None
     limit: Optional[float] = None
     floor: Optional[float] = None
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "now": self.now,
-            "p50": self.p50,
-            "limit": self.limit,
-            "floor": self.floor,
-        }
 
 
 @dataclass(frozen=True)
@@ -143,19 +110,6 @@ class GpuRow:
     power_limit: Optional[float] = None
     reported: bool = False
 
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "gpu_idx": self.gpu_idx,
-            "util_now": self.util_now,
-            "util_p50": self.util_p50,
-            "mem_used": self.mem_used,
-            "mem_total": self.mem_total,
-            "temp": self.temp,
-            "power": self.power,
-            "power_limit": self.power_limit,
-            "reported": self.reported,
-        }
-
 
 @dataclass(frozen=True)
 class RunContext:
@@ -168,14 +122,6 @@ class RunContext:
     # were seen in the window, and its name. A mapping rather than an
     # index because the card needs all three to say "node 0 of 2".
     system_node: Optional[Dict[str, Any]] = None
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "world_size": self.world_size,
-            "gpu_count": self.gpu_count,
-            "hostname": self.hostname,
-            "system_node": self.system_node,
-        }
 
 
 @dataclass(frozen=True)
@@ -193,15 +139,6 @@ class CpuRunSeries:
     max: Tuple[float, ...] = ()
     span_s: float = 0.0
     window_s: float = 0.0
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "t": list(self.t),
-            "avg": list(self.avg),
-            "max": list(self.max),
-            "span_s": self.span_s,
-            "window_s": self.window_s,
-        }
 
 
 @dataclass(frozen=True)
@@ -233,60 +170,20 @@ class SystemRollups:
 
     @property
     def gpus_unreported(self) -> bool:
-        """Whether every GPU present has told us nothing.
+        """Whether every GPU present sent nothing but the zero fallback.
 
-        One rule, answered once. The card asked a different question of
-        the same rows and could disagree with this.
+        The sampler emits an all-zero row when it cannot read a device,
+        which is absence rather than a GPU sitting at zero, and the card
+        must not draw it as a measurement.
+
+        Reads the computer's ``reported`` flag rather than re-deriving the
+        answer. The card used to test whether ``mem_total`` and ``power``
+        were both absent, a stricter rule than the computer's (``mem_total``
+        or ``power_limit_w`` present), so the two disagreed about a GPU
+        carrying a power limit and no memory total. This is the only place
+        the question is answered.
         """
         return bool(self.gpus) and not any(g.reported for g in self.gpus)
-
-    @property
-    def is_empty(self) -> bool:
-        """Whether nothing was computed, as opposed to computed as zero."""
-        return (
-            not self.gpus
-            and self.ctx is None
-            and self.status is None
-            and all(
-                v is None
-                for v in (
-                    self.cpu,
-                    self.ram,
-                    self.gpu_util,
-                    self.gpu_delta,
-                    self.gpu_mem,
-                    self.temp,
-                    self.gpu_power,
-                )
-            )
-        )
-
-    def to_dict(self) -> Dict[str, Any]:
-        # The empty payload carries an empty mapping rather than a shell of
-        # null-valued keys, and two tests assert that by equality.
-        if self.is_empty:
-            return {}
-        out: Dict[str, Any] = {"gpu_available": self.gpu_available}
-        for key, value in (
-            ("cpu", self.cpu),
-            ("ram", self.ram),
-            ("gpu_util", self.gpu_util),
-            ("gpu_delta", self.gpu_delta),
-            ("gpu_mem", self.gpu_mem),
-            ("temp", self.temp),
-            ("gpu_power", self.gpu_power),
-        ):
-            if value is not None:
-                out[key] = value.to_dict()
-        out["gpus"] = [g.to_dict() for g in self.gpus]
-        out["odd_gpus"] = list(self.odd_gpus)
-        out["util_range"] = self.util_range
-        out["rows_over"] = self.rows_over
-        if self.ctx is not None:
-            out["ctx"] = self.ctx.to_dict()
-        if self.status is not None:
-            out["status"] = self.status
-        return out
 
     @classmethod
     def from_dict(cls, raw: Dict[str, Any]) -> "SystemRollups":
@@ -379,7 +276,10 @@ class SystemSeries:
     x_time: Tuple[str, ...] = ()
     cpu: Tuple[Optional[float], ...] = ()
     gpu_avg: Tuple[Optional[float], ...] = ()
-    gpu_power: Tuple[Optional[float], ...] = ()
+    # Per-GPU power over the window: one entry per device, each
+    # {"gpu_idx", "values"}. Not a flat series, which is what the
+    # annotation used to claim.
+    gpu_power: Tuple[Dict[str, Any], ...] = ()
     cpu_run: CpuRunSeries = field(default_factory=CpuRunSeries)
     gpu_power_run: Tuple[Dict[str, Any], ...] = ()
     # Which view each chart is in. Both answered by one rule in the
@@ -387,18 +287,6 @@ class SystemSeries:
     # different rules and its charts could disagree.
     cpu_run_whole: bool = False
     power_run_whole: bool = False
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "x_time": list(self.x_time),
-            "cpu": list(self.cpu),
-            "gpu_avg": list(self.gpu_avg),
-            "gpu_power": list(self.gpu_power),
-            "cpu_run": self.cpu_run.to_dict(),
-            "gpu_power_run": [dict(b) for b in self.gpu_power_run],
-            "cpu_run_whole": self.cpu_run_whole,
-            "power_run_whole": self.power_run_whole,
-        }
 
     @classmethod
     def from_dict(cls, raw: Dict[str, Any]) -> "SystemSeries":
@@ -430,14 +318,6 @@ class SystemDashboardPayload:
     gpu_available: bool = False
     rollups: SystemRollups = field(default_factory=SystemRollups)
     series: SystemSeries = field(default_factory=SystemSeries)
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "window_len": self.window_len,
-            "gpu_available": self.gpu_available,
-            "rollups": self.rollups.to_dict(),
-            "series": self.series.to_dict(),
-        }
 
 
 __all__ = [

--- a/src/traceml_ai/renderers/system/dashboard_models.py
+++ b/src/traceml_ai/renderers/system/dashboard_models.py
@@ -180,22 +180,19 @@ class RunContext:
 
 @dataclass(frozen=True)
 class CpuRunSeries:
-    """Host CPU over the whole run, rolled and decimated to fit a chart."""
+    """Host CPU over the whole run, rolled and decimated to fit a chart.
+
+    Whether this series has earned the whole-run view is NOT asked here.
+    ``_has_whole_run`` in the compute layer decides it for both charts and
+    the answer travels as ``SystemSeries.cpu_run_whole``. A second copy of
+    that rule on this class is how the card came to hold two of them.
+    """
 
     t: Tuple[float, ...] = ()
     avg: Tuple[float, ...] = ()
     max: Tuple[float, ...] = ()
     span_s: float = 0.0
     window_s: float = 0.0
-
-    @property
-    def is_populated(self) -> bool:
-        """Whether the whole-run view has anything to draw.
-
-        Stated here so the card stops deciding it, which it did with two
-        different rules for its two charts.
-        """
-        return len(self.t) > 2
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/src/traceml_ai/renderers/system/renderer.py
+++ b/src/traceml_ai/renderers/system/renderer.py
@@ -27,6 +27,7 @@ from traceml_ai.renderers.base_renderer import BaseRenderer
 from traceml_ai.utils.formatting import fmt_mem_new, fmt_percent
 
 from .computer import SystemMetricsComputer
+from .dashboard_models import SystemDashboardPayload
 
 
 class SystemRenderer(BaseRenderer):
@@ -201,7 +202,7 @@ class SystemRenderer(BaseRenderer):
             width=panel_width,
         )
 
-    def get_dashboard_renderable(self) -> Dict[str, Any]:
+    def get_dashboard_renderable(self) -> SystemDashboardPayload:
         """
         Return a compact dashboard payload.
 

--- a/src/traceml_ai/renderers/system/renderer.py
+++ b/src/traceml_ai/renderers/system/renderer.py
@@ -9,7 +9,7 @@ System renderer.
 
 Presentation logic for system-level telemetry:
 - CLI rendering (Rich)
-- Dashboard payload (dict)
+- Dashboard payload (typed)
 - Summary logging (optional)
 
 All metric computation is delegated to SystemMetricsComputer.
@@ -50,7 +50,9 @@ class SystemRenderer(BaseRenderer):
     def _compute_cli(self) -> Dict[str, Any]:
         return self._computer.compute_cli()
 
-    def _compute_dashboard(self, window_n: int = 100) -> Dict[str, Any]:
+    def _compute_dashboard(
+        self, window_n: int = 100
+    ) -> SystemDashboardPayload:
         return self._computer.compute_dashboard(window_n=window_n)
 
     def get_panel_renderable(self) -> Panel:

--- a/tests/display/test_context_layout.py
+++ b/tests/display/test_context_layout.py
@@ -115,7 +115,9 @@ def test_driver_feeds_context_layout_in_both_profiles(
     assert ctx["world_size"] == 2
     # The System payload no longer carries the strip's facts.
     system = driver.latest_data[SYSTEM_LAYOUT]
-    assert "ranks_reporting" not in system.get("rollups", {}).get("ctx", {})
+    # The System payload is typed now; its context carries only the fields
+    # the System block owns, and the strip's cross-rank count is not one.
+    assert not hasattr(system.rollups.ctx, "ranks_reporting")
 
 
 def test_update_context_section_consumes_the_context_payload() -> None:

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -62,31 +62,37 @@ def test_disclosure_text_states_the_range_and_no_verdict() -> None:
     def g(idx, util):
         return {"gpu_idx": idx, "util_p50": util, "util_now": util}
 
+    def roll(gpus):
+        """The range now arrives on the payload; the card only formats it."""
+        values = [x["util_p50"] for x in gpus]
+        return {"util_range": (min(values), max(values)) if values else None}
+
     one_busy = [g(0, 100), g(1, 0), g(2, 0), g(3, 0)]
     all_busy = [g(i, 99) for i in range(4)]
     ramp = [g(0, 100), g(1, 60), g(2, 55), g(3, 40)]
 
-    assert disclosure_text(one_busy, is_open=True) == (
+    assert disclosure_text(one_busy, roll(one_busy), is_open=True) == (
         "4 GPUs · util 0 to 100% · click to close"
     )
-    assert disclosure_text(one_busy, is_open=False) == (
+    assert disclosure_text(one_busy, roll(one_busy), is_open=False) == (
         "4 GPUs · util 0 to 100% · click to open"
     )
-    assert disclosure_text(ramp, is_open=True) == (
+    assert disclosure_text(ramp, roll(ramp), is_open=True) == (
         "4 GPUs · util 40 to 100% · click to close"
     )
-    assert disclosure_text(all_busy, is_open=False) == (
+    assert disclosure_text(all_busy, roll(all_busy), is_open=False) == (
         "4 GPUs · util 99 to 99% · click to open"
     )
     # One GPU has no range to speak of, and no rows worth naming.
     assert (
-        disclosure_text([g(0, 99)], is_open=False) == "1 GPU · click to open"
+        disclosure_text([g(0, 99)], roll([g(0, 99)]), is_open=False)
+        == "1 GPU · click to open"
     )
-    assert disclosure_text([], is_open=False) == ""
+    assert disclosure_text([], {}, is_open=False) == ""
     # No word anywhere claims a verdict the engine owns.
     for text in (
-        disclosure_text(one_busy, is_open=True),
-        disclosure_text(all_busy, is_open=False),
+        disclosure_text(one_busy, roll(one_busy), is_open=True),
+        disclosure_text(all_busy, roll(all_busy), is_open=False),
     ):
         for word in ("idle", "busy", "alike", "uneven", "low", "healthy"):
             assert word not in text
@@ -167,7 +173,7 @@ def test_rows_table_reads_per_gpu_and_tints_only_the_busy_row() -> None:
         {"gpu_idx": 0, "values": [66.0, 68.0]},
         {"gpu_idx": 1, "values": [33.0, 33.0]},
     ]
-    html = rows_html(_gpus(), series, spread=100.0)
+    html = rows_html(_gpus(), series, {"rows_over": True, "odd_gpus": [0]})
     assert "gpu0" in html and "gpu1" in html
     assert "6.67 / 16.1" in html and "0.47 / 16.1" in html
     assert "68 / 70" in html and "33 / 70" in html
@@ -179,7 +185,7 @@ def test_rows_table_reads_per_gpu_and_tints_only_the_busy_row() -> None:
         in html
     )
     # ...and none when every GPU reads the same.
-    calm = rows_html(_gpus(), series, spread=0.0)
+    calm = rows_html(_gpus(), series, {"rows_over": False})
     assert "tml-mark" not in calm
     # No verdict words anywhere on the block.
     for word in ("Hot", "Warm", "HIGH", "verdict"):
@@ -187,19 +193,18 @@ def test_rows_table_reads_per_gpu_and_tints_only_the_busy_row() -> None:
 
 
 def test_tint_marks_the_odd_ones_out() -> None:
-    def g(i, u):
-        return {"gpu_idx": i, "util_p50": u, "util_now": u}
+    """The card reads the marked set; the rule itself lives in compute.
 
-    # 1 busy of 4: the busy GPU is the anomaly.
-    assert odd_ones_out([g(0, 100), g(1, 0), g(2, 0), g(3, 0)]) == {0}
-    # 3 busy of 4 (a starved or dead rank): the idle GPU is the anomaly,
-    # not the first busy row.
-    assert odd_ones_out([g(0, 100), g(1, 100), g(2, 100), g(3, 0)]) == {3}
-    # 2 and 2: ties go to the busy side.
-    assert odd_ones_out([g(0, 100), g(1, 0), g(2, 100), g(3, 0)]) == {0, 2}
-    # Nothing to mark when every GPU reads the same, or only one reports.
-    assert odd_ones_out([g(0, 100), g(1, 100)]) == set()
-    assert odd_ones_out([g(0, 100), {"gpu_idx": 1}]) == set()
+    These cases moved with it and are asserted unchanged against
+    `_odd_gpus` in tests/display/test_system_section_characterization.py.
+    What is checked here is that the card marks what it is handed and
+    invents nothing.
+    """
+    assert odd_ones_out({"odd_gpus": [0]}) == {0}
+    assert odd_ones_out({"odd_gpus": [3]}) == {3}
+    assert odd_ones_out({"odd_gpus": [0, 2]}) == {0, 2}
+    assert odd_ones_out({"odd_gpus": []}) == set()
+    assert odd_ones_out({}) == set()
 
 
 def test_no_gpu_colour_is_the_limit_red() -> None:
@@ -226,7 +231,7 @@ def test_rows_table_shows_absence_not_zero() -> None:
             "power_limit": None,
         }
     )
-    html = rows_html(gpus, [], spread=None)
+    html = rows_html(gpus, [], {"rows_over": False})
     assert "gpu1" in html
     assert "n/a" in html
     assert "0 / 0" not in html
@@ -418,6 +423,11 @@ def test_section_builds_and_updates_without_a_browser() -> None:
             "ram": {"now": 9.0 * GB, "total": 200.0 * GB},
             "gpu_util": {"now": 0.0, "p50": 25.0, "p95": 25.0},
             "gpu_delta": {"now": 0.0, "p95": 100.0},
+            # The computer decides both of these now, so a hand-built
+            # payload has to carry its answers rather than let the card
+            # re-derive them from the rows.
+            "rows_over": True,
+            "util_range": (0.0, 100.0),
             "gpu_mem": {"now": 6.67 * GB, "total": 16.1 * GB},
             "temp": {"now": 54.0, "status": "OK"},
             "gpu_power": {"now": 68.0, "p50": 67.0, "limit": 70.0},

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -286,6 +286,10 @@ def test_whole_run_charts_share_one_clock_axis() -> None:
             "cpu": [30.0, 31.0],
             "gpu_avg": [99.0, 99.0],
             "gpu_power": [{"gpu_idx": 0, "values": [66.0, 68.0]}],
+            # Both flags are computed now, so a hand-built payload states
+            # which view each chart is in rather than the card inferring it.
+            "cpu_run_whole": True,
+            "power_run_whole": True,
             "cpu_run": {
                 "t": cpu_t,
                 "avg": [30.0] * 40,

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -31,6 +31,7 @@ from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section impor
     should_auto_open,
     sparkline_svg,
 )
+from traceml_ai.renderers.system.dashboard_models import GpuRow  # noqa: E402
 
 GB = 1e9
 
@@ -60,11 +61,11 @@ def test_disclosure_text_states_the_range_and_no_verdict() -> None:
     """
 
     def g(idx, util):
-        return {"gpu_idx": idx, "util_p50": util, "util_now": util}
+        return GpuRow(gpu_idx=idx, util_p50=util, util_now=util)
 
     def roll(gpus):
         """The range now arrives on the payload; the card only formats it."""
-        values = [x["util_p50"] for x in gpus]
+        values = [x.util_p50 for x in gpus if x.util_p50 is not None]
         return as_rollups(
             {"util_range": (min(values), max(values)) if values else None}
         )

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -307,7 +307,6 @@ def test_whole_run_charts_share_one_clock_axis() -> None:
         "window_len": 2,
         "gpu_available": True,
         "rollups": {
-            "gpu_available": True,
             "cpu": {"now": 30.0, "p50": 32.0, "p95": 44.0},
             "ram": {"now": 9.0 * GB, "total": 200.0 * GB},
             "gpu_util": {"now": 99.0, "p50": 99.0, "p95": 99.0},
@@ -406,7 +405,6 @@ def test_power_chart_draws_limit_and_floor_reference_lines() -> None:
             "window_len": 2,
             "gpu_available": True,
             "rollups": {
-                "gpu_available": True,
                 "cpu": {"now": 9.0, "p50": 8.0, "p95": 12.0},
                 "ram": {"now": 9.0 * GB, "total": 200.0 * GB},
                 "gpu_util": {"now": 25.0, "p50": 25.0, "p95": 25.0},
@@ -467,7 +465,6 @@ def test_section_builds_and_updates_without_a_browser() -> None:
         "window_len": 2,
         "gpu_available": True,
         "rollups": {
-            "gpu_available": True,
             "cpu": {"now": 9.0, "p50": 8.0, "p95": 12.0},
             "ram": {"now": 9.0 * GB, "total": 200.0 * GB},
             "gpu_util": {"now": 0.0, "p50": 25.0, "p95": 25.0},
@@ -589,7 +586,6 @@ def test_section_builds_and_updates_without_a_browser() -> None:
                 "window_len": 1,
                 "gpu_available": False,
                 "rollups": {
-                    "gpu_available": False,
                     "cpu": {"now": 3.0, "p50": 3.0},
                     "ram": {"now": 1.0 * GB, "total": 16.0 * GB},
                     "gpu_power": {"now": None, "p50": None, "limit": None},
@@ -650,7 +646,6 @@ def test_every_tile_keeps_a_qualifier_line() -> None:
             "window_len": 2,
             "gpu_available": True,
             "rollups": {
-                "gpu_available": True,
                 "cpu": {"now": 9.0, "p50": 8.0},
                 "ram": {"now": 9.0 * GB, "total": 200.0 * GB},
                 "gpu_util": {"now": 99.0, "p50": 99.0},

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -65,7 +65,9 @@ def test_disclosure_text_states_the_range_and_no_verdict() -> None:
     def roll(gpus):
         """The range now arrives on the payload; the card only formats it."""
         values = [x["util_p50"] for x in gpus]
-        return {"util_range": (min(values), max(values)) if values else None}
+        return as_rollups(
+            {"util_range": (min(values), max(values)) if values else None}
+        )
 
     one_busy = [g(0, 100), g(1, 0), g(2, 0), g(3, 0)]
     all_busy = [g(i, 99) for i in range(4)]
@@ -88,7 +90,7 @@ def test_disclosure_text_states_the_range_and_no_verdict() -> None:
         disclosure_text([g(0, 99)], roll([g(0, 99)]), is_open=False)
         == "1 GPU · click to open"
     )
-    assert disclosure_text([], {}, is_open=False) == ""
+    assert disclosure_text([], as_rollups({}), is_open=False) == ""
     # No word anywhere claims a verdict the engine owns.
     for text in (
         disclosure_text(one_busy, roll(one_busy), is_open=True),
@@ -141,6 +143,41 @@ def test_sparkline_is_inline_svg_with_gaps_dropped() -> None:
     assert sparkline_svg([None, None], gpu_color(1)) == ""
 
 
+def as_payload(raw: dict):
+    """The dict fixtures below, as the typed payload the card now takes.
+
+    The fixtures stay mappings because they are more readable that way and
+    because they describe the SHAPE the compute layer produces. The models
+    own the adaptation, so this is the same path production takes.
+    """
+    from traceml_ai.renderers.system.dashboard_models import (
+        SystemDashboardPayload,
+        SystemRollups,
+        SystemSeries,
+    )
+
+    return SystemDashboardPayload(
+        window_len=raw.get("window_len", 0),
+        gpu_available=bool(raw.get("gpu_available")),
+        rollups=SystemRollups.from_dict(raw.get("rollups") or {}),
+        series=SystemSeries.from_dict(raw.get("series") or {}),
+    )
+
+
+def _ctx(raw: dict):
+    """One ctx mapping, typed."""
+    from traceml_ai.renderers.system.dashboard_models import RunContext
+
+    return RunContext(system_node=raw.get("system_node"))
+
+
+def as_rollups(raw: dict):
+    """One rollups mapping, typed."""
+    from traceml_ai.renderers.system.dashboard_models import SystemRollups
+
+    return SystemRollups.from_dict(raw)
+
+
 def _gpus():
     return [
         {
@@ -173,7 +210,11 @@ def test_rows_table_reads_per_gpu_and_tints_only_the_busy_row() -> None:
         {"gpu_idx": 0, "values": [66.0, 68.0]},
         {"gpu_idx": 1, "values": [33.0, 33.0]},
     ]
-    html = rows_html(_gpus(), series, {"rows_over": True, "odd_gpus": [0]})
+    html = rows_html(
+        as_rollups({"gpus": _gpus()}).gpus,
+        series,
+        as_rollups({"rows_over": True, "odd_gpus": [0]}),
+    )
     assert "gpu0" in html and "gpu1" in html
     assert "6.67 / 16.1" in html and "0.47 / 16.1" in html
     assert "68 / 70" in html and "33 / 70" in html
@@ -185,7 +226,11 @@ def test_rows_table_reads_per_gpu_and_tints_only_the_busy_row() -> None:
         in html
     )
     # ...and none when every GPU reads the same.
-    calm = rows_html(_gpus(), series, {"rows_over": False})
+    calm = rows_html(
+        as_rollups({"gpus": _gpus()}).gpus,
+        series,
+        as_rollups({"rows_over": False}),
+    )
     assert "tml-mark" not in calm
     # No verdict words anywhere on the block.
     for word in ("Hot", "Warm", "HIGH", "verdict"):
@@ -200,11 +245,11 @@ def test_tint_marks_the_odd_ones_out() -> None:
     What is checked here is that the card marks what it is handed and
     invents nothing.
     """
-    assert odd_ones_out({"odd_gpus": [0]}) == {0}
-    assert odd_ones_out({"odd_gpus": [3]}) == {3}
-    assert odd_ones_out({"odd_gpus": [0, 2]}) == {0, 2}
-    assert odd_ones_out({"odd_gpus": []}) == set()
-    assert odd_ones_out({}) == set()
+    assert odd_ones_out(as_rollups({"odd_gpus": [0]})) == {0}
+    assert odd_ones_out(as_rollups({"odd_gpus": [3]})) == {3}
+    assert odd_ones_out(as_rollups({"odd_gpus": [0, 2]})) == {0, 2}
+    assert odd_ones_out(as_rollups({"odd_gpus": []})) == set()
+    assert odd_ones_out(as_rollups({})) == set()
 
 
 def test_no_gpu_colour_is_the_limit_red() -> None:
@@ -231,7 +276,7 @@ def test_rows_table_shows_absence_not_zero() -> None:
             "power_limit": None,
         }
     )
-    html = rows_html(gpus, [], {"rows_over": False})
+    html = rows_html(as_rollups({"gpus": gpus}).gpus, [], as_rollups({}))
     assert "gpu1" in html
     assert "n/a" in html
     assert "0 / 0" not in html
@@ -310,7 +355,7 @@ def test_whole_run_charts_share_one_clock_axis() -> None:
             ],
         },
     }
-    update_system_section(panel, payload)
+    update_system_section(panel, as_payload(payload))
     cpu_axis = panel["cpu_chart"].options["xAxis"]
     pwr_axis = panel["power_chart"].options["xAxis"]
     assert (cpu_axis["min"], cpu_axis["max"]) == (
@@ -382,7 +427,7 @@ def test_power_chart_draws_limit_and_floor_reference_lines() -> None:
                 "gpu_power": [{"gpu_idx": 0, "values": [66.0, 68.0]}],
             },
         }
-        update_system_section(panel, payload)
+        update_system_section(panel, as_payload(payload))
         mark = panel["power_chart"].options["series"][0]["markLine"]
         _last_refs.clear()
         _last_refs.update(mark)
@@ -451,7 +496,7 @@ def test_section_builds_and_updates_without_a_browser() -> None:
             ],
         },
     }
-    update_system_section(panel, payload)
+    update_system_section(panel, as_payload(payload))
     # The util tile is the window median, not the raw last tick (0).
     assert "25" in panel["tiles"]["util"].content
     assert "0<" not in panel["tiles"]["util"].content
@@ -492,7 +537,7 @@ def test_section_builds_and_updates_without_a_browser() -> None:
     sent = []
     panel["cpu_chart"].update = lambda: sent.append("cpu")
     panel["power_chart"].update = lambda: sent.append("power")
-    update_system_section(panel, payload)
+    update_system_section(panel, as_payload(payload))
     assert panel["rows"].value is False
     assert panel["rows_hint"].text == "2 GPUs · util 0 to 100% · click to open"
     assert sent == []
@@ -506,7 +551,7 @@ def test_section_builds_and_updates_without_a_browser() -> None:
     later["series"]["x_time"] = payload["series"]["x_time"][:1] + [
         "2026-08-21T10:03:22+00:00"
     ]
-    update_system_section(panel, later)
+    update_system_section(panel, as_payload(later))
     # (option mutations also notify the element, so count kinds not calls)
     assert set(sent) == {"cpu", "power"}
     assert panel["power_chart"].options["series"][0]["markLine"] == {
@@ -532,30 +577,32 @@ def test_section_builds_and_updates_without_a_browser() -> None:
         }
         for i in range(2)
     ]
-    update_system_section(panel, zeroed)
+    update_system_section(panel, as_payload(zeroed))
     assert panel["tiles"]["mem"].content == "n/a"
     assert panel["subs"]["temp"].text == "GPU sample unreported"
 
     # A CPU-only box hides the GPU tiles, the power chart and the rows.
     update_system_section(
         panel,
-        {
-            "window_len": 1,
-            "gpu_available": False,
-            "rollups": {
+        as_payload(
+            {
+                "window_len": 1,
                 "gpu_available": False,
-                "cpu": {"now": 3.0, "p50": 3.0},
-                "ram": {"now": 1.0 * GB, "total": 16.0 * GB},
-                "gpu_power": {"now": None, "p50": None, "limit": None},
-                "gpus": [],
-            },
-            "series": {
-                "x_time": ["2026-08-21T10:00:00+00:00"],
-                "cpu": [3.0],
-                "gpu_avg": [],
-                "gpu_power": [],
-            },
-        },
+                "rollups": {
+                    "gpu_available": False,
+                    "cpu": {"now": 3.0, "p50": 3.0},
+                    "ram": {"now": 1.0 * GB, "total": 16.0 * GB},
+                    "gpu_power": {"now": None, "p50": None, "limit": None},
+                    "gpus": [],
+                },
+                "series": {
+                    "x_time": ["2026-08-21T10:00:00+00:00"],
+                    "cpu": [3.0],
+                    "gpu_avg": [],
+                    "gpu_power": [],
+                },
+            }
+        ),
     )
     assert panel["gpu_visible"] is False
     # The four tiles stay in place; the GPU ones read a dash and say why.
@@ -574,14 +621,14 @@ def test_header_names_the_node_when_others_were_dropped() -> None:
         node_scope_text,
     )
 
-    assert node_scope_text({}) == ""
+    assert node_scope_text(as_rollups({}).ctx) == ""
     one = {"hostname": "a", "node_rank": 0, "nodes_in_window": 1}
     two = {"hostname": "a", "node_rank": 0, "nodes_in_window": 2}
-    assert node_scope_text({"system_node": one}) == ""
-    assert node_scope_text({"system_node": two}) == "node 0 of 2"
+    assert node_scope_text(_ctx({"system_node": one})) == ""
+    assert node_scope_text(_ctx({"system_node": two})) == "node 0 of 2"
     # Only the System payload's own facts are read: a strip-style
     # node_count on the dict changes nothing.
-    assert node_scope_text({"system_node": one, "node_count": 2}) == ""
+    assert node_scope_text(_ctx({"system_node": one, "node_count": 2})) == ""
 
 
 def test_every_tile_keeps_a_qualifier_line() -> None:
@@ -643,7 +690,7 @@ def test_every_tile_keeps_a_qualifier_line() -> None:
     for n in (1, 4):
         with ui.element("div"):
             panel = build_system_section()
-        update_system_section(panel, payload(n))
+        update_system_section(panel, as_payload(payload(n)))
         subs = {
             k: panel["subs"][k].text for k in ("util", "mem", "temp", "ram")
         }

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -146,6 +146,7 @@ def _gpus():
             "temp": 54.0,
             "power": 68.0,
             "power_limit": 70.0,
+            "reported": True,
         },
         {
             "gpu_idx": 1,
@@ -156,6 +157,7 @@ def _gpus():
             "temp": 41.0,
             "power": 33.0,
             "power_limit": 70.0,
+            "reported": True,
         },
     ]
 
@@ -512,6 +514,7 @@ def test_section_builds_and_updates_without_a_browser() -> None:
             "temp": None,
             "power": None,
             "power_limit": None,
+            "reported": False,
         }
         for i in range(2)
     ]
@@ -604,6 +607,7 @@ def test_every_tile_keeps_a_qualifier_line() -> None:
                         "temp": 48.0,
                         "power": 66.0,
                         "power_limit": 70.0,
+                        "reported": True,
                     }
                     for i in range(n_gpus)
                 ],

--- a/tests/display/test_system_section_characterization.py
+++ b/tests/display/test_system_section_characterization.py
@@ -165,5 +165,5 @@ def test_both_charts_answer_the_whole_run_question_the_same_way():
 def test_a_short_run_puts_neither_chart_in_the_whole_run_view(process_free_db):
     """End to end: the flags travel on the payload and agree."""
     out = process_free_db
-    assert out["series"]["cpu_run_whole"] is False
-    assert out["series"]["power_run_whole"] is False
+    assert out.series.cpu_run_whole is False
+    assert out.series.power_run_whole is False

--- a/tests/display/test_system_section_characterization.py
+++ b/tests/display/test_system_section_characterization.py
@@ -40,6 +40,7 @@ def _gpu(idx: int, **kw):
         "util_now": None,
         "mem_total": None,
         "power": None,
+        "reported": False,
     }
     row.update(kw)
     return row
@@ -90,22 +91,29 @@ def test_a_gpu_with_no_utilisation_at_all_is_not_in_either_group():
 
 
 # --- the two definitions of "never reported" -----------------------------
-def test_the_card_calls_a_gpu_unreported_only_when_both_fields_are_absent():
-    """The card's rule is `mem_total is None AND power is None`.
+def test_the_card_asks_the_computer_whether_a_gpu_reported():
+    """Updated deliberately: the computer's rule replaced the card's.
 
-    The compute layer answers the same question with OR over `mem_total`
-    and `power_limit_w`. The two therefore disagree about a GPU that
-    reports one field and not the other, and this test pins the card's
-    side of that disagreement so moving the rule has to confront it.
+    The card used to derive this itself, asking whether `mem_total` and
+    `power` were both absent. That is stricter than the computer's rule,
+    which asks whether `mem_total` or `power_limit_w` is present, so the
+    two disagreed about a GPU carrying a power limit and no memory total.
+    The computer decides what a metric means, so its answer is the one
+    that survives and the card now reads the flag.
+
+    The consequence is visible: a row with no values but `reported` true
+    is a device that spoke and had nothing to say, and it no longer makes
+    the card announce that the whole GPU sample is missing.
     """
-    both_absent = [_gpu(0), _gpu(1)]
-    assert system_section.gpus_unreported(both_absent) is True
+    none_reported = [_gpu(0), _gpu(1)]
+    assert system_section.gpus_unreported(none_reported) is True
 
-    power_only = [_gpu(0, power=42.0), _gpu(1, power=41.0)]
-    assert system_section.gpus_unreported(power_only) is False
+    one_reported = [_gpu(0, reported=True), _gpu(1)]
+    assert system_section.gpus_unreported(one_reported) is False
 
-    mem_only = [_gpu(0, mem_total=16.0e9)]
-    assert system_section.gpus_unreported(mem_only) is False
+    # The case the two rules disagreed about: values absent, device present.
+    valueless_but_present = [_gpu(0, reported=True)]
+    assert system_section.gpus_unreported(valueless_but_present) is False
 
 
 def test_no_gpus_at_all_is_not_the_same_as_unreported():

--- a/tests/display/test_system_section_characterization.py
+++ b/tests/display/test_system_section_characterization.py
@@ -31,6 +31,7 @@ pytest.importorskip("nicegui")
 from traceml_ai.aggregator.display_drivers.nicegui_sections import (  # noqa: E402
     system_section,
 )
+from traceml_ai.renderers.system import dashboard_compute  # noqa: E402
 
 
 def _gpu(idx: int, **kw):
@@ -46,16 +47,18 @@ def _gpu(idx: int, **kw):
     return row
 
 
-# --- the outlier split ---------------------------------------------------
+# --- the outlier split, now owned by the compute layer -------------------
+# The rule moved out of the card in part 5a-ii. Its assertions are
+# unchanged, which is the point: the move preserved behaviour exactly.
 def test_one_busy_gpu_among_four_is_the_marked_one():
     gpus = [_gpu(i, util_p50=u) for i, u in enumerate([100.0, 2.0, 2.0, 2.0])]
-    assert system_section.odd_ones_out(gpus) == {0}
+    assert dashboard_compute._odd_gpus(gpus) == [0]
 
 
 def test_one_idle_gpu_among_four_is_the_marked_one():
     """The smaller group is marked whichever side of the split it is on."""
     gpus = [_gpu(i, util_p50=u) for i, u in enumerate([98.0, 98.0, 98.0, 3.0])]
-    assert system_section.odd_ones_out(gpus) == {3}
+    assert dashboard_compute._odd_gpus(gpus) == [3]
 
 
 def test_a_two_gpu_host_marks_the_faster_one():
@@ -67,27 +70,27 @@ def test_a_two_gpu_host_marks_the_faster_one():
     even when the interesting one is the card that fell behind.
     """
     gpus = [_gpu(0, util_p50=95.0), _gpu(1, util_p50=10.0)]
-    assert system_section.odd_ones_out(gpus) == {0}
+    assert dashboard_compute._odd_gpus(gpus) == [0]
 
 
 def test_evenly_loaded_gpus_mark_nothing():
     gpus = [_gpu(i, util_p50=50.0) for i in range(4)]
-    assert system_section.odd_ones_out(gpus) == set()
+    assert dashboard_compute._odd_gpus(gpus) == []
 
 
 def test_a_single_gpu_marks_nothing():
-    assert system_section.odd_ones_out([_gpu(0, util_p50=99.0)]) == set()
+    assert dashboard_compute._odd_gpus([_gpu(0, util_p50=99.0)]) == []
 
 
 def test_the_split_falls_back_to_the_instantaneous_reading():
     """`util_p50` is preferred; `util_now` is used when it is absent."""
     gpus = [_gpu(0, util_now=100.0), _gpu(1, util_now=1.0)]
-    assert system_section.odd_ones_out(gpus) == {0}
+    assert dashboard_compute._odd_gpus(gpus) == [0]
 
 
 def test_a_gpu_with_no_utilisation_at_all_is_not_in_either_group():
     gpus = [_gpu(0, util_p50=90.0), _gpu(1, util_p50=5.0), _gpu(2)]
-    assert 2 not in system_section.odd_ones_out(gpus)
+    assert 2 not in dashboard_compute._odd_gpus(gpus)
 
 
 # --- the two definitions of "never reported" -----------------------------

--- a/tests/display/test_system_section_characterization.py
+++ b/tests/display/test_system_section_characterization.py
@@ -28,9 +28,6 @@ import pytest
 
 pytest.importorskip("nicegui")
 
-from traceml_ai.aggregator.display_drivers.nicegui_sections import (  # noqa: E402
-    system_section,
-)
 from traceml_ai.renderers.system import dashboard_compute  # noqa: E402
 
 
@@ -58,7 +55,8 @@ def _gpu(idx: int, **kw):
     `_odd_gpus` reads mappings because that is what it is handed inside
     the compute layer; `gpus_unreported` reads the typed rows the card
     receives. `_typed_gpu` below bridges the two for the tests that need
-    the card's side.
+    the card's side, and `_unreported` asks the payload, which is where
+    the card asks it.
     """
     row = {
         "gpu_idx": idx,
@@ -78,6 +76,13 @@ def _typed_gpu(idx: int, **kw):
     )
 
     return gpu_rows_from_dicts([_gpu(idx, **kw)])[0]
+
+
+def _unreported(rows) -> bool:
+    """The card's answer, asked where the card asks it: the payload."""
+    from traceml_ai.renderers.system.dashboard_models import SystemRollups
+
+    return SystemRollups(gpus=tuple(rows)).gpus_unreported
 
 
 # --- the outlier split, now owned by the compute layer -------------------
@@ -142,18 +147,18 @@ def test_the_card_asks_the_computer_whether_a_gpu_reported():
     the card announce that the whole GPU sample is missing.
     """
     none_reported = [_typed_gpu(0), _typed_gpu(1)]
-    assert system_section.gpus_unreported(none_reported) is True
+    assert _unreported(none_reported) is True
 
     one_reported = [_typed_gpu(0, reported=True), _typed_gpu(1)]
-    assert system_section.gpus_unreported(one_reported) is False
+    assert _unreported(one_reported) is False
 
     # The case the two rules disagreed about: values absent, device present.
     valueless_but_present = [_typed_gpu(0, reported=True)]
-    assert system_section.gpus_unreported(valueless_but_present) is False
+    assert _unreported(valueless_but_present) is False
 
 
 def test_no_gpus_at_all_is_not_the_same_as_unreported():
-    assert system_section.gpus_unreported([]) is False
+    assert _unreported([]) is False
 
 
 # --- one rule for "is this the whole-run view" ---------------------------

--- a/tests/display/test_system_section_characterization.py
+++ b/tests/display/test_system_section_characterization.py
@@ -53,6 +53,13 @@ def process_free_db(tmp_path):
 
 
 def _gpu(idx: int, **kw):
+    """One GPU row, as the compute layer's mapping.
+
+    `_odd_gpus` reads mappings because that is what it is handed inside
+    the compute layer; `gpus_unreported` reads the typed rows the card
+    receives. `_typed_gpu` below bridges the two for the tests that need
+    the card's side.
+    """
     row = {
         "gpu_idx": idx,
         "util_p50": None,
@@ -63,6 +70,14 @@ def _gpu(idx: int, **kw):
     }
     row.update(kw)
     return row
+
+
+def _typed_gpu(idx: int, **kw):
+    from traceml_ai.renderers.system.dashboard_models import (
+        gpu_rows_from_dicts,
+    )
+
+    return gpu_rows_from_dicts([_gpu(idx, **kw)])[0]
 
 
 # --- the outlier split, now owned by the compute layer -------------------
@@ -126,14 +141,14 @@ def test_the_card_asks_the_computer_whether_a_gpu_reported():
     is a device that spoke and had nothing to say, and it no longer makes
     the card announce that the whole GPU sample is missing.
     """
-    none_reported = [_gpu(0), _gpu(1)]
+    none_reported = [_typed_gpu(0), _typed_gpu(1)]
     assert system_section.gpus_unreported(none_reported) is True
 
-    one_reported = [_gpu(0, reported=True), _gpu(1)]
+    one_reported = [_typed_gpu(0, reported=True), _typed_gpu(1)]
     assert system_section.gpus_unreported(one_reported) is False
 
     # The case the two rules disagreed about: values absent, device present.
-    valueless_but_present = [_gpu(0, reported=True)]
+    valueless_but_present = [_typed_gpu(0, reported=True)]
     assert system_section.gpus_unreported(valueless_but_present) is False
 
 

--- a/tests/display/test_system_section_characterization.py
+++ b/tests/display/test_system_section_characterization.py
@@ -34,6 +34,24 @@ from traceml_ai.aggregator.display_drivers.nicegui_sections import (  # noqa: E4
 from traceml_ai.renderers.system import dashboard_compute  # noqa: E402
 
 
+@pytest.fixture
+def process_free_db(tmp_path):
+    """An empty system database, computed through the real compute layer."""
+    import sqlite3
+
+    from traceml_ai.aggregator.sqlite_writers.system import init_schema
+    from traceml_ai.renderers.system.dashboard_compute import (
+        SystemDashboardComputer,
+    )
+
+    path = tmp_path / "telemetry.db"
+    conn = sqlite3.connect(path)
+    init_schema(conn)
+    conn.commit()
+    conn.close()
+    return SystemDashboardComputer(db_path=str(path)).compute()
+
+
 def _gpu(idx: int, **kw):
     row = {
         "gpu_idx": idx,
@@ -121,3 +139,31 @@ def test_the_card_asks_the_computer_whether_a_gpu_reported():
 
 def test_no_gpus_at_all_is_not_the_same_as_unreported():
     assert system_section.gpus_unreported([]) is False
+
+
+# --- one rule for "is this the whole-run view" ---------------------------
+def test_both_charts_answer_the_whole_run_question_the_same_way():
+    """The card asked two different questions and could disagree.
+
+    It tested `len(t) > 2` of the CPU history and merely non-empty of the
+    power history, so on a run with one or two power buckets the power
+    chart claimed the whole-run view while the CPU chart did not, and the
+    pair stopped sharing a clock.
+    """
+    two_points = {"t": [1.0, 2.0], "avg": [1.0, 2.0]}
+    three_points = {"t": [1.0, 2.0, 3.0], "avg": [1.0, 2.0, 3.0]}
+    assert dashboard_compute._has_whole_run(two_points) is False
+    assert dashboard_compute._has_whole_run(three_points) is True
+
+    # The bucket list form answers the same question the same way.
+    assert dashboard_compute._has_whole_run([{"t": [1.0, 2.0]}]) is False
+    assert dashboard_compute._has_whole_run([{"t": [1.0, 2.0, 3.0]}]) is True
+    assert dashboard_compute._has_whole_run([]) is False
+    assert dashboard_compute._has_whole_run({}) is False
+
+
+def test_a_short_run_puts_neither_chart_in_the_whole_run_view(process_free_db):
+    """End to end: the flags travel on the payload and agree."""
+    out = process_free_db
+    assert out["series"]["cpu_run_whole"] is False
+    assert out["series"]["power_run_whole"] is False

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -137,6 +137,12 @@ def test_one_busy_of_four_reads_average_with_full_spread(
         "temp": 54.0,
         "power": 68.0,
         "power_limit": LIMIT,
+        # Added deliberately. The card used to work out whether a device
+        # had reported by testing which of its fields were None, using a
+        # rule that disagreed with the computer's about a GPU carrying a
+        # power limit and no memory total. The computer states it here so
+        # there is one answer rather than two.
+        "reported": True,
     }
     assert gpus[3]["util_p50"] == 0.0
     assert gpus[3]["power"] == 33.0

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -29,6 +29,12 @@ from tests.sqlite_fixtures import (
 from traceml_ai.renderers.system.dashboard_compute import (
     SystemDashboardComputer,
 )
+from traceml_ai.renderers.system.dashboard_models import (
+    CpuRunSeries,
+    GpuRow,
+    PowerStat,
+    SystemDashboardPayload,
+)
 
 GB = 1e9
 TICKS = 20
@@ -98,14 +104,14 @@ def _write(
             )
 
 
-def _payload(path: Path) -> Dict[str, Any]:
-    """The payload as a mapping.
+def _payload(path: Path) -> SystemDashboardPayload:
+    """The payload the card is handed.
 
-    `compute()` returns the typed payload now. These tests describe the
-    SHAPE the card is handed, which `to_dict` still renders exactly, so
-    they assert against it rather than being rewritten field by field.
+    Read through the types, not through a mapping: a field that is absent
+    is a construction error here rather than a missing key discovered at
+    render time, which is the whole point of the payload being typed.
     """
-    return SystemDashboardComputer(str(path)).compute(window_n=100).to_dict()
+    return SystemDashboardComputer(str(path)).compute(window_n=100)
 
 
 def test_one_busy_of_four_reads_average_with_full_spread(
@@ -114,62 +120,62 @@ def test_one_busy_of_four_reads_average_with_full_spread(
     db = tmp_path / "b.db"
     _write(db, lambda seq: _one_busy_of_four())
     out = _payload(db)
-    roll = out["rollups"]
+    roll = out.rollups
 
     # The headline stays the across-GPU average (25) and the spread that
     # opens the per-GPU rows reads the full 100 points.
-    assert roll["gpu_util"]["p50"] == 25.0
-    assert roll["gpu_delta"]["p95"] == 100.0
+    assert roll.gpu_util.p50 == 25.0
+    assert roll.gpu_delta.p95 == 100.0
 
     # Every aggregate cell is the max GPU, never a sum.
-    assert roll["gpu_power"] == {
-        "now": 68.0,
-        "p50": 68.0,
-        "limit": LIMIT,
-        "floor": 33.0,  # the idle GPUs' draw, the run's lowest
-    }
-    assert roll["gpu_mem"]["now"] == 6.67 * GB
-    assert roll["gpu_mem"]["total"] == 16.1 * GB
-    assert roll["temp"]["now"] == 54.0
+    assert roll.gpu_power == PowerStat(
+        now=68.0,
+        p50=68.0,
+        limit=LIMIT,
+        floor=33.0,  # the idle GPUs' draw, the run's lowest
+    )
+    assert roll.gpu_mem.now == 6.67 * GB
+    assert roll.gpu_mem.total == 16.1 * GB
+    assert roll.temp.now == 54.0
 
-    gpus = roll["gpus"]
-    assert [g["gpu_idx"] for g in gpus] == [0, 1, 2, 3]
-    assert gpus[0] == {
-        "gpu_idx": 0,
-        "util_now": 100.0,
-        "util_p50": 100.0,
-        "mem_used": 6.67 * GB,
-        "mem_total": 16.1 * GB,
-        "temp": 54.0,
-        "power": 68.0,
-        "power_limit": LIMIT,
+    gpus = roll.gpus
+    assert [g.gpu_idx for g in gpus] == [0, 1, 2, 3]
+    assert gpus[0] == GpuRow(
+        gpu_idx=0,
+        util_now=100.0,
+        util_p50=100.0,
+        mem_used=6.67 * GB,
+        mem_total=16.1 * GB,
+        temp=54.0,
+        power=68.0,
+        power_limit=LIMIT,
         # Added deliberately. The card used to work out whether a device
         # had reported by testing which of its fields were None, using a
         # rule that disagreed with the computer's about a GPU carrying a
         # power limit and no memory total. The computer states it here so
         # there is one answer rather than two.
-        "reported": True,
-    }
-    assert gpus[3]["util_p50"] == 0.0
-    assert gpus[3]["power"] == 33.0
+        reported=True,
+    )
+    assert gpus[3].util_p50 == 0.0
+    assert gpus[3].power == 33.0
 
-    power = out["series"]["gpu_power"]
+    power = out.series.gpu_power
     assert [p["gpu_idx"] for p in power] == [0, 1, 2, 3]
     assert power[0]["values"] == [68.0] * TICKS
     assert power[1]["values"] == [33.0] * TICKS
-    assert len(out["series"]["x_time"]) == TICKS
-    assert out["series"]["cpu_run"]["t"] == []
-    assert out["series"]["gpu_power_run"] == []
+    assert len(out.series.x_time) == TICKS
+    assert out.series.cpu_run.t == ()
+    assert out.series.gpu_power_run == ()
 
 
 def test_all_busy_reads_zero_spread(tmp_path: Path) -> None:
     db = tmp_path / "a.db"
     _write(db, lambda seq: _all_busy())
-    roll = _payload(db)["rollups"]
-    assert roll["gpu_util"]["p50"] == 100.0
-    assert roll["gpu_delta"]["p95"] == 0.0
-    assert roll["gpu_power"]["now"] == 69.0  # max GPU (gpu3), not 270
-    assert roll["temp"]["now"] == 56.0
+    roll = _payload(db).rollups
+    assert roll.gpu_util.p50 == 100.0
+    assert roll.gpu_delta.p95 == 0.0
+    assert roll.gpu_power.now == 69.0  # max GPU (gpu3), not 270
+    assert roll.temp.now == 56.0
 
 
 def test_missing_gpu_row_is_a_gap_not_a_zero(tmp_path: Path) -> None:
@@ -181,44 +187,34 @@ def test_missing_gpu_row_is_a_gap_not_a_zero(tmp_path: Path) -> None:
 
     _write(db, rows)
     out = _payload(db)
-    gpu3 = out["series"]["gpu_power"][3]["values"]
+    gpu3 = out.series.gpu_power[3]["values"]
     assert len(gpu3) == TICKS
     assert gpu3[10] is None
     assert gpu3[9] == 69.0
     # The rows still list every GPU seen in the window.
-    assert [g["gpu_idx"] for g in out["rollups"]["gpus"]] == [0, 1, 2, 3]
+    assert [g.gpu_idx for g in out.rollups.gpus] == [0, 1, 2, 3]
 
 
 def test_no_gpu_payload_carries_empty_gpu_lists(tmp_path: Path) -> None:
     db = tmp_path / "c.db"
     _write(db, lambda seq: (), gpu_available=False)
     out = _payload(db)
-    assert out["gpu_available"] is False
-    assert out["rollups"]["gpus"] == []
-    assert out["rollups"]["gpu_power"] == {
-        "now": None,
-        "p50": None,
-        "limit": None,
-        "floor": None,
-    }
-    assert out["series"]["gpu_power"] == []
-    assert out["series"]["cpu"] == [8.0] * TICKS
+    assert out.gpu_available is False
+    assert out.rollups.gpus == ()
+    assert out.rollups.gpu_power == PowerStat()
+    assert out.series.gpu_power == ()
+    assert list(out.series.cpu) == [8.0] * TICKS
 
 
 def test_unreported_power_stays_none(tmp_path: Path) -> None:
     db = tmp_path / "p.db"
     _write(db, lambda seq: _one_busy_of_four(power=False))
     out = _payload(db)
-    assert out["rollups"]["gpu_power"] == {
-        "now": None,
-        "p50": None,
-        "limit": None,
-        "floor": None,
-    }
-    assert out["rollups"]["gpus"][0]["power"] is None
-    assert out["series"]["gpu_power"][0]["values"] == [None] * TICKS
+    assert out.rollups.gpu_power == PowerStat()
+    assert out.rollups.gpus[0].power is None
+    assert out.series.gpu_power[0]["values"] == [None] * TICKS
     # Utilisation is unaffected by a missing power column.
-    assert out["rollups"]["gpu_util"]["p50"] == 25.0
+    assert out.rollups.gpu_util.p50 == 25.0
 
 
 def test_empty_database_payload_keeps_the_schema(tmp_path: Path) -> None:
@@ -226,32 +222,20 @@ def test_empty_database_payload_keeps_the_schema(tmp_path: Path) -> None:
     with sqlite_database(db, init_summary_schema):
         pass
     out = _payload(db)
-    assert out["window_len"] == 0
-    assert out["series"]["gpu_power"] == []
-    assert out["series"]["cpu_run"] == {
-        "t": [],
-        "avg": [],
-        "max": [],
-        "span_s": 0.0,
-        "window_s": 0.0,
-    }
-    assert out["series"]["gpu_power_run"] == []
+    assert out.window_len == 0
+    assert out.series.gpu_power == ()
+    assert out.series.cpu_run == CpuRunSeries()
+    assert out.series.gpu_power_run == ()
 
 
 def test_failed_first_read_keeps_the_series_schema(tmp_path: Path) -> None:
     db = tmp_path / "missing" / "run.db"
     out = _payload(db)
 
-    assert out["window_len"] == 0
-    assert out["rollups"]["status"] == "No fresh system data"
-    assert out["series"]["cpu_run"] == {
-        "t": [],
-        "avg": [],
-        "max": [],
-        "span_s": 0.0,
-        "window_s": 0.0,
-    }
-    assert out["series"]["gpu_power_run"] == []
+    assert out.window_len == 0
+    assert out.rollups.status == "No fresh system data"
+    assert out.series.cpu_run == CpuRunSeries()
+    assert out.series.gpu_power_run == ()
 
 
 def test_two_node_window_shows_the_leader_node_only(tmp_path: Path) -> None:
@@ -283,20 +267,20 @@ def test_two_node_window_shows_the_leader_node_only(tmp_path: Path) -> None:
                     ],
                 )
     out = _payload(db)
-    roll = out["rollups"]
-    assert roll["ctx"]["system_node"] == {
+    roll = out.rollups
+    assert roll.ctx.system_node == {
         "hostname": "node-a",
         "node_rank": 0,
         "nodes_in_window": 2,
     }
     # Node 0's own window, not a zig-zag between the two hosts.
-    assert set(out["series"]["cpu"]) == {10.0}
-    assert roll["cpu"]["p50"] == 10.0
-    assert roll["gpu_util"]["p50"] == 100.0
-    assert [g["gpu_idx"] for g in roll["gpus"]] == [0]
-    assert roll["gpus"][0]["power"] == 66.0
-    assert out["series"]["gpu_power"][0]["values"] == [66.0] * TICKS
-    assert len(out["series"]["x_time"]) == TICKS
+    assert set(out.series.cpu) == {10.0}
+    assert roll.cpu.p50 == 10.0
+    assert roll.gpu_util.p50 == 100.0
+    assert [g.gpu_idx for g in roll.gpus] == [0]
+    assert roll.gpus[0].power == 66.0
+    assert out.series.gpu_power[0]["values"] == [66.0] * TICKS
+    assert len(out.series.x_time) == TICKS
 
 
 def test_null_util_and_temp_stay_none_not_zero(tmp_path: Path) -> None:
@@ -313,11 +297,11 @@ def test_null_util_and_temp_stay_none_not_zero(tmp_path: Path) -> None:
 
     _write(db, rows)
     out = _payload(db)
-    g1 = out["rollups"]["gpus"][1]
-    assert g1["util_now"] is None
-    assert g1["temp"] is None
-    assert g1["power"] == 67.0  # still reported
-    assert g1["util_p50"] == 100.0  # the median ignores the unreported ticks
+    g1 = out.rollups.gpus[1]
+    assert g1.util_now is None
+    assert g1.temp is None
+    assert g1.power == 67.0  # still reported
+    assert g1.util_p50 == 100.0  # the median ignores the unreported ticks
 
 
 def test_sampler_zero_fallback_tick_is_unreported(tmp_path: Path) -> None:
@@ -343,17 +327,17 @@ def test_sampler_zero_fallback_tick_is_unreported(tmp_path: Path) -> None:
 
     _write(db, rows)
     out = _payload(db)
-    roll = out["rollups"]
+    roll = out.rollups
     # The limit is a constant seen earlier in the window: it stays.
-    assert roll["gpu_power"]["limit"] == LIMIT
-    assert roll["gpu_power"]["now"] is None
-    assert roll["gpu_power"]["floor"] == 66.0
-    for g in roll["gpus"]:
-        assert g["power"] is None and g["power_limit"] is None
-        assert g["mem_total"] is None and g["temp"] is None
-        assert g["util_p50"] == 100.0
-    assert out["series"]["gpu_power"][0]["values"][-1] is None
-    assert out["series"]["gpu_power"][0]["values"][-2] == 66.0
+    assert roll.gpu_power.limit == LIMIT
+    assert roll.gpu_power.now is None
+    assert roll.gpu_power.floor == 66.0
+    for g in roll.gpus:
+        assert g.power is None and g.power_limit is None
+        assert g.mem_total is None and g.temp is None
+        assert g.util_p50 == 100.0
+    assert out.series.gpu_power[0]["values"][-1] is None
+    assert out.series.gpu_power[0]["values"][-2] == 66.0
 
 
 def test_reported_zero_power_remains_in_whole_run_history(
@@ -369,8 +353,8 @@ def test_reported_zero_power_remains_in_whole_run_history(
     )
 
     out = _payload(db)
-    assert out["rollups"]["gpu_power"]["floor"] == 0.0
-    assert set(out["series"]["gpu_power_run"][0]["min"]) == {0.0}
+    assert out.rollups.gpu_power.floor == 0.0
+    assert set(out.series.gpu_power_run[0]["min"]) == {0.0}
 
 
 def test_cpu_only_run_does_not_read_gpu_power_history(
@@ -416,8 +400,8 @@ def test_rows_without_a_hostname_are_not_a_node(tmp_path: Path) -> None:
                 gpu_samples=_all_busy(),
             )
     out = _payload(db)
-    assert out["window_len"] == TICKS
-    assert out["rollups"]["ctx"]["system_node"] == {
+    assert out.window_len == TICKS
+    assert out.rollups.ctx.system_node == {
         "hostname": "box",
         "node_rank": 0,
         "nodes_in_window": 1,
@@ -461,19 +445,19 @@ def test_whole_run_series_are_decimated_and_keep_peaks(tmp_path: Path) -> None:
             )
     out = _payload(db)
 
-    run = out["series"]["cpu_run"]
-    assert 2 < len(run["t"]) <= 181  # decimated, not one point per sample
-    assert len(run["avg"]) == len(run["t"]) == len(run["max"])
-    assert run["span_s"] == pytest.approx(2.0 * (ticks - 1))
+    run = out.series.cpu_run
+    assert 2 < len(run.t) <= 181  # decimated, not one point per sample
+    assert len(run.avg) == len(run.t) == len(run.max)
+    assert run.span_s == pytest.approx(2.0 * (ticks - 1))
     # The drift survives. Measured against the run's floor, not slice 0:
     # the spike at tick 0 lands inside the first slice and lifts its mean.
-    assert run["avg"][-1] > min(run["avg"]) + 20
-    assert max(run["max"]) >= 95.0  # and so do the spikes
+    assert run.avg[-1] > min(run.avg) + 20
+    assert max(run.max) >= 95.0  # and so do the spikes
     # The rolling mean never reaches the spike: it is smoothed away
     # there and preserved in "max", which is the point of carrying both.
-    assert max(run["avg"]) < 95.0
+    assert max(run.avg) < 95.0
 
-    power = out["series"]["gpu_power_run"]
+    power = out.series.gpu_power_run
     assert [p["gpu_idx"] for p in power] == [0]
     e = power[0]
     assert 2 < len(e["t"]) <= 181
@@ -502,9 +486,9 @@ def test_cpu_whole_run_series_honors_point_cap(tmp_path: Path) -> None:
                 gpu_samples=(),
             )
 
-    run = _payload(db)["series"]["cpu_run"]
-    assert 2 < len(run["t"]) <= 120
-    assert len(run["t"]) == len(run["avg"]) == len(run["max"])
+    run = _payload(db).series.cpu_run
+    assert 2 < len(run.t) <= 120
+    assert len(run.t) == len(run.avg) == len(run.max)
 
 
 def test_cpu_whole_run_keeps_all_eligible_points_under_cap(
@@ -529,11 +513,11 @@ def test_cpu_whole_run_keeps_all_eligible_points_under_cap(
                 gpu_samples=(),
             )
 
-    run = _payload(db)["series"]["cpu_run"]
+    run = _payload(db).series.cpu_run
     # A 30-second rolling window at a 2-second cadence excludes the first
     # 14 samples. The remaining 116 fit under the cap and should all survive.
-    assert len(run["t"]) == 116
-    assert len(run["t"]) == len(run["avg"]) == len(run["max"])
+    assert len(run.t) == 116
+    assert len(run.t) == len(run.avg) == len(run.max)
 
 
 def test_whole_run_series_follow_the_node_scope(tmp_path: Path) -> None:
@@ -567,6 +551,6 @@ def test_whole_run_series_follow_the_node_scope(tmp_path: Path) -> None:
                     ],
                 )
     out = _payload(db)
-    assert out["rollups"]["ctx"]["system_node"]["hostname"] == "node-a"
+    assert out.rollups.ctx.system_node["hostname"] == "node-a"
     # node-a alone: never blended with node-b's 90%
-    assert max(out["series"]["cpu_run"]["max"]) == pytest.approx(10.0)
+    assert max(out.series.cpu_run.max) == pytest.approx(10.0)

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -99,7 +99,13 @@ def _write(
 
 
 def _payload(path: Path) -> Dict[str, Any]:
-    return SystemDashboardComputer(str(path)).compute(window_n=100)
+    """The payload as a mapping.
+
+    `compute()` returns the typed payload now. These tests describe the
+    SHAPE the card is handed, which `to_dict` still renders exactly, so
+    they assert against it rather than being rewritten field by field.
+    """
+    return SystemDashboardComputer(str(path)).compute(window_n=100).to_dict()
 
 
 def test_one_busy_of_four_reads_average_with_full_spread(
@@ -384,7 +390,7 @@ def test_cpu_only_run_does_not_read_gpu_power_history(
         fail_if_called,
     )
     out = computer.compute(window_n=100)
-    assert out["series"]["gpu_power_run"] == []
+    assert out.series.gpu_power_run == ()
 
 
 def test_rows_without_a_hostname_are_not_a_node(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #420. Part 5a-ii of #403. Follows #421, which merged; this branch is rebased onto it.

The System payload becomes types, the card reads them, and the rules the card was deciding for
itself move to the compute layer.

No visual change, and that is proven rather than asserted: the 22-cell scenario matrix was
rendered on `version_0.3.7` at `5093cbb` and on this branch, and every cell's strip text, System
card text and panel list is identical. Zero differing fields across 66 comparisons.

## Review scope

The System block only. No screenshots are attached: the claim this PR makes about rendering is
that nothing changed, and a pair of identical pictures is weaker evidence than the cell-by-cell
text diff in the SCENARIOS line below.

## What moves, and why each one is interpretation rather than formatting

| rule | was | now |
|---|---|---|
| the outlier split | `odd_ones_out` in the view, deriving a midpoint threshold and selecting GPUs by it | `_odd_gpus` in compute, `SystemRollups.odd_gpus` |
| the utilisation spread shown on the disclosure | an inline expression in the view | `_util_range` in compute, `SystemRollups.util_range` |
| whether the spread has earned opening the rows | `SPREAD_EXPAND_PTS` in the view | the same constant in compute, `SystemRollups.rows_over` |
| whether a GPU ever reported | the view asked `mem_total is None and power is None` | the computer's `reported` flag, read through `SystemRollups.gpus_unreported` |
| whether a chart is in the whole-run view | the view, with two different rules for its two charts | `_has_whole_run` in compute, `cpu_run_whole` and `power_run_whole` |

A threshold compared against a measurement is a severity call, and selecting entities by a derived
threshold is a diagnosis. Neither belongs in a module whose job is to format.

## The two rules the issue asked to decide, not relocate

**A two-GPU host still highlights the busier card.** The split marks the smaller group and ties go
to the higher one, so with two GPUs the groups always tie and the faster card is always the marked
one, including when the card that fell behind is the interesting one. Preserved deliberately and
pinned by `test_a_two_gpu_host_marks_the_faster_one`. Changing it changes what a user sees on the
most common multi-GPU box, which is a decision worth making on its own evidence rather than inside
a refactor.

**The computer's definition of "never reported" wins.** The card's rule was stricter, so the two
disagreed about a GPU carrying a power limit and no memory total. The computer decides what a
metric means, so its answer is the one that survives and the card now reads the flag. The visible
consequence is that a device that spoke and had nothing to say no longer makes the card announce
that the whole GPU sample is missing.

## One disagreement the move made visible, and did not resolve

The disclosure line and the auto-open gate are two different definitions of "spread". The text
shows `util_range`, the range across per-GPU medians. The gate uses `gpu_delta.p95`, the 95th
percentile of per-tick max minus min. They can disagree, and cell `D_F1_fsdp4` in the matrix is a
live instance: the rows read `util 98 to 100%` and are open, because the per-tick spread crossed
20 points even though the medians are two apart.

That was true before this PR, hidden inside one inline expression and one gate the view could not
see together. It is now two named fields on the payload, which is the state a decision can be made
from. Deciding it belongs with #419.

## Three things found reviewing this branch against our own architecture notes

**The whole-run rule had a dormant second copy.** `CpuRunSeries.is_populated` restated
`len(t) > 2` on the payload and claimed in its docstring to be why the card stopped deciding. It
had no readers; the card reads `cpu_run_whole`. Two definitions of one question is the exact defect
this PR removes from the card, so it is removed from the payload too.

**`SystemSeries.gpu_power` was annotated as a flat float series.** It carries one entry per device,
each `{"gpu_idx", "values"}`. Nothing broke because nothing checked, which is the point: a type
that lies is worse than no type, and this one shipped inside the PR whose purpose is that the
contract stops the card guessing.

**`to_dict` had no consumer.** Eleven methods reproducing the old mapping key for key, called by
one test helper and nothing else. It was written as a migration bridge while the card still read
dicts, and the commit that migrated the card is what ended that. The test now reads the types, which also satisfies the constraint the issue flagged: the two degraded
paths that asserted the `cpu_run` mapping by equality now assert `CpuRunSeries()`, so adding a
field is a deliberate change to those tests rather than an accidental break.

`from_dict` stays. The compute layer still assembles mappings internally and adapting them in one
place is what keeps that private.

## What is deliberately still a mapping

`RunContext.system_node` and the two per-GPU series, `gpu_power` and `gpu_power_run`. Each is a
shape the card reads by key today. Typing them is a change to what the compute layer emits, not to
how the card reads it, so it belongs with #419 rather than being smuggled in here.

```
STRUCTURE: System payload contract -> renderers/system/dashboard_models.py (new, owner of the
compute-to-card types); mirrored from renderers/process/dashboard_models.py; boundaries crossed:
none
DATA PATH: system_section <- SYSTEM_LAYOUT <- SystemRenderer <- SystemDashboardComputer
           <- SystemRepository <- system_samples + system_gpu_samples
SCOPE: declared renderers/system plus system_section.py and their tests -> diff touches
dashboard_models.py, dashboard_compute.py, renderer.py, system_section.py and four test files ->
within
TWINS: searched the CONCEPT, not the symbol - spread / util_range / gpu_delta / rows_over /
disclosure / the literal 20.0 -> 3 view sites (system_section.py:118, :256, :796), all now reading
the payload; the constant and both spread definitions live in dashboard_compute.py; the Process
card's own spread family is a different card and is untouched
```

## Verification

```
GATE: pytest tests/ -> 1556 passed, 2 skipped, against the base's 1554 passed, 2 skipped at 5093cbb; System-scoped 112 against the base's 110; black, isort and ruff clean at 79 on every file in the diff
TRANSITIONS: the recent-to-whole-run switch is the only one this PR touches, and it moves from two rules in the view to one in compute; both charts now answer it identically, asserted by test_both_charts_answer_the_whole_run_question_the_same_way and end to end by test_a_short_run_puts_neither_chart_in_the_whole_run_view
RANKS: unchanged; node scoping and the per-GPU rows read the same rows for the same node as the base, and the two-node cells E and E' render identically
TRIPWIRE: the card holds no threshold and derives no entity selection; odd_gpus, util_range, rows_over, reported and the whole-run flags all arrive decided, and the characterization suite fails if any of them moves back
SCENARIOS: A live recipe (run by hand) · A2 live recipe (run by hand) · B ok (B_xf_1gpu_long, B_cnn_1gpu) · C ok (C_M1_bert, C_sysB_1of4) · D ok (D_S2_ddp4, D_F1_fsdp4, D_sysA_ddp4_3k) · D' ok (Dd_S2_rank3_dead) · E ok (E_xf_2x1_long, E_cnn_2x1_fsdp) · E' ok (Ed_2x1_rank1_dead) · F no fixture · W ok (W_W1_busy, W_W2_idle) · Wc live recipe (run by hand) · V ok (V_S3_input_straggler, V_S4_straggler, V_S2_compute_bound, V_F1_residual_fsdp, V_M2_two_rank, V_S5_input_bound, V_S6_h2d_bound, V_M1_single_compute, V_S8_warmup); every cell diffed against the same render on 5093cbb, 0 of 66 text fields differ
PLATFORM: macOS 26.1, Python 3.12.13, SQLite 3.51.2
```

## Not in this PR

#419 consumes the shared run-series and freshness modules, types the two remaining mappings, and
is where the spread disagreement above gets decided. #418 is a NULL-timestamp crash present in
`version_0.3.7` today and independent of this work.
