### PR TITLE
System: an absence and a zero must not look alike

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -83,11 +83,8 @@ def format_span(seconds: Optional[float]) -> str:
 def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
     """A level against its capacity: ('6.3', '/ 16.1 GB').
 
-    A measured value never renders as "0.0". This card prints ``n/a`` for
-    a value it does not have, so a real 27 MB shown with one decimal is
-    indistinguishable from a missing one. Sub-gigabyte levels keep two
-    decimals instead, which is the rule the Process card's formatter has
-    had since it hit the same problem.
+    Sub-gigabyte levels keep two decimals so small measurements retain
+    useful precision, matching the Process card's formatting rule.
     """
     used = gb_si(used_bytes) if used_bytes is not None else None
     if used is None:

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -81,11 +81,18 @@ def format_span(seconds: Optional[float]) -> str:
 
 
 def format_gb_pair(used_bytes: Any, total_bytes: Any) -> Tuple[str, str]:
-    """A level against its capacity: ('6.3', '/ 16.1 GB')."""
+    """A level against its capacity: ('6.3', '/ 16.1 GB').
+
+    A measured value never renders as "0.0". This card prints ``n/a`` for
+    a value it does not have, so a real 27 MB shown with one decimal is
+    indistinguishable from a missing one. Sub-gigabyte levels keep two
+    decimals instead, which is the rule the Process card's formatter has
+    had since it hit the same problem.
+    """
     used = gb_si(used_bytes) if used_bytes is not None else None
     if used is None:
         return (NA, "")
-    num = f"{used:.1f}"
+    num = f"{used:.2f}" if 0 < used < 1 else f"{used:.1f}"
     total = gb_si(total_bytes) if total_bytes is not None else None
     if total is None or total <= 0:
         return (num, "GB")

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -95,6 +95,30 @@ def _typed(
     )
 
 
+def _nan_pct(values: Any, q: float) -> float:
+    """A percentile over the ticks that were measured.
+
+    An all-absent window has no percentile, and returns 0.0 so the caller
+    behaves as it did when absence was stored as zero.
+    """
+    if values.size == 0 or bool(np.all(np.isnan(values))):
+        return 0.0
+    return float(np.nanpercentile(values, q))
+
+
+def _last_measured(values: Any) -> float:
+    """The newest measured value, skipping absent ticks."""
+    for value in reversed(values.tolist()):
+        if value == value:  # not NaN
+            return float(value)
+    return 0.0
+
+
+def _gap_list(values: Any) -> List[Optional[float]]:
+    """A series where an absent tick is a gap rather than a zero."""
+    return [None if v != v else float(v) for v in values.tolist()]
+
+
 def _empty_cpu_run() -> Dict[str, Any]:
     """The whole-run CPU shape with nothing in it."""
     return {"t": [], "avg": [], "max": [], "span_s": 0.0, "window_s": 0.0}
@@ -260,11 +284,15 @@ class SystemDashboardComputer:
         gpu_rows_by_key = self._db.group_gpu_rows_by_global_rank_seq(gpu_rows)
 
         n = len(samples)
-        gpu_avg = np.zeros(n, dtype=np.float64)
-        gpu_delta = np.zeros(n, dtype=np.float64)
-        gpu_mem_worst = np.zeros(n, dtype=np.float64)
-        gpu_mem_headroom_min = np.zeros(n, dtype=np.float64)
-        temp_max = np.zeros(n, dtype=np.float64)
+        # NaN, not zero: a tick in which nothing reported is an absence,
+        # and a zero here is drawn as a real 0% and folded into the window
+        # percentiles. Same rule the per-GPU histories below follow with
+        # None, and the same rule the per-device aggregates follow.
+        gpu_avg = np.full(n, np.nan, dtype=np.float64)
+        gpu_delta = np.full(n, np.nan, dtype=np.float64)
+        gpu_mem_worst = np.full(n, np.nan, dtype=np.float64)
+        gpu_mem_headroom_min = np.full(n, np.nan, dtype=np.float64)
+        temp_max = np.full(n, np.nan, dtype=np.float64)
         gpu_mem_worst_total = 0.0
         # Util readings in the newest tick. This distinguishes a measured
         # zero from no current reading; it does not describe coverage of
@@ -360,13 +388,12 @@ class SystemDashboardComputer:
                     for used, total in mem_pairs
                     if total is not None and total > 0.0
                 ]
