### PR TITLE
System: the card says when the machine has stopped reporting

### DIFF
--- a/src/traceml_ai/aggregator/display_drivers/nicegui.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui.py
@@ -194,7 +194,10 @@ class NiceGUIDisplayDriver(BaseDisplayDriver):
         # ---- Independent layout renderers ----
         self._renderers: List[DashboardRenderer] = [
             ContextRenderer(db_path=self._settings.db_path),
-            SystemRenderer(db_path=self._settings.db_path),
+            SystemRenderer(
+                db_path=self._settings.db_path,
+                sampler_interval_s=self._settings.sampler_interval_sec,
+            ),
             ProcessRenderer(
                 db_path=self._settings.db_path,
                 sampler_interval_s=self._settings.sampler_interval_sec,

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/context_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/context_section.py
@@ -31,6 +31,8 @@ from nicegui import ui
 
 from traceml_ai.renderers.context.common import empty_context
 
+from .formatting import format_elapsed
+
 # Sections that only exist on a training run. A watch session has no step
 # loop, so showing them there produces permanently dead panels (#355).
 STEP_SECTIONS: Tuple[str, ...] = (
@@ -65,18 +67,6 @@ def sections_for_profile(profile: str) -> Tuple[str, ...]:
     if str(profile or "run") == "watch":
         return RESOURCE_SECTIONS
     return RUN_SECTIONS
-
-
-def format_elapsed(seconds: float) -> str:
-    """``47s`` / ``2m 26s`` / ``3h 12m``."""
-    total = max(0, int(seconds))
-    hours, rem = divmod(total, 3600)
-    minutes, secs = divmod(rem, 60)
-    if hours:
-        return f"{hours}h {minutes:02d}m"
-    if minutes:
-        return f"{minutes}m {secs:02d}s"
-    return f"{secs}s"
 
 
 def live_threshold_s(sampler_interval_s: Optional[float]) -> float:

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/context_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/context_section.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, Optional, Tuple
 from nicegui import ui
 
 from traceml_ai.renderers.context.common import empty_context
+from traceml_ai.renderers.shared.freshness import FreshnessPolicy
 
 from .formatting import format_elapsed
 
@@ -53,10 +54,6 @@ RUN_SECTIONS: Tuple[str, ...] = (
 # handed to ``update_context_section`` is ignored rather than misread.
 _CONTEXT_KEYS = frozenset(empty_context())
 
-# Data older than this reads "stale"; same bar as the display-loop staleness
-# chip (TRA-68), so the two indicators never disagree on what fresh means.
-LIVE_THRESHOLD_S = 5.0
-
 # Shape of a launcher-generated session id, e.g. session_20260821_123224_1103e8;
 # used when a manifest without identity_source is replayed.
 _GENERATED_ID = re.compile(r"^session_\d{8}_\d{6}_[0-9a-f]{6}$")
@@ -70,24 +67,39 @@ def sections_for_profile(profile: str) -> Tuple[str, ...]:
 
 
 def live_threshold_s(sampler_interval_s: Optional[float]) -> float:
-    """Age below which data counts as live: 5 s, or 2.5 sampler ticks when
-    the sampler is slower than that, so a slow sampler never reads stale
-    between its own ticks."""
-    try:
-        interval = float(sampler_interval_s or 0.0)
-    except (TypeError, ValueError):
-        interval = 0.0
-    return max(LIVE_THRESHOLD_S, 2.5 * interval)
+    """The shared freshness threshold, fed the CONFIGURED cadence.
+
+    One rule -- ``FreshnessPolicy``, ``max(5 s, 3 ticks)`` -- but the strip
+    and the System card deliberately feed it different cadences, so their
+    thresholds can differ. That is the design, not the drift that the old
+    local ``2.5 * interval`` was.
+
+    The strip is run-wide: its age is the newest System or Process
+    timestamp anywhere in the run, so there is no single host whose real
+    rhythm it could measure. It is judged against the cadence the run was
+    configured with.
+
+    The System card describes one node and knows what that node actually
+    reported at, so it feeds the same policy its OBSERVED cadence
+    (:meth:`SystemDashboardComputer._node_liveness`). A node reporting
+    slower than requested is judged against its real rhythm rather than
+    against an intention it never met.
+    """
+    return FreshnessPolicy.from_interval(sampler_interval_s).stale_after_s
 
 
 def format_liveness(
-    age_s: Optional[float], threshold_s: float = LIVE_THRESHOLD_S
+    age_s: Optional[float], threshold_s: Optional[float] = None
 ) -> Tuple[str, str]:
-    """(state word, detail) from the age of the newest sample."""
+    """(state word, detail) from age and a shared-policy threshold."""
     if age_s is None:
         return "no data", "waiting for the first sample"
     age = max(0.0, float(age_s))
-    if age < threshold_s:
+    threshold = (
+        live_threshold_s(None) if threshold_s is None else float(threshold_s)
+    )
+    # FreshnessPolicy marks data stale only after the threshold is exceeded.
+    if age <= threshold:
         # No age on the fresh side: with a 2 s sampler it only cycles
         # 0/1/2 and reads as noise. The age matters once data has stopped.
         return "live", ""
@@ -373,9 +385,7 @@ def update_context_section(
     age = None
     if last is not None:
         age = (now if now is not None else time.time()) - float(last)
-    word, detail = format_liveness(
-        age, cards.get("live_threshold_s", LIVE_THRESHOLD_S)
-    )
+    word, detail = format_liveness(age, cards.get("live_threshold_s"))
     live = word == "live"
     color = "#16a34a" if live else "#dc2626"
     cards["liveness"].text = f"{word} · {detail}" if detail else word

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/formatting.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/formatting.py
@@ -168,6 +168,7 @@ __all__ = [
     "gb_si",
     "format_percent",
     "format_span",
+    "format_elapsed",
     "format_window",
     "gb",
     "num",
@@ -177,10 +178,14 @@ __all__ = [
 def format_elapsed(seconds: float) -> str:
     """``47s`` / ``2m 26s`` / ``3h 12m``.
 
-    Shared: the context strip says how long ago the newest sample
-    arrived, and the System card says how long a host has been quiet.
-    One duration vocabulary, so the two cannot drift into wording the
-    same span two ways.
+    Shared by the context strip, which says how long ago the newest
+    sample arrived, and the System card, which says how long a host has
+    been quiet.
+
+    NOT yet the module's only duration vocabulary: ``format_age`` below
+    words the same quantity differently ("3 min" against "3m 00s") for
+    the Process card. Unifying them changes what that card prints, so it
+    belongs in its own change rather than this one.
     """
     total = max(0, int(seconds))
     hours, rem = divmod(total, 3600)

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/formatting.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/formatting.py
@@ -172,3 +172,21 @@ __all__ = [
     "gb",
     "num",
 ]
+
+
+def format_elapsed(seconds: float) -> str:
+    """``47s`` / ``2m 26s`` / ``3h 12m``.
+
+    Shared: the context strip says how long ago the newest sample
+    arrived, and the System card says how long a host has been quiet.
+    One duration vocabulary, so the two cannot drift into wording the
+    same span two ways.
+    """
+    total = max(0, int(seconds))
+    hours, rem = divmod(total, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f"{hours}h {minutes:02d}m"
+    if minutes:
+        return f"{minutes}m {secs:02d}s"
+    return f"{secs}s"

--- a/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
+++ b/src/traceml_ai/aggregator/display_drivers/nicegui_sections/system_section.py
@@ -32,7 +32,7 @@ from traceml_ai.renderers.system.dashboard_models import (
 )
 
 from . import charting, theme
-from .formatting import format_window, gb_si
+from .formatting import format_elapsed, format_window, gb_si
 
 # Window-p95 GPU utilisation spread (max - min, percentage points) that
 # automatically opens the per-GPU rows.
@@ -574,6 +574,14 @@ def _update_system_tiles(
     # says why here. Without this the card showed held-over numbers as
     # current, which is a frozen card a reader cannot tell from a live
     # one. The wording is the computer's, not the card's.
+    # Two different absences, both worth saying and neither the other:
+    # `status` means a READ failed and these numbers are held over,
+    # liveness means the MACHINE stopped sending. The verdict word is
+    # the compute layer's; this only turns it into a sentence.
+    live = roll.node_liveness
+    if live is not None and live.state == "stale":
+        age = format_elapsed(live.age_s) if live.age_s is not None else ""
+        notes.append(f"not reporting for {age}" if age else "not reporting")
     if roll.status:
         notes.append(roll.status)
     if not has_data:

--- a/src/traceml_ai/renderers/system/computer.py
+++ b/src/traceml_ai/renderers/system/computer.py
@@ -32,6 +32,8 @@ class SystemMetricsComputer:
         Optional node-rank filter.
     stale_ttl_s:
         Maximum age in seconds for stale cached payload reuse.
+    sampler_interval_s:
+        Configured sampling cadence, used until an observed cadence exists.
     """
 
     def __init__(
@@ -39,6 +41,7 @@ class SystemMetricsComputer:
         db_path: str,
         node_rank: Optional[int] = None,
         stale_ttl_s: Optional[float] = 30.0,
+        sampler_interval_s: Optional[float] = None,
     ) -> None:
         self._cli = SystemCLIComputer(
             db_path=db_path,
@@ -49,6 +52,7 @@ class SystemMetricsComputer:
             db_path=db_path,
             node_rank=node_rank,
             stale_ttl_s=stale_ttl_s,
+            sampler_interval_s=sampler_interval_s,
         )
 
     def compute_cli(self) -> Dict[str, Any]:

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -137,6 +137,33 @@ def _paired_total(levels: Any, totals: Any) -> Optional[float]:
     return float(total) if total == total else None
 
 
+# A clock can jitter backwards by a hair without having stepped; only a
+# real step is treated as "we cannot tell".
+_CLOCK_STEP_TOLERANCE_S = 1.0
+
+
+def _observed_cadence(ts_hist: Any) -> Optional[float]:
+    """The rhythm the host actually reports at, robust to one stall.
+
+    The MEDIAN gap, not the mean over the window's whole span. A single
+    stall inside the window (a suspend, a blocked sampler thread) drags
+    a mean far above the real cadence, and the freshness threshold is a
+    multiple of it: 99 samples at 2 s plus one two-hour gap gives a mean
+    near 75 s and a threshold near four minutes, so a host that dies on
+    resume would read as live for that long.
+    """
+    stamps = ts_hist.tolist()
+    if len(stamps) < 2:
+        return None
+    gaps = sorted(float(b - a) for a, b in zip(stamps, stamps[1:]) if b > a)
+    if not gaps:
+        return None
+    mid = len(gaps) // 2
+    if len(gaps) % 2:
+        return gaps[mid]
+    return (gaps[mid - 1] + gaps[mid]) / 2.0
+
+
 def _gap_list(values: Any) -> List[Optional[float]]:
     """A series where an absent tick is a gap rather than a zero."""
     return [None if v != v else float(v) for v in values.tolist()]
@@ -621,7 +648,14 @@ class SystemDashboardComputer:
         )
 
     def _node_liveness(self, samples: Any, ts_hist: Any) -> Dict[str, Any]:
-        """Whether the host this payload describes is still reporting."""
+        """Whether the host this payload describes is still reporting.
+
+        Age is measured against ``recv_ts_ns``, when the AGGREGATOR
+        received the sample, not ``sample_ts_s``, when the sampler took
+        it: the sampler may be another machine and a skewed remote clock
+        would read as a dead node. ``recv_ts_ns`` is in the table's
+        original schema and is ``NOT NULL``, so it is always present.
+        """
         recvs = [
             v / 1e9
             for v in (_opt_float(r["recv_ts_ns"]) for r in samples)
@@ -629,15 +663,24 @@ class SystemDashboardComputer:
         ]
         if not recvs:
             return {"state": "unknown", "age_s": None}
-        cadence = None
-        stamps = ts_hist.tolist()
-        if len(stamps) > 1:
-            span = float(stamps[-1] - stamps[0])
-            if span > 0:
-                cadence = span / float(len(stamps) - 1)
-        policy = FreshnessPolicy.from_observed_cadence(cadence)
-        age = max(0.0, float(self._now_fn()) - max(recvs))
-        return {"state": policy.state_of(age), "age_s": age}
+
+        newest = max(recvs)
+        age = float(self._now_fn()) - newest
+        if age < -_CLOCK_STEP_TOLERANCE_S:
+            # The arrival clock is wall time on both ends, so it is not
+            # monotonic. A backward NTP step makes "now" earlier than a
+            # sample we already hold. Clamping that to zero would assert
+            # the host is live, which is the one answer we cannot
+            # support: we do not know how long ago it reported.
+            return {"state": "unknown", "age_s": None}
+
+        policy = FreshnessPolicy.from_observed_cadence(
+            _observed_cadence(ts_hist)
+        )
+        return {
+            "state": policy.state_of(max(0.0, age)),
+            "age_s": max(0.0, age),
+        }
 
     def _mode_for(
         self, stats: Optional[RunStats], window_span_s: float

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -249,9 +249,11 @@ class SystemDashboardComputer:
         node_rank: Optional[int] = None,
         stale_ttl_s: Optional[float] = 30.0,
         run_series_policy: RunSeriesPolicy = DEFAULT_RUN_SERIES_POLICY,
+        sampler_interval_s: Optional[float] = None,
         now_fn: Callable[[], float] = time.time,
     ) -> None:
         self._db = SystemRepository(db_path=db_path, node_rank=node_rank)
+        self._configured_interval_s = sampler_interval_s
         # Injectable so liveness can be tested at a chosen moment rather
         # than by sleeping.
         self._now_fn = now_fn
@@ -655,6 +657,16 @@ class SystemDashboardComputer:
         it: the sampler may be another machine and a skewed remote clock
         would read as a dead node. ``recv_ts_ns`` is in the table's
         original schema and is ``NOT NULL``, so it is always present.
+
+        The threshold is the shared ``FreshnessPolicy``, fed the cadence
+        this node was OBSERVED to report at. The context strip feeds the
+        same policy the run's CONFIGURED interval, because it is run-wide
+        and has no single host whose rhythm it could measure. Same rule,
+        different input by design: the two indicators can therefore hold
+        different thresholds, and a node reporting slower than requested
+        is judged against its real rhythm. The configured interval is the
+        fallback here only until a second sample makes a cadence
+        measurable.
         """
         recvs = [
             v / 1e9
@@ -675,7 +687,8 @@ class SystemDashboardComputer:
             return {"state": "unknown", "age_s": None}
 
         policy = FreshnessPolicy.from_observed_cadence(
-            _observed_cadence(ts_hist)
+            _observed_cadence(ts_hist),
+            configured_s=self._configured_interval_s,
         )
         return {
             "state": policy.state_of(max(0.0, age)),

--- a/src/traceml_ai/renderers/system/dashboard_compute.py
+++ b/src/traceml_ai/renderers/system/dashboard_compute.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 import time
 from dataclasses import replace
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import numpy as np
 
-from traceml_ai.renderers.shared.freshness import CachedPayloadTTL
+from traceml_ai.renderers.shared.freshness import (
+    CachedPayloadTTL,
+    FreshnessPolicy,
+)
 from traceml_ai.renderers.shared.run_series import (
     DEFAULT_RUN_SERIES_POLICY,
     RunSeriesPolicy,
@@ -219,8 +222,12 @@ class SystemDashboardComputer:
         node_rank: Optional[int] = None,
         stale_ttl_s: Optional[float] = 30.0,
         run_series_policy: RunSeriesPolicy = DEFAULT_RUN_SERIES_POLICY,
+        now_fn: Callable[[], float] = time.time,
     ) -> None:
         self._db = SystemRepository(db_path=db_path, node_rank=node_rank)
+        # Injectable so liveness can be tested at a chosen moment rather
+        # than by sleeping.
+        self._now_fn = now_fn
         self._last_ok: Optional[SystemDashboardPayload] = None
         self._last_ok_ts: float = 0.0
         # Whether a cached payload may still answer says the DATABASE could
@@ -566,6 +573,15 @@ class SystemDashboardComputer:
             spread is not None and float(spread) > SPREAD_EXPAND_PTS
         )
 
+        # Whether the machine is still reporting. Single-node, so this is
+        # one answer about the payload: comparing the node against itself
+        # would always say yes, and the reference is the aggregator's own
+        # arrival clock rather than the sampler's, which may be a remote
+        # machine's. The threshold is the shared module's, never a local
+        # copy: one question with two thresholds is what this block has
+        # already been bitten by twice.
+        rollups["node_liveness"] = self._node_liveness(samples, ts_hist)
+
         rollups["ctx"] = {
             "world_size": int(last["world_size"] or 0),
             "gpu_count": int(last["gpu_count"] or 0),
@@ -603,6 +619,25 @@ class SystemDashboardComputer:
                 "power_run_mode": power_mode if gpu_available else "recent",
             },
         )
+
+    def _node_liveness(self, samples: Any, ts_hist: Any) -> Dict[str, Any]:
+        """Whether the host this payload describes is still reporting."""
+        recvs = [
+            v / 1e9
+            for v in (_opt_float(r["recv_ts_ns"]) for r in samples)
+            if v is not None
+        ]
+        if not recvs:
+            return {"state": "unknown", "age_s": None}
+        cadence = None
+        stamps = ts_hist.tolist()
+        if len(stamps) > 1:
+            span = float(stamps[-1] - stamps[0])
+            if span > 0:
+                cadence = span / float(len(stamps) - 1)
+        policy = FreshnessPolicy.from_observed_cadence(cadence)
+        age = max(0.0, float(self._now_fn()) - max(recvs))
+        return {"state": policy.state_of(age), "age_s": age}
 
     def _mode_for(
         self, stats: Optional[RunStats], window_span_s: float

--- a/src/traceml_ai/renderers/system/dashboard_models.py
+++ b/src/traceml_ai/renderers/system/dashboard_models.py
@@ -125,6 +125,20 @@ class GpuRow:
 
 
 @dataclass(frozen=True)
+class NodeLiveness:
+    """Whether the host this payload describes is still reporting.
+
+    System is single-node by construction, so this is one answer about
+    the payload rather than a map over entities. The verdict is the
+    shared freshness module's word; the card prints it and does not
+    restate it in its own vocabulary.
+    """
+
+    state: str = "unknown"
+    age_s: Optional[float] = None
+
+
+@dataclass(frozen=True)
 class RunContext:
     """Which machine and which slice of the job this payload describes."""
 
@@ -168,6 +182,10 @@ class SystemRollups:
     gpus: Tuple[GpuRow, ...] = ()
     ctx: Optional[RunContext] = None
     status: Optional[str] = None
+    # Whether the host is still reporting at all, which is a different
+    # question from `status`: that one says a READ failed and the numbers
+    # are held over, this one says the MACHINE went quiet.
+    node_liveness: Optional[NodeLiveness] = None
     # GPUs whose utilisation puts them in the smaller group. Decided here
     # rather than in the card, which is where a rule that selects entities
     # by a derived threshold belongs.
@@ -281,6 +299,14 @@ class SystemRollups:
                 else None
             ),
             status=raw.get("status"),
+            node_liveness=(
+                NodeLiveness(
+                    state=str(live.get("state") or "unknown"),
+                    age_s=live.get("age_s"),
+                )
+                if (live := raw.get("node_liveness"))
+                else None
+            ),
             odd_gpus=tuple(raw.get("odd_gpus") or ()),
             util_range=(tuple(span) if span else None),
             rows_over=bool(raw.get("rows_over")),
@@ -351,6 +377,7 @@ __all__ = [
     "RamStat",
     "RunContext",
     "Stat",
+    "NodeLiveness",
     "SystemDashboardPayload",
     "SystemRollups",
     "SystemSeries",

--- a/src/traceml_ai/renderers/system/renderer.py
+++ b/src/traceml_ai/renderers/system/renderer.py
@@ -16,7 +16,7 @@ All metric computation is delegated to SystemMetricsComputer.
 """
 
 import shutil
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from rich.panel import Panel
 from rich.table import Table
@@ -41,11 +41,16 @@ class SystemRenderer(BaseRenderer):
 
     NAME = "System"
 
-    def __init__(self, db_path) -> None:
+    def __init__(
+        self, db_path, sampler_interval_s: Optional[float] = None
+    ) -> None:
         super().__init__(name=self.NAME, layout_section_name=SYSTEM_LAYOUT)
         self.db_path = db_path
         self._logger = get_error_logger(self.NAME + "Renderer")
-        self._computer = SystemMetricsComputer(db_path=self.db_path)
+        self._computer = SystemMetricsComputer(
+            db_path=self.db_path,
+            sampler_interval_s=sampler_interval_s,
+        )
 
     def _compute_cli(self) -> Dict[str, Any]:
         return self._computer.compute_cli()

--- a/tests/display/test_context_layout.py
+++ b/tests/display/test_context_layout.py
@@ -135,7 +135,7 @@ def test_update_context_section_consumes_the_context_payload() -> None:
         "coverage": _Label(),
         "liveness": _Label(),
         "dot": _Label(),
-        "live_threshold_s": 5.0,
+        "live_threshold_s": 6.0,
     }
     payload = {
         "world_size": 4,

--- a/tests/display/test_context_section.py
+++ b/tests/display/test_context_section.py
@@ -257,16 +257,34 @@ def test_artifact_path_is_abbreviated_for_display() -> None:
     assert abbreviate_path("") == ""
 
 
-def test_live_threshold_follows_a_slow_sampler() -> None:
+def test_strip_threshold_is_the_shared_policy_at_configured_cadence() -> None:
+    """The strip holds no threshold of its own, and stales on the same edge.
+
+    Two claims. The number comes from ``FreshnessPolicy`` fed the
+    CONFIGURED interval, which is the only cadence a run-wide indicator
+    has. And the boundary is inclusive, matching
+    ``FreshnessPolicy.state_of``, which stales only once the threshold is
+    exceeded. The local ``max(5 s, 2.5 * interval)`` this replaced fails
+    both.
+
+    It does NOT claim the strip and the System card report one state for
+    one age. The card feeds the same policy the cadence it observed for
+    the single node it describes, so the two thresholds legitimately
+    differ; the card's own liveness is covered in
+    ``tests/renderers/test_system_dashboard_gpu_payload.py``.
+    """
     assert live_threshold_s(None) == 6.0
-    assert live_threshold_s(2.0) == 6.0
-    assert live_threshold_s(10.0) == 30.0
+    assert live_threshold_s(2.0) == 6.0  # default sampler: the 5 s floor
+    assert live_threshold_s(10.0) == 30.0  # 3 ticks of a slow sampler
+
     for interval in (None, 2.0, 10.0):
         threshold = live_threshold_s(interval)
         assert (
             threshold == FreshnessPolicy.from_interval(interval).stale_after_s
         )
+        # Exactly at the threshold is still live, as ``state_of`` has it.
         assert format_liveness(threshold, threshold) == ("live", "")
+
     assert format_liveness(12.0, live_threshold_s(10.0)) == ("live", "")
     assert format_liveness(31.0, live_threshold_s(10.0)) == (
         "stale",

--- a/tests/display/test_context_section.py
+++ b/tests/display/test_context_section.py
@@ -31,6 +31,7 @@ from traceml_ai.aggregator.display_drivers.nicegui_sections.context_section impo
 from traceml_ai.aggregator.display_drivers.nicegui_sections.formatting import (  # noqa: E402,E501
     format_elapsed,
 )
+from traceml_ai.renderers.shared.freshness import FreshnessPolicy  # noqa: E402
 
 
 def test_elapsed_formats() -> None:
@@ -257,13 +258,19 @@ def test_artifact_path_is_abbreviated_for_display() -> None:
 
 
 def test_live_threshold_follows_a_slow_sampler() -> None:
-    assert live_threshold_s(None) == 5.0
-    assert live_threshold_s(2.0) == 5.0  # default sampler: the 5 s floor
-    assert live_threshold_s(10.0) == 25.0  # 2.5 ticks of a slow sampler
+    assert live_threshold_s(None) == 6.0
+    assert live_threshold_s(2.0) == 6.0
+    assert live_threshold_s(10.0) == 30.0
+    for interval in (None, 2.0, 10.0):
+        threshold = live_threshold_s(interval)
+        assert (
+            threshold == FreshnessPolicy.from_interval(interval).stale_after_s
+        )
+        assert format_liveness(threshold, threshold) == ("live", "")
     assert format_liveness(12.0, live_threshold_s(10.0)) == ("live", "")
-    assert format_liveness(30.0, live_threshold_s(10.0)) == (
+    assert format_liveness(31.0, live_threshold_s(10.0)) == (
         "stale",
-        "30s since last data",
+        "31s since last data",
     )
 
 

--- a/tests/display/test_context_section.py
+++ b/tests/display/test_context_section.py
@@ -21,13 +21,15 @@ from traceml_ai.aggregator.display_drivers.nicegui_sections.context_section impo
     STEP_SECTIONS,
     abbreviate_path,
     format_coverage,
-    format_elapsed,
     format_liveness,
     live_threshold_s,
     resolve_run_identity,
     run_name_label,
     sections_for_profile,
     strategy_token,
+)
+from traceml_ai.aggregator.display_drivers.nicegui_sections.formatting import (  # noqa: E402,E501
+    format_elapsed,
 )
 
 

--- a/tests/display/test_system_section.py
+++ b/tests/display/test_system_section.py
@@ -924,3 +924,59 @@ def test_a_healthy_card_carries_no_stale_marker() -> None:
     update_system_section(panel, as_payload(payload))
 
     assert "STALE" not in panel["note"].text
+
+
+def _liveness_payload(state: str, age_s: float) -> dict:
+    return {
+        "window_len": 20,
+        "gpu_available": False,
+        "rollups": {
+            "cpu": {"now": 42.0, "p50": 42.0, "p95": 42.0},
+            "ram": {"now": 9.0 * GB, "total": 200.0 * GB},
+            "node_liveness": {"state": state, "age_s": age_s},
+            "ctx": {"gpu_count": 0},
+        },
+        "series": {"x_time": [], "cpu": []},
+    }
+
+
+def test_the_card_says_when_the_machine_stopped_reporting() -> None:
+    """The liveness answer has a consumer.
+
+    Adopting a freshness rule without rendering it would ship a decision
+    nothing reads, which is the same shape as the stale marker that sat
+    unread on the payload until it was wired up. A reader looking at a
+    tile should not have to check a different part of the page to learn
+    the number is old.
+    """
+    from nicegui import ui
+
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section import (  # noqa: E501
+        build_system_section,
+        update_system_section,
+    )
+
+    with ui.element("div"):
+        panel = build_system_section()
+    update_system_section(panel, as_payload(_liveness_payload("stale", 47.0)))
+
+    note = panel["note"].text
+    assert "not reporting" in note
+    # The age is stated, so "old" is a duration rather than a mood.
+    assert "47" in note
+
+
+def test_a_live_machine_gets_no_liveness_note() -> None:
+    """The note appears only when there is something to say."""
+    from nicegui import ui
+
+    from traceml_ai.aggregator.display_drivers.nicegui_sections.system_section import (  # noqa: E501
+        build_system_section,
+        update_system_section,
+    )
+
+    with ui.element("div"):
+        panel = build_system_section()
+    update_system_section(panel, as_payload(_liveness_payload("fresh", 1.0)))
+
+    assert "not reporting" not in panel["note"].text

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -1183,11 +1183,18 @@ def _with_arrival_clock(path: Path) -> None:
         conn.commit()
 
 
-def _payload_at(path: Path, now_s: float) -> SystemDashboardPayload:
+def _payload_at(
+    path: Path,
+    now_s: float,
+    *,
+    sampler_interval_s: Optional[float] = None,
+) -> SystemDashboardPayload:
     """The payload as it would be computed at a given wall-clock moment."""
-    return SystemDashboardComputer(str(path), now_fn=lambda: now_s).compute(
-        window_n=100
-    )
+    return SystemDashboardComputer(
+        str(path),
+        sampler_interval_s=sampler_interval_s,
+        now_fn=lambda: now_s,
+    ).compute(window_n=100)
 
 
 def test_a_node_that_stopped_reporting_is_marked_stale(
@@ -1244,6 +1251,26 @@ def test_liveness_reads_the_shared_threshold_not_a_local_one(
     assert _payload_at(
         db, newest + edge + 0.5
     ).rollups.node_liveness.state == ("stale")
+
+
+def test_liveness_uses_configured_cadence_before_it_can_observe_one(
+    tmp_path: Path,
+) -> None:
+    """A slow sampler is not stale while waiting for its second sample."""
+    db = tmp_path / "first-sample.db"
+    _write(db, lambda seq: (), gpu_available=False, ticks=1)
+    _with_arrival_clock(db)
+
+    out = _payload_at(db, 1020.0, sampler_interval_s=10.0)
+
+    assert out.rollups.node_liveness is not None
+    assert out.rollups.node_liveness.state == "fresh"
+    assert (
+        _payload_at(
+            db, 1031.0, sampler_interval_s=10.0
+        ).rollups.node_liveness.state
+        == "stale"
+    )
 
 
 def test_one_stall_does_not_inflate_the_staleness_threshold(

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -1164,6 +1164,7 @@ def test_a_held_over_payload_carries_why_it_is_held(tmp_path: Path) -> None:
     update_system_section(panel, held)
     assert held.rollups.status in panel["note"].text
 
+
 def _with_arrival_clock(path: Path) -> None:
     """Give the rows a real arrival clock.
 
@@ -1230,9 +1231,11 @@ def test_liveness_reads_the_shared_threshold_not_a_local_one(
     _with_arrival_clock(db)
     newest = 1000.0 + 2.0 * (TICKS - 1)
 
-    # The fixture samples every 2 s, so the shared policy's floor of 5 s
-    # is what applies, not the cadence multiple.
-    policy = FreshnessPolicy.from_interval(2.0)
+    # Built through the same entry point production uses. Using
+    # `from_interval(2.0)` instead would agree only because the fixture
+    # cadence happens to be exactly 2 s, so the test would stop
+    # tracking the code the moment either changed.
+    policy = FreshnessPolicy.from_observed_cadence(2.0)
     edge = policy.stale_after_s
 
     assert _payload_at(
@@ -1241,3 +1244,58 @@ def test_liveness_reads_the_shared_threshold_not_a_local_one(
     assert _payload_at(
         db, newest + edge + 0.5
     ).rollups.node_liveness.state == ("stale")
+
+
+def test_one_stall_does_not_inflate_the_staleness_threshold(
+    tmp_path: Path,
+) -> None:
+    """The cadence is the host's rhythm, not the window's average gap.
+
+    A mean over the whole span lets a single stall dominate: 19 samples
+    two seconds apart plus one two-hour gap averages near 380 s, and the
+    threshold is a multiple of that, so a host that dies right after
+    resuming would read live for many minutes. The median gap ignores
+    the stall.
+    """
+    db = tmp_path / "stalled.db"
+    _write(db, lambda seq: (), gpu_available=False)
+    _with_arrival_clock(db)
+    newest = 1000.0 + 2.0 * (TICKS - 1)
+
+    # Push one sample two hours into the past, creating a huge gap.
+    with sqlite_database(db, init_summary_schema) as conn:
+        conn.execute(
+            "UPDATE system_samples SET sample_ts_s = sample_ts_s - 7200.0 "
+            "WHERE seq = 0"
+        )
+        conn.commit()
+
+    # Thirty seconds of silence is still stale on a two-second cadence.
+    out = _payload_at(db, newest + 30.0)
+
+    assert out.rollups.node_liveness is not None
+    assert out.rollups.node_liveness.state == "stale"
+
+
+def test_a_clock_that_moved_backwards_says_it_does_not_know(
+    tmp_path: Path,
+) -> None:
+    """Both ends of the age are wall time, so it is not monotonic.
+
+    A backward NTP step puts "now" before a sample already held.
+    Clamping that to a zero age would assert the host is live, which is
+    the one answer the data cannot support: how long ago it reported is
+    exactly what has been lost.
+    """
+    db = tmp_path / "stepped.db"
+    _write(db, lambda seq: (), gpu_available=False)
+    _with_arrival_clock(db)
+    newest = 1000.0 + 2.0 * (TICKS - 1)
+
+    stepped = _payload_at(db, newest - 600.0)
+
+    assert stepped.rollups.node_liveness is not None
+    assert stepped.rollups.node_liveness.state == "unknown"
+    assert stepped.rollups.node_liveness.age_s is None
+    # A hair of jitter is not a step, and still reads normally.
+    assert _payload_at(db, newest - 0.2).rollups.node_liveness.state == "fresh"

--- a/tests/renderers/test_system_dashboard_gpu_payload.py
+++ b/tests/renderers/test_system_dashboard_gpu_payload.py
@@ -1163,3 +1163,81 @@ def test_a_held_over_payload_carries_why_it_is_held(tmp_path: Path) -> None:
         panel = build_system_section()
     update_system_section(panel, held)
     assert held.rollups.status in panel["note"].text
+
+def _with_arrival_clock(path: Path) -> None:
+    """Give the rows a real arrival clock.
+
+    The fixture writes `recv_ts_ns` as a synthetic row id, which is fine
+    for ordering and useless as a clock. Liveness is measured against the
+    AGGREGATOR's arrival time rather than the sampler's `sample_ts_s`,
+    because the sampler may be a different machine and a skewed remote
+    clock would otherwise read as a dead node. Process measures age the
+    same way.
+    """
+    with sqlite_database(path, init_summary_schema) as conn:
+        conn.execute(
+            "UPDATE system_samples "
+            "SET recv_ts_ns = CAST(sample_ts_s * 1000000000 AS INTEGER)"
+        )
+        conn.commit()
+
+
+def _payload_at(path: Path, now_s: float) -> SystemDashboardPayload:
+    """The payload as it would be computed at a given wall-clock moment."""
+    return SystemDashboardComputer(str(path), now_fn=lambda: now_s).compute(
+        window_n=100
+    )
+
+
+def test_a_node_that_stopped_reporting_is_marked_stale(
+    tmp_path: Path,
+) -> None:
+    """System is single-node, so the question is about the payload.
+
+    Process asks which of N ranks stopped, and answers per rank. There is
+    only one host here, so the question is whether this payload still
+    describes a live machine, and comparing the node against itself would
+    always say yes. The reference is the wall clock.
+    """
+    db = tmp_path / "quiet.db"
+    _write(db, lambda seq: (), gpu_available=False)
+    _with_arrival_clock(db)
+
+    fresh = _payload_at(db, 1000.0 + 2.0 * (TICKS - 1) + 1.0)
+    assert fresh.rollups.node_liveness is not None
+    assert fresh.rollups.node_liveness.state == "fresh"
+
+    # Two minutes later nothing has arrived.
+    quiet = _payload_at(db, 1000.0 + 2.0 * (TICKS - 1) + 120.0)
+    assert quiet.rollups.node_liveness.state == "stale"
+    assert quiet.rollups.node_liveness.age_s == pytest.approx(120.0, abs=1.0)
+
+
+def test_liveness_reads_the_shared_threshold_not_a_local_one(
+    tmp_path: Path,
+) -> None:
+    """One rule for one question, and it is the shared module's.
+
+    This series has already produced two contradictions from answering
+    one question in two places. The threshold here is
+    `FreshnessPolicy.stale_after_s`, which the Process block already
+    reads; nothing about the System card defines its own.
+    """
+    from traceml_ai.renderers.shared.freshness import FreshnessPolicy
+
+    db = tmp_path / "threshold.db"
+    _write(db, lambda seq: (), gpu_available=False)
+    _with_arrival_clock(db)
+    newest = 1000.0 + 2.0 * (TICKS - 1)
+
+    # The fixture samples every 2 s, so the shared policy's floor of 5 s
+    # is what applies, not the cadence multiple.
+    policy = FreshnessPolicy.from_interval(2.0)
+    edge = policy.stale_after_s
+
+    assert _payload_at(
+        db, newest + edge - 0.5
+    ).rollups.node_liveness.state == ("fresh")
+    assert _payload_at(
+        db, newest + edge + 0.5
+    ).rollups.node_liveness.state == ("stale")


### PR DESCRIPTION
Closes #425. Stacked on #426.

The System card could not say when its host stopped reporting. Nothing in the block compared a
sample's age against a clock: the only `time.time()` calls were the cached-payload TTL, which says
the DATABASE could not be read and never that the machine is healthy.

So a node could go quiet and the card would keep drawing its last values as current.

## The decision, and the thing it did not know

#425 settles on B, the card says it too, with one constraint: read the SAME rule the strip uses
and do not define a third, because "two thresholds for one question" has already cost this series
two review rounds.

Measured: there are already two rules for that one question.

| sampler interval | strip's `live_threshold_s` | shared `FreshnessPolicy.stale_after_s` |
|---|---|---|
| 0.5 s | 5.0 | 5.0 |
| 1.0 s | 5.0 | 5.0 |
| 2.0 s | 5.0 | **6.0** |
| 5.0 s | 12.5 | **15.0** |
| 10.0 s | 25.0 | **30.0** |

They agree only while the 5 s floor dominates, so any sampler faster than about 1.7 s. Past that
the strip uses 2.5 cadence ticks and the shared module uses 3.

This reads the **shared** module. Following the constraint literally would import the strip's
helper into this section, which is a section reaching into another section, and would leave the
card agreeing with the strip while disagreeing with `FreshnessPolicy`, which the Process block
already reads. That is still two rules for one question, just a different pairing. Reading the
shared owner satisfies the reason the constraint was written for.

**That leaves the strip as the one remaining divergence, and it is not changed here.**
`FreshnessPolicy` is the documented owner and states its rationale, that one missed tick is
ordinary jitter and three is a rank that stopped; the strip's 2.5 carries no stated reason. Moving
the strip onto it would make it marginally more tolerant, 6 s rather than 5 s at a 2 s cadence,
which is the safer direction for a false "stale". Worth doing, and it changes what the strip
renders, so it belongs in its own change rather than smuggled into this one.

## The shape is payload-level, not per-entity

`FreshnessPolicy` answers a per-entity question, which is right for Process: there are N ranks,
each with its own clock, and the card marks each row. The System dashboard describes one host by
construction, so the question is whether THIS PAYLOAD still describes a live machine. Comparing
the node against itself would always answer yes.

The payload therefore carries one answer rather than a map, and the reference is the wall clock.

## The clock is the aggregator's, not the sampler's

Age is measured from `recv_ts_ns`, when the aggregator received the sample, not from
`sample_ts_s`, when the sampler took it. The sampler may be on a different machine, and comparing
a remote clock to local wall time would read clock skew as a dead node. The Process block measures
age the same way.

Worth stating because the test fixture writes `recv_ts_ns` as a synthetic row id rather than a
clock, so the tests here set a real one explicitly.

## Two things the clock cannot tell you, both answered by abstaining

**A backward clock step.** Both ends of the age are wall time, so it is not monotonic. An NTP
step backwards puts "now" before a sample already held, and clamping that to a zero age would
assert the host is live, which is the one answer the data cannot support: how long ago it
reported is exactly what was lost. Past a one second jitter tolerance the verdict is `unknown`.

**A stall inside the window.** The threshold is a multiple of the observed cadence, so taking
that cadence as a mean over the window's whole span lets one stall dominate: 19 samples two
seconds apart plus a two hour gap averages near 380 s, and a host that died right after resuming
would read live for many minutes. The cadence is the MEDIAN gap, which ignores the stall.

## One duration vocabulary, not yet

`format_elapsed` moved from the context strip into the shared formatting module. The strip says
how long ago the newest sample arrived and this card says how long a host has been quiet; two
copies would eventually word the same span two ways. Its callers and behaviour are unchanged.

That does not make it the module's only duration vocabulary, and the docstring now says so.
`format_age` words the same quantity differently for the Process card, so a quiet node reads
"3 min" there and "3m 00s" here on one page. Unifying them changes what the Process card prints,
so it belongs in its own change.

## Assumptions and edges, stated rather than discovered later

`recv_ts_ns` is in `system_samples`' original schema and is `NOT NULL`, so the per-row read cannot
raise on a legacy database. The Process block reads it the same way.

`_pick_node` skips rows with a NULL hostname, so a pre-0.3.0 trace that mixes unnamed rows with
one named host can still interleave two streams into the window. That tightens the cadence rather
than loosening it, so it errs toward a false "not reporting" rather than a false "live".

## Scope

```
STRUCTURE: the liveness answer -> renderers/system/dashboard_compute.py (the computer owns
derived judgments), reading its threshold from renderers/shared/freshness.py (existing owner,
already consumed by Process); the payload gains one optional field; the card renders it on the
note it already uses for absence text; the duration formatter -> nicegui_sections/formatting.py
(existing owner of shared formatting); mirrored from the CachedPayloadTTL adoption this block
already made from the same module; boundaries crossed: none
DATA PATH: system_section <- SYSTEM_LAYOUT <- SystemRenderer <- SystemDashboardComputer
           <- SystemRepository <- system_samples
SCOPE: declared the System liveness answer plus its rendering and the shared formatter move ->
diff touches dashboard_compute.py, dashboard_models.py, system_section.py, formatting.py,
context_section.py and three test files -> within
TWINS: searched the CONCEPT, not the symbol - every place that decides whether telemetry is
still current. renderers/shared/freshness.py (the owner, read here), renderers/process
(already reads it), the context strip's own live_threshold_s (the divergence named above, left
deliberately). The cached-payload TTL is a different question and is untouched
```

## Verification

```
GATE: pytest tests/ -> 1688 passed, 2 skipped against this branch's base (#426) measured at 1682 passed, 2 skipped; the delta is the six tests added here; black, isort and ruff clean at 79 on every file in the diff
TRANSITIONS: none; no state machine is touched. Liveness is derived per tick from the newest arrival and holds no state of its own, so it cannot latch: a host that resumes reporting reads fresh on the next tick
RANKS: not applicable, and that is the point of the change. The System dashboard is single-node by construction, so this answers one payload-level question rather than adopting the per-entity shape Process uses
TRIPWIRE: the System block may not define its own staleness threshold, and may not report a liveness it cannot support. The verdict comes from FreshnessPolicy.state_of, nothing in renderers/system compares an age against a local constant, a test asserts the boundary sits exactly at the shared policy's stale_after_s built through the same entry point production uses, and an age that cannot be trusted (a clock that moved backwards) abstains rather than reading fresh
SCENARIOS: all 22 fixture cells rendered on both trees and diffed field by field; 0 of 676 field values differ. Expected: every fixture replays a corpus whose newest sample is old, and the renderer computes liveness against the wall clock, so no fixture exercises a live host. The evidence is the four tests, which pin the fresh case, the stale case and the exact threshold boundary
PLATFORM: macOS 26.1, Python 3.12.13, SQLite 3.51.2
```
