### PR TITLE
System: cap the whole-run power chart by widening its buckets

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/formatting.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/formatting.py
@@ -20,6 +20,7 @@ choose decimals, units and phrasing.
 
 from __future__ import annotations
 
+import math
 from typing import Any, Optional, Tuple
 
 NA = "n/a"
@@ -105,16 +106,27 @@ def format_span(seconds: Optional[float]) -> str:
 
 
 def format_window(window_s: Optional[float]) -> str:
-    """The rolling window in words: ``'30 s'``, ``'2 min'``.
+    """The window a chart aggregates over: ``'30 s'``, ``'2 min'``, ``'1 h 24 min'``.
 
-    The compute layer picks round windows, so this reads as a duration a
-    person recognises rather than an arbitrary number of seconds.
+    The compute layer picks the duration, not this function. Rolling
+    charts get a round window; the bucketed whole-run power chart gets a
+    width that widens past a round step to hold its point budget, which
+    is what puts multi-hour values here.
+
+    Non-finite is guarded explicitly because the hours split converts to
+    an integer, which raises on nan and inf where a format string
+    quietly produced "nan min". A formatter on a card must degrade, not
+    take the section down with it.
     """
-    if not window_s or window_s <= 0:
+    if not window_s or window_s <= 0 or not math.isfinite(window_s):
         return ""
     if window_s < 60:
         return f"{window_s:.0f} s"
-    return f"{window_s / 60.0:.0f} min"
+    minutes = round(window_s / 60.0)
+    if minutes < 60:
+        return f"{minutes:.0f} min"
+    hours, rest = divmod(minutes, 60)
+    return f"{hours:.0f} h" if rest == 0 else f"{hours:.0f} h {rest:.0f} min"
 
 
 def format_age(seconds: Any) -> str:

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -61,14 +61,24 @@ def gpu_color(index: int) -> str:
 def format_window(window_s: float) -> str:
     """The rolling window in words: '30 s', '2 min'.
 
-    The payload picks round windows (``RunSeriesPolicy.window_for``) so it reads
-    as a duration a person recognises.
+    The payload picks the duration, not this function: rolling charts get
+    a round window from ``RunSeriesPolicy.window_for``, and the bucketed
+    whole-run power chart gets ``bucket_width_for``, which may widen past
+    a round step to hold its point budget. Both land on whole minutes
+    here, so either still reads as a duration a person recognises.
     """
     if not window_s or window_s <= 0:
         return ""
     if window_s < 60:
         return f"{window_s:.0f} s"
-    return f"{window_s / 60.0:.0f} min"
+    minutes = round(window_s / 60.0)
+    if minutes < 60:
+        return f"{minutes:.0f} min"
+    # Capping the whole-run power chart widens its bucket rather than
+    # growing its point count, which puts multi-hour widths here for the
+    # first time. "84 min" is not how a person reads a duration.
+    hours, rest = divmod(minutes, 60)
+    return f"{hours:.0f} h" if rest == 0 else f"{hours:.0f} h {rest:.0f} min"
 
 
 def format_span(seconds: Optional[float]) -> str:

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -67,7 +67,11 @@ def format_window(window_s: float) -> str:
     a round step to hold its point budget. Both land on whole minutes
     here, so either still reads as a duration a person recognises.
     """
-    if not window_s or window_s <= 0:
+    if not window_s or window_s <= 0 or not math.isfinite(window_s):
+        # Non-finite is guarded explicitly: this function converts to an
+        # integer now, which raises on nan and inf where the old format
+        # string quietly produced "nan min". A formatter on a card must
+        # degrade, never take the section down with it.
         return ""
     if window_s < 60:
         return f"{window_s:.0f} s"

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -32,7 +32,7 @@ from traceml_ai.renderers.system.dashboard_models import (
 )
 
 from . import charting, theme
-from .formatting import gb_si
+from .formatting import format_window, gb_si
 
 # Window-p95 GPU utilisation spread (max - min, percentage points) that
 # automatically opens the per-GPU rows.