-                gpu_mem_headroom_min[i] = min(headrooms) if headrooms else 0.0
+                if headrooms:
+                    gpu_mem_headroom_min[i] = min(headrooms)
             else:
-                gpu_avg[i] = 0.0
-                gpu_delta[i] = 0.0
-                gpu_mem_worst[i] = 0.0
-                gpu_mem_headroom_min[i] = 0.0
-                temp_max[i] = 0.0
+                # No rows for this tick at all: leave every slot absent,
+                # which is what the pre-fill already says.
+                pass
 
         cpu_p50 = float(np.percentile(cpu_hist, 50)) if cpu_hist.size else 0.0
         cpu_p95 = float(np.percentile(cpu_hist, 95)) if cpu_hist.size else 0.0
@@ -377,21 +404,16 @@ class SystemDashboardComputer:
             else 0.0
         )
 
-        gpu_p50 = float(np.percentile(gpu_avg, 50)) if gpu_avg.size else 0.0
-        gpu_p95 = float(np.percentile(gpu_avg, 95)) if gpu_avg.size else 0.0
+        # nanpercentile, not percentile: a blind tick must not be counted
+        # as a measured zero when the window is summarised. All-NaN means
+        # nothing was measured at all, which is 0.0 as it was before.
+        gpu_p50 = _nan_pct(gpu_avg, 50)
+        gpu_p95 = _nan_pct(gpu_avg, 95)
+        delta_p95 = _nan_pct(gpu_delta, 95)
+        mem_p95 = _nan_pct(gpu_mem_worst, 95)
+        temp_p95 = _nan_pct(temp_max, 95)
 
-        delta_p95 = (
-            float(np.percentile(gpu_delta, 95)) if gpu_delta.size else 0.0
-        )
-
-        mem_p95 = (
-            float(np.percentile(gpu_mem_worst, 95))
-            if gpu_mem_worst.size
-            else 0.0
-        )
-        temp_p95 = float(np.percentile(temp_max, 95)) if temp_max.size else 0.0
-
-        temp_now = float(temp_max[-1]) if temp_max.size else 0.0
+        temp_now = _last_measured(temp_max)
         temp_status = (
             "Hot" if temp_now >= 85 else "Warm" if temp_now >= 80 else "OK"
         )
