### PR TITLE
System dashboard: consume the shared run-series module, and measure the rolling window in seconds

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -60,7 +60,7 @@ def gpu_color(index: int) -> str:
 def format_window(window_s: float) -> str:
     """The rolling window in words: '30 s', '2 min'.
 
-    The payload picks round windows (see ``choose_window_s``) so this reads
+    The payload picks round windows (``RunSeriesPolicy.window_for``) so it reads
     as a duration a person recognises.
     """
     if not window_s or window_s <= 0:
@@ -836,8 +836,8 @@ def update_system_section(panel: Dict[str, Any], data: Any) -> None:
     # Read, not decided. The card asked ">2 points" of one series and
     # "non-empty" of the other, so its two charts could disagree about
     # which view they were showing.
-    cpu_whole = series.cpu_run_whole
-    power_whole = series.power_run_whole
+    cpu_whole = series.cpu_run_mode == "retained"
+    power_whole = series.power_run_mode == "retained"
     # Whole-run charts share one clock so vertical comparisons align.
     aligned = (
         shared_run_axis(cpu_run_t, power_run)

--- a/src/traceml_ai/renderers/system/common.py
+++ b/src/traceml_ai/renderers/system/common.py
@@ -4,28 +4,16 @@
 # you may not use this file except in compliance with the License.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared models and SQLite helpers for system telemetry."""
+"""The CLI snapshot contract for system telemetry.
+
+The rolling-window ladder and the point budget used to live here as a
+second copy of the numbers `renderers/shared/run_series.py` already owns.
+They were deleted in part 5b; `RunSeriesPolicy.window_for` is the one
+definition now, and the System repository reads a plan built from it.
+"""
 
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
-
-# Whole-run CPU history uses a duration-based rolling window before sampling.
-# The duration keeps the aggregation consistent across sampling cadences.
-_ROLL_MIN_S = 30.0
-_ROLL_MAX_S = 300.0
-_ROLL_FRACTION = 50.0  # about a fiftieth of the run
-_MAX_RUN_POINTS = 120
-
-
-def choose_window_s(span_s: float) -> float:
-    """The rolling window for a run of ``span_s`` seconds, in round steps."""
-    if span_s <= 0:
-        return _ROLL_MIN_S
-    raw = max(_ROLL_MIN_S, min(_ROLL_MAX_S, span_s / _ROLL_FRACTION))
-    for step in (30.0, 60.0, 120.0, 300.0):
-        if raw <= step:
-            return step
-    return _ROLL_MAX_S
 
 
 @dataclass(frozen=True)

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -384,6 +384,11 @@ class SystemDashboardComputer:
             if cpu_mode == "retained"
             else _empty_cpu_run()
         )
+        # A retained read may be unavailable (for example on an older SQLite
+        # engine). The payload states the view it can actually draw, while the
+        # policy above still decides whether the retained read is attempted.
+        if cpu_mode == "retained" and not cpu_run.get("t"):
+            cpu_mode = "recent"
         power_stats = (
             self._db.gpu_power_run_stats(conn, hostname=host)
             if gpu_available
@@ -395,6 +400,8 @@ class SystemDashboardComputer:
             if power_mode == "retained"
             else []
         )
+        if power_mode == "retained" and not power_run:
+            power_mode = "recent"
         run_power_floor = min(
             (v for e in power_run for v in (e.get("min") or [])),
             default=None,

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -15,15 +15,20 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
+from traceml_ai.renderers.shared.freshness import CachedPayloadTTL
+from traceml_ai.renderers.shared.run_series import (
+    DEFAULT_RUN_SERIES_POLICY,
+    RunSeriesPolicy,
+    SeriesMode,
+    plan_run_series,
+)
+
 from .dashboard_models import (
     SystemDashboardPayload,
     SystemRollups,
     SystemSeries,
 )
-from .repository import SystemRepository
-
-# Whole-run charts add value only after the run outgrows the recent window.
-_RUN_VIEW_FACTOR = 1.2
+from .repository import RunStats, SystemRepository
 
 
 def _opt_float(value: Any) -> Optional[float]:
@@ -75,16 +80,9 @@ def _empty_dashboard_series() -> Dict[str, Any]:
             "window_s": 0.0,
         },
         "gpu_power_run": [],
-        "cpu_run_whole": False,
-        "power_run_whole": False,
+        "cpu_run_mode": "recent",
+        "power_run_mode": "recent",
     }
-
-
-# A whole-run line needs more than two points to say anything about a
-# trend. One rule, applied to both series: the card used to ask ">2
-# points" of the CPU history and merely "non-empty" of the power history,
-# so its two charts could disagree about which view they were showing.
-_MIN_WHOLE_RUN_POINTS = 2
 
 
 def _typed(
@@ -109,14 +107,9 @@ def _typed(
     )
 
 
-def _has_whole_run(entries: Any) -> bool:
-    """Whether a whole-run series has enough shape to draw."""
-    if isinstance(entries, dict):
-        return len(entries.get("t") or ()) > _MIN_WHOLE_RUN_POINTS
-    longest = 0
-    for entry in entries or ():
-        longest = max(longest, len(entry.get("t") or ()))
-    return longest > _MIN_WHOLE_RUN_POINTS
+def _empty_cpu_run() -> Dict[str, Any]:
+    """The whole-run CPU shape with nothing in it."""
+    return {"t": [], "avg": [], "max": [], "span_s": 0.0, "window_s": 0.0}
 
 
 def _gpu_medians(gpus: List[Dict[str, Any]]) -> List[tuple]:
@@ -193,13 +186,16 @@ class SystemDashboardComputer:
         db_path: str,
         node_rank: Optional[int] = None,
         stale_ttl_s: Optional[float] = 30.0,
+        run_series_policy: RunSeriesPolicy = DEFAULT_RUN_SERIES_POLICY,
     ) -> None:
         self._db = SystemRepository(db_path=db_path, node_rank=node_rank)
         self._last_ok: Optional[SystemDashboardPayload] = None
         self._last_ok_ts: float = 0.0
-        self._stale_ttl_s: Optional[float] = (
-            float(stale_ttl_s) if stale_ttl_s is not None else None
-        )
+        # Whether a cached payload may still answer says the DATABASE could
+        # not be read; it never says the host is healthy. The shared type
+        # keeps those two ideas from sharing one number, as they did here.
+        self._cache_ttl = CachedPayloadTTL(ttl_s=stale_ttl_s)
+        self._run_policy = run_series_policy
 
     def compute(self, window_n: int = 100) -> SystemDashboardPayload:
         """
@@ -381,19 +377,22 @@ class SystemDashboardComputer:
             else None
         )
         window_span = max(float(ts_hist[-1] - ts_hist[0]), 0.0)
-        min_run_span = window_span * _RUN_VIEW_FACTOR
-        cpu_run = self._db.fetch_cpu_run_history(
-            conn,
-            hostname=host,
-            min_span_s=min_run_span,
+        cpu_stats = self._db.cpu_run_stats(conn, hostname=host)
+        cpu_mode = self._mode_for(cpu_stats, window_span)
+        cpu_run = (
+            self._cpu_run_series(conn, cpu_stats, host)
+            if cpu_mode == "retained"
+            else _empty_cpu_run()
         )
-        power_run = (
-            self._db.fetch_gpu_power_run_history(
-                conn,
-                hostname=host,
-                min_span_s=min_run_span,
-            )
+        power_stats = (
+            self._db.gpu_power_run_stats(conn, hostname=host)
             if gpu_available
+            else None
+        )
+        power_mode = self._mode_for(power_stats, window_span)
+        power_run = (
+            self._power_run_series(conn, power_stats, host)
+            if power_mode == "retained"
             else []
         )
         run_power_floor = min(
@@ -506,13 +505,96 @@ class SystemDashboardComputer:
                 "cpu_run": cpu_run,
                 "gpu_power_run": power_run if gpu_available else [],
                 # Which view each chart is in, decided once here rather
-                # than twice in the card with two different rules.
-                "cpu_run_whole": _has_whole_run(cpu_run),
-                "power_run_whole": _has_whole_run(
-                    power_run if gpu_available else []
-                ),
+                # than twice in the card with two different rules, and
+                # named in the shared vocabulary both blocks now use.
+                "cpu_run_mode": cpu_mode,
+                "power_run_mode": power_mode if gpu_available else "recent",
             },
         )
+
+    def _mode_for(
+        self, stats: Optional[RunStats], window_span_s: float
+    ) -> SeriesMode:
+        """Whether a chart describes the window or the whole run.
+
+        The 1.2x factor that keeps a chart near the boundary from flipping
+        every tick used to be `_RUN_VIEW_FACTOR` here, a local copy of the
+        shared policy's `retained_factor`. Same number, one owner now.
+        """
+        if stats is None:
+            return "recent"
+        return self._run_policy.mode_for(stats.span_s, window_span_s)
+
+    def _cpu_run_series(
+        self,
+        conn: Any,
+        stats: Optional[RunStats],
+        host: Optional[str],
+    ) -> Dict[str, Any]:
+        """Whole-run host CPU, planned by the shared policy."""
+        if stats is None:
+            return _empty_cpu_run()
+        plan = plan_run_series(
+            span_s=stats.span_s,
+            sample_count=stats.sample_count,
+            policy=self._run_policy,
+        )
+        if plan is None:
+            return _empty_cpu_run()
+        rows = self._db.fetch_cpu_run(conn, plan, hostname=host)
+        if not rows:
+            return _empty_cpu_run()
+        return {
+            "t": [r[0] for r in rows],
+            "avg": [r[1] for r in rows],
+            "max": [r[2] for r in rows],
+            "span_s": stats.span_s,
+            "window_s": plan.window_s,
+        }
+
+    def _power_run_series(
+        self,
+        conn: Any,
+        stats: Optional[RunStats],
+        host: Optional[str],
+    ) -> List[Dict[str, Any]]:
+        """Whole-run per-GPU power, bucketed at the rolling window's width.
+
+        This path buckets rather than rolls, so only the window duration
+        carries over from the shared policy; there is no stride or point
+        budget to apply, and the bucket count is therefore still unbounded.
+        See the follow-up issue.
+        """
+        if stats is None:
+            return []
+        width = self._run_policy.window_for(stats.span_s)
+        rows = self._db.fetch_gpu_power_run(
+            conn,
+            width_s=width,
+            first_ts=stats.first_ts,
+            hostname=host,
+        )
+        by_gpu: Dict[int, Dict[str, Any]] = {}
+        for gpu_idx, ts, avg, low, high in rows:
+            entry = by_gpu.setdefault(
+                gpu_idx,
+                {
+                    "gpu_idx": gpu_idx,
+                    "t": [],
+                    "avg": [],
+                    "min": [],
+                    "max": [],
+                },
+            )
+            entry["t"].append(ts)
+            entry["avg"].append(avg)
+            entry["min"].append(low)
+            entry["max"].append(high)
+        out = [by_gpu[i] for i in sorted(by_gpu)]
+        for entry in out:
+            entry["span_s"] = stats.span_s
+            entry["window_s"] = width
+        return out
 
     @staticmethod
     def _pick_node(samples: List[Any]) -> Dict[str, Any]:
@@ -634,10 +716,7 @@ class SystemDashboardComputer:
         """
         now = time.time()
         if self._last_ok is not None:
-            if (
-                self._stale_ttl_s is None
-                or (now - self._last_ok_ts) <= self._stale_ttl_s
-            ):
+            if self._cache_ttl.may_reuse(now - self._last_ok_ts):
                 cached = self._last_ok
                 return replace(
                     cached,

--- a/src/traceml_ai/renderers/system/dashboard_models.py
+++ b/src/traceml_ai/renderers/system/dashboard_models.py
@@ -24,6 +24,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
+from traceml_ai.renderers.shared.run_series import SeriesMode
+
+
+def _mode(value: Any) -> SeriesMode:
+    """A series mode, defaulting to the view that needs no history."""
+    return "retained" if value == "retained" else "recent"
+
 
 @dataclass(frozen=True)
 class Stat:
@@ -129,8 +136,8 @@ class CpuRunSeries:
     """Host CPU over the whole run, rolled and decimated to fit a chart.
 
     Whether this series has earned the whole-run view is NOT asked here.
-    ``_has_whole_run`` in the compute layer decides it for both charts and
-    the answer travels as ``SystemSeries.cpu_run_whole``. A second copy of
+    ``ProcessDashboardComputer``'s policy decides it for both charts and
+    the answer travels as ``SystemSeries.cpu_run_mode``. A second copy of
     that rule on this class is how the card came to hold two of them.
     """
 
@@ -283,8 +290,8 @@ class SystemSeries:
     # Which view each chart is in. Both answered by one rule in the
     # compute layer; the card used to answer them itself with two
     # different rules and its charts could disagree.
-    cpu_run_whole: bool = False
-    power_run_whole: bool = False
+    cpu_run_mode: SeriesMode = "recent"
+    power_run_mode: SeriesMode = "recent"
 
     @classmethod
     def from_dict(cls, raw: Dict[str, Any]) -> "SystemSeries":
@@ -303,8 +310,8 @@ class SystemSeries:
                 window_s=float(run.get("window_s") or 0.0),
             ),
             gpu_power_run=tuple(raw.get("gpu_power_run") or ()),
-            cpu_run_whole=bool(raw.get("cpu_run_whole")),
-            power_run_whole=bool(raw.get("power_run_whole")),
+            cpu_run_mode=_mode(raw.get("cpu_run_mode")),
+            power_run_mode=_mode(raw.get("power_run_mode")),
         )
 
 

--- a/src/traceml_ai/renderers/system/repository.py
+++ b/src/traceml_ai/renderers/system/repository.py
@@ -11,20 +11,46 @@ part shape the Process block already has: this file reads, the compute
 layer judges, the card draws. Splitting them is what makes it possible to
 say where a number was decided.
 
-The class keeps its method names. Two of them are pinned by tests that
-reach in and replace one, so renaming here would be a silent break rather
-than a rename.
+The whole-run reads take a ``RunSeriesPlan`` rather than deciding the
+window themselves: choosing how much history a chart shows is a dashboard
+decision, and this file exists so that decision is visibly somewhere else.
 """
 
 import sqlite3
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
-from .common import choose_window_s
+from traceml_ai.renderers.shared.run_series import RunSeriesPlan
 
-# Points a whole-run chart may carry before it is decimated. The window
-# ladder itself stays in common.py, which the display tests import it from
-# by name.
-_MAX_RUN_POINTS = 120
+# An all-zero capacity row is the sampler's NVML failure fallback, not a
+# real 0 W observation. One predicate, applied by every query that reads
+# power, so the span a chart covers and the values it draws agree about
+# which rows exist.
+_GPU_REPORTED_SQL = """
+    power_usage_w IS NOT NULL
+    AND (
+        COALESCE(mem_total_bytes, 0) > 0
+        OR COALESCE(power_limit_w, 0) > 0
+    )
+"""
+
+
+@dataclass(frozen=True)
+class RunStats:
+    """The shape of one history, for planning a read of it.
+
+    Mirrors ``renderers/process/repository.RunStats``. System has no
+    per-rank counts because its dashboard is single-node by construction:
+    the computer picks one host and every read is filtered to it.
+    """
+
+    first_ts: float
+    last_ts: float
+    sample_count: int
+
+    @property
+    def span_s(self) -> float:
+        return max(0.0, self.last_ts - self.first_ts)
 
 
 class SystemRepository:
@@ -128,27 +154,8 @@ class SystemRepository:
         """
         return conn.execute(sql, (*bound, int(limit))).fetchall()
 
-    def fetch_cpu_run_history(
-        self,
-        conn: sqlite3.Connection,
-        hostname: Optional[str] = None,
-        min_span_s: float = 0.0,
-    ) -> Dict[str, Any]:
-        """Whole-run host CPU as rolling values sampled to a bounded series.
-
-        The window series answers "what is CPU doing now"; this answers
-        "what has it done over the run". SQL computes a rolling mean and
-        maximum, then samples the result so the payload remains bounded.
-
-        Aggregation is skipped when the run does not exceed ``min_span_s``.
-        """
-        empty: Dict[str, Any] = {
-            "t": [],
-            "avg": [],
-            "max": [],
-            "span_s": 0.0,
-            "window_s": 0.0,
-        }
+    def _run_scope(self, hostname: Optional[str]) -> Tuple[str, List[Any]]:
+        """The node filter every whole-run read shares."""
         where_sql, params = self.node_rank_filter()
         bound: List[Any] = list(params)
         if hostname is not None:
@@ -158,46 +165,43 @@ class SystemRepository:
                 else "WHERE hostname IS ?"
             )
             bound.append(str(hostname))
+        return where_sql, bound
+
+    def cpu_run_stats(
+        self, conn: sqlite3.Connection, hostname: Optional[str] = None
+    ) -> Optional[RunStats]:
+        """The shape of the whole-run CPU history, for planning a read."""
+        where_sql, bound = self._run_scope(hostname)
         try:
             row = conn.execute(
-                f"SELECT MIN(sample_ts_s), MAX(sample_ts_s) FROM "
-                f"system_samples {where_sql}",
+                "SELECT MIN(sample_ts_s), MAX(sample_ts_s), COUNT(*) "
+                f"FROM system_samples {where_sql}",
                 tuple(bound),
             ).fetchone()
         except sqlite3.Error:
-            return empty
+            return None
         if not row or row[0] is None or row[1] is None:
-            return empty
-        first, last = float(row[0]), float(row[1])
-        span = last - first
-        # The recent window already represents short runs; avoid their
-        # rolling-history query until a whole-run view adds information.
-        if span <= max(0.0, float(min_span_s)):
-            return empty
-        window_s = choose_window_s(span)
-        count = 0
-        try:
-            row = conn.execute(
-                f"SELECT COUNT(*) FROM system_samples {where_sql}",
-                tuple(bound),
-            ).fetchone()
-            count = int(row[0]) if row else 0
-        except sqlite3.Error:
-            return empty
-        if count < 2:
-            return empty
-        cadence = span / max(count - 1, 1)
-        preceding = max(1, int(round(window_s / max(cadence, 1e-6))) - 1)
-        # The first ``preceding`` samples are valid telemetry, but they do not
-        # yet cover a complete rolling window and are excluded by the query
-        # below. Calculate the stride from only the remaining chart-eligible
-        # points: this guarantees the 120-point limit without unnecessarily
-        # discarding detail when the eligible series already fits.
-        eligible_count = max(0, count - preceding)
-        stride = max(
-            1,
-            (eligible_count + _MAX_RUN_POINTS - 1) // _MAX_RUN_POINTS,
+            return None
+        return RunStats(
+            first_ts=float(row[0]),
+            last_ts=float(row[1]),
+            sample_count=int(row[2] or 0),
         )
+
+    def fetch_cpu_run(
+        self,
+        conn: sqlite3.Connection,
+        plan: RunSeriesPlan,
+        hostname: Optional[str] = None,
+    ) -> List[Tuple[float, float, float]]:
+        """Whole-run host CPU, rolled and decimated by ``plan``.
+
+        The frame comes from the plan, so on SQLite 3.28 and later this is
+        a RANGE window measured in seconds rather than a count of rows. The
+        two agree only when sampling is perfectly regular; across a gap the
+        row frame reaches further back in wall clock than the label claims.
+        """
+        where_sql, bound = self._run_scope(hostname)
         try:
             rows = conn.execute(
                 f"""
@@ -212,114 +216,88 @@ class SystemRepository:
                     {'AND' if where_sql else 'WHERE'} cpu_percent IS NOT NULL
                     WINDOW w AS (
                         ORDER BY sample_ts_s
-                        ROWS BETWEEN {preceding} PRECEDING AND CURRENT ROW
+                        {plan.frame_clause()}
                     )
                 )
                 SELECT t, a, m FROM rolled
-                WHERE rn % ? = 0 AND rn > {preceding}
+                WHERE rn % ? = 0 AND rn > ?
                 ORDER BY t ASC
                 """,
-                (*bound, stride),
+                (*bound, int(plan.stride), int(plan.preceding_rows)),
             ).fetchall()
         except sqlite3.Error:
             # Window functions need SQLite >= 3.25; without them the whole
             # run view is simply unavailable and the window view stands.
-            return empty
-        return {
-            "t": [float(r[0]) for r in rows],
-            "avg": [float(r[1]) for r in rows],
-            "max": [float(r[2]) for r in rows],
-            "span_s": span,
-            "window_s": window_s,
-        }
+            return []
+        return [(float(r[0]), float(r[1]), float(r[2])) for r in rows]
 
-    def fetch_gpu_power_run_history(
-        self,
-        conn: sqlite3.Connection,
-        hostname: Optional[str] = None,
-        min_span_s: float = 0.0,
-    ) -> List[Dict[str, Any]]:
-        """Whole-run per-GPU power grouped into fixed-duration buckets.
-
-        Each bucket carries mean, minimum and maximum power. The dashboard
-        draws the mean and minimum; the maximum remains available to callers.
-
-        Aggregation is skipped when the run does not exceed ``min_span_s``.
-        """
-        where_sql, params = self.node_rank_filter()
-        bound: List[Any] = list(params)
-        if hostname is not None:
-            where_sql = (
-                f"{where_sql} AND hostname IS ?"
-                if where_sql
-                else "WHERE hostname IS ?"
-            )
-            bound.append(str(hostname))
-        # An all-zero capacity row is the sampler's NVML failure fallback,
-        # not a real 0 W observation.
-        reported_sql = """
-            power_usage_w IS NOT NULL
-            AND (
-                COALESCE(mem_total_bytes, 0) > 0
-                OR COALESCE(power_limit_w, 0) > 0
-            )
-        """
+    def gpu_power_run_stats(
+        self, conn: sqlite3.Connection, hostname: Optional[str] = None
+    ) -> Optional[RunStats]:
+        """The shape of the whole-run power history, over reported rows."""
+        where_sql, bound = self._run_scope(hostname)
         try:
             row = conn.execute(
-                f"SELECT MIN(sample_ts_s), MAX(sample_ts_s) FROM "
+                "SELECT MIN(sample_ts_s), MAX(sample_ts_s), COUNT(*) FROM "
                 f"system_gpu_samples {where_sql} "
-                f"{'AND' if where_sql else 'WHERE'} {reported_sql}",
+                f"{'AND' if where_sql else 'WHERE'} {_GPU_REPORTED_SQL}",
                 tuple(bound),
             ).fetchone()
         except sqlite3.Error:
-            return []
+            return None
         if not row or row[0] is None or row[1] is None:
-            return []
-        first, last = float(row[0]), float(row[1])
-        span = last - first
-        if span <= max(0.0, float(min_span_s)):
-            return []
-        width = choose_window_s(span)
+            return None
+        return RunStats(
+            first_ts=float(row[0]),
+            last_ts=float(row[1]),
+            sample_count=int(row[2] or 0),
+        )
+
+    def fetch_gpu_power_run(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        width_s: float,
+        first_ts: float,
+        hostname: Optional[str] = None,
+    ) -> List[Tuple[int, float, float, float, float]]:
+        """Whole-run per-GPU power in fixed-duration buckets.
+
+        This path BUCKETS rather than rolls, so it takes a bucket width
+        rather than a ``RunSeriesPlan``: there is no stride, cadence or
+        point budget for the shared planner to supply. The width is the
+        same duration the rolling charts use, which is the only part of
+        the plan that applies here.
+        """
+        where_sql, bound = self._run_scope(hostname)
         try:
-            rows = conn.execute(
-                f"""
-                SELECT
-                    gpu_idx,
-                    MIN(sample_ts_s),
-                    AVG(power_usage_w),
-                    MIN(power_usage_w),
-                    MAX(power_usage_w)
-                FROM system_gpu_samples
-                {where_sql}
-                {'AND' if where_sql else 'WHERE'} {reported_sql}
-                GROUP BY gpu_idx, CAST((sample_ts_s - ?) / ? AS INTEGER)
-                ORDER BY gpu_idx ASC, 2 ASC
-                """,
-                (*bound, first, width),
-            ).fetchall()
+            return [
+                (
+                    int(r[0]),
+                    float(r[1]),
+                    float(r[2]),
+                    float(r[3]),
+                    float(r[4]),
+                )
+                for r in conn.execute(
+                    f"""
+                    SELECT
+                        gpu_idx,
+                        MIN(sample_ts_s),
+                        AVG(power_usage_w),
+                        MIN(power_usage_w),
+                        MAX(power_usage_w)
+                    FROM system_gpu_samples
+                    {where_sql}
+                    {'AND' if where_sql else 'WHERE'} {_GPU_REPORTED_SQL}
+                    GROUP BY gpu_idx, CAST((sample_ts_s - ?) / ? AS INTEGER)
+                    ORDER BY gpu_idx ASC, 2 ASC
+                    """,
+                    (*bound, float(first_ts), float(width_s)),
+                ).fetchall()
+            ]
         except sqlite3.Error:
             return []
-        by_gpu: Dict[int, Dict[str, Any]] = {}
-        for gpu_idx, ts, avg, mn, mx in rows:
-            e = by_gpu.setdefault(
-                int(gpu_idx),
-                {
-                    "gpu_idx": int(gpu_idx),
-                    "t": [],
-                    "avg": [],
-                    "min": [],
-                    "max": [],
-                },
-            )
-            e["t"].append(float(ts))
-            e["avg"].append(float(avg))
-            e["min"].append(float(mn))
-            e["max"].append(float(mx))
-        out = [by_gpu[i] for i in sorted(by_gpu)]
-        for e in out:
-            e["span_s"] = span
-            e["window_s"] = width
-        return out
 
     def fetch_gpu_rows_for_sample(
         self,

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -333,8 +333,8 @@ def test_whole_run_charts_share_one_clock_axis() -> None:
             "gpu_power": [{"gpu_idx": 0, "values": [66.0, 68.0]}],
             # Both flags are computed now, so a hand-built payload states
             # which view each chart is in rather than the card inferring it.
-            "cpu_run_whole": True,
-            "power_run_whole": True,
+            "cpu_run_mode": "retained",
+            "power_run_mode": "retained",
             "cpu_run": {
                 "t": cpu_t,
                 "avg": [30.0] * 40,
@@ -705,7 +705,11 @@ def test_rolling_window_is_spelled_out_not_named() -> None:
     "rolling 2 min" needs no glossary; "per slice" made a reader ask what a
     slice was, and disjoint slices did not smooth a fast oscillation anyway.
     """
-    from traceml_ai.renderers.system.common import choose_window_s
+    from traceml_ai.renderers.shared.run_series import (
+        DEFAULT_RUN_SERIES_POLICY,
+    )
+
+    choose_window_s = DEFAULT_RUN_SERIES_POLICY.window_for
 
     assert format_window(choose_window_s(96 * 60)) == "2 min"  # 96-min run
     assert format_window(choose_window_s(178 * 60)) == "5 min"  # 3-hour

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -709,11 +709,11 @@ def test_rolling_window_is_spelled_out_not_named() -> None:
         DEFAULT_RUN_SERIES_POLICY,
     )
 
-    choose_window_s = DEFAULT_RUN_SERIES_POLICY.window_for
+    window_for = DEFAULT_RUN_SERIES_POLICY.window_for
 
-    assert format_window(choose_window_s(96 * 60)) == "2 min"  # 96-min run
-    assert format_window(choose_window_s(178 * 60)) == "5 min"  # 3-hour
-    assert format_window(choose_window_s(23 * 60)) == "30 s"
-    assert format_window(choose_window_s(4 * 60)) == "30 s"  # the floor
-    assert format_window(choose_window_s(48 * 3600)) == "5 min"  # the cap
+    assert format_window(window_for(96 * 60)) == "2 min"  # 96-min run
+    assert format_window(window_for(178 * 60)) == "5 min"  # 3-hour
+    assert format_window(window_for(23 * 60)) == "30 s"
+    assert format_window(window_for(4 * 60)) == "30 s"  # the floor
+    assert format_window(window_for(48 * 3600)) == "5 min"  # the cap
     assert format_window(0.0) == ""

--- a/tests/display/test_system_section_characterization.py
+++ b/tests/display/test_system_section_characterization.py
@@ -163,27 +163,35 @@ def test_no_gpus_at_all_is_not_the_same_as_unreported():
 
 # --- one rule for "is this the whole-run view" ---------------------------
 def test_both_charts_answer_the_whole_run_question_the_same_way():
-    """The card asked two different questions and could disagree.
+    """One rule for both charts, and 5b changed where it looks.
 
-    It tested `len(t) > 2` of the CPU history and merely non-empty of the
-    power history, so on a run with one or two power buckets the power
-    chart claimed the whole-run view while the CPU chart did not, and the
-    pair stopped sharing a clock.
+    The card first asked `len(t) > 2` of the CPU history and merely
+    non-empty of the power history, so on a run with one or two power
+    buckets the two charts claimed different views and stopped sharing a
+    clock. 5a-ii gave both the same rule, `_has_whole_run`, which counted
+    the points that came BACK: the mode depended on the query result.
+
+    5b decides before reading. `RunSeriesPolicy.mode_for` compares the
+    run's span against the recent window, and the fetch follows the
+    decision instead of the decision following the fetch. Causality runs
+    one way, and a chart cannot be in a mode its own data disagrees with.
     """
-    two_points = {"t": [1.0, 2.0], "avg": [1.0, 2.0]}
-    three_points = {"t": [1.0, 2.0, 3.0], "avg": [1.0, 2.0, 3.0]}
-    assert dashboard_compute._has_whole_run(two_points) is False
-    assert dashboard_compute._has_whole_run(three_points) is True
+    from traceml_ai.renderers.shared.run_series import (
+        DEFAULT_RUN_SERIES_POLICY as policy,
+    )
 
-    # The bucket list form answers the same question the same way.
-    assert dashboard_compute._has_whole_run([{"t": [1.0, 2.0]}]) is False
-    assert dashboard_compute._has_whole_run([{"t": [1.0, 2.0, 3.0]}]) is True
-    assert dashboard_compute._has_whole_run([]) is False
-    assert dashboard_compute._has_whole_run({}) is False
+    # A run inside the window is the window's to describe.
+    assert policy.mode_for(60.0, 60.0) == "recent"
+    # And it must outgrow it by the hysteresis factor, not by a hair, so a
+    # chart at the boundary does not flip back and forth every tick.
+    assert policy.mode_for(70.0, 60.0) == "recent"
+    assert policy.mode_for(80.0, 60.0) == "retained"
+    # A window of zero spans nothing to compare against.
+    assert policy.mode_for(600.0, 0.0) == "recent"
 
 
 def test_a_short_run_puts_neither_chart_in_the_whole_run_view(process_free_db):
-    """End to end: the flags travel on the payload and agree."""
+    """End to end: the mode travels on the payload and both agree."""
     out = process_free_db
-    assert out.series.cpu_run_whole is False
-    assert out.series.power_run_whole is False
+    assert out.series.cpu_run_mode == "recent"
+    assert out.series.power_run_mode == "recent"

--- a/tests/renderers/system/conftest.py
+++ b/tests/renderers/system/conftest.py
@@ -1,0 +1,107 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A real system_samples database for the System repository tests.
+
+Rows go in through `tests/sqlite_fixtures.insert_system_sample`, which
+builds them from the writer's own schema, so a column rename in the writer
+fails these tests instead of drifting past them. Mirrors
+`tests/renderers/process/conftest.py`; the difference is that System's
+rows carry per-GPU children, so the factory takes a per-tick GPU list.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+import pytest
+
+from tests.sqlite_fixtures import init_summary_schema, insert_system_sample
+
+GB = 1_000_000_000.0
+
+
+def gpu(
+    idx: int,
+    *,
+    util: Optional[float] = 100.0,
+    power: Optional[float] = 66.0,
+    limit: Optional[float] = 70.0,
+    temp: Optional[float] = 45.0,
+    mem_used: Optional[float] = 6.3 * GB,
+    mem_total: Optional[float] = 16.1 * GB,
+) -> Mapping[str, Any]:
+    """One per-GPU child row."""
+    return {
+        "gpu_idx": idx,
+        "util": util,
+        "mem_used_bytes": mem_used,
+        "mem_total_bytes": mem_total,
+        "temperature_c": temp,
+        "power_usage_w": power,
+        "power_limit_w": limit,
+    }
+
+
+@pytest.fixture
+def system_db(tmp_path: Path) -> Callable[..., str]:
+    """Write a run of system samples and return the database path.
+
+    `cadence_s` and `ticks` shape the clock, which is what every
+    window-planning assertion in this file turns on. `gaps` inserts extra
+    seconds before the given tick indices, which is how a run with missing
+    samples is built without changing the rest of the timeline.
+    """
+
+    path = tmp_path / "telemetry.db"
+    conn = sqlite3.connect(path)
+    init_summary_schema(conn)
+    conn.commit()
+    conn.close()
+
+    def write(
+        ticks: int = 20,
+        *,
+        cadence_s: float = 2.0,
+        cpu: Callable[[int], Optional[float]] = lambda seq: 10.0,
+        gpus: Optional[Callable[[int], Sequence[Mapping[str, Any]]]] = None,
+        hostnames: Sequence[str] = ("box",),
+        gaps: Mapping[int, float] = {},
+        start_ts: float = 1000.0,
+    ) -> str:
+        row_id = 0
+        conn = sqlite3.connect(path)
+        try:
+            offset = 0.0
+            for seq in range(ticks):
+                offset += gaps.get(seq, 0.0)
+                for node, host in enumerate(hostnames):
+                    row_id += 1
+                    insert_system_sample(
+                        conn,
+                        row_id=row_id,
+                        rank=node,
+                        ts=start_ts + cadence_s * seq + offset,
+                        gpu_available=gpus is not None,
+                        gpu_count=len(gpus(seq)) if gpus else 0,
+                        world_size=len(hostnames),
+                        global_rank=node,
+                        node_rank=node,
+                        hostname=host,
+                        seq=seq,
+                        cpu_percent=cpu(seq),
+                        ram_used_bytes=2.0 * GB,
+                        ram_total_bytes=16.0 * GB,
+                        gpu_samples=list(gpus(seq)) if gpus else (),
+                    )
+            conn.commit()
+        finally:
+            conn.close()
+        return str(path)
+
+    return write

--- a/tests/renderers/system/test_system_repository.py
+++ b/tests/renderers/system/test_system_repository.py
@@ -1,0 +1,280 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+"""What SystemRepository does today, pinned before part 5b moves it.
+
+There were no SystemRepository tests at all before this file, while the
+Process repository has had them since #410. Part 5b replaces this module's
+hand-rolled window planning with `renderers/shared/run_series.py`, so the
+current behaviour is described here first and the move is then provably a
+move except where issue #419 declared a change.
+
+Where a rule is odd or is about to change, the test says so rather than
+asserting the nicer rule the code does not yet implement. Three are
+deliberately pinned as they are, because 5b changes them and the update
+should be a stated decision rather than a silent one:
+
+* the rolling frame counts ROWS, not seconds, so it spans more wall clock
+  than it claims across a gap,
+* the retained-vs-recent gate is a bare `span > min_span_s` with no
+  hysteresis,
+* a failed read returns an empty result rather than raising, which turns a
+  database failure into a confident "no data".
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from tests.renderers.system.conftest import gpu
+from traceml_ai.renderers.system.repository import SystemRepository
+
+
+def _repo(path: str) -> SystemRepository:
+    return SystemRepository(db_path=path)
+
+
+# --- the window ladder ---------------------------------------------------
+def test_the_rolling_window_is_chosen_from_the_run_length(system_db):
+    """Round steps, so the label a card prints stays recognisable."""
+    from traceml_ai.renderers.system.common import choose_window_s
+
+    assert choose_window_s(4 * 60) == 30.0  # the floor
+    assert choose_window_s(23 * 60) == 30.0
+    assert choose_window_s(96 * 60) == 120.0
+    assert choose_window_s(178 * 60) == 300.0
+    assert choose_window_s(48 * 3600) == 300.0  # the cap
+
+
+def test_a_run_shorter_than_the_gate_has_no_whole_run_history(system_db):
+    """`min_span_s` is what keeps a short run off the expensive query."""
+    path = system_db(ticks=10, cadence_s=2.0)  # 18 s span
+    repo = _repo(path)
+    with repo.connect() as conn:
+        out = repo.fetch_cpu_run_history(conn, min_span_s=60.0)
+    assert out["t"] == []
+    assert out["span_s"] == 0.0
+
+
+def test_the_gate_is_a_bare_comparison_with_no_hysteresis(system_db):
+    """Pinned because 5b replaces it with `policy.mode_for`.
+
+    A span one microsecond over the threshold produces the whole-run view
+    today. `mode_for` requires the run to outgrow the window by 1.2x first,
+    so a chart near the boundary cannot flip back and forth every tick.
+    """
+    path = system_db(ticks=40, cadence_s=2.0)  # 78 s span
+    repo = _repo(path)
+    with repo.connect() as conn:
+        assert repo.fetch_cpu_run_history(conn, min_span_s=77.9)["t"] != []
+        assert repo.fetch_cpu_run_history(conn, min_span_s=78.1)["t"] == []
+
+
+def test_fewer_than_two_samples_cannot_be_planned(system_db):
+    path = system_db(ticks=1)
+    repo = _repo(path)
+    with repo.connect() as conn:
+        assert repo.fetch_cpu_run_history(conn)["t"] == []
+
+
+# --- the point budget ----------------------------------------------------
+def test_the_whole_run_series_respects_the_120_point_cap(system_db):
+    path = system_db(ticks=600, cadence_s=2.0)
+    repo = _repo(path)
+    with repo.connect() as conn:
+        out = repo.fetch_cpu_run_history(conn)
+    assert 2 < len(out["t"]) <= 120
+    assert len(out["t"]) == len(out["avg"]) == len(out["max"])
+
+
+def test_eligible_points_under_the_cap_all_survive(system_db):
+    """The stride is planned over the points that will be EMITTED.
+
+    A 30 s window at a 2 s cadence excludes the first 14 samples, whose
+    rolling window is incomplete. The remaining 116 fit under the cap, so
+    none of them should be decimated away.
+    """
+    path = system_db(ticks=130, cadence_s=2.0)
+    repo = _repo(path)
+    with repo.connect() as conn:
+        out = repo.fetch_cpu_run_history(conn)
+    assert len(out["t"]) == 116
+
+
+def test_the_window_travels_on_the_payload(system_db):
+    path = system_db(ticks=600, cadence_s=2.0)
+    repo = _repo(path)
+    with repo.connect() as conn:
+        out = repo.fetch_cpu_run_history(conn)
+    assert out["window_s"] == 30.0
+    assert out["span_s"] == pytest.approx(2.0 * 599)
+
+
+# --- the rolling frame, which 5b changes ---------------------------------
+def test_the_frame_counts_rows_so_a_gap_widens_it(system_db):
+    """The defect issue #419 documents, pinned before it is fixed.
+
+    A ROWS frame reaches a fixed number of rows back regardless of how much
+    wall clock those rows span. Across a 60 s hole in a 2 s run it averages
+    in pre-gap values that a 30 s window should never have seen, so the
+    chart's own label stops being true exactly when someone is reading it
+    to find out what happened.
+
+    5b swaps this for `RANGE BETWEEN window_s PRECEDING`, and this
+    assertion inverts as the stated behaviour change.
+    """
+    path = system_db(
+        ticks=200,
+        cadence_s=2.0,
+        cpu=lambda seq: 90.0 if seq < 100 else 10.0,
+        gaps={100: 60.0},
+    )
+    repo = _repo(path)
+    with repo.connect() as conn:
+        out = repo.fetch_cpu_run_history(conn)
+
+    first_after_gap = next(
+        avg for t, avg in zip(out["t"], out["avg"]) if t >= 1000.0 + 260.0
+    )
+    # A time frame would report 10.0 here: nothing else is within 30 s.
+    assert first_after_gap > 50.0
+
+
+# --- node scope ----------------------------------------------------------
+def test_history_is_scoped_to_one_host(system_db):
+    """System telemetry is per machine; a two-host window is not pooled."""
+    path = system_db(
+        ticks=200,
+        cadence_s=2.0,
+        cpu=lambda seq: 10.0,
+        hostnames=("node-a", "node-b"),
+    )
+    repo = _repo(path)
+    with repo.connect() as conn:
+        out = repo.fetch_cpu_run_history(conn, hostname="node-a")
+    assert out["t"]
+    assert max(out["max"]) == pytest.approx(10.0)
+
+
+def test_the_newest_sample_carries_the_run_identity(system_db):
+    path = system_db(ticks=5)
+    repo = _repo(path)
+    with repo.connect() as conn:
+        row = repo.fetch_latest_system_sample(conn)
+    assert row is not None
+    assert row["hostname"] == "box"
+    assert row["cpu_percent"] == 10.0
+
+
+def test_the_recent_window_returns_at_most_what_was_asked_for(system_db):
+    path = system_db(ticks=50)
+    repo = _repo(path)
+    with repo.connect() as conn:
+        rows = repo.fetch_recent_system_samples(conn, 10)
+    assert len(rows) == 10
+
+
+# --- the GPU power history, which buckets rather than rolls --------------
+def test_power_history_buckets_per_gpu(system_db):
+    path = system_db(
+        ticks=600, cadence_s=2.0, gpus=lambda seq: [gpu(0), gpu(1)]
+    )
+    repo = _repo(path)
+    with repo.connect() as conn:
+        out = repo.fetch_gpu_power_run_history(conn)
+    assert [entry["gpu_idx"] for entry in out] == [0, 1]
+    for entry in out:
+        assert len(entry["t"]) == len(entry["avg"]) == len(entry["min"])
+        assert entry["span_s"] == pytest.approx(2.0 * 599)
+
+
+def test_power_history_has_no_point_cap(system_db):
+    """Pinned as a known gap, deferred to its own issue.
+
+    The CPU chart budgets 120 points. This path buckets at one bucket per
+    `choose_window_s`, which saturates at 300 s, so bucket count grows
+    without bound: about 288 per GPU on a 24 hour run.
+    """
+    path = system_db(
+        ticks=720, cadence_s=120.0, gpus=lambda seq: [gpu(0)]
+    )  # a 24 hour run
+    repo = _repo(path)
+    with repo.connect() as conn:
+        out = repo.fetch_gpu_power_run_history(conn)
+    # 86400 s of run at the 300 s window cap is 288 buckets, against the
+    # 120 the CPU chart budgets for. On an 8-GPU host that is ~2300 points.
+    assert len(out[0]["t"]) == 288
+
+
+def test_the_sampler_zero_fallback_is_not_a_power_reading(system_db):
+    """An all-zero capacity row is NVML failing, not a 0 W observation."""
+
+    def rows(seq):
+        if seq >= 500:
+            return [gpu(0, power=0.0, limit=0.0, mem_total=0.0, temp=0.0)]
+        return [gpu(0, power=66.0)]
+
+    path = system_db(ticks=600, cadence_s=2.0, gpus=rows)
+    repo = _repo(path)
+    with repo.connect() as conn:
+        out = repo.fetch_gpu_power_run_history(conn)
+    assert out
+    assert min(out[0]["min"]) == pytest.approx(66.0)
+
+
+def test_a_cpu_only_run_has_no_power_history(system_db):
+    path = system_db(ticks=600, cadence_s=2.0)
+    repo = _repo(path)
+    with repo.connect() as conn:
+        assert repo.fetch_gpu_power_run_history(conn) == []
+
+
+# --- error handling, which 5b deliberately does NOT change ---------------
+class _FailingConnection:
+    def execute(self, *_args, **_kwargs):
+        raise sqlite3.OperationalError("query failed")
+
+
+def test_a_failed_read_returns_empty_instead_of_raising(system_db):
+    """Pinned as-is, and it is a defect: see the follow-up issue.
+
+    The one error boundary is `SystemDashboardComputer.compute()`, which
+    returns the last good payload marked stale. Swallowing here turns a
+    database failure into a confident "no data" and that boundary never
+    runs. It is NOT fixed in 5b: `SystemRollups.status` is written by the
+    boundary and read nowhere in `system_section.py`, so propagating alone
+    would replace two empty charts with a frozen card carrying no stale
+    marker, which is worse. The fix needs the card note too.
+
+    The Process repository already propagates (`bde1ca6`), so this is also
+    the assertion that records the two blocks disagreeing.
+    """
+    path = system_db(ticks=5)
+    repo = _repo(path)
+    assert repo.fetch_cpu_run_history(_FailingConnection())["t"] == []
+    assert repo.fetch_gpu_power_run_history(_FailingConnection()) == []
+
+
+def test_one_swallow_is_a_capability_fallback_not_a_defect(system_db):
+    """Named so the follow-up does not delete all five uniformly.
+
+    The `except` around the rolling query stands in for "this SQLite has no
+    window functions" (< 3.25), where the whole-run view is genuinely
+    unavailable and the recent window still stands. Removing it with the
+    others would turn a missing chart into a dead card on an old host.
+    """
+    source = (
+        __import__(
+            "traceml_ai.renderers.system.repository",
+            fromlist=["repository"],
+        ).__file__
+        or ""
+    )
+    with open(source, encoding="utf-8") as handle:
+        text = handle.read()
+    assert "Window functions need SQLite >= 3.25" in text

--- a/tests/renderers/system/test_system_repository.py
+++ b/tests/renderers/system/test_system_repository.py
@@ -19,8 +19,9 @@ should be a stated decision rather than a silent one:
 
 * the rolling frame counts ROWS, not seconds, so it spans more wall clock
   than it claims across a gap,
-* the retained-vs-recent gate is a bare `span > min_span_s` with no
-  hysteresis,
+* the retained-vs-recent gate is a bare `span > min_span_s`, with the 1.2x
+  hysteresis held by the caller in a constant that duplicates the shared
+  policy's,
 * a failed read returns an empty result rather than raising, which turns a
   database failure into a confident "no data".
 """
@@ -32,6 +33,10 @@ import sqlite3
 import pytest
 
 from tests.renderers.system.conftest import gpu
+from traceml_ai.renderers.shared.run_series import (
+    DEFAULT_RUN_SERIES_POLICY,
+    plan_run_series,
+)
 from traceml_ai.renderers.system.repository import SystemRepository
 
 
@@ -39,47 +44,110 @@ def _repo(path: str) -> SystemRepository:
     return SystemRepository(db_path=path)
 
 
+def _cpu_run(repo, conn, hostname=None):
+    """Plan and read one whole-run CPU series, as the computer does."""
+    stats = repo.cpu_run_stats(conn, hostname=hostname)
+    if stats is None:
+        return None, []
+    plan = plan_run_series(
+        span_s=stats.span_s,
+        sample_count=stats.sample_count,
+        policy=DEFAULT_RUN_SERIES_POLICY,
+    )
+    if plan is None:
+        return stats, []
+    return stats, repo.fetch_cpu_run(conn, plan, hostname=hostname)
+
+
+def _power_run(repo, conn, hostname=None):
+    """Plan and read one whole-run power series, as the computer does."""
+    stats = repo.gpu_power_run_stats(conn, hostname=hostname)
+    if stats is None:
+        return None, []
+    width = DEFAULT_RUN_SERIES_POLICY.window_for(stats.span_s)
+    rows = repo.fetch_gpu_power_run(
+        conn,
+        width_s=width,
+        first_ts=stats.first_ts,
+        hostname=hostname,
+    )
+    per_gpu = {}
+    for idx, ts, avg, low, _high in rows:
+        entry = per_gpu.setdefault(idx, {"t": [], "avg": [], "min": []})
+        entry["t"].append(ts)
+        entry["avg"].append(avg)
+        entry["min"].append(low)
+    return stats, [per_gpu[i] for i in sorted(per_gpu)]
+
+
 # --- the window ladder ---------------------------------------------------
-def test_the_rolling_window_is_chosen_from_the_run_length(system_db):
-    """Round steps, so the label a card prints stays recognisable."""
-    from traceml_ai.renderers.system.common import choose_window_s
+def test_the_shared_ladder_is_the_ladder_system_had():
+    """The five rungs that used to live in `common.choose_window_s`.
 
-    assert choose_window_s(4 * 60) == 30.0  # the floor
-    assert choose_window_s(23 * 60) == 30.0
-    assert choose_window_s(96 * 60) == 120.0
-    assert choose_window_s(178 * 60) == 300.0
-    assert choose_window_s(48 * 3600) == 300.0  # the cap
+    Kept verbatim through the move, because this is the assertion that
+    makes the consolidation a consolidation: if the shared policy chose
+    different windows, every whole-run chart would change span and the
+    label a card prints would change with it.
+    """
+    from traceml_ai.renderers.shared.run_series import (
+        DEFAULT_RUN_SERIES_POLICY as policy,
+    )
+
+    assert policy.window_for(4 * 60) == 30.0  # the floor
+    assert policy.window_for(23 * 60) == 30.0
+    assert policy.window_for(96 * 60) == 120.0
+    assert policy.window_for(178 * 60) == 300.0
+    assert policy.window_for(48 * 3600) == 300.0  # the cap
 
 
-def test_a_run_shorter_than_the_gate_has_no_whole_run_history(system_db):
-    """`min_span_s` is what keeps a short run off the expensive query."""
+def test_a_short_run_is_kept_off_the_expensive_query_by_the_mode(system_db):
+    """The gate moved UP, out of the read and into the decision.
+
+    The repository used to take `min_span_s` and return an empty result,
+    which meant a short run still paid for two queries to be told no. The
+    computer now asks `mode_for` first and only reads when the answer is
+    `retained`, so the read is not reached at all.
+    """
     path = system_db(ticks=10, cadence_s=2.0)  # 18 s span
     repo = _repo(path)
     with repo.connect() as conn:
-        out = repo.fetch_cpu_run_history(conn, min_span_s=60.0)
-    assert out["t"] == []
-    assert out["span_s"] == 0.0
+        stats = repo.cpu_run_stats(conn)
+    assert stats is not None
+    assert stats.span_s == pytest.approx(18.0)
+    assert DEFAULT_RUN_SERIES_POLICY.mode_for(stats.span_s, 60.0) == "recent"
 
 
-def test_the_gate_is_a_bare_comparison_with_no_hysteresis(system_db):
-    """Pinned because 5b replaces it with `policy.mode_for`.
+def test_the_hysteresis_factor_now_has_one_owner(system_db):
+    """The repository compares; the hysteresis lives above it.
 
-    A span one microsecond over the threshold produces the whole-run view
-    today. `mode_for` requires the run to outgrow the window by 1.2x first,
-    so a chart near the boundary cannot flip back and forth every tick.
+    Corrected after reading the code rather than the issue summary. The
+    1.2x factor that stops a chart flipping between views every tick
+    already exists, as `_RUN_VIEW_FACTOR` in `dashboard_compute.py`, and is
+    multiplied in before `min_span_s` arrives here. So the repository's own
+    test is a bare comparison and that is correct.
+
+    What 5b changes is ownership, not behaviour: `_RUN_VIEW_FACTOR` is a
+    local copy of `RunSeriesPolicy.retained_factor`, which is the same
+    1.2, and the decision moves to `policy.mode_for` in the compute layer
+    where the rest of the planning now lives.
     """
     path = system_db(ticks=40, cadence_s=2.0)  # 78 s span
     repo = _repo(path)
     with repo.connect() as conn:
-        assert repo.fetch_cpu_run_history(conn, min_span_s=77.9)["t"] != []
-        assert repo.fetch_cpu_run_history(conn, min_span_s=78.1)["t"] == []
+        stats = repo.cpu_run_stats(conn)
+    assert stats is not None
+    mode = DEFAULT_RUN_SERIES_POLICY.mode_for
+    # 78 s of run against a 60 s window is 1.3x, past the 1.2x factor.
+    assert mode(stats.span_s, 60.0) == "retained"
+    assert mode(stats.span_s, 70.0) == "recent"
 
 
 def test_fewer_than_two_samples_cannot_be_planned(system_db):
     path = system_db(ticks=1)
     repo = _repo(path)
     with repo.connect() as conn:
-        assert repo.fetch_cpu_run_history(conn)["t"] == []
+        _stats, rows = _cpu_run(repo, conn)
+    assert rows == []
 
 
 # --- the point budget ----------------------------------------------------
@@ -87,9 +155,8 @@ def test_the_whole_run_series_respects_the_120_point_cap(system_db):
     path = system_db(ticks=600, cadence_s=2.0)
     repo = _repo(path)
     with repo.connect() as conn:
-        out = repo.fetch_cpu_run_history(conn)
-    assert 2 < len(out["t"]) <= 120
-    assert len(out["t"]) == len(out["avg"]) == len(out["max"])
+        _stats, rows = _cpu_run(repo, conn)
+    assert 2 < len(rows) <= 120
 
 
 def test_eligible_points_under_the_cap_all_survive(system_db):
@@ -102,31 +169,45 @@ def test_eligible_points_under_the_cap_all_survive(system_db):
     path = system_db(ticks=130, cadence_s=2.0)
     repo = _repo(path)
     with repo.connect() as conn:
-        out = repo.fetch_cpu_run_history(conn)
-    assert len(out["t"]) == 116
+        _stats, rows = _cpu_run(repo, conn)
+    assert len(rows) == 116
 
 
-def test_the_window_travels_on_the_payload(system_db):
+def test_the_window_and_span_come_from_the_plan_and_the_stats(system_db):
+    """Both used to be assembled inside the read; they are inputs now."""
     path = system_db(ticks=600, cadence_s=2.0)
     repo = _repo(path)
     with repo.connect() as conn:
-        out = repo.fetch_cpu_run_history(conn)
-    assert out["window_s"] == 30.0
-    assert out["span_s"] == pytest.approx(2.0 * 599)
+        stats = repo.cpu_run_stats(conn)
+    assert stats is not None
+    plan = plan_run_series(
+        span_s=stats.span_s,
+        sample_count=stats.sample_count,
+        policy=DEFAULT_RUN_SERIES_POLICY,
+    )
+    assert plan is not None
+    assert plan.window_s == 30.0
+    assert stats.span_s == pytest.approx(2.0 * 599)
 
 
 # --- the rolling frame, which 5b changes ---------------------------------
-def test_the_frame_counts_rows_so_a_gap_widens_it(system_db):
-    """The defect issue #419 documents, pinned before it is fixed.
+def test_the_frame_measures_seconds_so_a_gap_does_not_widen_it(system_db):
+    """The behaviour change this PR exists to make, asserted directly.
 
-    A ROWS frame reaches a fixed number of rows back regardless of how much
-    wall clock those rows span. Across a 60 s hole in a 2 s run it averages
-    in pre-gap values that a 30 s window should never have seen, so the
-    chart's own label stops being true exactly when someone is reading it
-    to find out what happened.
+    A ROWS frame reaches a fixed number of ROWS back regardless of how much
+    wall clock they span. Across a 60 s hole in a 2 s run it averaged in
+    pre-gap values a 30 s window should never have seen, so the chart's own
+    label stopped being true exactly when someone was reading it to find
+    out what happened.
 
-    5b swaps this for `RANGE BETWEEN window_s PRECEDING`, and this
-    assertion inverts as the stated behaviour change.
+    `RunSeriesPlan.frame_clause` emits `RANGE BETWEEN window_s PRECEDING`
+    on SQLite 3.28 and later, which counts seconds. The first sample after
+    the gap now averages only what is genuinely within 30 s of it, which is
+    itself.
+
+    This test was written in the previous commit asserting the OPPOSITE,
+    against untouched code, so the inversion here is the record of the
+    change rather than a claim about it.
     """
     path = system_db(
         ticks=200,
@@ -136,13 +217,12 @@ def test_the_frame_counts_rows_so_a_gap_widens_it(system_db):
     )
     repo = _repo(path)
     with repo.connect() as conn:
-        out = repo.fetch_cpu_run_history(conn)
+        _stats, rows = _cpu_run(repo, conn)
 
     first_after_gap = next(
-        avg for t, avg in zip(out["t"], out["avg"]) if t >= 1000.0 + 260.0
+        avg for ts, avg, _mx in rows if ts >= 1000.0 + 260.0
     )
-    # A time frame would report 10.0 here: nothing else is within 30 s.
-    assert first_after_gap > 50.0
+    assert first_after_gap == pytest.approx(10.0, abs=0.5)
 
 
 # --- node scope ----------------------------------------------------------
@@ -156,9 +236,9 @@ def test_history_is_scoped_to_one_host(system_db):
     )
     repo = _repo(path)
     with repo.connect() as conn:
-        out = repo.fetch_cpu_run_history(conn, hostname="node-a")
-    assert out["t"]
-    assert max(out["max"]) == pytest.approx(10.0)
+        _stats, rows = _cpu_run(repo, conn, hostname="node-a")
+    assert rows
+    assert max(r[2] for r in rows) == pytest.approx(10.0)
 
 
 def test_the_newest_sample_carries_the_run_identity(system_db):
@@ -186,11 +266,12 @@ def test_power_history_buckets_per_gpu(system_db):
     )
     repo = _repo(path)
     with repo.connect() as conn:
-        out = repo.fetch_gpu_power_run_history(conn)
-    assert [entry["gpu_idx"] for entry in out] == [0, 1]
+        stats, out = _power_run(repo, conn)
+    assert stats is not None
+    assert len(out) == 2
     for entry in out:
         assert len(entry["t"]) == len(entry["avg"]) == len(entry["min"])
-        assert entry["span_s"] == pytest.approx(2.0 * 599)
+    assert stats.span_s == pytest.approx(2.0 * 599)
 
 
 def test_power_history_has_no_point_cap(system_db):
@@ -205,7 +286,7 @@ def test_power_history_has_no_point_cap(system_db):
     )  # a 24 hour run
     repo = _repo(path)
     with repo.connect() as conn:
-        out = repo.fetch_gpu_power_run_history(conn)
+        _stats, out = _power_run(repo, conn)
     # 86400 s of run at the 300 s window cap is 288 buckets, against the
     # 120 the CPU chart budgets for. On an 8-GPU host that is ~2300 points.
     assert len(out[0]["t"]) == 288
@@ -222,7 +303,7 @@ def test_the_sampler_zero_fallback_is_not_a_power_reading(system_db):
     path = system_db(ticks=600, cadence_s=2.0, gpus=rows)
     repo = _repo(path)
     with repo.connect() as conn:
-        out = repo.fetch_gpu_power_run_history(conn)
+        _stats, out = _power_run(repo, conn)
     assert out
     assert min(out[0]["min"]) == pytest.approx(66.0)
 
@@ -231,7 +312,7 @@ def test_a_cpu_only_run_has_no_power_history(system_db):
     path = system_db(ticks=600, cadence_s=2.0)
     repo = _repo(path)
     with repo.connect() as conn:
-        assert repo.fetch_gpu_power_run_history(conn) == []
+        assert repo.gpu_power_run_stats(conn) is None
 
 
 # --- error handling, which 5b deliberately does NOT change ---------------
@@ -256,8 +337,14 @@ def test_a_failed_read_returns_empty_instead_of_raising(system_db):
     """
     path = system_db(ticks=5)
     repo = _repo(path)
-    assert repo.fetch_cpu_run_history(_FailingConnection())["t"] == []
-    assert repo.fetch_gpu_power_run_history(_FailingConnection()) == []
+    assert repo.cpu_run_stats(_FailingConnection()) is None
+    assert repo.gpu_power_run_stats(_FailingConnection()) is None
+    assert (
+        repo.fetch_gpu_power_run(
+            _FailingConnection(), width_s=30.0, first_ts=0.0
+        )
+        == []
+    )
 
 
 def test_one_swallow_is_a_capability_fallback_not_a_defect(system_db):

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -380,6 +380,46 @@ def test_cpu_only_run_does_not_read_gpu_power_history(
     assert out.series.gpu_power_run == ()
 
 
+def test_empty_retained_cpu_read_falls_back_to_recent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "cpu-retained-unavailable.db"
+    _write(db, lambda seq: (), gpu_available=False, ticks=130)
+    computer = SystemDashboardComputer(str(db))
+    monkeypatch.setattr(
+        computer._db,
+        "fetch_cpu_run",
+        lambda *_args, **_kwargs: [],
+    )
+
+    out = computer.compute(window_n=100)
+
+    assert out.series.cpu_run_mode == "recent"
+    assert out.series.cpu_run == CpuRunSeries()
+    assert len(out.series.cpu) == 100
+
+
+def test_empty_retained_power_read_falls_back_to_recent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = tmp_path / "power-retained-unavailable.db"
+    _write(db, lambda seq: _all_busy(), ticks=130)
+    computer = SystemDashboardComputer(str(db))
+    monkeypatch.setattr(
+        computer._db,
+        "fetch_gpu_power_run",
+        lambda *_args, **_kwargs: [],
+    )
+
+    out = computer.compute(window_n=100)
+
+    assert out.series.power_run_mode == "recent"
+    assert out.series.gpu_power_run == ()
+    assert out.series.gpu_power
+
+
 def test_rows_without_a_hostname_are_not_a_node(tmp_path: Path) -> None:
     """A database upgraded from a pre-0.3.0 writer has NULL hostnames on
     its oldest rows; they are not a second machine and are not dropped."""

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -368,9 +368,12 @@ def test_cpu_only_run_does_not_read_gpu_power_history(
     def fail_if_called(*args, **kwargs):
         raise AssertionError("CPU-only runs must not query GPU power history")
 
+    # 5b renamed this read. #421 deliberately left the name alone so this
+    # spy kept binding; renaming it here is the stated change, and the spy
+    # now watches the FIRST GPU-power read rather than the second.
     monkeypatch.setattr(
         computer._db,
-        "fetch_gpu_power_run_history",
+        "gpu_power_run_stats",
         fail_if_called,
     )
     out = computer.compute(window_n=100)


### PR DESCRIPTION
Closes #419. Part 5b of #403, and the last of the System structural work. Stacked on #422.

System reads its whole-run history through `renderers/shared/run_series.py` instead of a second
copy of the same arithmetic, and the rolling frame starts measuring seconds instead of counting
rows.

## Review scope

The System block only. `renderers/shared/` is unchanged; this PR consumes it.

**Base and CI.** This targets `dev/abhijeet/system-payload` rather than `version_0.3.7` so the diff
is the three commits of this part, not the eight that would include #422's. That has one cost
worth stating: `ci.yml` filters `pull_request` on `branches: [main, 'version_*']`, which matches
the BASE, so a branch-based PR fires no checks at all. The checks here were dispatched with
`gh workflow run CI --ref dev/abhijeet/system-shared-consume`; all 8 runs are attached to the head
commit and green. Once #422 merges, GitHub retargets this to `version_0.3.7` and CI fires on its
own from then on.

## What was duplicated, and where it went

| System had | shared already owned |
|---|---|
| `common.choose_window_s` plus `_ROLL_MIN_S`, `_ROLL_MAX_S`, `_ROLL_FRACTION` | `RunSeriesPolicy.window_for` and the same three numbers |
| `_MAX_RUN_POINTS = 120` and a ceiling-division stride in the repository | `RunSeriesPolicy.max_points` and `stride_for` |
| `cadence = span / (count - 1)`, `preceding`, `eligible_count` in the repository | `cadence_of`, `RunSeriesPlan.preceding_rows`, `.eligible_count` |
| `_RUN_VIEW_FACTOR = 1.2` in the computer | `RunSeriesPolicy.retained_factor`, also 1.2 |
| an inline `ttl is None or age <= ttl` in `_return_stale` | `CachedPayloadTTL.may_reuse`, which Process already uses |

A test asserts the shared ladder returns the same five rungs the deleted function did, because
that equality is what makes this a consolidation rather than a redesign: a different window would
change the span of every whole-run chart and the label printed above it.

## The decision moved up, not just the code

The repository used to choose the window, measure the cadence, plan the stride and gate itself on
`min_span_s`. It now receives a `RunSeriesPlan` and executes it. Choosing how much history a chart
shows is a dashboard decision, and the reason this file exists is so that decision is visibly
somewhere else.

One consequence is worth naming: the short-run gate moved from inside the read to before it. The
computer asks `policy.mode_for` first and only reads when the answer is `retained`, so a short run
no longer pays for two queries in order to be told it has nothing to draw.

The two whole-run reads are split in the sibling's shape: `cpu_run_stats` / `fetch_cpu_run(plan)`
and `gpu_power_run_stats` / `fetch_gpu_power_run(width_s, first_ts)`, mirroring
`renderers/process/repository.py`. **This renames reads that #421 deliberately left alone.**
`tests/renderers/test_system_dashboard_gpu_payload.py` monkeypatches one of them to prove a
CPU-only run never issues the GPU query; the spy is repointed at `gpu_power_run_stats`, which is
now the first GPU-power read rather than the second.

## The behaviour change: the frame measures seconds

`RunSeriesPlan.frame_clause()` emits `RANGE BETWEEN window_s PRECEDING` on SQLite 3.28 and later,
where the old query hardcoded `ROWS BETWEEN n PRECEDING`. The two agree only when sampling is
perfectly regular.

Measured on a 200-sample run at a 2 s cadence with one 60 s gap, 30 s window, 12 preceding rows.
At the first sample after the gap:

```
ROWS frame   77.69
RANGE frame  10.00
```

The row frame reaches twelve rows back regardless of how much wall clock they span, so it averages
in pre-gap values a 30 s window should never have seen. Both emit 94 points, so the cost is
identical; only the honesty differs. A chart that silently spans more time than its label claims
is worst exactly when someone is reading it to find out what happened.

Adopted deliberately. The test that asserts it was written in the previous commit asserting the
opposite, against untouched code, so the inversion in this diff is the record of the change rather
than a claim about it.

## The mode is decided before the read, not inferred from it

5a-ii gave both charts one rule, but that rule counted the points that came back, so the mode
depended on the query result. `policy.mode_for` compares the run's span against the recent window
before anything is read, and the payload carries `SeriesMode` (`"recent"` / `"retained"`) instead
of two booleans. Causality runs one way now, and a chart cannot be in a mode its own data
disagrees with. Same vocabulary as the Process block.

## What this PR does NOT do, and why

**`FreshnessPolicy` is not adopted.** Issue #419's title names it, so the omission is deliberate
and stated here. System has no liveness concept in any form: it never compares `sample_ts_s`
against a clock, and nothing on the card renders node liveness. Adopting it is a new capability
rather than a de-duplication, and the shape is wrong as well as the surface: the System dashboard
is single-node by construction, so its freshness question is payload-level, not the per-entity
question `FreshnessPolicy` answers on Process. Filed separately so the surface gets designed
rather than bolted on. `CachedPayloadTTL`, from the same module, IS adopted, because that one is a
straight replacement for code already here.

**The `except sqlite3.Error` blocks stay.** There were five before this PR and there are four
after, because merging the separate span and count queries into `cpu_run_stats` removed one; the
handling is unchanged. Three of the four are genuine swallows that turn a database failure into a
confident "no data" and bypass the one boundary that would have shown last-good data marked stale,
which is the pattern `bde1ca6` removed from the Process repository. Fixing them here would make
the card worse, not better: `_return_stale` writes `SystemRollups.status` and `system_section.py`
reads `status` zero times in 884 lines, so propagating alone would replace two empty charts with a
frozen card carrying no stale marker at all. The fourth, in `fetch_cpu_run`, is not a swallow but
a documented capability fallback for SQLite below 3.25, where window functions do not exist and
the whole-run view is genuinely unavailable. Filed as one issue covering all three halves.

**The GPU power history is still uncapped.** It buckets rather than rolls, so no stride or point
budget from the plan applies to it; only the window duration carries over, as the bucket width. At
the 300 s ceiling a 24 hour run emits 288 buckets per GPU against the 120 the CPU chart budgets
for, which a test now pins. Filed separately, because capping it changes what the power chart
shows.

## Scope

```
STRUCTURE: whole-run planning -> renderers/shared/run_series.py (existing owner); System stops
holding a second copy; mirrored from renderers/process/repository.py; boundaries crossed: none
DATA PATH: system_section <- SYSTEM_LAYOUT <- SystemRenderer <- SystemDashboardComputer
           <- RunSeriesPlan + SystemRepository <- system_samples + system_gpu_samples
SCOPE: declared renderers/system plus its tests -> diff touches common.py, repository.py,
dashboard_compute.py, dashboard_models.py, one line of system_section.py and four test files ->
within
TWINS: searched the CONCEPT, not the symbol - window / rolling / span / stride / cadence /
preceding / point budget / the literals 30, 300, 50, 120, 1.2 -> every System site now reads the
shared policy; the Process block already consumed it in #411. `choose_window_s` has no definition
and no caller left; the name survives only in two docstrings that explain where it went
```

## Verification

```
GATE: pytest tests/ -> 1573 passed, 2 skipped, against this branch's base at 1556 passed, 2 skipped; the delta is exactly the 17 new repository tests; black, isort and ruff clean at 79 on every file in the diff
TRANSITIONS: the recent-to-retained switch is the one this PR touches. It is numerically unchanged, 1.2x either way, and now has one owner instead of a local constant plus a shared policy that disagreed about nothing; both charts take it from the same call, asserted end to end
RANKS: not applicable; the System dashboard is single-node by construction and node scoping is unchanged, with the two-node cells E and E' rendering identically to the base
TRIPWIRE: no window, cadence, stride or point budget is computed inside renderers/system any more; a reintroduced local copy fails the ladder-equality test, and the repository takes a plan rather than deciding one
SCENARIOS: all 22 fixture cells rendered and diffed field by field against the same render on the base; 0 of 66 text fields differ. That is the expected result and NOT evidence the frame change is inert: every fixture replays at a regular cadence, so ROWS and RANGE agree on all of them. The change is only observable on irregular sampling, which no cell exercises, and the engineered-gap unit test is the only evidence for it. Registry cell F remains a coverage gap (2 nodes x N GPUs, no fixture)
PLATFORM: macOS 26.1, Python 3.12.13, SQLite 3.51.2, so the RANGE path is the one exercised locally; the ROWS fallback is what runs below 3.28
```

## Not in this PR

The three issues above, and #409, which is the last part of #403.