@@ -56,33 +56,6 @@ _MONO = "font-family:var(--mono);"
 # --- pure display rules ----------------------------------------------------
 def gpu_color(index: int) -> str:
     return _GPU_COLORS[int(index) % len(_GPU_COLORS)]
-
-
-def format_window(window_s: float) -> str:
-    """The rolling window in words: '30 s', '2 min'.
-
-    The payload picks the duration, not this function: rolling charts get
-    a round window from ``RunSeriesPolicy.window_for``, and the bucketed
-    whole-run power chart gets ``bucket_width_for``, which may widen past
-    a round step to hold its point budget. Both land on whole minutes
-    here, so either still reads as a duration a person recognises.
-    """
-    if not window_s or window_s <= 0 or not math.isfinite(window_s):
-        # Non-finite is guarded explicitly: this function converts to an
-        # integer now, which raises on nan and inf where the old format
-        # string quietly produced "nan min". A formatter on a card must
-        # degrade, never take the section down with it.
-        return ""
-    if window_s < 60:
-        return f"{window_s:.0f} s"
-    minutes = round(window_s / 60.0)
-    if minutes < 60:
-        return f"{minutes:.0f} min"
-    # Capping the whole-run power chart widens its bucket rather than
-    # growing its point count, which puts multi-hour widths here for the
-    # first time. "84 min" is not how a person reads a duration.
-    hours, rest = divmod(minutes, 60)
-    return f"{hours:.0f} h" if rest == 0 else f"{hours:.0f} h {rest:.0f} min"
 
 
 def format_span(seconds: Optional[float]) -> str:

--- a/src/traceml_ai/renderers/shared/run_series.py
+++ b/src/traceml_ai/renderers/shared/run_series.py
@@ -108,6 +108,29 @@ class RunSeriesPolicy:
                 return min(max(step, self.roll_min_s), self.roll_max_s)
         return self.roll_max_s
 
+    def bucket_width_for(self, span_s: float) -> float:
+        """The width for a whole-run series that BUCKETS rather than rolls.
+
+        The rolling window is the floor: while the run still fits the
+        point budget a bucket is exactly the window, so a short run keeps
+        its resolution and the label it already prints. Past the budget
+        the bucket WIDENS instead of the count growing, which is what
+        makes ``max_points`` a real ceiling rather than a suggestion.
+
+        Widening rather than striding is deliberate. Every point stays
+        the real mean and the real floor of one contiguous slice, so a
+        chart labelled "average and lowest" is telling the truth about
+        both words. A strided series cannot show a dip it never plotted.
+        The cost is stated rather than hidden: a brief dip inside one
+        wide slice is averaged in, and the recent-window view is what
+        resolves short events.
+        """
+        window = self.window_for(span_s)
+        usable = finite(span_s)
+        if usable is None or usable <= 0:
+            return window
+        return max(window, usable / self.max_points)
+
     def mode_for(self, run_span_s: float, window_span_s: float) -> SeriesMode:
         """Whether the chart should describe the window or the whole run."""
         run = finite(run_span_s)

--- a/src/traceml_ai/renderers/shared/run_series.py
+++ b/src/traceml_ai/renderers/shared/run_series.py
@@ -129,7 +129,14 @@ class RunSeriesPolicy:
         usable = finite(span_s)
         if usable is None or usable <= 0:
             return window
-        return max(window, usable / self.max_points)
+        # Samples at both ends of the span can open a bucket, so a budget of
+        # N points has N - 1 intervals between them.
+        cap_width = (
+            math.nextafter(usable, math.inf)
+            if self.max_points == 1
+            else usable / float(self.max_points - 1)
+        )
+        return max(window, cap_width)
 
     def mode_for(self, run_span_s: float, window_span_s: float) -> SeriesMode:
         """Whether the chart should describe the window or the whole run."""

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -650,16 +650,16 @@ class SystemDashboardComputer:
         stats: Optional[RunStats],
         host: Optional[str],
     ) -> List[Dict[str, Any]]:
