### PR TITLE
System: a row without a clock is not a sample

### DIFF
--- a/src/traceml_ai/renderers/system/repository.py
+++ b/src/traceml_ai/renderers/system/repository.py
@@ -26,6 +26,11 @@ from traceml_ai.renderers.shared.run_series import RunSeriesPlan
 # real 0 W observation. One predicate, applied by every query that reads
 # power, so the span a chart covers and the values it draws agree about
 # which rows exist.
+# A row without a clock cannot be placed on a chart or counted toward a
+# cadence. `sample_ts_s` is nullable in the writer's schema, so this is a
+# real state, not a defensive check: every whole-run read requires it.
+_HAS_CLOCK_SQL = "sample_ts_s IS NOT NULL"
+
 _GPU_REPORTED_SQL = """
     power_usage_w IS NOT NULL
     AND (
@@ -147,6 +152,7 @@ class SystemRepository:
                 SELECT *
                 FROM system_samples
                 {where_sql}
+                {'AND' if where_sql else 'WHERE'} {_HAS_CLOCK_SQL}
                 ORDER BY id DESC
                 LIMIT ?
             )
@@ -175,7 +181,8 @@ class SystemRepository:
         try:
             row = conn.execute(
                 "SELECT MIN(sample_ts_s), MAX(sample_ts_s), COUNT(*) "
-                f"FROM system_samples {where_sql}",
+                f"FROM system_samples {where_sql} "
+                f"{'AND' if where_sql else 'WHERE'} {_HAS_CLOCK_SQL}",
                 tuple(bound),
             ).fetchone()
         except sqlite3.Error:
@@ -214,6 +221,7 @@ class SystemRepository:
                     FROM system_samples
                     {where_sql}
                     {'AND' if where_sql else 'WHERE'} cpu_percent IS NOT NULL
+                      AND {_HAS_CLOCK_SQL}
                     WINDOW w AS (
                         ORDER BY sample_ts_s
                         {plan.frame_clause()}
@@ -240,7 +248,8 @@ class SystemRepository:
             row = conn.execute(
                 "SELECT MIN(sample_ts_s), MAX(sample_ts_s), COUNT(*) FROM "
                 f"system_gpu_samples {where_sql} "
-                f"{'AND' if where_sql else 'WHERE'} {_GPU_REPORTED_SQL}",
+                f"{'AND' if where_sql else 'WHERE'} {_GPU_REPORTED_SQL} "
+                f"AND {_HAS_CLOCK_SQL}",
                 tuple(bound),
             ).fetchone()
         except sqlite3.Error:
@@ -290,6 +299,7 @@ class SystemRepository:
                     FROM system_gpu_samples
                     {where_sql}
                     {'AND' if where_sql else 'WHERE'} {_GPU_REPORTED_SQL}
+                      AND {_HAS_CLOCK_SQL}
                     GROUP BY gpu_idx, CAST((sample_ts_s - ?) / ? AS INTEGER)
                     ORDER BY gpu_idx ASC, 2 ASC
                     """,

--- a/src/traceml_ai/renderers/system/repository.py
+++ b/src/traceml_ai/renderers/system/repository.py
@@ -22,15 +22,15 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from traceml_ai.renderers.shared.run_series import RunSeriesPlan
 
+# A row without a clock cannot be placed on a chart or counted toward a
+# cadence. `sample_ts_s` is nullable in the writer's schema, so this is a
+# real state, not a defensive check: every time-series read requires it.
+_HAS_CLOCK_SQL = "sample_ts_s IS NOT NULL"
+
 # An all-zero capacity row is the sampler's NVML failure fallback, not a
 # real 0 W observation. One predicate, applied by every query that reads
 # power, so the span a chart covers and the values it draws agree about
 # which rows exist.
