### PR TITLE
Dev/abhinav/train proc stdout err

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ which carry the full historical notes for versions predating this file.
 
 ## [Unreleased]
 
+- Added a byte-oriented subprocess-output drainer for future launcher-owned
+  stdout/stderr persistence; existing launcher behavior remains unchanged.
 - Root `system_manifest.json` writes now come only from global rank 0, avoiding
   nondeterministic node ownership on shared filesystems.
 - **Breaking:** Opt-in `--capture-stderr` output moved for both single-node and

--- a/src/traceml_ai/launcher/process.py
+++ b/src/traceml_ai/launcher/process.py
@@ -29,6 +29,8 @@ _CREATE_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
 DEFAULT_TCP_READY_TIMEOUT_SEC = 15.0
 DEFAULT_SHUTDOWN_TIMEOUT_SEC = 5.0
 DEFAULT_STDERR_TAIL_BYTES = 64 * 1024
+_OUTPUT_READ_BYTES = 64 * 1024
+_OUTPUT_STOP_GRACE_SEC = 0.1
 INTERRUPTED_EXIT_CODE = 130
 
 
@@ -60,6 +62,226 @@ class TrainingOutcome:
         if not _IS_WINDOWS and self.returncode < 0:
             return 128 - self.returncode
         return self.returncode