-        """Whole-run per-GPU power, bucketed at the rolling window's width.
+        """Whole-run per-GPU power, bucketed to fit the point budget.
 
-        This path buckets rather than rolls, so only the window duration
-        carries over from the shared policy; there is no stride or point
-        budget to apply, and the bucket count is therefore still unbounded.
-        See the follow-up issue.
+        This path buckets rather than rolls, so the shared plan's stride
+        does not apply; the policy answers the bucket question directly
+        instead. Below the budget the bucket is the rolling window, above
+        it the bucket widens so the count stays bounded.
         """
         if stats is None:
             return []
-        width = self._run_policy.window_for(stats.span_s)
+        width = self._run_policy.bucket_width_for(stats.span_s)
         rows = self._db.fetch_gpu_power_run(
             conn,
             width_s=width,

--- a/src/traceml_ai/renderers/system/repository.py
+++ b/src/traceml_ai/renderers/system/repository.py
@@ -274,9 +274,16 @@ class SystemRepository:
 
         This path BUCKETS rather than rolls, so it takes a bucket width
         rather than a ``RunSeriesPlan``: there is no stride, cadence or
-        point budget for the shared planner to supply. The width is the
-        same duration the rolling charts use, which is the only part of
-        the plan that applies here.
+        point budget for the shared planner to supply. The width comes
+        from ``RunSeriesPolicy.bucket_width_for``, which is the rolling
+        window until the run outgrows the point budget and then widens
+        past it, so it is NOT always the duration the rolling charts use.
+
+        The offset is clamped at zero. ``CAST`` truncates toward zero
+        rather than flooring, so a row older than ``first_ts`` would
+        otherwise land in a negative bucket and push the count past the
+        budget. ``first_ts`` is read by a separate query, so on a live
+        dashboard a delayed sample can arrive between the two.
         """
         where_sql, bound = self._run_scope(hostname)
         try:
@@ -300,7 +307,9 @@ class SystemRepository:
                     {where_sql}
                     {'AND' if where_sql else 'WHERE'} {_GPU_REPORTED_SQL}
                       AND {_HAS_CLOCK_SQL}
