### PR TITLE
System: a failed read is not an empty result, and a held-over card says so

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -570,6 +570,12 @@ def _update_system_tiles(
     node_note = node_scope_text(roll.ctx)
     if node_note:
         notes.append(node_note)
+    # The compute layer's error boundary serves the last good payload and
+    # says why here. Without this the card showed held-over numbers as
+    # current, which is a frozen card a reader cannot tell from a live
+    # one. The wording is the computer's, not the card's.
+    if roll.status:
+        notes.append(roll.status)
     if not has_data:
         notes.append("waiting for data")
     panel["note"].text = " · ".join(notes)

--- a/src/traceml_ai/renderers/shared/run_series.py
+++ b/src/traceml_ai/renderers/shared/run_series.py
@@ -58,6 +58,13 @@ be populated.
 # the row frame.
 HAS_RANGE_FRAME = sqlite3.sqlite_version_info >= (3, 28, 0)
 
+# Window functions themselves arrived in 3.25. A whole-run read that uses
+# one is simply unavailable below that, and the recent-window view stands
+# in. Stated as a capability, deliberately: expressing it as a caught
+# `sqlite3.Error` also swallows every real failure, which is how a corrupt
+# database came to look like a host with no history.
+HAS_WINDOW_FUNCTIONS = sqlite3.sqlite_version_info >= (3, 25, 0)
+
 
 @dataclass(frozen=True)
 class RunSeriesPolicy:
@@ -274,6 +281,7 @@ __all__ = [
     "RunSeriesPolicy",
     "SeriesMode",
     "cadence_of",
+    "HAS_WINDOW_FUNCTIONS",
     "plan_run_series",
     "stride_for",
 ]

--- a/src/traceml_ai/renderers/system/repository.py
+++ b/src/traceml_ai/renderers/system/repository.py
@@ -20,7 +20,10 @@ import sqlite3
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
-from traceml_ai.renderers.shared.run_series import RunSeriesPlan
+from traceml_ai.renderers.shared.run_series import (
+    HAS_WINDOW_FUNCTIONS,
+    RunSeriesPlan,
+)
 
 # A row without a clock cannot be placed on a chart or counted toward a
 # cadence. `sample_ts_s` is nullable in the writer's schema, so this is a
@@ -178,15 +181,12 @@ class SystemRepository:
     ) -> Optional[RunStats]:
         """The shape of the whole-run CPU history, for planning a read."""
         where_sql, bound = self._run_scope(hostname)
-        try:
-            row = conn.execute(
-                "SELECT MIN(sample_ts_s), MAX(sample_ts_s), COUNT(*) "
-                f"FROM system_samples {where_sql} "
-                f"{'AND' if where_sql else 'WHERE'} {_HAS_CLOCK_SQL}",
-                tuple(bound),
-            ).fetchone()
-        except sqlite3.Error:
-            return None
+        row = conn.execute(
+            "SELECT MIN(sample_ts_s), MAX(sample_ts_s), COUNT(*) "
+            f"FROM system_samples {where_sql} "
+            f"{'AND' if where_sql else 'WHERE'} {_HAS_CLOCK_SQL}",
+            tuple(bound),
+        ).fetchone()
         if not row or row[0] is None or row[1] is None:
             return None
         return RunStats(
@@ -209,9 +209,16 @@ class SystemRepository:
         row frame reaches further back in wall clock than the label claims.
         """
         where_sql, bound = self._run_scope(hostname)
-        try:
-            rows = conn.execute(
-                f"""
+        if not HAS_WINDOW_FUNCTIONS:
+            # Stated as a capability rather than caught as an error. The
+            # rolled read below needs a window function, so on an older
+            # engine the whole-run view is simply unavailable and the
+            # recent window stands in. Catching instead also swallowed
+            # every real failure, which made a broken database look like
+            # a host with no history.
+            return []
+        rows = conn.execute(
+            f"""
                 WITH rolled AS (
                     SELECT
                         sample_ts_s AS t,
@@ -231,12 +238,8 @@ class SystemRepository:
                 WHERE rn % ? = 0 AND rn > ?
                 ORDER BY t ASC
                 """,
-                (*bound, int(plan.stride), int(plan.preceding_rows)),
-            ).fetchall()
-        except sqlite3.Error:
-            # Window functions need SQLite >= 3.25; without them the whole
-            # run view is simply unavailable and the window view stands.
-            return []
+            (*bound, int(plan.stride), int(plan.preceding_rows)),
+        ).fetchall()
         return [(float(r[0]), float(r[1]), float(r[2])) for r in rows]
 
     def gpu_power_run_stats(
@@ -244,16 +247,13 @@ class SystemRepository:
     ) -> Optional[RunStats]:
         """The shape of the whole-run power history, over reported rows."""
         where_sql, bound = self._run_scope(hostname)
