### PR TITLE
stderr_added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ which carry the full historical notes for versions predating this file.
 
 ## [Unreleased]
 
+- Launcher-owned aggregator stderr is now saved separately at
+  `logs/<run-name>/aggregator/process.stderr.log`. Summary and dashboard modes
+  mirror it live; CLI mode preserves the Rich display and reports the saved
+  path if telemetry fails.
 - Training stdout and stderr are now saved by default in separate node-scoped
   files under `logs/<run-name>/nodes/node_<node-rank>/`. Summary and dashboard
   modes mirror them live; CLI mode keeps the Rich display clean and prints a

--- a/docs/user_guide/distributed-training.md
+++ b/docs/user_guide/distributed-training.md
@@ -57,6 +57,11 @@ launcher, which owns the aggregator process and can observe its exit and
 finalization. Non-owner launchers do not infer final aggregator health from a
 startup TCP readiness check.
 
+Each node launcher writes its own `nodes/node_<node_rank>/training.*.log`
+files when training-output saving is enabled. Only node 0 writes
+`aggregator/process.stderr.log`, because it is the only launcher that owns the
+aggregator process.
+
 `--session-id` remains accepted as a backward-compatible alias for
 `--run-name`.
 

--- a/docs/user_guide/public-api.md
+++ b/docs/user_guide/public-api.md
@@ -134,6 +134,13 @@ prints a bounded stderr excerpt, the saved paths, and the final outcome. Use
 output files. Captured streams are pipes, so `isatty()` returns false. TraceML
 does not replace Python's `sys.stdout` or `sys.stderr` objects.
 
+`--no-save-training-output` controls only the supervised training streams. The
+owner launcher always saves raw aggregator diagnostics to
+`logs/<run-name>/aggregator/process.stderr.log`; only node 0 creates this file
+in a multi-node run. Summary and dashboard modes mirror it live, while CLI mode
+reports its path if telemetry fails. Aggregator stdout remains attached to the
+terminal and is not persisted.
+
 ## Direct Launch with `traceml serve`
 
 `traceml run` starts the aggregator and your script together. For direct

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -199,6 +199,19 @@ outlive training should redirect its own stdout and stderr, or the launch
 should use `--no-save-training-output`; otherwise the launcher eventually
 closes its output pipes during shutdown.
 
+The owner launcher also saves the aggregator's raw stderr separately:
+
+```text
+logs/<run-name>/aggregator/process.stderr.log
+```
+
+This file is a fallback for startup failures, native diagnostics, and errors
+emitted before structured logging is available. Summary and dashboard modes
+mirror it live. CLI mode does not mirror it over the Rich display; if telemetry
+fails, TraceML reports the saved path. This artifact is distinct from
+`aggregator/traceml_errors.log`, which contains structured TraceML log records.
+Aggregator stdout remains attached to the terminal and is not persisted.
+
 Phases that were never measured in the current window are omitted from the
 live step-time table rather than shown as `0.0 ms`, and the diagnosis block
 shows `INCOMPLETE DATA` with the missing signal names when no reliable

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -184,6 +184,30 @@ def _start_training_output(
     )
 
 