-# A row without a clock cannot be placed on a chart or counted toward a
-# cadence. `sample_ts_s` is nullable in the writer's schema, so this is a
-# real state, not a defensive check: every whole-run read requires it.
-_HAS_CLOCK_SQL = "sample_ts_s IS NOT NULL"
-
 _GPU_REPORTED_SQL = """
     power_usage_w IS NOT NULL
     AND (

--- a/tests/renderers/system/conftest.py
+++ b/tests/renderers/system/conftest.py
@@ -73,6 +73,7 @@ def system_db(tmp_path: Path) -> Callable[..., str]:
         hostnames: Sequence[str] = ("box",),
         gaps: Mapping[int, float] = {},
         start_ts: float = 1000.0,
+        null_ts_before: int = 0,
     ) -> str:
         row_id = 0
         conn = sqlite3.connect(path)
@@ -98,6 +99,18 @@ def system_db(tmp_path: Path) -> Callable[..., str]:
                         ram_used_bytes=2.0 * GB,
                         ram_total_bytes=16.0 * GB,
                         gpu_samples=list(gpus(seq)) if gpus else (),
+                    )
+            if null_ts_before:
+                # `sample_ts_s` is nullable in the writer's schema, so a row
+                # can carry telemetry and no clock. Real cause: a sampler
+                # that reports before its first clock read.
+                # Both tables carry their own clock, and a sample that
+                # reported without one has children in the same state.
+                for table in ("system_samples", "system_gpu_samples"):
+                    conn.execute(
+                        f"UPDATE {table} SET sample_ts_s = NULL "
+                        "WHERE seq < ?",
+                        (int(null_ts_before),),
                     )
             conn.commit()
         finally:

--- a/tests/renderers/system/conftest.py
+++ b/tests/renderers/system/conftest.py
@@ -101,11 +101,10 @@ def system_db(tmp_path: Path) -> Callable[..., str]:
                         gpu_samples=list(gpus(seq)) if gpus else (),
                     )
             if null_ts_before:
-                # `sample_ts_s` is nullable in the writer's schema, so a row
-                # can carry telemetry and no clock. Real cause: a sampler
-                # that reports before its first clock read.
-                # Both tables carry their own clock, and a sample that
-                # reported without one has children in the same state.
+                # The best-effort projection stores malformed or legacy
+                # telemetry without a usable `ts` as NULL. Both tables carry
+                # that projected clock, so a parent sample without one has
+                # GPU children in the same state.
                 for table in ("system_samples", "system_gpu_samples"):
                     conn.execute(
                         f"UPDATE {table} SET sample_ts_s = NULL "

--- a/tests/renderers/system/test_system_repository.py
+++ b/tests/renderers/system/test_system_repository.py
@@ -365,3 +365,76 @@ def test_one_swallow_is_a_capability_fallback_not_a_defect(system_db):
     with open(source, encoding="utf-8") as handle:
         text = handle.read()
     assert "Window functions need SQLite >= 3.25" in text
+
+
+# --- NULL sample timestamps (#418) ---------------------------------------
+def test_a_null_timestamp_row_is_not_a_sample(system_db):
+    """`sample_ts_s` is nullable, and a row without a clock is not usable.
+
+    Reproduced before it was fixed: with 30 such rows the CPU read raised
+    `TypeError` out of `float(r[0])`. It is masked below a threshold, which
+    is why nothing caught it. SQLite sorts NULLs first and the read already
+    drops the first `preceding_rows` as an incomplete window, so the crash
+    only appears once the NULL count exceeds that prefix, and the prefix
+    itself moves with the cadence.
+
+    `TypeError` is not `sqlite3.Error`, so it escaped the reader's own
+    handler and reached `compute()`, where the whole-run chart silently
+    vanished and the card fell back to the recent view with no reason
+    given.
+    """
+    path = system_db(ticks=200, cadence_s=2.0, null_ts_before=30)
+    repo = _repo(path)
+    with repo.connect() as conn:
+        stats = repo.cpu_run_stats(conn)
+        assert stats is not None
+        # The count must describe rows that can be placed on a clock, or
+        # the cadence derived from it is wrong for every one of them.
+        assert stats.sample_count == 170
+        _stats, rows = _cpu_run(repo, conn)
+    assert rows
+    assert all(ts is not None for ts, _a, _m in rows)
+
+
+def test_a_null_timestamp_row_is_not_a_power_sample(system_db):
+    """The same rule on the GPU path, which has the same nullable column."""
+    path = system_db(
+        ticks=200,
+        cadence_s=2.0,
+        gpus=lambda seq: [gpu(0)],
+        null_ts_before=30,
+    )
+    repo = _repo(path)
+    with repo.connect() as conn:
+        stats = repo.gpu_power_run_stats(conn)
+        assert stats is not None
+        assert stats.sample_count == 170
+        _stats, out = _power_run(repo, conn)
+    assert out
+    assert all(ts is not None for ts in out[0]["t"])
+
+
+def test_one_unclocked_row_does_not_erase_the_whole_run_chart(system_db):
+    """The costly half of #418, and the half the issue did not describe.
+
+    The issue reported a crash, which needs more unclocked rows than the
+    read's dropped prefix. The common case is one, and it never crashed:
+    `float(r["sample_ts_s"] or 0.0)` in the compute layer turned a missing
+    clock into epoch 1970, so the recent window appeared to span 54 years,
+    the run could never outgrow it, and the whole-run chart silently
+    vanished with the card falling back to the recent view.
+
+    Silent and wrong is worse than loud and wrong, and one row is far more
+    likely than thirty.
+    """
+    from traceml_ai.renderers.system.dashboard_compute import (
+        SystemDashboardComputer,
+    )
+
+    path = system_db(ticks=200, cadence_s=2.0, null_ts_before=1)
+    out = SystemDashboardComputer(path).compute(window_n=100)
+
+    assert out.series.cpu_run_mode == "retained"
+    assert len(out.series.cpu_run.t) > 2
+    # And no drawn timestamp is the empty string the 1970 value formatted to.
+    assert all(x for x in out.series.x_time)

--- a/tests/renderers/system/test_system_repository.py
+++ b/tests/renderers/system/test_system_repository.py
@@ -431,7 +431,12 @@ def test_one_unclocked_row_does_not_erase_the_whole_run_chart(system_db):
         SystemDashboardComputer,
     )
 
-    path = system_db(ticks=200, cadence_s=2.0, null_ts_before=1)
+    path = system_db(ticks=200, cadence_s=2.0)
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "UPDATE system_samples SET sample_ts_s = NULL "
+            "WHERE seq = (SELECT MAX(seq) FROM system_samples)"
+        )
     out = SystemDashboardComputer(path).compute(window_n=100)
 
     assert out.series.cpu_run_mode == "retained"


### PR DESCRIPTION
Closes #418.

`sample_ts_s` is nullable, so a sample can arrive with its telemetry intact and its clock reading
missing. Every whole-run read treated such a row as a usable sample. One named rule now says it is
not.

## The issue described the smaller half

The report was an uncaught `TypeError` from `float(r[0])` sitting outside the reader's `try`. That
reproduces, but it took **30** unclocked rows. SQLite sorts NULLs first and the read already drops
the leading `preceding_rows` as an incomplete rolling window, so the crash only appears once the
NULL count exceeds that prefix, and the prefix itself moves with the cadence. That is why nothing
ever hit it.

The expensive half needs **one** row and never crashes.
`dashboard_compute.py` built its window clock with `float(r["sample_ts_s"] or 0.0)`, so a missing
clock became 0.0, which is 1 January 1970. The recent window then measured itself from 1970 to now,
`mode_for` was asked whether a 22 minute run outgrows a 54 year window, and the whole-run chart
silently disappeared. No exception, no log line, and a chart label that calmly reads `last 3 min`
for a run that lasted 22.

![before and after](https://traceopt-share-543486084785.s3.eu-central-1.amazonaws.com/pr-shots/pr418-null-ts/before_after.png)

Silent and wrong is worse than loud and wrong, and one row is far more likely than thirty.

## The fix

One predicate, named once, applied to every read that treats a row as a sample:

```python
_HAS_CLOCK_SQL = "sample_ts_s IS NOT NULL"
```

`cpu_run_stats` · `fetch_cpu_run` · `gpu_power_run_stats` · `fetch_gpu_power_run` ·
`fetch_recent_system_samples`.

Not moving the crashing comprehension inside the `try`, which the issue offered as an alternative.
That stops the exception and leaves the wrong chart, because the wrong chart is not caused by the
exception. It also matters that the stats query is covered: `COUNT(*)` over unclocked rows inflates
`sample_count`, and the cadence derived from it is then wrong for every sample in the plan.

## Reproduced end to end, before and after

Same 200-sample run at a 2 s cadence, varying how many rows lost their clock:

| unclocked rows | before | after |
|---|---|---|
| 0 | 93 points, retained | 93 points, retained |
| 1 | **chart gone**, mode recent | 92 points, retained |
| 30 | **TypeError** out of the reader | 78 points, retained |
| 150 | chart gone | 0 points, mode recent, correctly |

The last row is the case where there genuinely is not enough clocked data: 50 usable samples
spanning 98 s do not outgrow the window, so `recent` is the right answer and the payload says so
rather than claiming a view it cannot draw.

## Scope

```
STRUCTURE: "a row without a clock is not a sample" -> renderers/system/repository.py (owner of the
reads); one module-level predicate beside the existing _GPU_REPORTED_SQL, which is the same shape
of rule; boundaries crossed: none
DATA PATH: system_section <- SYSTEM_LAYOUT <- SystemRenderer <- SystemDashboardComputer
           <- SystemRepository <- system_samples + system_gpu_samples
SCOPE: declared renderers/system/repository.py plus its tests -> diff touches exactly those two
plus the System test fixture -> within
TWINS: searched the CONCEPT, not the reported crash - every read of sample_ts_s in the System
block, whether it crashes or coerces. Five sites, three shapes: float(r[0]) on a NULL (crashes),
float(ts or 0.0) (silently becomes 1970), and COUNT(*) (inflates the cadence). A grep for the
TypeError would have found only the first
```

## Verification

```
GATE: pytest tests/ -> 1578 passed, 2 skipped against the base's 1575 passed, 2 skipped; the delta is the three tests added here; black, isort and ruff clean at 79 on every file in the diff
TRANSITIONS: the recent-to-retained switch is what the silent half of this bug broke, and it is now reached correctly; asserted end to end by test_one_unclocked_row_does_not_erase_the_whole_run_chart, which fails on the base
RANKS: not applicable; System is single-node and node scoping is untouched. The unclocked row is excluded per host, so a two-node window is unaffected
TRIPWIRE: no read in renderers/system may treat a row without sample_ts_s as a sample; all five carry the predicate, and the stats counts are asserted at 170 of 200 rather than only the row values
SCENARIOS: all 22 fixture cells rendered on the merged base at e12c2b0 and on this branch, diffed field by field; 0 of 66 differ, so no regression on healthy runs. That is NOT evidence the fix works: no fixture carries an unclocked row, so the matrix cannot exercise this bug at all. The three unit tests and the reproduction table above are the evidence. Worth a fixture cell later
PLATFORM: macOS 26.1, Python 3.12.13, SQLite 3.51.2
```

## Adjacent, not fixed here

The silent half of this bug is an instance of the pattern in #426: a failure that renders as
"nothing to show" rather than as a failure. #426 is what gives the card a way to say so, and it
should land after this.
