### PR TITLE
distributed log done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ which carry the full historical notes for versions predating this file.
 
 ## [Unreleased]
 
+- Opt-in `--capture-stderr` output now uses
+  `nodes/node_<node-rank>/crash_stderr.log`, preventing multi-node launchers
+  from overwriting a shared root file.
 - **Breaking:** `--summary-window-rows` and
   `TRACEML_SUMMARY_WINDOW_ROWS` were removed. Use
   `--history-retention`, `history_retention`, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ which carry the full historical notes for versions predating this file.
 
 ## [Unreleased]
 
-- Opt-in `--capture-stderr` output now uses
-  `nodes/node_<node-rank>/crash_stderr.log`, preventing multi-node launchers
-  from overwriting a shared root file.
+- **Breaking:** Opt-in `--capture-stderr` output moved for both single-node and
+  multi-node runs from `logs/<run-name>/crash_stderr.log` to
+  `logs/<run-name>/nodes/node_<node-rank>/crash_stderr.log`, preventing
+  multi-node launchers from overwriting a shared root file.
 - **Breaking:** `--summary-window-rows` and
   `TRACEML_SUMMARY_WINDOW_ROWS` were removed. Use
   `--history-retention`, `history_retention`, or

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -359,8 +359,9 @@ traceml run train.py --mode=summary --capture-stderr
 
 You can also set `TRACEML_CAPTURE_STDERR=1`. TraceML continues to print the
 child process's stderr to the terminal and stores only its last 64 KiB in
-`logs/<run-name>/crash_stderr.log` when the child exits. The file remains local
-and stderr capture is disabled by default.
+`logs/<run-name>/nodes/node_<node-rank>/crash_stderr.log` when the child exits.
+The node-scoped path prevents launchers from overwriting one another on shared
+filesystems. The file remains local and stderr capture is disabled by default.
 
 ---
 