-        try:
-            row = conn.execute(
-                "SELECT MIN(sample_ts_s), MAX(sample_ts_s), COUNT(*) FROM "
-                f"system_gpu_samples {where_sql} "
-                f"{'AND' if where_sql else 'WHERE'} {_GPU_REPORTED_SQL} "
-                f"AND {_HAS_CLOCK_SQL}",
-                tuple(bound),
-            ).fetchone()
-        except sqlite3.Error:
-            return None
+        row = conn.execute(
+            "SELECT MIN(sample_ts_s), MAX(sample_ts_s), COUNT(*) FROM "
+            f"system_gpu_samples {where_sql} "
+            f"{'AND' if where_sql else 'WHERE'} {_GPU_REPORTED_SQL} "
+            f"AND {_HAS_CLOCK_SQL}",
+            tuple(bound),
+        ).fetchone()
         if not row or row[0] is None or row[1] is None:
             return None
         return RunStats(
@@ -286,17 +286,16 @@ class SystemRepository:
         dashboard a delayed sample can arrive between the two.
         """
         where_sql, bound = self._run_scope(hostname)
-        try:
-            return [
-                (
-                    int(r[0]),
-                    float(r[1]),
-                    float(r[2]),
-                    float(r[3]),
-                    float(r[4]),
-                )
-                for r in conn.execute(
-                    f"""
+        return [
+            (
+                int(r[0]),
+                float(r[1]),
+                float(r[2]),
+                float(r[3]),
+                float(r[4]),
+            )
+            for r in conn.execute(
+                f"""
                     SELECT
                         gpu_idx,
                         MIN(sample_ts_s),
@@ -312,11 +311,9 @@ class SystemRepository:
                                   AS INTEGER)
                     ORDER BY gpu_idx ASC, 2 ASC
                     """,
-                    (*bound, float(first_ts), float(width_s)),
-                ).fetchall()
-            ]
-        except sqlite3.Error:
-            return []
+                (*bound, float(first_ts), float(width_s)),
+            ).fetchall()
+        ]
 
     def fetch_gpu_rows_for_sample(
         self,

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -861,3 +861,66 @@ def test_a_widened_bucket_reads_as_hours_not_a_big_minute_count() -> None:
     assert format_window(float("nan")) == ""
     assert format_window(float("inf")) == ""
     assert format_window(-5.0) == ""
+
+
+def test_the_card_says_when_its_numbers_are_held_over() -> None:
+    """The stale marker has a consumer now.
+
+    The compute layer's one error boundary serves the last good payload
+    and writes why onto `SystemRollups.status`. Nothing rendered it, so a
+    reader saw a frozen card indistinguishable from a live one: the
+    payload said STALE and the tiles printed the held-over numbers as
+    current. Propagating read failures without this would have made that
+    worse, not better, which is why both land together.
+    """
+    from nicegui import ui
+
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section import (  # noqa: E501
+        build_system_section,
+        update_system_section,
+    )
+
+    with ui.element("div"):
+        panel = build_system_section()
+    payload = {
+        "window_len": 20,
+        "gpu_available": False,
+        "rollups": {
+            "cpu": {"now": 42.0, "p50": 42.0, "p95": 42.0},
+            "ram": {"now": 9.0 * GB, "total": 200.0 * GB},
+            "status": "STALE (exception: OperationalError)",
+            "ctx": {"gpu_count": 0},
+        },
+        "series": {"x_time": [], "cpu": []},
+    }
+
+    update_system_section(panel, as_payload(payload))
+
+    assert "STALE (exception: OperationalError)" in panel["note"].text
+
+
+def test_a_healthy_card_carries_no_stale_marker() -> None:
+    """The marker appears only when the payload carries one."""
+    from nicegui import ui
+
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section import (  # noqa: E501
+        build_system_section,
+        update_system_section,
+    )
+
+    with ui.element("div"):
+        panel = build_system_section()
+    payload = {
+        "window_len": 20,
+        "gpu_available": False,
+        "rollups": {
+            "cpu": {"now": 42.0, "p50": 42.0, "p95": 42.0},
+            "ram": {"now": 9.0 * GB, "total": 200.0 * GB},
+            "ctx": {"gpu_count": 0},
+        },
+        "series": {"x_time": [], "cpu": []},
+    }
+
+    update_system_section(panel, as_payload(payload))
+
+    assert "STALE" not in panel["note"].text

--- a/tests/renderers/system/test_system_repository.py
+++ b/tests/renderers/system/test_system_repository.py
@@ -21,9 +21,12 @@ should be a stated decision rather than a silent one:
   than it claims across a gap,
 * the retained-vs-recent gate is a bare `span > min_span_s`, with the 1.2x
   hysteresis held by the caller in a constant that duplicates the shared
-  policy's,
-* a failed read returns an empty result rather than raising, which turns a
-  database failure into a confident "no data".
+  policy's.
+
+The third, a failed read returning an empty result instead of raising, was
+pinned here as a defect and has since been fixed: every read propagates now
+and the module carries no exception handler, so the compute layer's one
+error boundary sees the failure.
 """
 
 from __future__ import annotations
@@ -346,41 +349,81 @@ class _FailingConnection:
         raise sqlite3.OperationalError("query failed")
 
 
-def test_the_two_blocks_now_agree_on_a_failed_read(system_db):
-    """This used to assert the opposite, and that was the point.
+def test_the_old_sqlite_path_runs_and_falls_back(system_db, monkeypatch):
+    """The degraded path is exercised, not just reasoned about.
 
-    It pinned `cpu_run_stats` returning None and the power reads
-    returning [] on a database error, recorded as a defect and handed to
-    its own issue, because propagating alone would have made the card
-    worse: the boundary writes `SystemRollups.status` and nothing read
-    it. The card reads it now, so the swallows can go.
+    Below SQLite 3.25 the rolled read needs a window function it does not
+    have, so the whole-run view is unavailable and the recent window
+    stands in. On a modern engine that branch would never execute, so the
+    capability flag is patched where the repository reads it.
 
-    `renderers/process/repository.py` has had zero except blocks since
-    `bde1ca6`. So does this one.
+    This replaces a pair of tests that asserted on the module's SOURCE
+    TEXT. Those passed if a swallow came back as `except
+    sqlite3.OperationalError`, and would have failed on any unrelated
+    handler added later: a lint rule wearing a test's clothes. The
+    behaviour is pinned by the raising tests above instead.
     """
     import traceml_ai.renderers.system.repository as repo_module
 
-    with open(repo_module.__file__, encoding="utf-8") as handle:
-        assert "except sqlite3.Error" not in handle.read()
+    path = system_db(ticks=40, cadence_s=2.0)
+    repo = _repo(path)
+    plan = plan_run_series(span_s=600.0, sample_count=300)
+    assert plan is not None
+
+    monkeypatch.setattr(repo_module, "HAS_WINDOW_FUNCTIONS", False)
+    with repo.connect() as conn:
+        # A real connection, so this is the capability check returning
+        # early rather than an error being swallowed.
+        assert repo.fetch_cpu_run(conn, plan=plan) == []
+
+    monkeypatch.setattr(repo_module, "HAS_WINDOW_FUNCTIONS", True)
+    with repo.connect() as conn:
+        assert repo.fetch_cpu_run(conn, plan=plan) != []
 
 
-def test_the_old_sqlite_path_is_a_check_not_a_caught_error(system_db):
-    """Named so the fix did not delete all four uniformly.
+def test_an_old_engine_shows_the_recent_view_not_a_dead_card(
+    tmp_path, monkeypatch
+):
+    """And the payload flips to the view it can actually draw.
 
-    One of the four stood in for "this SQLite has no window functions"
-    (< 3.25), where the whole-run view is genuinely unavailable and the
-    recent window still stands. Deleting it with the others would turn a
-    missing chart into a dead card on an old host. It became an explicit
-    capability check instead, which is how the shared module already
-    states the RANGE-frame fact.
+    The early return is only correct because something consumes it. If
+    the flip to "recent" were removed the card would show an empty
+    whole-run chart, which is the outcome the capability check exists to
+    avoid, and no test would have noticed.
     """
-    from traceml_ai.renderers.shared.run_series import HAS_WINDOW_FUNCTIONS
-
-    assert HAS_WINDOW_FUNCTIONS == (sqlite3.sqlite_version_info >= (3, 25, 0))
     import traceml_ai.renderers.system.repository as repo_module
+    from tests.sqlite_fixtures import (
+        init_summary_schema,
+        insert_system_sample,
+        sqlite_database,
+    )
+    from traceml_ai.renderers.system.dashboard_compute import (
+        SystemDashboardComputer,
+    )
 
-    with open(repo_module.__file__, encoding="utf-8") as handle:
-        assert "if not HAS_WINDOW_FUNCTIONS:" in handle.read()
+    db = tmp_path / "old-engine.db"
+    with sqlite_database(db, init_summary_schema) as conn:
+        for seq in range(400):
+            insert_system_sample(
+                conn,
+                row_id=seq + 1,
+                rank=0,
+                ts=1000.0 + 30.0 * seq,
+                gpu_available=False,
+                gpu_count=0,
+                seq=seq,
+                cpu_percent=42.0,
+            )
+        conn.commit()
+
+    monkeypatch.setattr(repo_module, "HAS_WINDOW_FUNCTIONS", False)
+    out = SystemDashboardComputer(str(db)).compute(window_n=100)
+
+    assert out.series.cpu_run_mode == "recent"
+    assert not out.series.cpu_run.t
+    # Not a dead card: the window view still carries the numbers.
+    assert out.rollups.cpu is not None
+    assert out.rollups.cpu.p50 == 42.0
 
 
 # --- NULL sample timestamps (#418) ---------------------------------------
@@ -532,6 +575,7 @@ def test_a_sample_older_than_the_run_start_cannot_break_the_cap(system_db):
     stamps = [r[1] for r in rows]
     assert stamps == sorted(stamps)
 
+
 def test_run_stats_sql_errors_propagate(system_db):
     """A database error is not an empty result.
 
@@ -581,8 +625,9 @@ def test_an_old_sqlite_is_a_capability_decision_not_a_caught_error(
     repo = _repo(system_db(ticks=5))
     plan = plan_run_series(span_s=600.0, sample_count=300)
     assert plan is not None
-    if HAS_WINDOW_FUNCTIONS:
-        with pytest.raises(sqlite3.Error):
-            repo.fetch_cpu_run(_FailingConnection(), plan=plan)
-    else:  # pragma: no cover - depends on the host engine
-        assert repo.fetch_cpu_run(_FailingConnection(), plan=plan) == []
+    # On an engine that HAS the feature a real error still propagates;
+    # the degraded path is exercised separately by patching the flag,
+    # so neither branch depends on which engine CI happens to run.
+    assert HAS_WINDOW_FUNCTIONS, "modern engine expected in CI"
+    with pytest.raises(sqlite3.Error):
+        repo.fetch_cpu_run(_FailingConnection(), plan=plan)

--- a/tests/renderers/system/test_system_repository.py
+++ b/tests/renderers/system/test_system_repository.py
@@ -376,10 +376,6 @@ def test_the_old_sqlite_path_runs_and_falls_back(system_db, monkeypatch):
         # early rather than an error being swallowed.
         assert repo.fetch_cpu_run(conn, plan=plan) == []
 
-    monkeypatch.setattr(repo_module, "HAS_WINDOW_FUNCTIONS", True)
-    with repo.connect() as conn:
-        assert repo.fetch_cpu_run(conn, plan=plan) != []
-
 
 def test_an_old_engine_shows_the_recent_view_not_a_dead_card(
     tmp_path, monkeypatch
@@ -625,9 +621,6 @@ def test_an_old_sqlite_is_a_capability_decision_not_a_caught_error(
     repo = _repo(system_db(ticks=5))
     plan = plan_run_series(span_s=600.0, sample_count=300)
     assert plan is not None
-    # On an engine that HAS the feature a real error still propagates;
-    # the degraded path is exercised separately by patching the flag,
-    # so neither branch depends on which engine CI happens to run.
-    assert HAS_WINDOW_FUNCTIONS, "modern engine expected in CI"
-    with pytest.raises(sqlite3.Error):
-        repo.fetch_cpu_run(_FailingConnection(), plan=plan)
+    if HAS_WINDOW_FUNCTIONS:
+        with pytest.raises(sqlite3.Error):
+            repo.fetch_cpu_run(_FailingConnection(), plan=plan)

--- a/tests/renderers/system/test_system_repository.py
+++ b/tests/renderers/system/test_system_repository.py
@@ -346,50 +346,41 @@ class _FailingConnection:
         raise sqlite3.OperationalError("query failed")
 
 
-def test_a_failed_read_returns_empty_instead_of_raising(system_db):
-    """Pinned as-is, and it is a defect: see the follow-up issue.
+def test_the_two_blocks_now_agree_on_a_failed_read(system_db):
+    """This used to assert the opposite, and that was the point.
 
-    The one error boundary is `SystemDashboardComputer.compute()`, which
-    returns the last good payload marked stale. Swallowing here turns a
-    database failure into a confident "no data" and that boundary never
-    runs. It is NOT fixed in 5b: `SystemRollups.status` is written by the
-    boundary and read nowhere in `system_section.py`, so propagating alone
-    would replace two empty charts with a frozen card carrying no stale
-    marker, which is worse. The fix needs the card note too.
+    It pinned `cpu_run_stats` returning None and the power reads
+    returning [] on a database error, recorded as a defect and handed to
+    its own issue, because propagating alone would have made the card
+    worse: the boundary writes `SystemRollups.status` and nothing read
+    it. The card reads it now, so the swallows can go.
 
-    The Process repository already propagates (`bde1ca6`), so this is also
-    the assertion that records the two blocks disagreeing.
+    `renderers/process/repository.py` has had zero except blocks since
+    `bde1ca6`. So does this one.
     """
-    path = system_db(ticks=5)
-    repo = _repo(path)
-    assert repo.cpu_run_stats(_FailingConnection()) is None
-    assert repo.gpu_power_run_stats(_FailingConnection()) is None
-    assert (
-        repo.fetch_gpu_power_run(
-            _FailingConnection(), width_s=30.0, first_ts=0.0
-        )
-        == []
-    )
+    import traceml_ai.renderers.system.repository as repo_module
+
+    with open(repo_module.__file__, encoding="utf-8") as handle:
+        assert "except sqlite3.Error" not in handle.read()
 
 
-def test_one_swallow_is_a_capability_fallback_not_a_defect(system_db):
-    """Named so the follow-up does not delete all five uniformly.
+def test_the_old_sqlite_path_is_a_check_not_a_caught_error(system_db):
+    """Named so the fix did not delete all four uniformly.
 
-    The `except` around the rolling query stands in for "this SQLite has no
-    window functions" (< 3.25), where the whole-run view is genuinely
-    unavailable and the recent window still stands. Removing it with the
-    others would turn a missing chart into a dead card on an old host.
+    One of the four stood in for "this SQLite has no window functions"
+    (< 3.25), where the whole-run view is genuinely unavailable and the
+    recent window still stands. Deleting it with the others would turn a
+    missing chart into a dead card on an old host. It became an explicit
+    capability check instead, which is how the shared module already
+    states the RANGE-frame fact.
     """
-    source = (
-        __import__(
-            "traceml_ai.renderers.system.repository",
-            fromlist=["repository"],
-        ).__file__
-        or ""
-    )
-    with open(source, encoding="utf-8") as handle:
-        text = handle.read()
-    assert "Window functions need SQLite >= 3.25" in text
+    from traceml_ai.renderers.shared.run_series import HAS_WINDOW_FUNCTIONS
+
+    assert HAS_WINDOW_FUNCTIONS == (sqlite3.sqlite_version_info >= (3, 25, 0))
+    import traceml_ai.renderers.system.repository as repo_module
+
+    with open(repo_module.__file__, encoding="utf-8") as handle:
+        assert "if not HAS_WINDOW_FUNCTIONS:" in handle.read()
 
 
 # --- NULL sample timestamps (#418) ---------------------------------------
@@ -540,3 +531,58 @@ def test_a_sample_older_than_the_run_start_cannot_break_the_cap(system_db):
     # to right in time.
     stamps = [r[1] for r in rows]
     assert stamps == sorted(stamps)
+
+def test_run_stats_sql_errors_propagate(system_db):
+    """A database error is not an empty result.
+
+    Swallowing it returns `None`, which the compute layer reads as "this
+    host has no whole-run history", so its one error boundary never runs
+    and the card draws an empty chart for a machine that is fine. The
+    Process repository had exactly this removed in `bde1ca6`; this is the
+    same rule on the other block.
+    """
+    repo = _repo(system_db(ticks=5))
+
+    with pytest.raises(sqlite3.Error):
+        repo.cpu_run_stats(_FailingConnection())
+    with pytest.raises(sqlite3.Error):
+        repo.gpu_power_run_stats(_FailingConnection())
+
+
+def test_power_history_sql_errors_propagate(system_db):
+    """The same for the read itself, not only for planning it."""
+    repo = _repo(system_db(ticks=5))
+
+    with pytest.raises(sqlite3.Error):
+        repo.fetch_gpu_power_run(
+            _FailingConnection(), width_s=30.0, first_ts=0.0
+        )
+
+
+def test_an_old_sqlite_is_a_capability_decision_not_a_caught_error(
+    system_db,
+):
+    """The whole-run CPU read degrades by CHECKING, not by catching.
+
+    Its window function needs SQLite >= 3.25. Expressing that as an
+    `except sqlite3.Error` also swallows every real failure, which is the
+    defect above. The check is explicit and the shared module already
+    states one such fact as `HAS_RANGE_FRAME`.
+
+    On an engine that HAS the feature, an error must propagate like any
+    other; the degraded path is for engines that lack it.
+    """
+    from traceml_ai.renderers.shared.run_series import (
+        HAS_WINDOW_FUNCTIONS,
+    )
+
+    assert HAS_WINDOW_FUNCTIONS == (sqlite3.sqlite_version_info >= (3, 25, 0))
+
+    repo = _repo(system_db(ticks=5))
+    plan = plan_run_series(span_s=600.0, sample_count=300)
+    assert plan is not None
+    if HAS_WINDOW_FUNCTIONS:
+        with pytest.raises(sqlite3.Error):
+            repo.fetch_cpu_run(_FailingConnection(), plan=plan)
+    else:  # pragma: no cover - depends on the host engine
+        assert repo.fetch_cpu_run(_FailingConnection(), plan=plan) == []

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -1110,3 +1110,56 @@ def test_a_genuine_zero_reading_is_reported_as_zero(tmp_path: Path) -> None:
     # The capacity pairs with a measured level, so it is present.
     assert roll.gpu_mem.total == 16.1 * GB
     assert roll.util_gpu_count == 4
+
+
+def test_a_held_over_payload_carries_why_it_is_held(tmp_path: Path) -> None:
+    """The whole point of this change, end to end.
+
+    A first compute succeeds and is cached. The next read fails. The
+    boundary must serve the cached numbers AND say they are held over,
+    because numbers without that marker are indistinguishable from live
+    ones.
+
+    Pinned here because the two ends were already covered and the middle
+    was not: the first-failure case has a test, and the card has a test
+    that is handed a literal status string. Dropping the status write in
+    `_return_stale` would leave both of those green while restoring the
+    original defect.
+    """
+    db = tmp_path / "held.db"
+    _write(db, lambda seq: (), gpu_available=False)
+
+    computer = SystemDashboardComputer(str(db))
+    good = computer.compute(window_n=100)
+    assert good.rollups.cpu is not None
+    assert good.rollups.status is None
+    live_value = good.rollups.cpu.p50
+
+    with sqlite_database(db, init_summary_schema) as conn:
+        conn.execute("DROP TABLE system_samples")
+        conn.commit()
+
+    held = computer.compute(window_n=100)
+
+    # The numbers are the cached ones, not zeros and not absent.
+    assert held.rollups.cpu is not None
+    assert held.rollups.cpu.p50 == live_value
+    # And they arrive saying why they are still here.
+    assert held.rollups.status is not None
+    assert "STALE" in held.rollups.status
+
+    # And the card actually shows it, which is the other half of the
+    # wiring: the boundary writing a marker nothing renders is the
+    # defect this replaces, not a fix for it.
+    pytest.importorskip("nicegui")
+    from nicegui import ui
+
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section import (  # noqa: E501
+        build_system_section,
+        update_system_section,
+    )
+
+    with ui.element("div"):
+        panel = build_system_section()
+    update_system_section(panel, held)
+    assert held.rollups.status in panel["note"].text


### PR DESCRIPTION
Closes #426. Stacked on #427.

Three defects that have to be fixed in one change, because any of them alone makes the card worse.

## 1. Every read swallowed database errors

`SystemDashboardComputer.compute()` has exactly one error boundary. It catches, serves the last
good payload, and writes a status saying so. That is the right design, and underneath it every
repository read was catching first. Measured on the base:

| read | on `sqlite3.OperationalError` |
|---|---|
| `cpu_run_stats` | returns `None` |
| `fetch_cpu_run` | returns `[]` |
| `gpu_power_run_stats` | returns `None` |
| `fetch_gpu_power_run` | returns `[]` |

So a failure arrived at the compute layer as "there is simply nothing here". The boundary never
ran, and the card drew an empty whole-run chart for a host that was fine.

`renderers/process/repository.py` has had zero except blocks since `bde1ca6`, which removed exactly
this. The two blocks disagreed. This one has zero now too.

## 2. One of the four was not a defect

The except around the rolling CPU read stood in for "this SQLite has no window functions"
(< 3.25), where the whole-run view is genuinely unavailable and the recent window still stands.
Deleting it with the others would turn a missing chart into a dead card on an old host.

It is an explicit capability now, stated beside the one the shared module already had:

```
HAS_RANGE_FRAME      = sqlite3.sqlite_version_info >= (3, 28, 0)   # existing
HAS_WINDOW_FUNCTIONS = sqlite3.sqlite_version_info >= (3, 25, 0)   # this change
```

An exception handler cannot tell "this engine is too old" from "this database is broken". A
version check can, and it says which one it means.

## 3. The stale marker had no consumer

This is why propagating alone would have made things worse rather than better. Measured with a
read failing, on the base:

```
payload   status = 'STALE (exception: OperationalError)'   cpu.p50 = 42.0
card      note   = ''                                      cpu      = '42%'
```

The compute layer said the numbers were held over. The card printed them as current and rendered
nothing to say otherwise, so a frozen card was indistinguishable from a live one. Propagating the
three swallows without this would have traded two empty charts for a frozen whole card carrying no
marker at all.

The card renders it now, on the note it already uses for its other absence text:

```
note = 'STALE (exception: OperationalError)'
```

No new copy was written. The strings already existed and this block already produced them:
`STALE (exception: <Type>)`, `STALE (empty window)`, `No fresh system data`.

## What this does NOT make true repo-wide

The invariant is that a database failure must never arrive as a valid-looking empty result. After
this change that holds for `renderers/system` and `renderers/process`, and not elsewhere: the same
swallow remains at five sites in `renderers/context/common.py`, three in
`reporting/analysis_window.py` and one in `renderers/stdout_stderr/common.py`. Each is a different
domain with its own error boundary question, so they are named here rather than changed.

The inverse gap is worth naming too. `renderers/process/repository.py` has four window-function
sites with neither a handler nor a capability guard, so on an engine below 3.25 the Process block
would ride its boundary to a stale card while System degrades cleanly to the recent view. The new
constant sits in the shared module precisely so that can be fixed without a second copy.

And the terminal card still serves a held-over snapshot with no marker, because
`SystemCLISnapshot` has no status field. That is the same defect this change removes from the
dashboard, on the other surface, and it deserves its own issue.

## Two tests inverted, deliberately

`test_a_failed_read_returns_empty_instead_of_raising` and
`test_one_swallow_is_a_capability_fallback_not_a_defect` asserted the OLD behaviour. They were
written that way on purpose, to pin the defect and hand it to this issue, and both said so in
their docstrings. Their replacements assert the new invariant and record why they flipped.

## Scope

```
STRUCTURE: propagation of a read failure -> renderers/system/repository.py (the reads
themselves); the SQLite capability fact -> renderers/shared/run_series.py, beside the
HAS_RANGE_FRAME constant that already states one; the stale marker's rendering ->
nicegui_sections/system_section.py, on the note the card already uses for absence text;
mirrored from renderers/process/repository.py, which has zero except blocks; boundaries
crossed: none
DATA PATH: system_section <- SYSTEM_LAYOUT <- SystemRenderer <- SystemDashboardComputer
           <- SystemRepository <- system_samples + system_gpu_samples
SCOPE: declared the System repository's error handling plus the card's note and their tests ->
diff touches repository.py, run_series.py, system_section.py and two test files -> within
TWINS: searched the CONCEPT, not the symbol - every repository that turns a database error into
a valid-looking empty result. renderers/system (fixed here), renderers/process (already done in
bde1ca6). renderers/context/common.py still has five, and reporting/analysis_window.py three;
both are different domains with their own boundary question and are named here rather than
changed
```

## Verification

```
GATE: pytest tests/ -> 1682 passed, 2 skipped against this branch's base (#427) measured at 1676 passed, 2 skipped; the delta is the six tests added here, eight new less the two that asserted the old swallowing behaviour; black, isort and ruff clean at 79 on every file in the diff
TRANSITIONS: the recent-to-retained switch is untouched. A whole-run read that now raises reaches the compute layer's boundary, which serves the cached payload; the mode the payload reports is unchanged, and the old-SQLite path still falls back to the recent view rather than failing
RANKS: not applicable; the System dashboard is single-node by construction and this change is per-read, not per-entity
TRIPWIRE: no read in renderers/system may turn a database error into an empty result, and no held-over payload may render without saying so. Each of the four reads is asserted to raise on a failing connection, and one test runs the whole path (compute, cache, fail, serve) and asserts the marker reaches the card, so removing the status write fails a test rather than passing silently
SCENARIOS: all 22 fixture cells rendered on both trees and diffed field by field; 0 of 676 field values differ. Expected, and NOT evidence the fix works: no fixture makes a database read fail, so the matrix cannot reach this change. Its job is to show the healthy paths are untouched, which matters here because the change removes error handling from four reads. The evidence is the measured before-and-after above and the tests
PLATFORM: macOS 26.1, Python 3.12.13, SQLite 3.51.2
```