@@ -454,18 +476,18 @@ class SystemDashboardComputer:
                 "headroom": max(ram_total - float(ram_used_hist[-1]), 0.0),
             },
             "gpu_util": {
-                "now": float(gpu_avg[-1]),
+                "now": _last_measured(gpu_avg),
                 "p50": gpu_p50,
                 "p95": gpu_p95,
             },
             "gpu_delta": {
-                "now": float(gpu_delta[-1]),
+                "now": _last_measured(gpu_delta),
                 "p95": delta_p95,
             },
             "gpu_mem": {
-                "now": float(gpu_mem_worst[-1]),
+                "now": _last_measured(gpu_mem_worst),
                 "p95": mem_p95,
-                "headroom": float(gpu_mem_headroom_min[-1]),
+                "headroom": _last_measured(gpu_mem_headroom_min),
                 # Capacity of the GPU shown in "now" (the max-used one),
                 # so the tile can read "used / total".
                 "total": gpu_mem_worst_total,
@@ -522,9 +544,7 @@ class SystemDashboardComputer:
             series={
                 "x_time": x_time,
                 "cpu": cpu_hist.astype(float).tolist(),
-                "gpu_avg": (
-                    gpu_avg.astype(float).tolist() if gpu_available else []
-                ),
+                "gpu_avg": (_gap_list(gpu_avg) if gpu_available else []),
                 "gpu_power": (
                     [
                         {"gpu_idx": idx, "values": power_hist[idx]}

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -98,12 +98,25 @@ def _typed(
 def _nan_pct(values: Any, q: float) -> float:
     """A percentile over the ticks that were measured.
 
-    An all-absent window has no percentile, and returns 0.0 so the caller
-    behaves as it did when absence was stored as zero.
+    A window in which nothing was measured has no percentile. It returns
+    0.0 rather than None, which is NOT a defence of that value: it is the
+    pre-existing shape of every rollup field, and making the all-absent
+    case abstain means giving the tiles an n/a path. Tracked separately;
+    this function narrows the defect to the all-absent window rather than
+    every window containing one blind tick.
     """
     if values.size == 0 or bool(np.all(np.isnan(values))):
         return 0.0
     return float(np.nanpercentile(values, q))
+
+
+def _last_measured_index(values: Any) -> Optional[int]:
+    """Index of the newest measured tick, or None if there is none."""
+    listed = values.tolist()
+    for i in range(len(listed) - 1, -1, -1):
+        if listed[i] == listed[i]:  # not NaN
+            return i
+    return None
 
 
 def _last_measured(values: Any) -> float:
@@ -112,6 +125,15 @@ def _last_measured(values: Any) -> float:
         if value == value:  # not NaN
             return float(value)
     return 0.0
+
+
+def _paired_total(levels: Any, totals: Any) -> float:
+    """The capacity belonging to the tick the level was read from."""
+    i = _last_measured_index(levels)
+    if i is None:
+        return 0.0
+    total = totals.tolist()[i]
+    return float(total) if total == total else 0.0
 
 
 def _gap_list(values: Any) -> List[Optional[float]]:
@@ -294,9 +316,14 @@ class SystemDashboardComputer:
         gpu_avg = np.full(n, np.nan, dtype=np.float64)
         gpu_delta = np.full(n, np.nan, dtype=np.float64)
         gpu_mem_worst = np.full(n, np.nan, dtype=np.float64)
+        # The capacity of the device in gpu_mem_worst, per tick.
+        # Kept per tick so the level and the capacity it is
+        # measured against can be read from the SAME moment; a
+        # level that skips back past a blind tick while its
+        # capacity does not describes two different instants.
+        gpu_mem_total_hist = np.full(n, np.nan, dtype=np.float64)
         gpu_mem_headroom_min = np.full(n, np.nan, dtype=np.float64)
         temp_max = np.full(n, np.nan, dtype=np.float64)
-        gpu_mem_worst_total = 0.0
         # Util readings in the newest tick. This distinguishes a measured
         # zero from no current reading; it does not describe coverage of
         # the window median shown by the tile. A device can report and
@@ -356,8 +383,8 @@ class SystemDashboardComputer:
                         mem_pairs, key=lambda pair: pair[0]
                     )
                     gpu_mem_worst[i] = worst_used
-                    if i == n - 1:
-                        gpu_mem_worst_total = worst_total or 0.0
+                    if worst_total is not None:
+                        gpu_mem_total_hist[i] = worst_total
                 if temps:
                     temp_max[i] = max(temps)
                 if i == n - 1:
@@ -491,7 +518,7 @@ class SystemDashboardComputer:
                 "headroom": _last_measured(gpu_mem_headroom_min),
                 # Capacity of the GPU shown in "now" (the max-used one),
                 # so the tile can read "used / total".
-                "total": gpu_mem_worst_total,
+                "total": _paired_total(gpu_mem_worst, gpu_mem_total_hist),
             },
             "temp": {
                 "now": temp_now,

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -263,12 +263,15 @@ class SystemDashboardComputer:
             [float(r["sample_ts_s"] or 0.0) for r in samples],
             dtype=np.float64,
         )
+        # NaN for a missing reading, for the same reason the GPU arrays
+        # below use it: `cpu_percent` is nullable, and a coerced zero is
+        # both drawn as a real 0% and folded into the window percentile.
         cpu_hist = np.array(
-            [float(r["cpu_percent"] or 0.0) for r in samples],
+            [_opt_float(r["cpu_percent"]) for r in samples],
             dtype=np.float64,
         )
         ram_used_hist = np.array(
-            [float(r["ram_used_bytes"] or 0.0) for r in samples],
+            [_opt_float(r["ram_used_bytes"]) for r in samples],
             dtype=np.float64,
         )
         ram_total = float(last["ram_total_bytes"] or 0.0)
@@ -395,14 +398,10 @@ class SystemDashboardComputer:
                 # which is what the pre-fill already says.
                 pass
 
-        cpu_p50 = float(np.percentile(cpu_hist, 50)) if cpu_hist.size else 0.0
-        cpu_p95 = float(np.percentile(cpu_hist, 95)) if cpu_hist.size else 0.0
+        cpu_p50 = _nan_pct(cpu_hist, 50)
+        cpu_p95 = _nan_pct(cpu_hist, 95)
 
-        ram_p95 = (
-            float(np.percentile(ram_used_hist, 95))
-            if ram_used_hist.size
-            else 0.0
-        )
+        ram_p95 = _nan_pct(ram_used_hist, 95)
 
         # nanpercentile, not percentile: a blind tick must not be counted
         # as a measured zero when the window is summarised. All-NaN means
@@ -465,15 +464,17 @@ class SystemDashboardComputer:
 
         rollups = {
             "cpu": {
-                "now": float(cpu_hist[-1]),
+                "now": _last_measured(cpu_hist),
                 "p50": cpu_p50,
                 "p95": cpu_p95,
             },
             "ram": {
-                "now": float(ram_used_hist[-1]),
+                "now": _last_measured(ram_used_hist),
                 "p95": ram_p95,
                 "total": ram_total,
-                "headroom": max(ram_total - float(ram_used_hist[-1]), 0.0),
+                "headroom": max(
+                    ram_total - _last_measured(ram_used_hist), 0.0
+                ),
             },
             "gpu_util": {
                 "now": _last_measured(gpu_avg),
@@ -543,7 +544,7 @@ class SystemDashboardComputer:
             rollups=rollups,
             series={
                 "x_time": x_time,
-                "cpu": cpu_hist.astype(float).tolist(),
+                "cpu": _gap_list(cpu_hist),
                 "gpu_avg": (_gap_list(gpu_avg) if gpu_available else []),
                 "gpu_power": (
                     [

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -48,9 +48,7 @@ def test_levels_carry_their_denominator() -> None:
     assert format_gb_pair(6.31 * GB, 16.1 * GB) == ("6.3", "/ 16.1 GB")
     assert format_gb_pair(9.0 * GB, 200.0 * GB) == ("9.0", "/ 200 GB")
     assert format_gb_pair(None, 16.1 * GB) == ("n/a", "")
-    # Changed deliberately: this used to read ("0.5", "GB"). A level below
-    # one gigabyte keeps two decimals now, because "0.0" is what this card
-    # prints for a value it does not have.
+    # Changed deliberately: sub-gigabyte values keep useful precision.
     assert format_gb_pair(0.47 * GB, None) == ("0.47", "GB")
 
 
@@ -741,16 +739,7 @@ def test_rolling_window_is_spelled_out_not_named() -> None:
 
 
 def test_a_small_real_reading_is_not_printed_as_zero() -> None:
-    """A 27 MB level must not render the way absence renders.
-
-    The System card prints `n/a` for a value it does not have. Printing a
-    real 27 MB as `0.0` makes a measurement indistinguishable from a
-    missing one, which is the reading a user most needs to tell apart on a
-    CPU-only host or in the first seconds of a run.
-
-    The Process card's formatter has kept two decimals below a gigabyte
-    since #401 for exactly this reason; this card's copy did not.
-    """
+    """Sub-gigabyte levels retain useful precision, matching Process."""
     from traceml_ai.aggregator.display_drivers.nicegui_sections import (
         system_section,
     )
@@ -759,5 +748,5 @@ def test_a_small_real_reading_is_not_printed_as_zero() -> None:
     assert system_section.format_gb_pair(500e6, 16.1e9)[0] == "0.50"
     # At and above a gigabyte the extra digit is noise, so one decimal.
     assert system_section.format_gb_pair(6.3e9, 16.1e9)[0] == "6.3"
-    # And absence still reads as absence, not as a small number.
+    # Absence remains distinct from every measured value.
     assert system_section.format_gb_pair(None, 16.1e9)[0] == "n/a"

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -48,7 +48,10 @@ def test_levels_carry_their_denominator() -> None:
     assert format_gb_pair(6.31 * GB, 16.1 * GB) == ("6.3", "/ 16.1 GB")
     assert format_gb_pair(9.0 * GB, 200.0 * GB) == ("9.0", "/ 200 GB")
     assert format_gb_pair(None, 16.1 * GB) == ("n/a", "")
-    assert format_gb_pair(0.47 * GB, None) == ("0.5", "GB")
+    # Changed deliberately: this used to read ("0.5", "GB"). A level below
+    # one gigabyte keeps two decimals now, because "0.0" is what this card
+    # prints for a value it does not have.
+    assert format_gb_pair(0.47 * GB, None) == ("0.47", "GB")
 
 
 def test_disclosure_text_states_the_range_and_no_verdict() -> None:
@@ -735,3 +738,26 @@ def test_rolling_window_is_spelled_out_not_named() -> None:
     assert format_window(window_for(4 * 60)) == "30 s"  # the floor
     assert format_window(window_for(48 * 3600)) == "5 min"  # the cap
     assert format_window(0.0) == ""
+
+
+def test_a_small_real_reading_is_not_printed_as_zero() -> None:
+    """A 27 MB level must not render the way absence renders.
+
+    The System card prints `n/a` for a value it does not have. Printing a
+    real 27 MB as `0.0` makes a measurement indistinguishable from a
+    missing one, which is the reading a user most needs to tell apart on a
+    CPU-only host or in the first seconds of a run.
+
+    The Process card's formatter has kept two decimals below a gigabyte
+    since #401 for exactly this reason; this card's copy did not.
+    """
+    from traceml_ai.aggregator.display_drivers.nicegui_sections import (
+        system_section,
+    )
+
+    assert system_section.format_gb_pair(27e6, 16.1e9)[0] == "0.03"
+    assert system_section.format_gb_pair(500e6, 16.1e9)[0] == "0.50"
+    # At and above a gigabyte the extra digit is noise, so one decimal.
+    assert system_section.format_gb_pair(6.3e9, 16.1e9)[0] == "6.3"
+    # And absence still reads as absence, not as a small number.
+    assert system_section.format_gb_pair(None, 16.1e9)[0] == "n/a"

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -853,3 +853,49 @@ def test_a_blind_tick_does_not_drag_the_window_statistics(tmp_path: Path):
     assert roll.gpu_util.p50 == 100.0
     assert roll.gpu_delta.p95 == 0.0
     assert roll.temp.p95 == 45.0
+
+
+def test_a_missing_cpu_reading_does_not_halve_the_cpu_tile(tmp_path: Path):
+    """The same rule on the host CPU history, in the same function.
+
+    `cpu_percent` is nullable, and the window was built with
+    `float(x or 0.0)`, so a missing reading entered the percentile as a
+    measured 0%. A host sitting at a steady 80% with half its rows
+    lacking the reading showed 40% on the tile: the exact arithmetic of
+    counting absences as zeros.
+    """
+    import sqlite3
+
+    from tests.sqlite_fixtures import init_summary_schema, insert_system_sample
+    from traceml_ai.renderers.system.dashboard_compute import (
+        SystemDashboardComputer,
+    )
+
+    db = tmp_path / "null-cpu.db"
+    conn = sqlite3.connect(db)
+    init_summary_schema(conn)
+    for seq in range(20):
+        insert_system_sample(
+            conn,
+            row_id=seq + 1,
+            rank=0,
+            ts=1000.0 + 2.0 * seq,
+            gpu_available=False,
+            gpu_count=0,
+            seq=seq,
+            cpu_percent=80.0,
+            ram_used_bytes=8.0 * GB,
+            ram_total_bytes=16.0 * GB,
+        )
+    conn.commit()
+    conn.execute(
+        "UPDATE system_samples SET cpu_percent = NULL WHERE seq % 2 = 0"
+    )
+    conn.commit()
+    conn.close()
+
+    out = SystemDashboardComputer(str(db)).compute(window_n=100)
+    assert out.rollups.cpu.p50 == 80.0
+    assert out.rollups.cpu.p95 == 80.0
+    # And the chart shows the gaps rather than drawing them at zero.
+    assert list(out.series.cpu).count(None) == 10

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -778,3 +778,78 @@ def test_a_gpu_that_goes_quiet_midway_only_leaves_its_own_ticks(tmp_path):
     assert roll.gpu_delta.p95 == 0.0
     # The newest tick is one of the ones it missed.
     assert roll.util_gpu_count == 3
+
+
+# --- a tick where nothing reported is a gap, not a zero (#430) -----------
+def test_a_tick_where_no_gpu_reported_is_a_gap_in_the_chart(tmp_path: Path):
+    """A transient host-wide NVML failure is an absence, not 0% util.
+
+    #432 stopped a single unreported DEVICE being averaged in as a real
+    zero. This is the same idea one level up: a tick in which NO device
+    reported left its slot at the pre-filled 0.0, so the chart drew a
+    utilisation point, a memory point and a temperature point for a
+    moment nothing was measured.
+
+    The correct convention already exists four lines away in the same
+    loop, where the per-GPU power history stores None for a gap.
+    """
+    db = tmp_path / "blind-tick.db"
+    zero = {
+        "gpu_idx": 0,
+        "util": 0.0,
+        "mem_used_bytes": 0.0,
+        "mem_total_bytes": 0.0,
+        "temperature_c": 0.0,
+        "power_usage_w": 0.0,
+        "power_limit_w": 0.0,
+    }
+
+    def rows(seq: int):
+        if seq == TICKS // 2:
+            return [dict(zero, gpu_idx=i) for i in range(4)]
+        return [
+            _gpu(i, 100.0, 66.0, temp=45.0, mem_used=6.3 * GB)
+            for i in range(4)
+        ]
+
+    _write(db, rows)
+    out = _payload(db)
+
+    series = list(out.series.gpu_avg)
+    assert series[TICKS // 2] is None
+    assert all(v == 100.0 for i, v in enumerate(series) if i != TICKS // 2)
+
+
+def test_a_blind_tick_does_not_drag_the_window_statistics(tmp_path: Path):
+    """The tile summarises what was measured, not what was not.
+
+    A zero in the array is not only drawn, it is also fed to the window
+    percentiles, so repeated blind ticks pull the headline number down on
+    a host that never left 100%.
+    """
+    db = tmp_path / "blind-many.db"
+    zero = {
+        "gpu_idx": 0,
+        "util": 0.0,
+        "mem_used_bytes": 0.0,
+        "mem_total_bytes": 0.0,
+        "temperature_c": 0.0,
+        "power_usage_w": 0.0,
+        "power_limit_w": 0.0,
+    }
+
+    def rows(seq: int):
+        # Half the window blind, so the median moves if the blind ticks
+        # are counted: ten zeros and ten hundreds median to 50.
+        if seq % 2 == 0:
+            return [dict(zero, gpu_idx=i) for i in range(4)]
+        return [
+            _gpu(i, 100.0, 66.0, temp=45.0, mem_used=6.3 * GB)
+            for i in range(4)
+        ]
+
+    _write(db, rows)
+    roll = _payload(db).rollups
+    assert roll.gpu_util.p50 == 100.0
+    assert roll.gpu_delta.p95 == 0.0
+    assert roll.temp.p95 == 45.0

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -899,3 +899,60 @@ def test_a_missing_cpu_reading_does_not_halve_the_cpu_tile(tmp_path: Path):
     assert out.rollups.cpu.p95 == 80.0
     # And the chart shows the gaps rather than drawing them at zero.
     assert list(out.series.cpu).count(None) == 10
+
+
+def test_memory_and_its_capacity_come_from_the_same_tick(tmp_path: Path):
+    """A level and the capacity it is measured against must be one moment.
+
+    Skipping backwards past a blind tick for the value while leaving the
+    capacity at the newest tick pairs two different moments, and when the
+    newest tick is blind the capacity is zero, so the tile silently drops
+    its denominator and renders a bare number.
+    """
+    db = tmp_path / "paired.db"
+    zero = {
+        "gpu_idx": 0,
+        "util": 0.0,
+        "mem_used_bytes": 0.0,
+        "mem_total_bytes": 0.0,
+        "temperature_c": 0.0,
+        "power_usage_w": 0.0,
+        "power_limit_w": 0.0,
+    }
+
+    def rows(seq: int):
+        if seq == TICKS - 1:  # the NEWEST tick is blind
+            return [dict(zero, gpu_idx=i) for i in range(4)]
+        return [
+            _gpu(i, 100.0, 66.0, temp=45.0, mem_used=6.3 * GB)
+            for i in range(4)
+        ]
+
+    _write(db, rows)
+    mem = _payload(db).rollups.gpu_mem
+    assert mem is not None
+    assert mem.now == 6.3 * GB
+    assert mem.total == 16.1 * GB
+
+
+def test_a_tick_with_no_gpu_rows_at_all_is_also_a_gap(tmp_path: Path):
+    """The branch the all-zero fixtures do not reach.
+
+    A row that is present and unreadable takes the reported-ness filter;
+    a tick with NO rows takes a different branch entirely. Both must leave
+    the slot absent, and only the first was covered.
+    """
+    db = tmp_path / "norows.db"
+
+    def rows(seq: int):
+        if seq == TICKS // 2:
+            return ()
+        return [
+            _gpu(i, 100.0, 66.0, temp=45.0, mem_used=6.3 * GB)
+            for i in range(4)
+        ]
+
+    _write(db, rows)
+    out = _payload(db)
+    assert list(out.series.gpu_avg)[TICKS // 2] is None
+    assert out.rollups.gpu_util.p50 == 100.0

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -855,14 +855,14 @@ def test_a_blind_tick_does_not_drag_the_window_statistics(tmp_path: Path):
     assert roll.temp.p95 == 45.0
 
 
-def test_a_missing_cpu_reading_does_not_halve_the_cpu_tile(tmp_path: Path):
-    """The same rule on the host CPU history, in the same function.
+def test_missing_host_readings_are_not_counted_as_zero(tmp_path: Path):
+    """Missing CPU and RAM readings stay absent from host rollups.
 
     `cpu_percent` is nullable, and the window was built with
     `float(x or 0.0)`, so a missing reading entered the percentile as a
     measured 0%. A host sitting at a steady 80% with half its rows
     lacking the reading showed 40% on the tile: the exact arithmetic of
-    counting absences as zeros.
+    counting absences as zeros. RAM follows the same rule.
     """
     import sqlite3
 
@@ -891,6 +891,11 @@ def test_a_missing_cpu_reading_does_not_halve_the_cpu_tile(tmp_path: Path):
     conn.execute(
         "UPDATE system_samples SET cpu_percent = NULL WHERE seq % 2 = 0"
     )
+    # Leave the newest RAM reading absent to cover both the percentile and
+    # the newest-measured value used to derive headroom.
+    conn.execute(
+        "UPDATE system_samples SET ram_used_bytes = NULL WHERE seq % 2 = 1"
+    )
     conn.commit()
     conn.close()
 
@@ -899,6 +904,10 @@ def test_a_missing_cpu_reading_does_not_halve_the_cpu_tile(tmp_path: Path):
     assert out.rollups.cpu.p95 == 80.0
     # And the chart shows the gaps rather than drawing them at zero.
     assert list(out.series.cpu).count(None) == 10
+    assert out.rollups.ram is not None
+    assert out.rollups.ram.now == 8.0 * GB
+    assert out.rollups.ram.p95 == 8.0 * GB
+    assert out.rollups.ram.headroom == 8.0 * GB
 
 
 def test_memory_and_its_capacity_come_from_the_same_tick(tmp_path: Path):


### PR DESCRIPTION
Closes #435. Closes #430. Stacked on #436.

One argument, applied wherever the System block breaks it: **a real absence and a real zero must
not look alike.** The card already has a marker for "no value", so any path that renders a
non-measurement as a number takes that distinction away from the reader.

Four places broke it, three of which were found by sweeping for the first.

## 1. A real 27 MB printed as `0.0`

`format_gb_pair` in `system_section.py` kept one decimal at every scale, so a level below a
gigabyte lost its digits. `0.0` is what this card prints when it has nothing, so a measurement and
a missing value rendered identically. Sub-gigabyte levels now keep two decimals, which is the rule
`formatting.format_gb_pair` has had since the Process card hit the same problem.

Visible on the fixtures, which is the useful part: 7 of 22 cells change, all of them GPU memory
below a gigabyte.

```
0.5 -> 0.47      0.6 -> 0.58      0.6 -> 0.65
0.7 -> 0.70      0.8 -> 0.83      1.0 -> 0.97
```

The last one is worth pausing on. A 0.97 GB reading was rendering as `1.0 GB`, so the old format
was not only losing small values, it was rounding a sub-gigabyte reading up to a full one.

## 2. A tick where nothing reported was charted as zero

The per-tick arrays were pre-filled with `np.zeros`, so a tick in which no device reported kept
its `0.0` and was both drawn on the chart and folded into the window percentiles. On a transient
host-wide NVML failure the chart drew a 0% utilisation point, a 0-byte memory point and a 0 degree
temperature point for a moment nothing was measured.

They are pre-filled with `NaN` now. The percentiles use `nanpercentile`, the newest-value reads
skip back to the newest MEASURED tick, and the series converts `NaN` to `None` so the chart draws
a gap. That is the convention the per-GPU power history in the same loop already followed.

## 3. The same defect twenty lines above, on the host CPU

Sweeping for twins found `cpu_hist` and `ram_used_hist` built with `float(x or 0.0)`, and
`cpu_percent` is a nullable `REAL` column.

Measured: a host sitting at a steady 80% with half its rows missing the reading showed **40.0** on
the tile. That is arithmetically the cost of counting absences as zeros, and it is in the same
function as the arrays above.

Folded in rather than filed. This PR's whole argument is that absence and zero must not look
alike; shipping it while leaving the identical bug twenty lines up would not be a coherent change.

## 4. A level and its capacity read from different ticks

Introduced by part 2 and caught before it shipped. Making the newest-value read skip backwards
past a blind tick, while the capacity kept reading the newest tick, paired two different moments.
With the newest tick blind the capacity was `0`, and `format_gb_pair` drops the denominator at
zero, so the tile silently rendered a bare `6.3 GB` with nothing to measure it against.

The capacity is now carried per tick and both halves are read at one index. A level and the
capacity it is measured against have to be simultaneously true.

## What is deliberately NOT fixed

A window in which **nothing at all** was measured still renders as zeros, and two of those read as
alarming rather than missing: `gpu_mem.headroom = 0` reads as memory full, and
`ram.headroom = ram_total` reads as all RAM free. `temp.status` also says `"OK"`, which is a
verdict derived from no reading.

That is #437. This change narrows the defect from *any* window containing a blind tick to *only* a
window with no measurements at all, and closing the remainder means the rollup fields become
optional and the tiles gain an n/a path, which is a card-surface change rather than a compute one.

## Scope

```
STRUCTURE: absence in a per-tick series -> renderers/system/dashboard_compute.py (owner of what a
metric means); the rendering rule for a sub-gigabyte level -> the section that formats it;
mirrored from the per-GPU power history in the same loop, which already stored None for a gap;
boundaries crossed: none
DATA PATH: system_section <- SYSTEM_LAYOUT <- SystemRenderer <- SystemDashboardComputer
           <- SystemRepository <- system_samples + system_gpu_samples
SCOPE: declared renderers/system plus the System section and their tests -> diff touches
dashboard_compute.py, system_section.py and two test files -> within
TWINS: searched the CONCEPT, not the symbol - every place a missing reading becomes a number.
np.zeros standing in for absence (5 arrays, fixed), float(x or 0.0) on a nullable column (cpu_hist
and ram_used_hist, fixed), np.percentile over slots that may be absent (5 call sites, moved to a
nan-aware helper), and a paired value whose capacity did not follow it (fixed). The remaining
all-absent case is #437
```

## Verification

```
GATE: pytest tests/ -> 1641 passed, 2 skipped against this branch's base at 1635 passed, 2 skipped; the delta is the six tests added here; black, isort and ruff clean at 79 on every file in the diff
TRANSITIONS: none; no state machine is touched. The recent-to-retained switch and the whole-run mode are unchanged and their tests are untouched
RANKS: not applicable; System is single-node. The per-device work this builds on is unchanged, and the per-GPU rows already marked a silent device
TRIPWIRE: no absent reading in renderers/system may reach a percentile, a newest-value read or a chart series as a number. Five arrays carry NaN, five percentile sites are nan-aware, and a NaN-leak probe across healthy, all-CPU-NULL, all-RAM-NULL, blind-GPU and single-sample-all-NULL payloads finds zero NaN in any field
SCENARIOS: all 22 fixture cells rendered and diffed field by field against the same render on the base; 7 of 66 fields differ, every one of them a sub-gigabyte GPU memory value gaining its second decimal, listed above. Unlike the recent refactors this diff is EXPECTED to be non-empty: part 1 changes what the card prints. Parts 2, 3 and 4 are invisible here because no fixture carries a blind tick or a NULL cpu_percent, so their evidence is the six tests and the measurements quoted above
PLATFORM: macOS 26.1, Python 3.12.13, SQLite 3.51.2
```

## Base

Stacked on #436 because part 1 edits a function that PR rewrote. `ci.yml` filters `pull_request`
on the base branch, so a branch-based PR fires no checks; these were dispatched with
`gh workflow run CI --ref dev/abhijeet/absence-not-zero`. GitHub retargets this to
`version_0.3.7` when #436 merges, and CI runs on its own from then on.