-                    GROUP BY gpu_idx, CAST((sample_ts_s - ?) / ? AS INTEGER)
+                    GROUP BY gpu_idx,
+                             CAST(MAX(sample_ts_s - ?, 0.0) / ?
+                                  AS INTEGER)
                     ORDER BY gpu_idx ASC, 2 ASC
                     """,
                     (*bound, float(first_ts), float(width_s)),

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -835,3 +835,23 @@ def test_tiles_abstain_when_the_payload_carries_no_measurement() -> None:
         assert not re.search(r"\d", _tile_number(content)), key
     # Not "0%", which is what a measured idle host reads.
     assert panel["cpu_value"].text == ""
+
+
+def test_a_widened_bucket_reads_as_hours_not_a_big_minute_count() -> None:
+    """Long runs now produce widths past an hour, so the label must too.
+
+    Before the whole-run power chart was capped, its width could not
+    exceed the 300 s window ceiling, so this branch was unreachable and
+    minutes were always enough. Capping widens the bucket instead of
+    growing the count, which puts multi-hour widths on the label: a seven
+    day run buckets at 5040 s, and "84 min" is not how a person reads it.
+    """
+    assert format_window(120.0) == "2 min"
+    assert format_window(719.0) == "12 min"
+    assert format_window(1440.0) == "24 min"
+    assert format_window(3600.0) == "1 h"
+    assert format_window(5040.0) == "1 h 24 min"
+    assert format_window(7200.0) == "2 h"
+    # Unchanged below a minute, and still empty for nothing.
+    assert format_window(30.0) == "30 s"
+    assert format_window(0.0) == ""

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -855,3 +855,9 @@ def test_a_widened_bucket_reads_as_hours_not_a_big_minute_count() -> None:
     # Unchanged below a minute, and still empty for nothing.
     assert format_window(30.0) == "30 s"
     assert format_window(0.0) == ""
+    # The hours branch converts to an integer, which raises on a
+    # non-finite value where the old format string produced "nan min".
+    # A card formatter has to degrade rather than take the section down.
+    assert format_window(float("nan")) == ""
+    assert format_window(float("inf")) == ""
+    assert format_window(-5.0) == ""

--- a/tests/renderers/shared/test_run_series.py
+++ b/tests/renderers/shared/test_run_series.py
@@ -195,3 +195,53 @@ def test_a_hand_built_plan_with_corrupt_numbers_still_answers():
     )
     assert plan.preceding_rows == 1
     assert "nan" not in plan.frame_clause().lower()
+
+
+def test_bucket_width_caps_the_point_count_on_a_long_run():
+    """Past the window ceiling the bucket widens instead of multiplying.
+
+    `window_for` saturates at its 300 s ceiling, so a bucket per window
+    means the count is `span / 300` and rises linearly with run length
+    forever: 288 per GPU at 24 hours, 2016 at 7 days, against the 120
+    the CPU chart budgets.
+    """
+    policy = RunSeriesPolicy()
+
+    for span in (86_400.0, 172_800.0, 604_800.0):
+        width = policy.bucket_width_for(span)
+        assert span / width <= policy.max_points
+
+
+def test_bucket_width_leaves_short_runs_alone():
+    """A run whose window already fits the budget is not re-shaped.
+
+    The cap is a ceiling, not a replacement rule: below it the bucket is
+    still the rolling window, so the chart keeps the resolution it has
+    and the label a reader sees does not move.
+    """
+    policy = RunSeriesPolicy()
+
+    assert policy.bucket_width_for(3_600.0) == policy.window_for(3_600.0)
+    assert policy.bucket_width_for(21_600.0) == policy.window_for(21_600.0)
+    assert 3_600.0 / policy.bucket_width_for(3_600.0) == 30
+    assert 21_600.0 / policy.bucket_width_for(21_600.0) == 72
+
+
+def test_a_bucket_is_never_narrower_than_the_rolling_window():
+    """Widening only. The bucket cannot drop below the window.
+
+    A narrower bucket would give the whole-run chart finer resolution
+    than the live window it is supposed to summarise.
+    """
+    policy = RunSeriesPolicy()
+
+    for span in (0.0, 60.0, 3_600.0, 86_400.0, 604_800.0, 6_048_000.0):
+        assert policy.bucket_width_for(span) >= policy.window_for(span)
+
+
+def test_a_degenerate_span_still_yields_a_usable_width():
+    """No division by zero, and never a zero or negative width."""
+    policy = RunSeriesPolicy()
+
+    for span in (0.0, -1.0, float("nan"), float("inf")):
+        assert policy.bucket_width_for(span) > 0.0

--- a/tests/renderers/shared/test_run_series.py
+++ b/tests/renderers/shared/test_run_series.py
@@ -209,7 +209,10 @@ def test_bucket_width_caps_the_point_count_on_a_long_run():
 
     for span in (86_400.0, 172_800.0, 604_800.0):
         width = policy.bucket_width_for(span)
-        assert span / width <= policy.max_points
+        assert int(span / width) + 1 <= policy.max_points
+
+    one_point = RunSeriesPolicy(max_points=1)
+    assert int(86_400.0 / one_point.bucket_width_for(86_400.0)) + 1 == 1
 
 
 def test_bucket_width_leaves_short_runs_alone():

--- a/tests/renderers/system/test_system_repository.py
+++ b/tests/renderers/system/test_system_repository.py
@@ -290,11 +290,8 @@ def test_power_history_is_capped_on_a_long_run(system_db):
         stats, out = _power_run(repo, conn)
 
     budget = DEFAULT_RUN_SERIES_POLICY.max_points
-    # At most one bucket over the budget: the buckets are half-open, so
-    # the run's final instant opens one more. That is a bounded overshoot
-    # of exactly one, not the unbounded growth this replaces.
-    assert len(out[0]["t"]) <= budget + 1
-    assert len(out[0]["t"]) == 121
+    assert len(out[0]["t"]) <= budget
+    assert len(out[0]["t"]) == 120
     # The width did the work, and it is wider than the window ceiling.
     assert stats is not None
     width = DEFAULT_RUN_SERIES_POLICY.bucket_width_for(stats.span_s)
@@ -538,7 +535,7 @@ def test_a_sample_older_than_the_run_start_cannot_break_the_cap(system_db):
         )
 
     budget = DEFAULT_RUN_SERIES_POLICY.max_points
-    assert len(rows) <= budget + 1
+    assert len(rows) <= budget
     # Every bucket index is non-negative, so the series still reads left
     # to right in time.
     stamps = [r[1] for r in rows]

--- a/tests/renderers/system/test_system_repository.py
+++ b/tests/renderers/system/test_system_repository.py
@@ -477,27 +477,69 @@ def test_a_dip_survives_the_cap_on_a_long_run(system_db):
     """Why the buckets widen instead of the series being strided.
 
     The chart is labelled "average and lowest". Widening keeps both words