+
+
+@dataclass(frozen=True)
+class ProcessOutputResult:
+    """Final facts from a bounded subprocess-output drain."""
+
+    stdout_path: Optional[Path]
+    stderr_path: Optional[Path]
+    stderr_tail: bytes
+    warning: Optional[str]
+
+
+class ProcessOutputDrainer:
+    """Concurrently persist and optionally mirror raw process output.
+
+    One worker owns each supplied stream and its optional file. File failures
+    switch that stream to its fallback without stopping the drain. ``finish``
+    returns one warning value instead of raising into training control flow.
+    """
+
+    def __init__(
+        self,
+        *,
+        stdout: Optional[BinaryIO] = None,
+        stderr: Optional[BinaryIO] = None,
+        stdout_path: Optional[Path | str] = None,
+        stderr_path: Optional[Path | str] = None,
+        stdout_mirror: Optional[BinaryIO] = None,
+        stderr_mirror: Optional[BinaryIO] = None,
+        stdout_fallback: Optional[BinaryIO] = None,
+        stderr_fallback: Optional[BinaryIO] = None,
+        max_stderr_tail_bytes: int = DEFAULT_STDERR_TAIL_BYTES,
+    ) -> None:
+        if max_stderr_tail_bytes <= 0:
+            raise ValueError("max_stderr_tail_bytes must be greater than zero")
+
+        self._max_stderr_tail_bytes = int(max_stderr_tail_bytes)
+        self._stderr_tail = bytearray()
+        self._warnings: list[str] = []
+        self._lock = threading.Lock()
+        self._result: Optional[ProcessOutputResult] = None
+        self._completed_paths: dict[str, Path] = {}
+        self._workers: list[tuple[str, BinaryIO, threading.Thread]] = []
+
+        for name, source, path, mirror, fallback in (
+            ("stdout", stdout, stdout_path, stdout_mirror, stdout_fallback),
+            ("stderr", stderr, stderr_path, stderr_mirror, stderr_fallback),
+        ):
+            if source is None:
+                continue
+            resolved_path = Path(path).resolve() if path is not None else None
+            thread = threading.Thread(
+                target=self._drain,
+                args=(
+                    name,
+                    source,
+                    resolved_path,
+                    mirror,
+                    fallback,
+                ),
+                name=f"traceml-process-{name}",
+                daemon=True,
+            )
+            self._workers.append((name, source, thread))
+            try:
+                thread.start()
+            except Exception as exc:
+                self._workers.pop()
+                self._warn(f"{name} output worker could not start: {exc}")
+                self._close(source, f"{name} output stream")
+
+    def _warn(self, message: str) -> None:
+        with self._lock:
+            if message not in self._warnings:
+                self._warnings.append(message)
+
+    def _remember_stderr(self, chunk: bytes) -> None:
+        with self._lock:
+            self._stderr_tail.extend(chunk)
+            excess = len(self._stderr_tail) - self._max_stderr_tail_bytes
+            if excess > 0:
+                del self._stderr_tail[:excess]
+
+    @staticmethod
+    def _write(target: BinaryIO, chunk: bytes) -> None:
+        offset = 0
+        while offset < len(chunk):
+            written = target.write(chunk[offset:])
+            if written is None or int(written) <= 0:
+                raise OSError("output destination made no write progress")
+            offset += int(written)
+        target.flush()
+
+    def _drain(
+        self,
+        name: str,
+        source: BinaryIO,
+        path: Optional[Path],
+        mirror: Optional[BinaryIO],
+        fallback: Optional[BinaryIO],
+    ) -> None:
+        sink: Optional[BinaryIO] = None
+        sink_failed = False
+        drained = False
+        try:
+            if path is not None:
+                try:
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    sink = path.open("wb", buffering=0)
+                except Exception as exc:
+                    sink_failed = True
+                    self._warn(
+                        f"{name} output file could not be opened: {exc}"
+                    )
+
+            read = getattr(source, "read1", source.read)
+            while True:
+                chunk = read(_OUTPUT_READ_BYTES)
+                if not chunk:
+                    break
+                if not isinstance(chunk, (bytes, bytearray, memoryview)):
+                    raise TypeError("subprocess output stream must be binary")
+                raw_chunk = bytes(chunk)
+                if name == "stderr":
+                    self._remember_stderr(raw_chunk)
+
+                if sink is not None:
+                    try:
+                        self._write(sink, raw_chunk)
+                    except Exception as exc:
+                        sink_failed = True
+                        self._warn(f"{name} output file write failed: {exc}")
+                        self._close(sink, f"{name} output file")
+                        sink = None
+
+                mirrored = False
+                if mirror is not None:
+                    try:
+                        self._write(mirror, raw_chunk)
+                        mirrored = True
+                    except Exception as exc:
+                        self._warn(f"{name} output mirror failed: {exc}")
+                        mirror = None
+
+                if sink_failed and not mirrored and fallback is not None:
+                    try:
+                        self._write(fallback, raw_chunk)
+                    except Exception as exc:
+                        self._warn(f"{name} output fallback failed: {exc}")
+                        fallback = None
+            drained = True
+        except Exception as exc:
+            self._warn(f"{name} output read failed: {exc}")
+        finally:
+            self._close(source, f"{name} output stream")
+            if sink is not None and not self._close(
+                sink, f"{name} output file"
+            ):
+                sink_failed = True
+            if drained and path is not None and not sink_failed:
+                with self._lock:
+                    self._completed_paths[name] = path
+
+    def _close(self, target: BinaryIO, label: str) -> bool:
+        try:
+            target.close()
+        except Exception as exc:
+            self._warn(f"{label} close failed: {exc}")
+            return False
+        return True
+
+    def finish(
+        self,
+        *,
+        timeout_sec: float = DEFAULT_SHUTDOWN_TIMEOUT_SEC,
+    ) -> ProcessOutputResult:
+        """Finish once, returning confirmed paths, stderr tail, and warning."""
+        if self._result is not None:
+            return self._result
+
+        deadline = time.monotonic() + max(0.0, float(timeout_sec))
+        for _, _, thread in self._workers:
+            thread.join(timeout=max(0.0, deadline - time.monotonic()))
+
+        active = [worker for worker in self._workers if worker[2].is_alive()]
+        timed_out = {name for name, _, _ in active}
+        if active:
+            self._warn(
+                "output drain timed out for "
+                + ", ".join(name for name, _, _ in active)
+            )
+            for name, source, _ in active:
+                try:
+                    threading.Thread(
+                        target=self._close,
+                        args=(source, f"{name} output stream"),
+                        daemon=True,
+                    ).start()
+                except Exception as exc:
+                    self._warn(f"{name} output close could not start: {exc}")
+
+            stop_deadline = time.monotonic() + _OUTPUT_STOP_GRACE_SEC
+            for _, _, thread in active:
+                thread.join(timeout=max(0.0, stop_deadline - time.monotonic()))
+
+        with self._lock:
+            stderr_tail = bytes(self._stderr_tail)
+            warning = "; ".join(self._warnings) or None
+            completed_paths = {
+                name: path
+                for name, path in self._completed_paths.items()
+                if name not in timed_out
+            }
+        self._result = ProcessOutputResult(
+            stdout_path=completed_paths.get("stdout"),
+            stderr_path=completed_paths.get("stderr"),
+            stderr_tail=stderr_tail,
+            warning=warning,
+        )
+        return self._result
 
 
 class StderrTailCapture:

--- a/src/traceml_ai/launcher/process.py
+++ b/src/traceml_ai/launcher/process.py
@@ -29,6 +29,7 @@ _CREATE_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
 DEFAULT_TCP_READY_TIMEOUT_SEC = 15.0
 DEFAULT_SHUTDOWN_TIMEOUT_SEC = 5.0
 DEFAULT_STDERR_TAIL_BYTES = 64 * 1024
+# Read throughput and retained-tail size are independent policies.
 _OUTPUT_READ_BYTES = 64 * 1024
 _OUTPUT_STOP_GRACE_SEC = 0.1
 INTERRUPTED_EXIT_CODE = 130
@@ -80,6 +81,7 @@ class ProcessOutputDrainer:
     One worker owns each supplied stream and its optional file. File failures
     switch that stream to its fallback without stopping the drain. ``finish``
     returns one warning value instead of raising into training control flow.
+    The drainer closes supplied streams; callers must not read them afterward.
     """
 
     def __init__(

--- a/tests/runtime/test_process_output.py
+++ b/tests/runtime/test_process_output.py
@@ -1,0 +1,161 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import io
+import subprocess
+import sys
+import threading
+import time
+from collections import deque
+from pathlib import Path
+
+from traceml_ai.launcher.process import (
+    DEFAULT_STDERR_TAIL_BYTES,
+    ProcessOutputDrainer,
+)
+
+
+class _ChunkStream:
+    def __init__(self, *chunks: bytes) -> None:
+        self._chunks = deque(chunks)
+        self.closed = False
+
+    def read(self, _size: int) -> bytes:
+        return self._chunks.popleft() if self._chunks else b""
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FailingSink(io.BytesIO):
+    def __init__(self) -> None:
+        super().__init__()
+        self._writes = 0
+
+    def write(self, data: bytes) -> int:
+        self._writes += 1
+        if self._writes == 2:
+            raise OSError("disk unavailable")
+        return super().write(data)
+
+
+class _BlockingStream:
+    def __init__(self) -> None:
+        self._closed = threading.Event()
+
+    def read(self, _size: int) -> bytes:
+        self._closed.wait(timeout=30)
+        return b""
+
+    def close(self) -> None:
+        self._closed.set()
+
+
+def test_drains_flooded_streams_as_exact_separate_bytes(tmp_path) -> None:
+    stdout_chunk = b"\xffOUT\x00" * 128
+    stderr_chunk = b"\xfeERR\n" * 128
+    repeats = 1024
+    stdout_end = b"stdout-partial"
+    stderr_end = b"stderr-partial"
+    script = (
+        "import os\n"
+        "from threading import Thread\n"
+        f"stdout_chunk = {stdout_chunk!r}\n"
+        f"stderr_chunk = {stderr_chunk!r}\n"
+        f"repeats = {repeats}\n"
+        "def emit(fd, chunk, end):\n"
+        "    for _ in range(repeats):\n"
+        "        os.write(fd, chunk)\n"
+        "    os.write(fd, end)\n"
+        "threads = [\n"
+        f"    Thread(target=emit, args=(1, stdout_chunk, {stdout_end!r})),\n"
+        f"    Thread(target=emit, args=(2, stderr_chunk, {stderr_end!r})),\n"
+        "]\n"
+        "[thread.start() for thread in threads]\n"
+        "[thread.join() for thread in threads]\n"
+    )
+    stdout_path = tmp_path / "training.stdout.log"
+    stderr_path = tmp_path / "training.stderr.log"
+    stdout_mirror = io.BytesIO()
+    stderr_mirror = io.BytesIO()
+    expected_stdout = stdout_chunk * repeats + stdout_end
+    expected_stderr = stderr_chunk * repeats + stderr_end
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert proc.stdout is not None and proc.stderr is not None
+    output = ProcessOutputDrainer(
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+        stdout_mirror=stdout_mirror,
+        stderr_mirror=stderr_mirror,
+    )
+
+    assert proc.wait(timeout=10) == 0
+    result = output.finish()
+
+    assert result.warning is None
+    assert result.stdout_path == stdout_path.resolve()
+    assert result.stderr_path == stderr_path.resolve()
+    assert stdout_path.read_bytes() == expected_stdout
+    assert stderr_path.read_bytes() == expected_stderr
+    assert stdout_mirror.getvalue() == expected_stdout
+    assert stderr_mirror.getvalue() == expected_stderr
+    assert result.stderr_tail == expected_stderr[-DEFAULT_STDERR_TAIL_BYTES:]
+    assert proc.stdout.closed and proc.stderr.closed
+
+
+def test_sink_failure_falls_back_and_keeps_draining(
+    monkeypatch, tmp_path
+) -> None:
+    source = _ChunkStream(b"one", b"two", b"three")
+    sink = _FailingSink()
+    fallback = io.BytesIO()
+    monkeypatch.setattr(Path, "open", lambda *_args, **_kwargs: sink)
+
+    output = ProcessOutputDrainer(
+        stderr=source,
+        stderr_path=tmp_path / "training.stderr.log",
+        stderr_fallback=fallback,
+        max_stderr_tail_bytes=8,
+    )
+    result = output.finish()
+
+    assert result.stderr_path is None
+    assert result.stderr_tail == b"twothree"
+    assert fallback.getvalue() == b"twothree"
+    assert result.warning is not None
+    assert result.warning.count("stderr output file write failed") == 1
+    assert source.closed
+
+
+def test_finish_is_bounded_and_idempotent(tmp_path) -> None:
+    source = _BlockingStream()
+    output = ProcessOutputDrainer(
+        stdout=source,
+        stdout_path=tmp_path / "training.stdout.log",
+    )
+
+    started = time.monotonic()
+    result = output.finish(timeout_sec=0.01)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5
+    assert result.stdout_path is None
+    assert result.warning is not None
+    assert "output drain timed out for stdout" in result.warning
+    assert output.finish() is result
+    assert not any(
+        thread.name == "traceml-process-stdout"
+        for thread in threading.enumerate()
+    )

--- a/tests/runtime/test_process_output.py
+++ b/tests/runtime/test_process_output.py
@@ -139,6 +139,48 @@ def test_sink_failure_falls_back_and_keeps_draining(
     assert source.closed
 
 
+def test_sink_open_failure_falls_back_and_is_reported(
+    monkeypatch, tmp_path
+) -> None:
+    source = _ChunkStream(b"all output")
+    fallback = io.BytesIO()
+
+    def fail_open(*_args, **_kwargs):
+        raise OSError("read-only directory")
+
+    monkeypatch.setattr(Path, "open", fail_open)
+    result = ProcessOutputDrainer(
+        stdout=source,
+        stdout_path=tmp_path / "training.stdout.log",
+        stdout_fallback=fallback,
+    ).finish()
+
+    assert result.stdout_path is None
+    assert fallback.getvalue() == b"all output"
+    assert result.warning is not None
+    assert result.warning.count("stdout output file could not be opened") == 1
+
+
+def test_mirror_failure_does_not_invalidate_saved_output(tmp_path) -> None:
+    source = _ChunkStream(b"one", b"two")
+    mirror = _FailingSink()
+    fallback = io.BytesIO()
+    output_path = tmp_path / "training.stdout.log"
+
+    result = ProcessOutputDrainer(
+        stdout=source,
+        stdout_path=output_path,
+        stdout_mirror=mirror,
+        stdout_fallback=fallback,
+    ).finish()
+
+    assert result.stdout_path == output_path.resolve()
+    assert output_path.read_bytes() == b"onetwo"
+    assert fallback.getvalue() == b""
+    assert result.warning is not None
+    assert result.warning.count("stdout output mirror failed") == 1
+
+
 def test_finish_is_bounded_and_idempotent(tmp_path) -> None:
     source = _BlockingStream()
     output = ProcessOutputDrainer(
@@ -155,7 +197,14 @@ def test_finish_is_bounded_and_idempotent(tmp_path) -> None:
     assert result.warning is not None
     assert "output drain timed out for stdout" in result.warning
     assert output.finish() is result
-    assert not any(
-        thread.name == "traceml-process-stdout"
-        for thread in threading.enumerate()
-    )
+
+    def worker_is_alive() -> bool:
+        return any(
+            thread.name == "traceml-process-stdout"
+            for thread in threading.enumerate()
+        )
+
+    deadline = time.monotonic() + 2.0
+    while worker_is_alive() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not worker_is_alive()

--- a/tests/samplers/test_system_manifest.py
+++ b/tests/samplers/test_system_manifest.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from traceml_ai.samplers import system_manifest
+
+
+@pytest.mark.parametrize(
+    ("global_rank", "should_write"), [(0, True), (4, False)]
+)
+def test_only_global_rank_zero_writes_root_system_manifest(
+    monkeypatch, tmp_path, global_rank: int, should_write: bool
+) -> None:
+    monkeypatch.setenv("TRACEML_LOGS_DIR", str(tmp_path))
+    monkeypatch.setenv("TRACEML_SESSION_ID", "shared-run")
+    monkeypatch.setenv("RANK", str(global_rank))
+    build_manifest = Mock(return_value={"rank": global_rank})
+    monkeypatch.setattr(
+        system_manifest, "build_system_manifest", build_manifest
+    )
+
+    system_manifest.write_system_manifest_if_missing(
+        cpu_logical_core_count=1,
+        ram_total_memory=1.0,
+        gpu_available=False,
+        gpu_count=0,
+        logger=Mock(),
+    )
+
+    manifest_path = tmp_path / "shared-run" / "system_manifest.json"
+    assert manifest_path.exists() is should_write
+    if should_write:
+        build_manifest.assert_called_once()
+        assert json.loads(manifest_path.read_text()) == {"rank": global_rank}
+    else:
+        build_manifest.assert_not_called()


### PR DESCRIPTION
## Summary

Implements **PR 5 of RFC-0001** by adding a reusable, byte-oriented subprocess-output drainer. This prepares the launcher to persist complete training stdout and stderr without changing current launcher or CLI behavior yet.

## What changed

- Added `ProcessOutputDrainer` to the existing launcher process module.
- Drains stdout and stderr concurrently to prevent pipe deadlocks.
- Preserves exact raw bytes in separate output files.
- Supports optional terminal mirroring for later display-mode integration.
- Retains only the final 64 KiB of stderr for failure excerpts.
- Continues draining and falls back to the terminal if file persistence fails.
- Returns confirmed output paths and one consolidated warning without affecting the training result.
- Provides bounded, idempotent shutdown and closes owned streams.
- Added focused coverage for:
  - simultaneous stdout/stderr flooding;
  - invalid UTF-8 and partial final lines;
  - exact file and mirror output;
  - bounded stderr retention;
  - file-open and file-write failures;
  - mirror failure;
  - terminal fallback;
  - bounded and idempotent shutdown.

## Relationship to PR 4

PR 4 established distributed-safe artifact ownership and node-scoped directories.

This PR does not change that ownership model. It adds the reusable output primitive that will later write:

- `nodes/node_<node_rank>/training.stdout.log`
- `nodes/node_<node_rank>/training.stderr.log`

## Scope

This PR only introduces and tests the reusable process-output primitive. Existing launcher behavior remains unchanged, and no production caller uses the new drainer yet.

## Out of scope

- Starting training with stdout/stderr pipes.
- Adding `--save-training-output`.
- Changing CLI, summary, or dashboard presentation.
- Removing the existing `StreamCapture`, `StdoutStderrSampler`, or `StderrTailCapture`.
- Removing `crash_stderr.log`.
- Capturing aggregator stderr.
- Consolidating TraceML internal error logs.
- Per-rank raw-output routing, rotation, compression, or upload.

## Follow-up PRs

- **PR 6:** Integrate the drainer into the launcher, save node-scoped training output, keep Rich CLI output quiet, show a bounded failure excerpt, and disable the old in-process stdout/stderr capture path for new runs.
- **PR 7:** Reuse the drainer to persist raw aggregator stderr.
- **PR 8:** Consolidate TraceML internal error-log ownership.

## Validation

- Full test suite: `1631 passed, 2 skipped`
- `git diff --check`: clean