### PR TITLE
docs: add landing page, brand fonts, and fix slate h1 contrast

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,79 @@
----
-hide:
-  - navigation
-  - toc
+# TraceML
+
+**Real-time bottleneck finder for PyTorch training runs.**
+
+TraceML instruments your existing training loop and tells you *why* it's
+slow — input-bound, compute-bound, waiting on a distributed straggler, or
+leaking memory — instead of leaving you to guess from raw CPU/GPU graphs. It
+runs alongside your script, streams a live terminal or dashboard view during
+the run, and writes a structured `final_summary.json` plus a human-readable
+report at the end.
+
+```bash
+pip install traceml-ai
+```
+
+Already using Hugging Face, Lightning, Ray, DeepSpeed, W&B, or MLflow? See
+[Integrations](user_guide/integrations.md) for framework-specific setup.
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch:{ .lg .middle } **Quickstart**
+
+    ---
+
+    Instrument your training step and get your first diagnosis in a few
+    minutes.
+
+    [:octicons-arrow-right-24: Get started](user_guide/quickstart.md)
+
+-   :material-file-search-outline:{ .lg .middle } **Reading output**
+
+    ---
+
+    Understand the terminal card, the dashboard, and the fields in
+    `final_summary.json`.
+
+    [:octicons-arrow-right-24: Read the guide](user_guide/reading-output.md)
+
+-   :material-puzzle-outline:{ .lg .middle } **Integrations**
+
+    ---
+
+    Use TraceML with Hugging Face, Accelerate, Lightning, Ray, DeepSpeed,
+    W&B, or MLflow.
+
+    [:octicons-arrow-right-24: See integrations](user_guide/integrations.md)
+
+-   :material-scale-balance:{ .lg .middle } **Compare runs**
+
+    ---
+
+    Diff two `final_summary.json` files to see what changed between runs.
+
+    [:octicons-arrow-right-24: Compare runs](user_guide/compare.md)
+
+-   :material-code-braces:{ .lg .middle } **Public API**
+
+    ---
+
+    The full `traceml_ai` reference: `init()`, `trace_step()`, and
+    `summary()`.
+
+    [:octicons-arrow-right-24: API reference](user_guide/public-api.md)
+
+-   :material-source-branch:{ .lg .middle } **Developer guide**
+
+    ---
+
+    Architecture, pipeline contracts, and how to contribute to TraceML.
+
+    [:octicons-arrow-right-24: Contribute](developer_guide/contributing.md)
+
+</div>
+
 ---
 
-<meta http-equiv="refresh" content="0; url=user_guide/quickstart/">
-<link rel="canonical" href="user_guide/quickstart/">
-<script>window.location.replace("user_guide/quickstart/");</script>
-
-Redirecting to the [Quickstart](user_guide/quickstart.md)…
+TraceML is open source under the Apache 2.0 license. Learn more at
+[traceopt.ai](https://traceopt.ai) or star the project on
+[GitHub](https://github.com/traceopt-ai/traceml).

--- a/docs/stylesheets/traceopt.css
+++ b/docs/stylesheets/traceopt.css
@@ -94,3 +94,10 @@ body,
   color: #ffa94d;
   opacity: 1;
 }
+
+/* Material's default h1 color (--md-default-fg-color--light) reads as
+   muted, low-contrast gray on the slate background. Reuse the full-contrast
+   foreground color already defined for this scheme instead. */
+[data-md-color-scheme="slate"] .md-typeset h1 {
+  color: var(--md-default-fg-color);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,9 @@ theme:
   name: material
   # logo: assets/logo.png        # uncomment when traceopt.ai logo is available
   # favicon: assets/favicon.png
+  font:
+    text: Geist
+    code: Geist Mono
   palette:
     - scheme: default
       primary: custom
@@ -78,6 +81,7 @@ markdown_extensions:
   - toc: { permalink: true }
 
 nav:
+  - Home: index.md
   - Guides:
       - Slow PyTorch Training: guides/slow-pytorch-training.md
       - Find Input Pipeline Bottlenecks: guides/pytorch-input-pipeline-bottleneck.md


### PR DESCRIPTION

<img width="1470" height="956" alt="Screenshot 2026-09-03 at 10 35 45 PM" src="https://github.com/user-attachments/assets/f4f4b3a9-6376-44a5-80a6-adec27934a3c" />

<img width="1470" height="956" alt="Screenshot 2026-09-03 at 10 35 52 PM" src="https://github.com/user-attachments/assets/655e7fcc-69b5-48ce-a6e7-78148208e459" />

## Summary

Addresses two of the three entry-experience problems from #150:

- **Docs landing page (item B):** `docs/index.md` was a meta-refresh/JS redirect stub straight to Quickstart, so clicking "Docs" from traceopt.ai never showed a home page. Replaced it with a real landing page: one-paragraph value prop, `pip install traceml-ai`, and a card grid linking to Quickstart, Reading output, Integrations, Compare Runs, Public API, and the Developer Guide. Added `Home: index.md` to the nav.
- **Brand alignment, partial (item C):** set `theme.font` to Geist / Geist Mono (matching traceopt.ai, was default Roboto) and fixed slate-mode h1 contrast — Material's default `--md-default-fg-color--light` renders at ~4.9:1 against the slate background; reused the scheme's full-contrast foreground color instead, giving ~8.9:1 (computed against mkdocs-material's actual palette values).

## Out of scope for this PR

- **Logo/favicon:** no TraceOpt logo asset exists anywhere in this repo (`mkdocs.yml` has had it commented out as "uncomment when available" — still true). Left commented; someone with the actual asset should follow up.
- **Stale `v0.2.15` release badge (item A):** the header badge tracks the latest *GitHub release*, not the latest tag/PyPI version. Fixing it means cutting the missing `v0.3.0`/`v0.3.1` releases on this repo, which needs maintainer/upstream write access I don't have as a contributor. Flagging for a maintainer:
  ```
  gh release create v0.3.0 --repo traceopt-ai/traceml --generate-notes
  gh release create v0.3.1 --repo traceopt-ai/traceml --generate-notes --latest
  ```

## Test plan

- [x] `mkdocs build --strict` passes clean (no broken links/anchors, index.md no longer flagged as orphaned from nav)
- [x] `pre-commit run --all-files` passes on changed files
- [x] `mkdocs serve` locally: landing page renders with all 6 cards, links resolve, "Home" appears in nav, no redirect
- [x] Compared side-by-side against the live site (https://traceopt-ai.github.io/traceml/) in both light and slate palettes
- [x] Contrast ratio verified numerically against mkdocs-material's actual slate palette CSS values (4.9:1 → 8.9:1, both above the WCAG AA large-text threshold of 3:1)

Fixes #150 (partially — logo/favicon and the release badge remain, as noted above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Replaced the documentation homepage redirect with a TraceML landing page covering installation, integrations, quickstart usage, output guidance, run comparisons, APIs, and developer resources.
  - Added links to the TraceML website, GitHub repository, and license.
  - Added a Home entry to the documentation navigation.

- **Style**
  - Improved dark-theme heading contrast.
  - Updated documentation typography with Geist and Geist Mono fonts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->