-    true, because every point remains the real mean and the real floor of
-    one contiguous slice, so a momentary dip is still the minimum of the
-    slice that contains it. A strided series would sample every Nth
-    bucket and could not show a dip it never plotted.
+    true, because the buckets TILE the run: every instant belongs to
+    exactly one plotted slice, so a momentary dip is the minimum of the
+    slice containing it and cannot fall between two plotted points. A
+    strided series samples every Nth bucket and would leave holes.
 
-    One tick out of 720 drops to 11 W. It has to reach the floor line.
+    One tick out of 720 drops to 11 W.
     """
+    cadence = 120.0
 
     def rows(seq):
         return [gpu(0, power=11.0 if seq == 431 else 66.0)]
 
-    path = system_db(ticks=720, cadence_s=120.0, gpus=rows)
+    path = system_db(ticks=720, cadence_s=cadence, gpus=rows)
     repo = _repo(path)
     with repo.connect() as conn:
-        _stats, out = _power_run(repo, conn)
+        stats, out = _power_run(repo, conn)
 
+    assert stats is not None
     assert min(out[0]["min"]) == 11.0
-    # One slice's floor, not the whole series collapsing to it: every
-    # other bucket still reports the steady 66 W.
     assert sum(1 for v in out[0]["min"] if v == 11.0) == 1
-    assert set(out[0]["min"]) == {11.0, 66.0}
-    # And the dip is averaged INTO its slice rather than becoming it,
-    # which is the stated cost of widening.
+    # Averaged INTO its slice rather than becoming it, the stated cost.
     assert 11.0 < min(out[0]["avg"]) < 66.0
+
+    # The three assertions above hold under the OLD narrow buckets too,
+    # so alone they do not test this change at all. Coverage is what
+    # does: consecutive buckets start within one width (plus the sample
+    # cadence, since a bucket begins at its first sample rather than on
+    # the boundary), which is only true while the slices are contiguous.
+    width = DEFAULT_RUN_SERIES_POLICY.bucket_width_for(stats.span_s)
+    stamps = out[0]["t"]
+    gaps = [b - a for a, b in zip(stamps, stamps[1:])]
+    assert gaps, "a capped run still has more than one bucket"
+    assert max(gaps) <= width + cadence
+    # And the slices reach both ends of the run.
+    assert stamps[0] == pytest.approx(stats.first_ts)
+    assert stats.last_ts - stamps[-1] <= width + cadence
+
+
+def test_a_sample_older_than_the_run_start_cannot_break_the_cap(system_db):
+    """The bound is proved above the SQL, so the SQL has to hold it.
+
+    `first_ts` comes from a separate query than the fetch, so on a live
+    dashboard a delayed sample can arrive between the two carrying a
+    timestamp older than the one already read. `CAST` truncates toward
+    zero rather than flooring, so such a row would land in a NEGATIVE
+    bucket and push the count past the budget the caller asserts.
+
+    Clamped at zero, it folds into the first bucket instead.
+    """
+    path = system_db(ticks=720, cadence_s=120.0, gpus=lambda seq: [gpu(0)])
+    repo = _repo(path)
+    with repo.connect() as conn:
+        stats = repo.gpu_power_run_stats(conn)
+        assert stats is not None
+        width = DEFAULT_RUN_SERIES_POLICY.bucket_width_for(stats.span_s)
+        # A sample from well before the start the planner saw.
+        rows = repo.fetch_gpu_power_run(
+            conn, width_s=width, first_ts=stats.first_ts + 2.0 * width
+        )
+
+    budget = DEFAULT_RUN_SERIES_POLICY.max_points
+    assert len(rows) <= budget + 1
+    # Every bucket index is non-negative, so the series still reads left
+    # to right in time.
+    stamps = [r[1] for r in rows]
+    assert stamps == sorted(stamps)

--- a/tests/renderers/system/test_system_repository.py
+++ b/tests/renderers/system/test_system_repository.py
@@ -64,7 +64,7 @@ def _power_run(repo, conn, hostname=None):
     stats = repo.gpu_power_run_stats(conn, hostname=hostname)
     if stats is None:
         return None, []
-    width = DEFAULT_RUN_SERIES_POLICY.window_for(stats.span_s)
+    width = DEFAULT_RUN_SERIES_POLICY.bucket_width_for(stats.span_s)
     rows = repo.fetch_gpu_power_run(
         conn,
         width_s=width,
@@ -274,22 +274,50 @@ def test_power_history_buckets_per_gpu(system_db):
     assert stats.span_s == pytest.approx(2.0 * 599)
 
 
-def test_power_history_has_no_point_cap(system_db):
-    """Pinned as a known gap, deferred to its own issue.
+def test_power_history_is_capped_on_a_long_run(system_db):
+    """A long run widens its buckets instead of growing its point count.
 
-    The CPU chart budgets 120 points. This path buckets at one bucket per
-    `choose_window_s`, which saturates at 300 s, so bucket count grows
-    without bound: about 288 per GPU on a 24 hour run.
+    This used to be pinned at 288 buckets per GPU for 24 hours, because
+    the width saturated at the 300 s window ceiling and the count was
+    just `span / 300`. It rose linearly forever: 576 at 48 hours, 2016 at
+    seven days, and each entry carries four parallel arrays.
     """
     path = system_db(
         ticks=720, cadence_s=120.0, gpus=lambda seq: [gpu(0)]
     )  # a 24 hour run
     repo = _repo(path)
     with repo.connect() as conn:
-        _stats, out = _power_run(repo, conn)
-    # 86400 s of run at the 300 s window cap is 288 buckets, against the
-    # 120 the CPU chart budgets for. On an 8-GPU host that is ~2300 points.
-    assert len(out[0]["t"]) == 288
+        stats, out = _power_run(repo, conn)
+
+    budget = DEFAULT_RUN_SERIES_POLICY.max_points
+    # At most one bucket over the budget: the buckets are half-open, so
+    # the run's final instant opens one more. That is a bounded overshoot
+    # of exactly one, not the unbounded growth this replaces.
+    assert len(out[0]["t"]) <= budget + 1
+    assert len(out[0]["t"]) == 121
+    # The width did the work, and it is wider than the window ceiling.
+    assert stats is not None
+    width = DEFAULT_RUN_SERIES_POLICY.bucket_width_for(stats.span_s)
+    assert width > DEFAULT_RUN_SERIES_POLICY.roll_max_s
+
+
+def test_a_short_run_keeps_its_window_sized_buckets(system_db):
+    """The cap is a ceiling, not a reshaping. Below it nothing moves.
+
+    A two hour run's buckets are still the rolling window, so the chart
+    keeps the resolution it had and the "rolling N min" label a reader
+    sees does not change.
+    """
+    path = system_db(ticks=60, cadence_s=120.0, gpus=lambda seq: [gpu(0)])
+    repo = _repo(path)
+    with repo.connect() as conn:
+        stats, out = _power_run(repo, conn)
+
+    assert stats is not None
+    assert DEFAULT_RUN_SERIES_POLICY.bucket_width_for(
+        stats.span_s
+    ) == DEFAULT_RUN_SERIES_POLICY.window_for(stats.span_s)
+    assert len(out[0]["t"]) < DEFAULT_RUN_SERIES_POLICY.max_points
 
 
 def test_a_legacy_zero_placeholder_is_not_a_power_reading(system_db):