--- a/src/traceml_ai/launcher/cli.py
+++ b/src/traceml_ai/launcher/cli.py
@@ -231,7 +231,8 @@ def _add_launch_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help=(
             "Tee child stderr to the console and retain its last 64 KiB in "
-            "logs/<run-name>/crash_stderr.log. Default: disabled."
+            "logs/<run-name>/nodes/node_<node-rank>/crash_stderr.log. "
+            "Default: disabled."
         ),
     )
 

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -28,6 +28,7 @@ from traceml_ai.launcher.launch_config import (
 from traceml_ai.launcher.manifest import (
     collect_existing_artifacts,
     is_current_summary_artifact,
+    node_artifact_dir,
     read_current_finalization_reason,
     update_run_manifest,
     utc_now_iso,
@@ -155,12 +156,12 @@ def _stderr_capture_enabled(
 
 
 def _finish_stderr_capture(
-    capture: Optional[StderrTailCapture], session_root: Path
+    capture: Optional[StderrTailCapture], output_path: Path
 ) -> None:
     """Persist an optional stderr tail without affecting the training result."""
     if capture is None:
         return
-    capture.finish(session_root / "crash_stderr.log")
+    capture.finish(output_path)
 
 
 def _run_noncritical_launcher_step(
@@ -527,6 +528,8 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
     _require_dashboard_dependencies(str(cfg["mode"]))
 
     owns_aggregator = aggregator_cfg.is_owner(node_rank=torchrun_cfg.node_rank)
+    # Root run metadata has one writer even when every node has a launcher.
+    is_root_writer = torchrun_cfg.node_rank == 0
 
     env = os.environ.copy()
     env["PYTHONUNBUFFERED"] = "1"
@@ -582,42 +585,45 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
     session_root = Path(cfg["logs_dir"]).resolve() / session_id
     aggregator_dir = session_root / "aggregator"
     db_path = aggregator_dir / "telemetry"
+    node_dir = node_artifact_dir(session_root, torchrun_cfg.node_rank)
+    crash_stderr_path = node_dir / "crash_stderr.log"
 
-    code_manifest_path = write_code_manifest(
-        session_root=session_root,
-        script_path=script_path,
-    )
-
-    manifest_path = write_run_manifest(
-        session_root=session_root,
-        session_id=session_id,
-        run=run_identity.to_manifest(),
-        script_path=script_path,
-        profile=env["TRACEML_PROFILE"],
-        ui_mode=cfg["mode"],
-        logs_dir=cfg["logs_dir"],
-        aggregator_host=aggregator_cfg.connect_host,
-        aggregator_bind_host=aggregator_cfg.bind_host,
-        aggregator_port=aggregator_cfg.port,
-        nnodes=torchrun_cfg.nnodes,
-        node_rank=torchrun_cfg.node_rank,
-        master_addr=torchrun_cfg.master_addr,
-        master_port=torchrun_cfg.master_port,
-        nproc_per_node=torchrun_cfg.nproc_per_node,
-        history_enabled=cfg["history_enabled"],
-        history_retention_s=float(cfg["history_retention"]),
-        finalize_timeout_sec=float(env["TRACEML_FINALIZE_TIMEOUT_SEC"]),
-        status="starting",
-        telemetry_status="starting" if owns_aggregator else None,
-        launch_cwd=execution_cwd,
-        aggregator_dir=aggregator_dir,
-        db_path=db_path,
-        extra=(
-            {"artifacts": {"code_manifest": str(code_manifest_path)}}
-            if code_manifest_path is not None
-            else None
-        ),
-    )
+    manifest_path: Optional[Path] = None
+    if is_root_writer:
+        code_manifest_path = write_code_manifest(
+            session_root=session_root,
+            script_path=script_path,
+        )
+        manifest_path = write_run_manifest(
+            session_root=session_root,
+            session_id=session_id,
+            run=run_identity.to_manifest(),
+            script_path=script_path,
+            profile=env["TRACEML_PROFILE"],
+            ui_mode=cfg["mode"],
+            logs_dir=cfg["logs_dir"],
+            aggregator_host=aggregator_cfg.connect_host,
+            aggregator_bind_host=aggregator_cfg.bind_host,
+            aggregator_port=aggregator_cfg.port,
+            nnodes=torchrun_cfg.nnodes,
+            node_rank=torchrun_cfg.node_rank,
+            master_addr=torchrun_cfg.master_addr,
+            master_port=torchrun_cfg.master_port,
+            nproc_per_node=torchrun_cfg.nproc_per_node,
+            history_enabled=cfg["history_enabled"],
+            history_retention_s=float(cfg["history_retention"]),
+            finalize_timeout_sec=float(env["TRACEML_FINALIZE_TIMEOUT_SEC"]),
+            status="starting",
+            telemetry_status="starting" if owns_aggregator else None,
+            launch_cwd=execution_cwd,
+            aggregator_dir=aggregator_dir,
+            db_path=db_path,
+            extra=(
+                {"artifacts": {"code_manifest": str(code_manifest_path)}}
+                if code_manifest_path is not None
+                else None
+            ),
+        )
 
     traceml_root = Path(__file__).resolve().parents[1]
     runner_path = str(traceml_root / "runtime" / "executor.py")
@@ -692,18 +698,19 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
             agg_proc = None
 
         if missing_aggregator_policy == "raise":
-            _run_noncritical_launcher_step(
-                "failed to record unavailable telemetry status",
-                lambda: update_run_manifest(
-                    manifest_path,
-                    status="failed",
-                    telemetry_status=(
-                        "unavailable" if owns_aggregator else None
+            if manifest_path is not None:
+                _run_noncritical_launcher_step(
+                    "failed to record unavailable telemetry status",
+                    lambda: update_run_manifest(
+                        manifest_path,
+                        status="failed",
+                        telemetry_status=(
+                            "unavailable" if owns_aggregator else None
+                        ),
+                        telemetry_reason=telemetry_startup_reason,
+                        aggregator_exit_code=aggregator_exit_code,
                     ),
-                    telemetry_reason=telemetry_startup_reason,
-                    aggregator_exit_code=aggregator_exit_code,
-                ),
-            )
+                )
             exit_detail = (
                 f" (exit={aggregator_exit_code})"
                 if aggregator_exit_code is not None
@@ -730,20 +737,21 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
         telemetry_available = True
         print("[TraceML] Aggregator ready.")
 
-    _run_noncritical_launcher_step(
-        "failed to record the running telemetry status",
-        lambda: update_run_manifest(
-            manifest_path,
-            status="running",
-            telemetry_status=(
-                ("running" if telemetry_available else "unavailable")
-                if owns_aggregator
-                else None
+    if manifest_path is not None:
+        _run_noncritical_launcher_step(
+            "failed to record the running telemetry status",
+            lambda: update_run_manifest(
+                manifest_path,
+                status="running",
+                telemetry_status=(
+                    ("running" if telemetry_available else "unavailable")
+                    if owns_aggregator
+                    else None
+                ),
+                telemetry_reason=telemetry_startup_reason,
+                aggregator_exit_code=aggregator_exit_code,
             ),
-            telemetry_reason=telemetry_startup_reason,
-            aggregator_exit_code=aggregator_exit_code,
-        ),
-    )
+        )
 
     train_proc = start_training_process(
         train_cmd=train_cmd,
@@ -751,7 +759,7 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
         cwd=execution_cwd,
         capture_stderr=capture_stderr,
     )
-    if owns_aggregator:
+    if manifest_path is not None:
         _run_noncritical_launcher_step(
             "failed to record the training start time",
             lambda: update_run_manifest(
@@ -769,7 +777,7 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
         train_rc = train_proc.poll()
         if train_rc is not None:
             outcome = TrainingOutcome(train_rc)
-            if owns_aggregator:
+            if manifest_path is not None:
                 _run_noncritical_launcher_step(
                     "failed to record the training end time",
                     lambda: update_run_manifest(
@@ -781,7 +789,9 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
                 )
             _run_noncritical_launcher_step(
                 "failed to finish stderr capture",
-                lambda: _finish_stderr_capture(stderr_capture, session_root),
+                lambda: _finish_stderr_capture(
+                    stderr_capture, crash_stderr_path
+                ),
             )
             if agg_proc is not None:
                 print(
@@ -829,19 +839,22 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
                         ),
                     )
                 )
-            _run_noncritical_launcher_step(
-                "failed to finalize the run manifest",
-                lambda: update_run_manifest(
-                    manifest_path,
-                    status=final_status,
-                    artifacts=collect_existing_artifacts(
-                        db_path, session_root=session_root
+            if manifest_path is not None:
+                _run_noncritical_launcher_step(
+                    "failed to finalize the run manifest",
+                    lambda: update_run_manifest(
+                        manifest_path,
+                        status=final_status,
+                        artifacts=collect_existing_artifacts(
+                            db_path,
+                            session_root=session_root,
+                            crash_stderr_path=crash_stderr_path,
+                        ),
+                        telemetry_status=telemetry_status,
+                        telemetry_reason=telemetry_reason,
+                        aggregator_exit_code=aggregator_exit_code,
                     ),
-                    telemetry_status=telemetry_status,
-                    telemetry_reason=telemetry_reason,
-                    aggregator_exit_code=aggregator_exit_code,
-                ),
-            )
+                )
             if owns_aggregator and telemetry_status is not None:
                 _print_telemetry_footer(
                     telemetry_status,
@@ -862,15 +875,16 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
                 "Training will continue without TraceML telemetry.",
                 file=sys.stderr,
             )
-            _run_noncritical_launcher_step(
-                "failed to record degraded telemetry status",
-                lambda: update_run_manifest(
-                    manifest_path,
-                    telemetry_status="degraded",
-                    telemetry_reason="aggregator_exited_early",
-                    aggregator_exit_code=agg_rc,
-                ),
-            )
+            if manifest_path is not None:
+                _run_noncritical_launcher_step(
+                    "failed to record degraded telemetry status",
+                    lambda: update_run_manifest(
+                        manifest_path,
+                        telemetry_status="degraded",
+                        telemetry_reason="aggregator_exited_early",
+                        aggregator_exit_code=agg_rc,
+                    ),
+                )
             agg_proc = None
 
         time.sleep(1.0)

--- a/src/traceml_ai/launcher/manifest.py
+++ b/src/traceml_ai/launcher/manifest.py
@@ -27,6 +27,11 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def node_artifact_dir(session_root: Path, node_rank: int) -> Path:
+    """Return the collision-free artifact directory owned by one node."""
+    return Path(session_root).resolve() / "nodes" / f"node_{int(node_rank)}"
+
+
 def load_json_or_warn(path: Path) -> Dict[str, Any]:
     """Load JSON from disk, returning an empty dict for missing/bad files."""
     path = Path(path).resolve()
@@ -344,6 +349,7 @@ def update_run_manifest(
 def collect_existing_artifacts(
     db_path: Path,
     session_root: Optional[Path] = None,
+    crash_stderr_path: Optional[Path] = None,
 ) -> Dict[str, str]:
     """Return only launcher artifacts that currently exist on disk."""
     candidates = {
@@ -357,9 +363,8 @@ def collect_existing_artifacts(
         candidates["code_manifest"] = (
             Path(session_root).resolve() / "code_manifest.json"
         )
-        candidates["crash_stderr_log"] = (
-            Path(session_root).resolve() / "crash_stderr.log"
-        )
+    if crash_stderr_path is not None:
+        candidates["crash_stderr_log"] = Path(crash_stderr_path).resolve()
 
     return {
         name: str(path) for name, path in candidates.items() if path.exists()

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -916,9 +916,7 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
         assert install_shutdown_handlers.call_args.kwargs["manifest_path"] == (
             tmp_path / "manifest.json"
         )
-        initial_telemetry = write_manifest.call_args.kwargs[
-            "telemetry_status"
-        ]
+        initial_telemetry = write_manifest.call_args.kwargs["telemetry_status"]
         reported_statuses = [
             call.kwargs.get("telemetry_status")
             for call in update_manifest.call_args_list
@@ -1359,7 +1357,7 @@ def test_collect_existing_artifacts_only_returns_existing_files(
     }
 
 
-def test_node_artifact_directories_are_rank_scoped(tmp_path) -> None:
+def test_node_artifact_directories_are_node_scoped(tmp_path) -> None:
     node_0 = node_artifact_dir(tmp_path, 0)
     node_1 = node_artifact_dir(tmp_path, 1)
 

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -35,6 +35,7 @@ from traceml_ai.launcher.manifest import (
     collect_existing_artifacts,
     is_current_summary_artifact,
     load_json_or_warn,
+    node_artifact_dir,
     read_current_finalization_reason,
     update_run_manifest,
     write_run_manifest,
@@ -85,6 +86,18 @@ def test_run_and_watch_accept_missing_aggregator_policy() -> None:
 
     assert run_args.on_missing_aggregator == "warn"
     assert watch_args.on_missing_aggregator is None
+
+
+def test_capture_stderr_help_uses_node_scoped_path(capsys) -> None:
+    parser = build_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["run", "--help"])
+
+    help_text = "".join(capsys.readouterr().out.split())
+    assert exc_info.value.code == 0
+    assert "nodes/node_<node-rank>/crash_stderr.log" in help_text
+    assert "logs/<run-name>/crash_stderr.log" not in help_text
 
 
 @pytest.mark.parametrize("default", ["raise", "warn"])
@@ -791,14 +804,16 @@ def test_strict_aggregator_failure_does_not_start_training(
     else:
         assert "(exit=" not in stderr
     start_training.assert_not_called()
-    assert update_manifest.call_args.kwargs["status"] == "failed"
-    assert update_manifest.call_args.kwargs["telemetry_status"] == (
-        "unavailable" if owner else None
-    )
     if owner:
+        assert update_manifest.call_args.kwargs["status"] == "failed"
+        assert (
+            update_manifest.call_args.kwargs["telemetry_status"]
+            == "unavailable"
+        )
         assert update_manifest.call_args.kwargs["telemetry_reason"] == reason
     else:
         start_aggregator.assert_not_called()
+        update_manifest.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -821,6 +836,7 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
         "warn-run",
         "--on-missing-aggregator",
         "warn",
+        "--capture-stderr",
     ]
     if not owner:
         cli.extend(["--nnodes", "2", "--node-rank", "1"])
@@ -831,6 +847,7 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
     aggregator.poll.return_value = 7
     training = Mock()
     training.poll.return_value = 0
+    stderr_capture = Mock()
 
     def _stop_aggregator(*_args, **_kwargs):
         events.append("stop")
@@ -841,7 +858,12 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
         return training
 
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(launcher_commands, "install_shutdown_handlers", Mock())
+    install_shutdown_handlers = Mock()
+    monkeypatch.setattr(
+        launcher_commands,
+        "install_shutdown_handlers",
+        install_shutdown_handlers,
+    )
     start_aggregator = Mock(return_value=aggregator)
     monkeypatch.setattr(
         launcher_commands, "start_aggregator_process", start_aggregator
@@ -853,10 +875,16 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
         launcher_commands, "start_training_process", _start_training
     )
     monkeypatch.setattr(
-        launcher_commands, "terminate_process_group", _stop_aggregator
+        launcher_commands,
+        "start_stderr_tail_capture",
+        Mock(return_value=stderr_capture),
     )
     monkeypatch.setattr(
-        launcher_commands, "write_code_manifest", Mock(return_value=None)
+        launcher_commands, "terminate_process_group", _stop_aggregator
+    )
+    write_code_manifest = Mock(return_value=None)
+    monkeypatch.setattr(
+        launcher_commands, "write_code_manifest", write_code_manifest
     )
     write_manifest = Mock(return_value=tmp_path / "manifest.json")
     update_manifest = Mock()
@@ -871,24 +899,41 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
         launch_process(str(script), args)
 
     assert exc.value.code == 0
+    node_rank = 0 if owner else 1
+    stderr_capture.finish.assert_called_once_with(
+        tmp_path.resolve()
+        / "logs"
+        / "warn-run"
+        / "nodes"
+        / f"node_{node_rank}"
+        / "crash_stderr.log"
+    )
     if owner:
         assert events == ["stop", "train"]
         start_aggregator.assert_called_once()
-    else:
-        assert events == ["train"]
-        start_aggregator.assert_not_called()
-
-    initial_telemetry = write_manifest.call_args.kwargs["telemetry_status"]
-    reported_statuses = [
-        call.kwargs.get("telemetry_status")
-        for call in update_manifest.call_args_list
-    ]
-    if owner:
+        write_code_manifest.assert_called_once()
+        write_manifest.assert_called_once()
+        assert install_shutdown_handlers.call_args.kwargs["manifest_path"] == (
+            tmp_path / "manifest.json"
+        )
+        initial_telemetry = write_manifest.call_args.kwargs[
+            "telemetry_status"
+        ]
+        reported_statuses = [
+            call.kwargs.get("telemetry_status")
+            for call in update_manifest.call_args_list
+        ]
         assert initial_telemetry == "starting"
         assert "unavailable" in reported_statuses
     else:
-        assert initial_telemetry is None
-        assert set(reported_statuses) == {None}
+        assert events == ["train"]
+        start_aggregator.assert_not_called()
+        write_code_manifest.assert_not_called()
+        write_manifest.assert_not_called()
+        update_manifest.assert_not_called()
+        assert (
+            install_shutdown_handlers.call_args.kwargs["manifest_path"] is None
+        )
 
 
 @pytest.mark.parametrize(
@@ -1314,14 +1359,35 @@ def test_collect_existing_artifacts_only_returns_existing_files(
     }
 
 
+def test_node_artifact_directories_are_rank_scoped(tmp_path) -> None:
+    node_0 = node_artifact_dir(tmp_path, 0)
+    node_1 = node_artifact_dir(tmp_path, 1)
+
+    assert node_0 == tmp_path.resolve() / "nodes" / "node_0"
+    assert node_1 == tmp_path.resolve() / "nodes" / "node_1"
+    assert node_0 != node_1
+
+    node_0.mkdir(parents=True)
+    node_1.mkdir(parents=True)
+    node_0_stderr = node_0 / "crash_stderr.log"
+    node_1_stderr = node_1 / "crash_stderr.log"
+    node_0_stderr.write_text("node 0", encoding="utf-8")
+    node_1_stderr.write_text("node 1", encoding="utf-8")
+
+    assert node_0_stderr.read_text(encoding="utf-8") == "node 0"
+    assert node_1_stderr.read_text(encoding="utf-8") == "node 1"
+
+
 def test_collect_existing_artifacts_includes_stderr_tail(tmp_path) -> None:
     db_path = tmp_path / "aggregator" / "telemetry"
-    stderr_path = tmp_path / "crash_stderr.log"
+    stderr_path = node_artifact_dir(tmp_path, 0) / "crash_stderr.log"
+    stderr_path.parent.mkdir(parents=True)
     stderr_path.write_bytes(b"native crash details\n")
 
     artifacts = collect_existing_artifacts(
         db_path,
         session_root=tmp_path,
+        crash_stderr_path=stderr_path,
     )
 
     assert artifacts["crash_stderr_log"] == str(stderr_path)


### PR DESCRIPTION
## Summar

This PR ensures that multiple TraceML node launchers using the same shared run directory do not overwrite the same root manifests or legacy stderr artifact.

## Problem

In a multi-node run, every launcher could previously write:

- `manifest.json`
- `code_manifest.json`
- `crash_stderr.log`
- root manifest lifecycle and telemetry updates

Because the documented multi-node topology uses a shared filesystem, these writers could overwrite one another.

## Changes

- Made node rank `0` the sole writer of:
  - `manifest.json`
  - `code_manifest.json`
  - root manifest lifecycle updates
  - root manifest telemetry updates
- Non-owner nodes now operate without creating or updating a root manifest.
- Added a small helper for deterministic node-owned artifact directories:

```text
<run>/nodes/node_<node-rank>/
```

- Moved the existing optional stderr-tail artifact from:

```text
<run>/crash_stderr.log
```

to:

```text
<run>/nodes/node_<node-rank>/crash_stderr.log
```

- Updated artifact discovery to accept the node-scoped stderr path.
- Updated CLI help and user documentation.
- Added focused coverage for root ownership, non-owner behavior, node-path isolation, shutdown wiring, artifact discovery, and CLI help.

## Artifact ownership

| Artifact | Writer | Location |
|---|---|---|
| `manifest.json` | Node rank 0 only | Run root |
| `code_manifest.json` | Node rank 0 only | Run root |
| `crash_stderr.log` | Each node launcher | `nodes/node_<node-rank>/` |

## Design

The implementation deliberately reuses the existing launcher and manifest modules.

It introduces:

- one explicit root-writer decision;
- one node-path helper;
- optional manifest handling for non-owner nodes.

It does not introduce:

- locks or coordination services;
- per-node manifests;
- a new artifact package or abstraction layer;
- a distributed metadata protocol;
- new configuration options;
- output parsing or traceback classification.

Atomic root-manifest writes remain unchanged.

## Scope

This PR establishes artifact ownership only.

The following are intentionally handled by later RFC PRs:

- complete stdout/stderr draining — PR 5;
- canonical node-scoped training stdout/stderr files — PR 6;
- removal of the transitional `crash_stderr.log` artifact — PR 6;
- aggregator process stderr persistence — PR 7;
- launcher/internal logger ownership and legacy error-log cleanup — PR 8.

(Current is PR4 for reference) 

This PR does not change what training output is captured. It only makes the existing optional stderr-tail path safe for multi-node execution.

## Output model after the full RFC series

The planned canonical workload files remain node-scoped:

```text
<run>/nodes/node_<node-rank>/training.stdout.log
<run>/nodes/node_<node-rank>/training.stderr.log
```

Per-rank raw-output redirection, Ray-owned worker logs, remote upload, rotation, compression, and centralized log collection are outside this PR.

## Validation

- Full test suite: `1611 passed, 2 skipped`
- Focused launcher suite: `95 passed`
- Runtime suite: `222 passed`
- `git diff --check`: clean
- No unresolved conflict markers
- Branch contains exactly one PR 4 commit on top of merged PR 3