+def _start_aggregator_output(
+    proc: subprocess.Popen,
+    *,
+    stderr_path: Path,
+    mode: str,
+) -> ProcessOutputDrainer:
+    """Persist launcher-owned aggregator stderr without capturing stdout."""
+    if proc.stderr is None:
+        raise ValueError("aggregator process stderr is not piped")
+    stderr_terminal = _binary_stream(sys.stderr)
+    return ProcessOutputDrainer(
+        stderr=proc.stderr,
+        stderr_path=stderr_path,
+        stderr_mirror=stderr_terminal if mode != "cli" else None,
+        stderr_fallback=stderr_terminal,
+    )
+
+
+def _print_aggregator_stderr_path(path: Optional[Path]) -> None:
+    """Report confirmed raw aggregator diagnostics after a failure."""
+    if path is not None:
+        print(f"[TraceML] Aggregator stderr: {path}", file=sys.stderr)
+
+
 def _print_training_output(
     result: Optional[ProcessOutputResult],
     *,
@@ -266,6 +290,7 @@ def _print_telemetry_footer(
     status: str,
     reason: Optional[str],
     aggregator_exit_code: Optional[int],
+    aggregator_stderr_path: Optional[Path] = None,
 ) -> None:
     """Print one factual telemetry line before the final training line."""
     if status == "complete":
@@ -294,6 +319,9 @@ def _print_telemetry_footer(
         message = f"Telemetry failed during finalization{suffix}."
     else:
         message = f"Telemetry {status}."
+
+    if status != "complete" and aggregator_stderr_path is not None:
+        message += f" Aggregator stderr: {aggregator_stderr_path}"
 
     print(f"[TraceML] {message}", file=sys.stderr, flush=True)
 
@@ -630,6 +658,7 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
     session_root = Path(cfg["logs_dir"]).resolve() / session_id
     aggregator_dir = session_root / "aggregator"
     db_path = aggregator_dir / "telemetry"
+    aggregator_stderr_log_path = aggregator_dir / "process.stderr.log"
     node_dir = node_artifact_dir(session_root, torchrun_cfg.node_rank)
     training_stdout_path = node_dir / "training.stdout.log"
     training_stderr_path = node_dir / "training.stderr.log"
@@ -703,6 +732,9 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
 
     agg_proc: Optional[subprocess.Popen] = None
     train_proc: Optional[subprocess.Popen] = None
+    aggregator_output: Optional[ProcessOutputDrainer] = None
+    aggregator_output_result: Optional[ProcessOutputResult] = None
+    confirmed_aggregator_stderr_path: Optional[Path] = None
     training_output: Optional[ProcessOutputDrainer] = None
     aggregator_started_at: Optional[str] = None
     aggregator_exit_code: Optional[int] = None
@@ -710,14 +742,37 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
     telemetry_available = False
     telemetry_startup_reason: Optional[str] = None
 
-    def finish_training_output() -> None:
+    def finish_aggregator_output() -> Optional[ProcessOutputResult]:
+        nonlocal aggregator_output_result
+        nonlocal confirmed_aggregator_stderr_path
+        if aggregator_output is None:
+            return None
+        if aggregator_output_result is None:
+            aggregator_output_result = aggregator_output.finish()
+            confirmed_aggregator_stderr_path = (
+                aggregator_output_result.stderr_path
+            )
+            if aggregator_output_result.warning:
+                print(
+                    f"[TraceML] WARNING: {aggregator_output_result.warning}",
+                    file=sys.stderr,
+                )
+        return aggregator_output_result
+
+    def finish_process_output() -> None:
         if training_output is not None:
             training_output.finish()
+        finish_aggregator_output()
+
+    def aggregator_output_artifacts() -> Optional[dict[str, str]]:
+        if confirmed_aggregator_stderr_path is None:
+            return None
+        return {"aggregator_stderr_log": str(confirmed_aggregator_stderr_path)}
 
     install_shutdown_handlers(
         lambda: (train_proc, agg_proc),
         manifest_path=manifest_path,
-        cleanup=finish_training_output,
+        cleanup=finish_process_output,
     )
 
     if owns_aggregator:
@@ -735,6 +790,11 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
             ready = False
             telemetry_startup_reason = "aggregator_spawn_failed"
         else:
+            aggregator_output = _start_aggregator_output(
+                agg_proc,
+                stderr_path=aggregator_stderr_log_path,
+                mode=str(cfg["mode"]),
+            )
             print(f"[TraceML] Aggregator PID: {agg_proc.pid}")
             ready = wait_for_tcp_listen(
                 host=aggregator_cfg.connect_host,
@@ -766,6 +826,8 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
             terminate_process_group(agg_proc, timeout_sec=3.0)
             aggregator_exit_code = agg_proc.returncode
             agg_proc = None
+        finish_aggregator_output()
+        _print_aggregator_stderr_path(confirmed_aggregator_stderr_path)
 
         if missing_aggregator_policy == "raise":
             if manifest_path is not None:
@@ -774,6 +836,7 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
                     lambda: update_run_manifest(
                         manifest_path,
                         status="failed",
+                        artifacts=aggregator_output_artifacts(),
                         telemetry_status=(
                             "unavailable" if owns_aggregator else None
                         ),
@@ -813,6 +876,7 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
             lambda: update_run_manifest(
                 manifest_path,
                 status="running",
+                artifacts=aggregator_output_artifacts(),
                 telemetry_status=(
                     ("running" if telemetry_available else "unavailable")
                     if owns_aggregator
@@ -882,6 +946,7 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
                     ),
                 )
                 aggregator_exit_code = agg_proc.returncode
+                finish_aggregator_output()
 
             final_status = "completed" if train_rc == 0 else "failed"
             telemetry_status: Optional[str] = None
@@ -931,6 +996,9 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
                                 if output_result is not None
                                 else None
                             ),
+                            aggregator_stderr_path=(
+                                confirmed_aggregator_stderr_path
+                            ),
                         ),
                         telemetry_status=telemetry_status,
                         telemetry_reason=telemetry_reason,
@@ -947,6 +1015,7 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
                     telemetry_status,
                     telemetry_reason,
                     aggregator_exit_code,
+                    confirmed_aggregator_stderr_path,
                 )
             _exit_with_training_outcome(
                 outcome,
@@ -957,16 +1026,19 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
             agg_rc = agg_proc.returncode
             aggregator_exited_early = True
             aggregator_exit_code = agg_rc
+            finish_aggregator_output()
             print(
                 f"[TraceML] WARNING: aggregator exited early (code={agg_rc}). "
                 "Training will continue without TraceML telemetry.",
                 file=sys.stderr,
             )
+            _print_aggregator_stderr_path(confirmed_aggregator_stderr_path)
             if manifest_path is not None:
                 _run_noncritical_launcher_step(
                     "failed to record degraded telemetry status",
                     lambda: update_run_manifest(
                         manifest_path,
+                        artifacts=aggregator_output_artifacts(),
                         telemetry_status="degraded",
                         telemetry_reason="aggregator_exited_early",
                         aggregator_exit_code=agg_rc,

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -760,9 +760,29 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
         return aggregator_output_result
 
     def finish_process_output() -> None:
-        if training_output is not None:
-            training_output.finish()
+        training_result = (
+            training_output.finish() if training_output is not None else None
+        )
         finish_aggregator_output()
+
+        # The signal handler marks the run interrupted before this cleanup.
+        # Merge paths only after both drainers have confirmed their files.
+        if manifest_path is not None:
+            artifacts = aggregator_output_artifacts() or {}
+            if training_result is not None:
+                confirmed_paths = {
+                    "training_stdout_log": training_result.stdout_path,
+                    "training_stderr_log": training_result.stderr_path,
+                }
+                artifacts.update(
+                    {
+                        name: str(path)
+                        for name, path in confirmed_paths.items()
+                        if path is not None
+                    }
+                )
+            if artifacts:
+                update_run_manifest(manifest_path, artifacts=artifacts)
 
     def aggregator_output_artifacts() -> Optional[dict[str, str]]:
         if confirmed_aggregator_stderr_path is None:

--- a/src/traceml_ai/launcher/manifest.py
+++ b/src/traceml_ai/launcher/manifest.py
@@ -351,6 +351,7 @@ def collect_existing_artifacts(
     session_root: Optional[Path] = None,
     training_stdout_path: Optional[Path] = None,
     training_stderr_path: Optional[Path] = None,
+    aggregator_stderr_path: Optional[Path] = None,
 ) -> Dict[str, str]:
     """Return only launcher artifacts that currently exist on disk."""
     candidates = {
@@ -371,6 +372,10 @@ def collect_existing_artifacts(
     if training_stderr_path is not None:
         candidates["training_stderr_log"] = Path(
             training_stderr_path
+        ).resolve()
+    if aggregator_stderr_path is not None:
+        candidates["aggregator_stderr_log"] = Path(
+            aggregator_stderr_path
         ).resolve()
 
     return {

--- a/src/traceml_ai/launcher/process.py
+++ b/src/traceml_ai/launcher/process.py
@@ -463,6 +463,7 @@ def start_aggregator_process(
         cmd,
         env=env,
         cwd=cwd,
+        stderr=subprocess.PIPE,
         **process_group_kwargs(),
     )
 

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -139,6 +139,33 @@ def test_training_output_display_policy_saves_both_streams(
     assert stderr_terminal.getvalue() == expected_stderr
 
 
+@pytest.mark.parametrize(
+    ("mode", "mirrors_live"),
+    [("summary", True), ("dashboard", True), ("cli", False)],
+)
+def test_aggregator_output_policy_saves_only_stderr(
+    monkeypatch, tmp_path, mode, mirrors_live
+) -> None:
+    terminal = io.BytesIO()
+    monkeypatch.setattr(
+        launcher_commands, "_binary_stream", lambda _stream: terminal
+    )
+    proc = Mock(stderr=io.BytesIO(b"aggregator failure\n"))
+    stderr_path = tmp_path / "aggregator" / "process.stderr.log"
+
+    result = launcher_commands._start_aggregator_output(
+        proc,
+        stderr_path=stderr_path,
+        mode=mode,
+    ).finish()
+
+    assert result.warning is None
+    assert result.stdout_path is None
+    assert stderr_path.read_bytes() == b"aggregator failure\n"
+    expected = b"aggregator failure\n" if mirrors_live else b""
+    assert terminal.getvalue() == expected
+
+
 def test_cli_failure_output_is_bounded_and_prints_confirmed_paths(
     tmp_path, capsys
 ) -> None:
@@ -757,7 +784,28 @@ def test_started_training_result_is_authoritative(
 
     aggregator = Mock(pid=10, returncode=aggregator_rc)
     training = Mock()
-    training.poll.return_value = train_rc
+    if aggregator_rc == 9:
+        training.poll.side_effect = [None, train_rc]
+    else:
+        training.poll.return_value = train_rc
+    aggregator_stderr_path = (
+        tmp_path
+        / "logs"
+        / "outcome-test"
+        / "aggregator"
+        / "process.stderr.log"
+    )
+    aggregator_stderr_path.parent.mkdir(parents=True)
+    aggregator_stderr_path.write_bytes(b"aggregator details\n")
+    aggregator_output_result = ProcessOutputResult(
+        stdout_path=None,
+        stderr_path=aggregator_stderr_path,
+        stderr_tail=b"aggregator details\n",
+        warning=(
+            "aggregator output capture degraded" if not save_output else None
+        ),
+    )
+    aggregator_output = Mock()
     training_output = Mock()
     training_output.finish.return_value = ProcessOutputResult(
         stdout_path=None,
@@ -771,6 +819,12 @@ def test_started_training_result_is_authoritative(
     def stop_aggregator(*_args, **_kwargs):
         events.append("stop")
 
+    def finish_aggregator_output():
+        events.append("aggregator-output")
+        return aggregator_output_result
+
+    aggregator_output.finish.side_effect = finish_aggregator_output
+
     def print_output(*args, **kwargs):
         events.append("output")
         print_training_output(*args, **kwargs)
@@ -782,6 +836,7 @@ def test_started_training_result_is_authoritative(
         "start_aggregator_process": Mock(return_value=aggregator),
         "wait_for_tcp_listen": Mock(return_value=True),
         "start_training_process": Mock(return_value=training),
+        "_start_aggregator_output": Mock(return_value=aggregator_output),
         "_start_training_output": Mock(return_value=training_output),
         "terminate_process_group": Mock(side_effect=stop_aggregator),
         "_print_training_output": Mock(side_effect=print_output),
@@ -792,6 +847,7 @@ def test_started_training_result_is_authoritative(
     }
     for name, replacement in replacements.items():
         monkeypatch.setattr(launcher_commands, name, replacement)
+    monkeypatch.setattr(launcher_commands.time, "sleep", Mock())
 
     if finalization_fails:
         monkeypatch.setattr(
@@ -821,6 +877,16 @@ def test_started_training_result_is_authoritative(
     ]["training_output"]
     assert output_manifest["enabled"] is save_output
     assert output_manifest["scope"] == "node"
+    replacements["_start_aggregator_output"].assert_called_once_with(
+        aggregator,
+        stderr_path=aggregator_stderr_path,
+        mode=mode,
+    )
+    aggregator_output.finish.assert_called_once_with()
+    if aggregator_rc == 9:
+        assert events.index("aggregator-output") < events.index("output")
+    else:
+        assert events.index("stop") < events.index("aggregator-output")
     if save_output:
         assert output_manifest["stdout_pattern"] == (
             "nodes/node_<node_rank>/training.stdout.log"
@@ -836,16 +902,30 @@ def test_started_training_result_is_authoritative(
         training_output.finish.assert_not_called()
         assert not list((tmp_path / "logs").rglob("training.*.log"))
     stderr_lines = capsys.readouterr().err.splitlines()
+    if not save_output:
+        assert (
+            stderr_lines.count(
+                "[TraceML] WARNING: aggregator output capture degraded"
+            )
+            == 1
+        )
     final_line = stderr_lines[-1]
     expected_status = "completed successfully" if train_rc == 0 else "failed"
     assert f"Training {expected_status}" in final_line
     assert stderr_lines[-2].startswith("[TraceML] Telemetry ")
     if train_rc != 0:
         assert "torchrun exited with code 1" in final_line
-    if mode == "cli":
+    if mode == "cli" and aggregator_rc != 9:
         assert events.index("stop") < events.index("output")
         if train_rc != 0 and save_output:
             assert "captured failure" in "\n".join(stderr_lines)
+    if aggregator_rc == 9:
+        assert "aggregator exited early" in "\n".join(stderr_lines)
+        assert any(
+            call.kwargs.get("artifacts")
+            == {"aggregator_stderr_log": str(aggregator_stderr_path)}
+            for call in replacements["update_run_manifest"].call_args_list
+        )
     if (
         train_rc == 0
         and aggregator_rc == 0
@@ -893,11 +973,25 @@ def test_strict_aggregator_failure_does_not_start_training(
     monkeypatch.setattr(launcher_commands, "install_shutdown_handlers", Mock())
     aggregator = Mock(pid=10, returncode=7)
     aggregator.poll.return_value = 7
+    aggregator_stderr_path = tmp_path / "aggregator" / "process.stderr.log"
+    aggregator_output = Mock()
+    aggregator_output.finish.return_value = ProcessOutputResult(
+        stdout_path=None,
+        stderr_path=aggregator_stderr_path,
+        stderr_tail=b"failed before readiness\n",
+        warning=None,
+    )
+    start_aggregator_output = Mock(return_value=aggregator_output)
     start_aggregator = Mock(return_value=aggregator)
     if failure == "spawn":
         start_aggregator.side_effect = FileNotFoundError("aggregator missing")
     monkeypatch.setattr(
         launcher_commands, "start_aggregator_process", start_aggregator
+    )
+    monkeypatch.setattr(
+        launcher_commands,
+        "_start_aggregator_output",
+        start_aggregator_output,
     )
     monkeypatch.setattr(
         launcher_commands, "wait_for_tcp_listen", Mock(return_value=False)
@@ -927,8 +1021,15 @@ def test_strict_aggregator_failure_does_not_start_training(
     assert "TRACEML_ON_MISSING_AGGREGATOR=warn" in stderr
     if failure == "readiness" and owner:
         assert "(exit=7)" in stderr
+        assert str(aggregator_stderr_path) in stderr
+        assert stderr.index("Aggregator stderr") < stderr.index("ERROR")
+        aggregator_output.finish.assert_called_once_with()
+        assert update_manifest.call_args.kwargs["artifacts"] == {
+            "aggregator_stderr_log": str(aggregator_stderr_path)
+        }
     else:
         assert "(exit=" not in stderr
+        start_aggregator_output.assert_not_called()
     start_training.assert_not_called()
     if owner:
         assert update_manifest.call_args.kwargs["status"] == "failed"
@@ -980,6 +1081,22 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
     )
     training_output = Mock()
     training_output.finish.return_value = output_result
+    aggregator_stderr_path = (
+        tmp_path / "logs" / "warn-run" / "aggregator" / "process.stderr.log"
+    )
+    aggregator_output = Mock()
+
+    def _finish_aggregator_output():
+        events.append("finish-output")
+        return ProcessOutputResult(
+            stdout_path=None,
+            stderr_path=aggregator_stderr_path,
+            stderr_tail=b"startup failure\n",
+            warning=None,
+        )
+
+    aggregator_output.finish.side_effect = _finish_aggregator_output
+    start_aggregator_output = Mock(return_value=aggregator_output)
 
     def _stop_aggregator(*_args, **_kwargs):
         events.append("stop")
@@ -1000,6 +1117,11 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
     start_aggregator = Mock(return_value=aggregator)
     monkeypatch.setattr(
         launcher_commands, "start_aggregator_process", start_aggregator
+    )
+    monkeypatch.setattr(
+        launcher_commands,
+        "_start_aggregator_output",
+        start_aggregator_output,
     )
     monkeypatch.setattr(
         launcher_commands, "wait_for_tcp_listen", Mock(return_value=ready)
@@ -1055,8 +1177,14 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
     )
     training_output.finish.assert_called_once_with()
     if owner:
-        assert events == ["stop", "train"]
+        assert events == ["stop", "finish-output", "train"]
         start_aggregator.assert_called_once()
+        start_aggregator_output.assert_called_once_with(
+            aggregator,
+            stderr_path=aggregator_stderr_path,
+            mode="cli",
+        )
+        aggregator_output.finish.assert_called_once_with()
         write_code_manifest.assert_called_once()
         write_manifest.assert_called_once()
         assert install_shutdown_handlers.call_args.kwargs["manifest_path"] == (
@@ -1069,9 +1197,15 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
         ]
         assert initial_telemetry == "starting"
         assert "unavailable" in reported_statuses
+        assert any(
+            call.kwargs.get("artifacts")
+            == {"aggregator_stderr_log": str(aggregator_stderr_path)}
+            for call in update_manifest.call_args_list
+        )
     else:
         assert events == ["train"]
         start_aggregator.assert_not_called()
+        start_aggregator_output.assert_not_called()
         write_code_manifest.assert_not_called()
         write_manifest.assert_not_called()
         update_manifest.assert_not_called()
@@ -1529,19 +1663,24 @@ def test_collect_existing_artifacts_includes_confirmed_training_output(
     node_dir = node_artifact_dir(tmp_path, 0)
     stdout_path = node_dir / "training.stdout.log"
     stderr_path = node_dir / "training.stderr.log"
+    aggregator_stderr_path = tmp_path / "aggregator" / "process.stderr.log"
     stderr_path.parent.mkdir(parents=True)
+    aggregator_stderr_path.parent.mkdir(parents=True)
     stdout_path.write_bytes(b"training output\n")
     stderr_path.write_bytes(b"native crash details\n")
+    aggregator_stderr_path.write_bytes(b"aggregator details\n")
 
     artifacts = collect_existing_artifacts(
         db_path,
         session_root=tmp_path,
         training_stdout_path=stdout_path,
         training_stderr_path=stderr_path,
+        aggregator_stderr_path=aggregator_stderr_path,
     )
 
     assert artifacts["training_stdout_log"] == str(stdout_path)
     assert artifacts["training_stderr_log"] == str(stderr_path)
+    assert artifacts["aggregator_stderr_log"] == str(aggregator_stderr_path)
 
 
 def test_run_view_reports_user_facing_errors(tmp_path, capsys) -> None:

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -1125,9 +1125,11 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
     aggregator.poll.return_value = 7
     training = Mock()
     training.poll.return_value = 0
+    node_rank = 0 if owner else 1
+    node_dir = tmp_path / "logs" / "warn-run" / "nodes" / f"node_{node_rank}"
     output_result = ProcessOutputResult(
-        stdout_path=None,
-        stderr_path=None,
+        stdout_path=node_dir / "training.stdout.log",
+        stderr_path=node_dir / "training.stderr.log",
         stderr_tail=b"",
         warning=None,
     )
@@ -1206,7 +1208,6 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
         launch_process(str(script), args)
 
     assert exc.value.code == 0
-    node_rank = 0 if owner else 1
     launcher_commands._start_training_output.assert_called_once_with(
         training,
         stdout_path=(
@@ -1254,6 +1255,17 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
             == {"aggregator_stderr_log": str(aggregator_stderr_path)}
             for call in update_manifest.call_args_list
         )
+
+        # Signal teardown invokes this callback after marking the run
+        # interrupted. It must then merge the paths confirmed by the drainers.
+        updates_before_cleanup = update_manifest.call_count
+        install_shutdown_handlers.call_args.kwargs["cleanup"]()
+        assert update_manifest.call_count == updates_before_cleanup + 1
+        assert update_manifest.call_args.kwargs["artifacts"] == {
+            "aggregator_stderr_log": str(aggregator_stderr_path),
+            "training_stdout_log": str(output_result.stdout_path),
+            "training_stderr_log": str(output_result.stderr_path),
+        }
     else:
         assert events == ["train"]
         start_aggregator.assert_not_called()

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -9,6 +9,7 @@ import io
 import json
 import os
 import signal
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import Mock
@@ -164,6 +165,29 @@ def test_aggregator_output_policy_saves_only_stderr(
     assert stderr_path.read_bytes() == b"aggregator failure\n"
     expected = b"aggregator failure\n" if mirrors_live else b""
     assert terminal.getvalue() == expected
+
+
+def test_aggregator_output_sink_failure_falls_back(
+    monkeypatch, tmp_path
+) -> None:
+    terminal = io.BytesIO()
+    monkeypatch.setattr(
+        launcher_commands, "_binary_stream", lambda _stream: terminal
+    )
+    blocked_parent = tmp_path / "not-a-directory"
+    blocked_parent.write_text("blocked", encoding="utf-8")
+    proc = Mock(stderr=io.BytesIO(b"aggregator failure\n"))
+
+    result = launcher_commands._start_aggregator_output(
+        proc,
+        stderr_path=blocked_parent / "process.stderr.log",
+        mode="cli",
+    ).finish()
+
+    assert result.stderr_path is None
+    assert terminal.getvalue() == b"aggregator failure\n"
+    assert result.warning is not None
+    assert "stderr output file could not be opened" in result.warning
 
 
 def test_cli_failure_output_is_bounded_and_prints_confirmed_paths(
@@ -1041,6 +1065,34 @@ def test_strict_aggregator_failure_does_not_start_training(
     else:
         start_aggregator.assert_not_called()
         update_manifest.assert_not_called()
+
+
+def test_stderr_from_process_exiting_before_readiness_is_exact(
+    tmp_path,
+) -> None:
+    expected = b"pre-readiness failure: \xff\n"
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import os; os.write(2, "
+            "b'pre-readiness failure: \\xff\\n'); raise SystemExit(7)",
+        ],
+        stderr=subprocess.PIPE,
+    )
+    stderr_path = tmp_path / "aggregator" / "process.stderr.log"
+    output = launcher_commands._start_aggregator_output(
+        proc, stderr_path=stderr_path, mode="cli"
+    )
+
+    assert proc.wait(timeout=5) == 7
+    assert not launcher_commands.wait_for_tcp_listen(
+        host="127.0.0.1", port=0, proc=proc, timeout_sec=0.1
+    )
+    result = output.finish()
+
+    assert stderr_path.read_bytes() == expected
+    assert result.stderr_path == stderr_path.resolve()
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime/test_process_output.py
+++ b/tests/runtime/test_process_output.py
@@ -19,6 +19,7 @@ from unittest.mock import Mock
 from traceml_ai.launcher.process import (
     DEFAULT_STDERR_TAIL_BYTES,
     ProcessOutputDrainer,
+    start_aggregator_process,
     start_training_process,
 )
 
@@ -185,6 +186,16 @@ def test_training_process_only_pipes_output_when_requested(
     )
     assert popen.call_args.kwargs["stdout"] is subprocess.PIPE
     assert popen.call_args.kwargs["stderr"] is subprocess.PIPE
+
+
+def test_aggregator_process_pipes_only_stderr(monkeypatch) -> None:
+    popen = Mock()
+    monkeypatch.setattr(subprocess, "Popen", popen)
+
+    start_aggregator_process(env={}, cwd=".")
+
+    assert popen.call_args.kwargs["stderr"] is subprocess.PIPE
+    assert "stdout" not in popen.call_args.kwargs
 
 
 def test_sink_failure_falls_back_and_keeps_draining(


### PR DESCRIPTION
## Summary

This PR persists raw stderr from the launcher-owned TraceML aggregator:

```text
logs/<run-name>/aggregator/process.stderr.log
```

It builds on the launcher-owned process-output infrastructure introduced in previous PRs.

## What changed

- Pipe and persist only aggregator stderr; stdout remains inherited.
- Mirror aggregator stderr in summary and dashboard modes.
- Keep stderr out of the Rich display in CLI mode and report its saved path when telemetry fails.
- Drain stderr during readiness failure, early exit, normal shutdown, and signal-driven teardown.
- Record the confirmed artifact path in `manifest.json`.
- Treat persistence failures as warnings without changing the training result.
- Restrict aggregator stderr ownership to node 0 in multi-node runs.
- Document the artifact, display behavior, flag boundary, and distributed ownership.

## Reliability

Tests cover:

- Exact binary stderr emitted before aggregator readiness.
- Aggregator sink failure and terminal fallback.
- Summary/dashboard mirroring and CLI suppression.
- Nonzero aggregator exit without stopping training.
- Normal shutdown ordering.
- Strict startup failure reporting.
- Manifest artifact recording.
- Node-0-only ownership.
- Independence from `--no-save-training-output`.

## Behavior preserved

- The training process remains authoritative after it starts.
- Aggregator stdout and Rich presentation output are not persisted.
- Standalone `traceml serve` remains unchanged.
- Existing training stdout/stderr behavior from PR 6 remains unchanged.
- Capture failures cannot fail training.

## Out of scope

- Internal TraceML error-log consolidation, which belongs to the next PR
- Per-rank training output.
- Output rotation, compression, upload, or remote log storage.
- A generic process-logging framework.

## Validation

- Focused launcher/output tests: `113 passed`
- Full suite: `1,664 passed, 2 skipped`
- `git diff --check` passed