@@ -443,3 +471,33 @@ def test_one_unclocked_row_does_not_erase_the_whole_run_chart(system_db):
     assert len(out.series.cpu_run.t) > 2
     # And no drawn timestamp is the empty string the 1970 value formatted to.
     assert all(x for x in out.series.x_time)
+
+
+def test_a_dip_survives_the_cap_on_a_long_run(system_db):
+    """Why the buckets widen instead of the series being strided.
+
+    The chart is labelled "average and lowest". Widening keeps both words
+    true, because every point remains the real mean and the real floor of
+    one contiguous slice, so a momentary dip is still the minimum of the
+    slice that contains it. A strided series would sample every Nth
+    bucket and could not show a dip it never plotted.
+
+    One tick out of 720 drops to 11 W. It has to reach the floor line.
+    """
+
+    def rows(seq):
+        return [gpu(0, power=11.0 if seq == 431 else 66.0)]
+
+    path = system_db(ticks=720, cadence_s=120.0, gpus=rows)
+    repo = _repo(path)
+    with repo.connect() as conn:
+        _stats, out = _power_run(repo, conn)
+
+    assert min(out[0]["min"]) == 11.0
+    # One slice's floor, not the whole series collapsing to it: every
+    # other bucket still reports the steady 66 W.
+    assert sum(1 for v in out[0]["min"] if v == 11.0) == 1
+    assert set(out[0]["min"]) == {11.0, 66.0}
+    # And the dip is averaged INTO its slice rather than becoming it,
+    # which is the stated cost of widening.
+    assert 11.0 < min(out[0]["avg"]) < 66.0


### PR DESCRIPTION
Closes #427.

The whole-run GPU power chart had no point cap. Its bucket width came from `window_for(span)`,
which saturates at a 300 s ceiling, so past roughly four hours the bucket count was simply
`span / 300` and rose linearly with run length, forever.

## Measured, on the base

| run | window | buckets per GPU | floats in every payload, 8 GPUs |
|---|---|---|---|
| 1 h | 120 s | 30 | 960 |
| 6 h | 300 s | 72 | 2304 |
| 24 h | 300 s | **288** | 9216 |
| 48 h | 300 s | **576** | 18432 |
| 7 d | 300 s | **2016** | **64512** |

The 24 hour figure is the one #427 records. The tail is worse than that: each entry carries four
parallel arrays (`t`, `avg`, `min`, `max`), so a week-long run on an 8-GPU host puts roughly
64,500 floats in every payload, on every tick, against a CPU chart that budgets 120 points.

This matters against the overhead budget, and it matters most on exactly the long multi-GPU runs
the block exists to describe.

## The rule

`bucket_width_for(span) = max(window_for(span), span / max_points)`

Below the budget the bucket is still the rolling window, so short runs are untouched: 1 h stays
120 s and 30 buckets, 6 h stays 300 s and 72. Above it the bucket widens rather than the count
growing, so 24 h becomes 720 s and 120 buckets.

It lives on `RunSeriesPolicy` beside `window_for`, not at the call site, because that class
already owns `max_points`. Computing `span / max_points` in the computer would be reaching into
the policy's knob to do the policy's arithmetic somewhere else.

## Why widening and not striding

This is the decision the issue carries, and it turns on the chart's wording. #389 settled that
chart as "average and lowest". Widening keeps both words literally true: every point remains the
real mean and the real floor of one contiguous slice. Striding breaks the second one, because a
floor line that skips two of every three slices is the lowest of whatever survived decimation,
and a chart cannot show a dip it never plotted.

The cost is stated rather than hidden: a brief dip inside a 12 minute slice is averaged in rather
than shown, and the recent-window view is what resolves short events. There is a test that plants
one 11 W tick in a 720-tick run and asserts it still reaches the floor line, that exactly one
bucket carries it, and that the same bucket's average sits between the dip and the steady value.

## Two consequences of capping, both handled here

**Widths now exceed an hour.** Before this the width could not pass the 300 s ceiling, so
`format_window` only ever needed seconds and minutes. A seven day run buckets at 5040 s, and the
label read "every 84 min". It reads "1 h 24 min" now.

**And that new branch introduced a crash.** Converting to an integer for the hours split raises on
a non-finite width, where the old format string quietly produced `"nan min"`. Caught by probing
the boundaries rather than assuming, and guarded: a formatter on a card has to degrade, not take
the section down with it. This is the same narrowing that `gb_si` hit in #436.

## Found while reading

The repository test helper computed the width itself with `DEFAULT_RUN_SERIES_POLICY.window_for`,
a second copy of the production rule. Two copies means a test can keep passing while production
diverges from it. Both read the policy method now.

## Scope

```
STRUCTURE: a whole-run bucket width -> renderers/shared/run_series.py, RunSeriesPolicy (owner of
whole-run series shaping, and the class that already holds max_points); mirrored from window_for
on that same class; the hours label -> the section that formats it; boundaries crossed: none
DATA PATH: system_section <- SYSTEM_LAYOUT <- SystemRenderer <- SystemDashboardComputer
           <- SystemRepository <- system_gpu_samples
SCOPE: declared the whole-run power path plus its label and their tests -> diff touches
run_series.py, dashboard_compute.py, system_section.py and three test files -> within
TWINS: searched the CONCEPT, not the symbol - every whole-run series that could grow without a
bound. Exactly one SQL bucketing site exists in the product (this one, fixed); every other
whole-run read goes through plan_run_series, which already caps via stride_for(eligible_count,
max_points). The CPU and Process whole-run series were already bounded
```

## Verification

```
GATE: pytest tests/ -> 1676 passed, 2 skipped against version_0.3.7 at d7c375f measured at 1668 passed, 2 skipped; the delta is the eight tests added here; black, isort and ruff clean at 79 on every file in the diff
TRANSITIONS: the recent-to-retained switch is untouched. This changes the SHAPE of the retained view, never whether a chart is in it: mode_for and the retained_factor are unchanged, and a short run's width is asserted equal to its window so the boundary cannot move
RANKS: not applicable; System is single-node and this path is per-device. The per-GPU grouping in the SQL is unchanged, and the cap applies per GPU rather than across devices
TRIPWIRE: no whole-run series in the product may grow its point count with run length. The one bucketed path is capped at max_points + 1 (the half-open final bucket), asserted at 24 h, 48 h and 7 days; every other whole-run read is planned by plan_run_series, which strides
SCENARIOS: all 22 fixture cells rendered on both trees and diffed field by field; 0 of 676 field values differ. That is the expected result and is NOT evidence the fix works: the cap engages only past 10 hours of run and the longest fixture is 2 h 57 m, so no cell can reach this change. Its job here is to show the measured paths are untouched. The evidence is the bucket counts above and the eight tests. A fixture longer than 10 hours would be worth adding and does not exist
PLATFORM: macOS 26.1, Python 3.12.13, SQLite 3.51.2
```
