### PR TITLE
Dev/abhinav/log consolidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ which carry the full historical notes for versions predating this file.
 
 ## [Unreleased]
 
+- **Breaking:** TraceML implementation errors now have one structured owner:
+  `rank_<global_rank>/traceml_errors.log`,
+  `aggregator/traceml_errors.log`, or
+  `nodes/node_<node_rank>/launcher_errors.log`. New runs no longer create the
+  duplicate `torchrun_error.log`, `runtime_error.log`, or
+  `aggregator_error.log` files.
 - Launcher-owned aggregator stderr is now saved separately at
   `logs/<run-name>/aggregator/process.stderr.log`. Summary and dashboard modes
   mirror it live; CLI mode preserves the Rich display and reports the saved

--- a/docs/developer_guide/extending.md
+++ b/docs/developer_guide/extending.md
@@ -236,6 +236,12 @@ TraceML should not break user training because optional telemetry, rendering,
 or reporting failed. Existing code logs advisory failures through
 `traceml_ai.loggers.error_log.get_error_logger`.
 
+Process entrypoints configure that logger once with the `rank`, `aggregator`,
+or `launcher` role. Components should request a named child logger rather than
+adding handlers or choosing paths themselves. Internal logs accept ERROR-level
+TraceML implementation failures only; do not send user exceptions or workload
+stderr to them.
+
 Use that pattern for non-critical paths:
 
 ```python

--- a/docs/developer_guide/extending.md
+++ b/docs/developer_guide/extending.md
@@ -240,16 +240,23 @@ Process entrypoints configure that logger once with the `rank`, `aggregator`,
 or `launcher` role. Components should request a named child logger rather than
 adding handlers or choosing paths themselves. Internal logs accept ERROR-level
 TraceML implementation failures only; do not send user exceptions or workload
-stderr to them.
+stderr to them. Use `log_internal_exception` when recording a caught exception;
+it preserves explicit TraceML causes without copying implicit context from a
+user exception that is already unwinding.
 
 Use that pattern for non-critical paths:
 
 ```python
+from traceml_ai.loggers.error_log import (
+    get_error_logger,
+    log_internal_exception,
+)
+
 logger = get_error_logger("MyComponent")
 try:
     ...
 except Exception as exc:
-    logger.exception("[TraceML] MyComponent failed: %s", exc)
+    log_internal_exception(logger, "[TraceML] MyComponent failed", exc)
 ```
 
 Prefer returning an empty payload, `NO DATA` diagnosis, or fallback text over

--- a/docs/user_guide/integrations/ray.md
+++ b/docs/user_guide/integrations/ray.md
@@ -238,3 +238,7 @@ then stops the actor in a ``finally`` block. Each worker also stops its local
 TraceML runtime in a ``finally`` block. Normal exceptions and keyboard
 interrupts should therefore release TraceML resources. A hard ``SIGKILL`` cannot
 run Python cleanup code in any framework.
+
+If aggregator finalization fails, the actor records the failure in
+``aggregator/traceml_errors.log``. Cleanup remains best effort at the Ray driver
+boundary, so a TraceML shutdown failure does not replace the Ray Train result.

--- a/docs/user_guide/public-api.md
+++ b/docs/user_guide/public-api.md
@@ -141,6 +141,12 @@ in a multi-node run. Summary and dashboard modes mirror it live, while CLI mode
 reports its path if telemetry fails. Aggregator stdout remains attached to the
 terminal and is not persisted.
 
+TraceML implementation errors are stored separately in
+`rank_<global_rank>/traceml_errors.log`,
+`aggregator/traceml_errors.log`, and
+`nodes/node_<node_rank>/launcher_errors.log`. User exceptions remain in the
+native training stderr artifacts above.
+
 ## Direct Launch with `traceml serve`
 
 `traceml run` starts the aggregator and your script together. For direct

--- a/docs/user_guide/reading-output.md
+++ b/docs/user_guide/reading-output.md
@@ -212,6 +212,21 @@ fails, TraceML reports the saved path. This artifact is distinct from
 `aggregator/traceml_errors.log`, which contains structured TraceML log records.
 Aggregator stdout remains attached to the terminal and is not persisted.
 
+### TraceML internal error logs
+
+TraceML implementation failures are kept separate from workload output. Each
+owning process writes ERROR-level records to one rotating file:
+
+```text
+logs/<run-name>/rank_<global_rank>/traceml_errors.log
+logs/<run-name>/aggregator/traceml_errors.log
+logs/<run-name>/nodes/node_<node_rank>/launcher_errors.log
+```
+
+User exceptions remain in native training stderr and are not copied into these
+files. The internal logger does not add a terminal handler; terminal output
+continues to follow the launcher and display policies described above.
+
 Phases that were never measured in the current window are omitted from the
 live step-time table rather than shown as `0.0 ms`, and the diagnosis block
 shows `INCOMPLETE DATA` with the missing signal names when no reliable

--- a/src/traceml_ai/aggregator/aggregator_main.py
+++ b/src/traceml_ai/aggregator/aggregator_main.py
@@ -217,13 +217,17 @@ def run_aggregator(
         )
 
         if err is not None:
-            try:
-                logger.error(
-                    "[TraceML] Aggregator exiting due to error",
-                    exc_info=(type(err), err, err.__traceback__),
-                )
-            except Exception:
-                pass
+            # Startup failures are logged by start_aggregator(), which is also
+            # used by integrations such as Ray. This boundary owns failures
+            # only after a handle has been returned.
+            if handle is not None:
+                try:
+                    logger.error(
+                        "[TraceML] Aggregator exiting due to error",
+                        exc_info=(type(err), err, err.__traceback__),
+                    )
+                except Exception:
+                    pass
 
             print(
                 "\n[TraceML] Aggregator exiting due to error. "

--- a/src/traceml_ai/aggregator/aggregator_main.py
+++ b/src/traceml_ai/aggregator/aggregator_main.py
@@ -18,9 +18,7 @@ Expected usage (via CLI)
 
 Error handling
 --------------
-- Fatal aggregator errors are logged through the configured logger.
-- Fatal aggregator errors are also written to ``aggregator_error.log`` under
-  the current session directory.
+- Fatal aggregator errors are logged once through the configured logger.
 - A brief error is printed to stderr as a last-resort fallback in case the
   terminal UI has already been torn down or failed.
 """
@@ -31,7 +29,6 @@ import sys
 import threading
 import traceback
 from dataclasses import replace
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -48,44 +45,6 @@ from traceml_ai.telemetry.retention import (
     DEFAULT_HISTORY_RETENTION_S,
     parse_history_retention,
 )
-
-AGGREGATOR_ERROR_LOG_NAME = "aggregator_error.log"
-
-
-def _utc_now_iso() -> str:
-    """Return the current UTC timestamp as an ISO-8601 string."""
-    return datetime.now(timezone.utc).isoformat()
-
-
-def write_aggregator_error_log(
-    session_root: Path,
-    header: str,
-    error: BaseException,
-) -> None:
-    """
-    Append a fatal aggregator error report to ``aggregator_error.log``.
-
-    This function is best-effort and must never raise. Aggregator failures
-    should still surface through stderr and exit codes even if file logging
-    fails.
-    """
-    try:
-        session_root.mkdir(parents=True, exist_ok=True)
-        path = session_root / AGGREGATOR_ERROR_LOG_NAME
-
-        with open(path, "a", encoding="utf-8", errors="replace") as f:
-            f.write("\n" + "=" * 80 + "\n")
-            f.write(f"{_utc_now_iso()}  {header}\n")
-            traceback.print_exception(
-                type(error),
-                error,
-                error.__traceback__,
-                file=f,
-            )
-            f.flush()
-    except Exception:
-        # Best-effort only: never mask the original failure.
-        pass
 
 
 def read_traceml_env() -> dict[str, Any]:
@@ -190,7 +149,7 @@ def run_aggregator(
     - prints the reachable endpoint
     - blocks until SIGINT/SIGTERM
     - shuts down cleanly, preserving final-summary behavior
-    - logs fatal aggregator errors to ``aggregator_error.log``
+    - logs fatal errors to its structured process-owned log
 
     Returns a process exit code (0 on clean shutdown, 1 on fatal error).
     """
@@ -209,7 +168,7 @@ def run_aggregator(
     os.environ["TRACEML_SESSION_ID"] = session_id
 
     if logger is None:
-        setup_error_logger(is_aggregator=True)
+        setup_error_logger(role="aggregator")
         logger = get_error_logger("TraceMLAggregatorMain")
 
     stop_event = threading.Event()
@@ -259,19 +218,18 @@ def run_aggregator(
 
         if err is not None:
             try:
-                logger.exception("[TraceML] Aggregator exiting due to error")
+                logger.error(
+                    "[TraceML] Aggregator exiting due to error",
+                    exc_info=(type(err), err, err.__traceback__),
+                )
             except Exception:
                 pass
 
-            write_aggregator_error_log(
-                session_root=session_root,
-                header="Fatal aggregator error",
-                error=err,
-            )
-
             print(
                 "\n[TraceML] Aggregator exiting due to error. "
-                f"See {session_root / AGGREGATOR_ERROR_LOG_NAME}",
+                f"Structured log: {session_dir / 'traceml_errors.log'}. "
+                "Launcher-owned runs also preserve raw stderr at "
+                f"{session_dir / 'process.stderr.log'}.",
                 file=sys.stderr,
                 flush=True,
             )
@@ -296,7 +254,7 @@ def main() -> None:
     ``traceml run`` launcher, builds settings, and delegates the lifecycle to
     :func:`run_aggregator`.
     """
-    setup_error_logger(is_aggregator=True)
+    setup_error_logger(role="aggregator")
     logger = get_error_logger("TraceMLAggregatorMain")
 
     cfg = read_traceml_env()

--- a/src/traceml_ai/aggregator/trace_aggregator.py
+++ b/src/traceml_ai/aggregator/trace_aggregator.py
@@ -179,12 +179,8 @@ class TraceMLAggregator:
         self._sqlite_writer.start()
         self._display_driver.start()
 
-        try:
-            self._thread.start()
-            self._started = True
-        except Exception:
-            self._logger.exception("[TraceML] Aggregator thread start failed")
-            raise
+        self._thread.start()
+        self._started = True
 
     @property
     def endpoint(self) -> AggregatorEndpoint:
@@ -277,7 +273,6 @@ class TraceMLAggregator:
                         profile=str(self._settings.profile),
                     )
                 except Exception as summary_exc:
-                    self._logger.exception("[TraceML] generate_summary raised")
                     summary_error = summary_exc
 
                 if self._summary_generation_id(summary_path) in (
@@ -292,6 +287,16 @@ class TraceMLAggregator:
                     raise refresh_error
 
                 if summary_error is not None:
+                    # A refreshed artifact makes this error nonfatal, so this
+                    # component remains its sole structured-log owner.
+                    self._logger.error(
+                        "[TraceML] generate_summary raised",
+                        exc_info=(
+                            type(summary_error),
+                            summary_error,
+                            summary_error.__traceback__,
+                        ),
+                    )
                     warning_payload = self._add_generate_summary_warning(
                         warning_payload,
                         summary_error,

--- a/src/traceml_ai/integrations/ray.py
+++ b/src/traceml_ai/integrations/ray.py
@@ -20,6 +20,10 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Mapping, Optional
 
+from traceml_ai.loggers.error_log import (
+    get_error_logger,
+    log_internal_exception,
+)
 from traceml_ai.runtime.lifecycle import RuntimeHandle, start_aggregator
 from traceml_ai.runtime.lifecycle import start_runtime as start_runtime_handle
 from traceml_ai.runtime.settings import (
@@ -223,6 +227,7 @@ class _TraceMLAggregatorActor:
                 connect_host=self._node_ip,
             )
         )
+        self._logger = get_error_logger("TraceMLRayAggregator")
 
     def endpoint(self) -> dict[str, Any]:
         """Return the reachable aggregator endpoint for Ray Train workers."""
@@ -234,11 +239,21 @@ class _TraceMLAggregatorActor:
         }
 
     def stop(self) -> None:
-        """Stop the TraceML aggregator once."""
+        """Stop the aggregator once and record a finalization failure."""
         if self._closed:
             return
         self._closed = True
-        self._handle.stop(timeout_sec=float(self._config.stop_timeout_sec))
+        try:
+            self._handle.stop(timeout_sec=float(self._config.stop_timeout_sec))
+        except BaseException as exc:
+            # Ray actors use the lifecycle handle directly, so they do not pass
+            # through aggregator_main's process-level failure log boundary.
+            log_internal_exception(
+                self._logger,
+                "[TraceML] Ray aggregator finalization failed",
+                exc,
+            )
+            raise
 
 
 @dataclass(frozen=True)
@@ -279,6 +294,8 @@ def _stop_actor_best_effort(ray: Any, actor: Any) -> None:
     try:
         ray.get(actor.stop.remote())
     except Exception:
+        # The actor records its own finalization failure before the RPC fails.
+        # Keep cleanup from replacing the Ray Train result at the driver.
         pass
 
     try:

--- a/src/traceml_ai/launcher/commands.py
+++ b/src/traceml_ai/launcher/commands.py
@@ -47,6 +47,7 @@ from traceml_ai.launcher.process import (
     terminate_process_group,
     wait_for_tcp_listen,
 )
+from traceml_ai.loggers.error_log import get_error_logger, setup_error_logger
 from traceml_ai.runtime.launch_context import LaunchContext
 from traceml_ai.runtime.session import get_session_id
 from traceml_ai.runtime.settings import (
@@ -141,9 +142,11 @@ def _dashboard_access_box(dashboard_port: int) -> str:
 def _log_launcher_exception(message: str, exc: Exception) -> None:
     """Log launcher failures when the shared error logger is available."""
     try:
-        from traceml_ai.loggers.error_log import get_error_logger
-
-        get_error_logger("TraceMLLauncher").exception("[TraceML] %s", message)
+        get_error_logger("TraceMLLauncher").error(
+            "[TraceML] %s",
+            message,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
     except Exception:
         pass
 
@@ -662,6 +665,17 @@ def launch_process(script_path: str, args: argparse.Namespace) -> None:
     node_dir = node_artifact_dir(session_root, torchrun_cfg.node_rank)
     training_stdout_path = node_dir / "training.stdout.log"
     training_stderr_path = node_dir / "training.stderr.log"
+
+    # Every node launcher owns one structured internal-error file. Logging is
+    # diagnostic only and must never prevent training from starting.
+    try:
+        setup_error_logger(
+            role="launcher",
+            session_root=session_root,
+            node_rank=torchrun_cfg.node_rank,
+        )
+    except Exception:
+        pass
 
     manifest_path: Optional[Path] = None
     if is_root_writer:

--- a/src/traceml_ai/loggers/error_log.py
+++ b/src/traceml_ai/loggers/error_log.py
@@ -6,112 +6,112 @@
 
 import logging
 import os
+import threading
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+from typing import Literal, Optional
 
 from traceml_ai.runtime.identity import resolve_runtime_identity
 from traceml_ai.runtime.session import rank_dir_name
 
+ErrorLogRole = Literal["rank", "aggregator", "launcher"]
+_HANDLER_MARKER = "_traceml_error_file_handler"
+_SETUP_LOCK = threading.Lock()
 
-def setup_error_logger(is_aggregator=False) -> logging.Logger:
-    """
-    Configure and initialize the global TraceML error logger.
 
-    This function sets up a process-wide logger named ``"traceml_ai"`` with:
-      - WARNING and above logged to stderr (for visibility during runs)
-      - ERROR and above logged to a rotating file on disk
+def _error_log_path(
+    role: ErrorLogRole,
+    *,
+    session_root: Optional[Path] = None,
+    node_rank: Optional[int] = None,
+) -> Path:
+    """Resolve the structured error path owned by one TraceML process."""
+    if session_root is None:
+        logs_dir = os.environ.get("TRACEML_LOGS_DIR", "./logs")
+        session_id = os.environ.get("TRACEML_SESSION_ID") or "default"
+        session_root = Path(logs_dir) / session_id
 
-    The logger is initialized only once per process. Subsequent calls
-    return the already-configured logger.
-
-    Logging behavior
-    ----------------
-    - stderr:
-        * Level: WARNING+
-        * Intended for immediate user feedback
-    - file:
-        * Level: ERROR+
-        * Rotating log file with size-based rollover
-
-    Distributed assumptions
-    -----------------------
-    - Uses global rank to separate process-owned log files.
-    - This avoids write contention between ranks across all nodes.
-
-    Returns
-    -------
-    logging.Logger
-        The configured TraceML root logger.
-    """
-    # Parent of every ``get_error_logger`` child ("traceml_ai.<name>"), so
-    # child records propagate into the handlers attached here.
-    logger = logging.getLogger("traceml_ai")
-
-    # If handlers are already attached, assume the logger
-    # has been initialized and return it as-is.
-    if logger.handlers:
-        return logger
-
-    # Root level is ERROR: more verbose output is controlled
-    # at the handler level.
-    logger.setLevel(logging.ERROR)
-
-    # ----------------------------
-    # File handler (ERROR+)
-    # ----------------------------
-    if is_aggregator is False:
-        rank_dir = rank_dir_name(resolve_runtime_identity().global_rank)
+    if role == "rank":
+        owner_dir = rank_dir_name(resolve_runtime_identity().global_rank)
+        filename = "traceml_errors.log"
+    elif role == "aggregator":
+        owner_dir = "aggregator"
+        filename = "traceml_errors.log"
+    elif role == "launcher":
+        if node_rank is None:
+            raise ValueError("node_rank is required for launcher error logs")
+        owner_dir = f"nodes/node_{int(node_rank)}"
+        filename = "launcher_errors.log"
     else:
-        rank_dir = "aggregator"
+        raise ValueError(f"unknown TraceML error logger role: {role!r}")
 
-    logs_dir = os.environ.get("TRACEML_LOGS_DIR")
-    session_id = os.environ.get("TRACEML_SESSION_ID")
+    return Path(session_root).resolve() / owner_dir / filename
 
-    # Directory layout:
-    #   <logs_dir>/<session_id>/rank_<global_rank>/traceml_errors.log
-    #   <logs_dir>/<session_id>/aggregator/traceml_errors.log
-    errors_dir = Path(logs_dir) / session_id / rank_dir
 
-    errors_dir.mkdir(parents=True, exist_ok=True)
+def setup_error_logger(
+    role: ErrorLogRole,
+    *,
+    session_root: Optional[Path] = None,
+    node_rank: Optional[int] = None,
+) -> logging.Logger:
+    """Configure the process-owned TraceML ERROR-level rotating file.
 
-    fh = RotatingFileHandler(
-        errors_dir / "traceml_errors.log",
-        maxBytes=50_000_000,  # ~5 MB per file
-        backupCount=3,  # keep last 3 rotated files
-        encoding="utf-8",
-    )
-    fh.setLevel(logging.ERROR)
-    fh.setFormatter(
-        logging.Formatter(
-            "%(asctime)s\t%(levelname)s\t%(name)s\t%(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-    )
-    logger.addHandler(fh)
-
-    # Prevent propagation to the root logger to avoid
-    # duplicate log lines in user applications.
+    No stderr handler is installed. Initialization is idempotent for the same
+    role and session, and filesystem failures leave logging disabled rather
+    than affecting training or telemetry control flow.
+    """
+    logger = logging.getLogger("traceml_ai")
+    logger.setLevel(logging.ERROR)
     logger.propagate = False
 
-    return logger
+    try:
+        path = _error_log_path(
+            role,
+            session_root=session_root,
+            node_rank=node_rank,
+        )
+    except Exception:
+        return logger
+
+    with _SETUP_LOCK:
+        for handler in list(logger.handlers):
+            if not getattr(handler, _HANDLER_MARKER, False):
+                continue
+            base_filename = getattr(handler, "baseFilename", None)
+            if base_filename is not None and Path(base_filename) == path:
+                return logger
+            logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            handler = RotatingFileHandler(
+                path,
+                maxBytes=50_000_000,
+                backupCount=3,
+                encoding="utf-8",
+            )
+        except Exception:
+            handler = logging.NullHandler()
+            setattr(handler, _HANDLER_MARKER, True)
+            logger.addHandler(handler)
+            return logger
+
+        handler.setLevel(logging.ERROR)
+        handler.setFormatter(
+            logging.Formatter(
+                "%(asctime)s\t%(levelname)s\t%(name)s\t%(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
+        )
+        setattr(handler, _HANDLER_MARKER, True)
+        logger.addHandler(handler)
+        return logger
 
 
 def get_error_logger(name: str) -> logging.Logger:
-    """
-    Return a child logger under the TraceML namespace.
-
-    This is a lightweight convenience wrapper that ensures all
-    TraceML loggers share a common root configuration created by
-    ``setup_error_logger()``.
-
-    Parameters
-    ----------
-    name : str
-        Sub-logger name (e.g., "Aggregator", "Sampler").
-
-    Returns
-    -------
-    logging.Logger
-        Logger instance named ``f"traceml_ai.{name}"``.
-    """
+    """Return a component child of the process-owned TraceML logger."""
     return logging.getLogger(f"traceml_ai.{name}")

--- a/src/traceml_ai/loggers/error_log.py
+++ b/src/traceml_ai/loggers/error_log.py
@@ -19,6 +19,13 @@ _HANDLER_MARKER = "_traceml_error_file_handler"
 _SETUP_LOCK = threading.Lock()
 
 
+class _SilentRotatingFileHandler(RotatingFileHandler):
+    """Keep diagnostic write failures from leaking into workload stderr."""
+
+    def handleError(self, record: logging.LogRecord) -> None:  # noqa: N802
+        pass
+
+
 def _error_log_path(
     role: ErrorLogRole,
     *,
@@ -71,14 +78,18 @@ def setup_error_logger(
             node_rank=node_rank,
         )
     except Exception:
-        return logger
+        path = None
 
     with _SETUP_LOCK:
         for handler in list(logger.handlers):
             if not getattr(handler, _HANDLER_MARKER, False):
                 continue
             base_filename = getattr(handler, "baseFilename", None)
-            if base_filename is not None and Path(base_filename) == path:
+            if (
+                path is not None
+                and base_filename is not None
+                and Path(base_filename) == path
+            ):
                 return logger
             logger.removeHandler(handler)
             try:
@@ -86,16 +97,21 @@ def setup_error_logger(
             except Exception:
                 pass
 
-        try:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            handler = RotatingFileHandler(
-                path,
-                maxBytes=50_000_000,
-                backupCount=3,
-                encoding="utf-8",
-            )
-        except Exception:
+        if path is None:
             handler = logging.NullHandler()
+        else:
+            try:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                handler = _SilentRotatingFileHandler(
+                    path,
+                    maxBytes=50_000_000,
+                    backupCount=3,
+                    encoding="utf-8",
+                )
+            except Exception:
+                handler = logging.NullHandler()
+
+        if isinstance(handler, logging.NullHandler):
             setattr(handler, _HANDLER_MARKER, True)
             logger.addHandler(handler)
             return logger

--- a/src/traceml_ai/loggers/error_log.py
+++ b/src/traceml_ai/loggers/error_log.py
@@ -7,9 +7,10 @@
 import logging
 import os
 import threading
+import traceback
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from traceml_ai.runtime.identity import resolve_runtime_identity
 from traceml_ai.runtime.session import rank_dir_name
@@ -17,6 +18,42 @@ from traceml_ai.runtime.session import rank_dir_name
 ErrorLogRole = Literal["rank", "aggregator", "launcher"]
 _HANDLER_MARKER = "_traceml_error_file_handler"
 _SETUP_LOCK = threading.Lock()
+
+
+def _format_internal_exception(error: BaseException) -> str:
+    """Render explicit causes without an unrelated implicit context.
+
+    A TraceML cleanup error can be raised while a user exception is already
+    unwinding. Python stores that user exception as implicit ``__context__``;
+    it must stay in workload stderr rather than enter TraceML's internal log.
+    Explicit ``raise ... from ...`` causes are retained because they explain
+    the TraceML failure itself.
+    """
+    rendered = traceback.TracebackException.from_exception(error)
+
+    # Edit the detached traceback representation, never the original
+    # exception. Causes may have inherited their own implicit context, so
+    # remove context at every level of the explicit cause chain.
+    current = rendered
+    while current is not None:
+        current.__context__ = None
+        current = current.__cause__
+
+    return "".join(rendered.format(chain=True)).rstrip()
+
+
+def log_internal_exception(
+    logger: Any,
+    message: str,
+    error: BaseException,
+) -> None:
+    """Write one best-effort internal record without copying user context."""
+    try:
+        logger.error(f"{message}\n{_format_internal_exception(error)}")
+    except Exception:
+        # Diagnostic logging must never change training or telemetry control
+        # flow, including when formatting or the underlying handler fails.
+        pass
 
 
 class _SilentRotatingFileHandler(RotatingFileHandler):

--- a/src/traceml_ai/runtime/executor.py
+++ b/src/traceml_ai/runtime/executor.py
@@ -13,6 +13,7 @@ torchrun remain responsible for exception reporting and process exit status.
 import os
 import runpy
 import sys
+import traceback
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
 
@@ -54,13 +55,21 @@ def _parse_optional_positive_int(value: Optional[str]) -> Optional[int]:
 
 
 def _log_runtime_exception(message: str, error: BaseException) -> None:
-    """Record an executor/runtime implementation failure without raising."""
+    """Record a TraceML failure without raising or copying user context."""
     try:
         setup_error_logger(role="rank")
+        error_traceback = "".join(
+            traceback.format_exception(
+                type(error),
+                error,
+                error.__traceback__,
+                chain=False,
+            )
+        ).rstrip()
         get_error_logger("TraceMLExecutor").error(
-            "[TraceML] %s",
+            "[TraceML] %s\n%s",
             message,
-            exc_info=(type(error), error, error.__traceback__),
+            error_traceback,
         )
     except Exception:
         pass

--- a/src/traceml_ai/runtime/executor.py
+++ b/src/traceml_ai/runtime/executor.py
@@ -13,11 +13,10 @@ torchrun remain responsible for exception reporting and process exit status.
 import os
 import runpy
 import sys
-import traceback
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
 
+from traceml_ai.loggers.error_log import get_error_logger, setup_error_logger
 from traceml_ai.runtime.launch_context import (
     LaunchContext,
     script_execution_context,
@@ -42,13 +41,6 @@ DEFAULT_AGGREGATOR_HOST = "127.0.0.1"
 DEFAULT_AGGREGATOR_BIND_HOST = "127.0.0.1"
 DEFAULT_AGGREGATOR_PORT = 29765
 DEFAULT_PROFILE = "run"
-USER_ERROR_LOG_NAME = "torchrun_error.log"
-RUNTIME_ERROR_LOG_NAME = "runtime_error.log"
-
-
-def _utc_now_iso() -> str:
-    """Return the current UTC time as a string."""
-    return datetime.now(timezone.utc).isoformat()
 
 
 def _parse_optional_positive_int(value: Optional[str]) -> Optional[int]:
@@ -61,100 +53,17 @@ def _parse_optional_positive_int(value: Optional[str]) -> Optional[int]:
     return parsed
 
 
-def _get_session_dir(cfg: Dict[str, Any]) -> Path:
-    """Return the TraceML session directory for the current run."""
-    logs_dir = Path(str(cfg.get("logs_dir", DEFAULT_LOGS_DIR)))
-    session_id = str(cfg.get("session_id", "") or "no_session")
-    return logs_dir / session_id
-
-
-def _append_error_log(
-    cfg: Dict[str, Any],
-    filename: str,
-    header: str,
-    error: Optional[BaseException] = None,
-) -> None:
-    """
-    Append an error report to a session log file.
-
-    Parameters
-    ----------
-    cfg:
-        Runtime configuration dictionary.
-    filename:
-        Target log filename under the session directory.
-    header:
-        Short human-readable header describing the failure.
-    error:
-        Optional exception to serialize as a traceback.
-
-    Notes
-    -----
-    This function must never raise. Logging failures should not change
-    the outcome of the user's run.
-    """
+def _log_runtime_exception(message: str, error: BaseException) -> None:
+    """Record an executor/runtime implementation failure without raising."""
     try:
-        out_dir = _get_session_dir(cfg)
-        out_dir.mkdir(parents=True, exist_ok=True)
-
-        path = out_dir / filename
-        with open(path, "a", encoding="utf-8", errors="replace") as f:
-            f.write("\n" + "=" * 80 + "\n")
-            f.write(f"{_utc_now_iso()}  {header}\n")
-
-            if error is not None:
-                traceback.print_exception(
-                    type(error),
-                    error,
-                    error.__traceback__,
-                    file=f,
-                )
-
-            f.flush()
+        setup_error_logger(role="rank")
+        get_error_logger("TraceMLExecutor").error(
+            "[TraceML] %s",
+            message,
+            exc_info=(type(error), error, error.__traceback__),
+        )
     except Exception:
-        # Never break the user's run because best-effort logging failed.
         pass
-
-
-def write_user_error_log(
-    cfg: Dict[str, Any],
-    header: str,
-    error: Optional[BaseException] = None,
-) -> None:
-    """
-    Append an ordinary user-script exception to torchrun_error.log.
-
-    This is a compatibility bridge until launcher-owned stderr persistence is
-    available for every display mode. It must never replace or alter native
-    exception propagation, and it can be removed once the launcher output is
-    the canonical durable record.
-    """
-    _append_error_log(
-        cfg=cfg,
-        filename=USER_ERROR_LOG_NAME,
-        header=header,
-        error=error,
-    )
-
-
-def write_runtime_error_log(
-    cfg: Dict[str, Any],
-    header: str,
-    error: Optional[BaseException] = None,
-) -> None:
-    """
-    Append a TraceML internal runtime or executor failure report to
-    runtime_error.log.
-
-    This log is reserved for TraceML infrastructure problems such as runtime
-    startup failure, runtime shutdown failure, and executor-internal errors.
-    """
-    _append_error_log(
-        cfg=cfg,
-        filename=RUNTIME_ERROR_LOG_NAME,
-        header=header,
-        error=error,
-    )
 
 
 def read_traceml_env() -> Dict[str, Any]:
@@ -303,17 +212,12 @@ def start_runtime(cfg: Dict[str, Any]) -> Union[TraceMLRuntime, NoOpRuntime]:
         handle = start_runtime_handle(settings, fail_open=False)
         return handle.runtime
     except Exception as error:
-        write_runtime_error_log(
-            cfg,
-            header="Failed to start TraceMLRuntime",
-            error=error,
-        )
+        _log_runtime_exception("Failed to start TraceMLRuntime", error)
         return NoOpRuntime()
 
 
 def stop_runtime(
     runtime: Union[TraceMLRuntime, NoOpRuntime],
-    cfg: Dict[str, Any],
 ) -> None:
     """
     Stop the TraceML runtime.
@@ -329,11 +233,7 @@ def stop_runtime(
         # runtime.log_summaries(path=None)
 
     except Exception as error:
-        write_runtime_error_log(
-            cfg,
-            header="Error during TraceML runtime shutdown",
-            error=error,
-        )
+        _log_runtime_exception("Error during TraceML runtime shutdown", error)
 
 
 def run_user_script(script_path: str, script_args: list[str]) -> None:
@@ -358,28 +258,18 @@ def run_user_script(script_path: str, script_args: list[str]) -> None:
 def _execute_with_runtime() -> None:
     """Execute the user script while owning one TraceML runtime lifecycle.
 
-    User exceptions are logged best effort for compatibility and then
-    re-raised unchanged. The ``finally`` block guarantees Python-level cleanup
-    without converting ``SystemExit``, ``KeyboardInterrupt``, or ordinary
-    exceptions into TraceML-specific failures.
+    User exceptions propagate unchanged to native Python/torchrun stderr. The
+    ``finally`` block guarantees Python-level cleanup without converting
+    ``SystemExit``, ``KeyboardInterrupt``, or ordinary exceptions into
+    TraceML-specific failures.
     """
     cfg = read_traceml_env()
     runtime = start_runtime(cfg)
 
     try:
-        run_user_script(
-            str(cfg["script_path"]),
-            extract_script_args(),
-        )
-    except Exception as error:
-        write_user_error_log(
-            cfg,
-            header="Unhandled exception in user script",
-            error=error,
-        )
-        raise
+        run_user_script(str(cfg["script_path"]), extract_script_args())
     finally:
-        stop_runtime(runtime, cfg)
+        stop_runtime(runtime)
 
 
 def _run_with_torchelastic_record(

--- a/src/traceml_ai/runtime/executor.py
+++ b/src/traceml_ai/runtime/executor.py
@@ -13,11 +13,14 @@ torchrun remain responsible for exception reporting and process exit status.
 import os
 import runpy
 import sys
-import traceback
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
 
-from traceml_ai.loggers.error_log import get_error_logger, setup_error_logger
+from traceml_ai.loggers.error_log import (
+    get_error_logger,
+    log_internal_exception,
+    setup_error_logger,
+)
 from traceml_ai.runtime.launch_context import (
     LaunchContext,
     script_execution_context,
@@ -58,18 +61,10 @@ def _log_runtime_exception(message: str, error: BaseException) -> None:
     """Record a TraceML failure without raising or copying user context."""
     try:
         setup_error_logger(role="rank")
-        error_traceback = "".join(
-            traceback.format_exception(
-                type(error),
-                error,
-                error.__traceback__,
-                chain=False,
-            )
-        ).rstrip()
-        get_error_logger("TraceMLExecutor").error(
-            "[TraceML] %s\n%s",
-            message,
-            error_traceback,
+        log_internal_exception(
+            get_error_logger("TraceMLExecutor"),
+            f"[TraceML] {message}",
+            error,
         )
     except Exception:
         pass

--- a/src/traceml_ai/runtime/exporter.py
+++ b/src/traceml_ai/runtime/exporter.py
@@ -14,7 +14,10 @@ import time
 from collections import deque
 from typing import Any, Deque, List, Optional
 
-from traceml_ai.loggers.error_log import get_error_logger
+from traceml_ai.loggers.error_log import (
+    get_error_logger,
+    log_internal_exception,
+)
 
 DEFAULT_EXPORT_QUEUE_SIZE = 2048
 DEFAULT_EXPORT_DRAIN_TIMEOUT_SEC = 2.0
@@ -175,13 +178,8 @@ class TelemetryExporter:
             self._log_exception("TCPClient.send_batch failed", exc)
 
     def _log_exception(self, label: str, exc: Exception) -> None:
-        log = getattr(self._logger, "exception", None)
-        if callable(log):
-            log("[TraceML] %s: %s", label, exc)
-            return
-        fallback = getattr(self._logger, "error", None)
-        if callable(fallback):
-            fallback(f"[TraceML] {label}: {exc}")
+        """Log an exporter failure without inheriting caller context."""
+        log_internal_exception(self._logger, f"[TraceML] {label}", exc)
 
 
 __all__ = [

--- a/src/traceml_ai/runtime/lifecycle.py
+++ b/src/traceml_ai/runtime/lifecycle.py
@@ -199,34 +199,40 @@ def start_aggregator(
         setup_error_logger(role="aggregator")
         logger = get_error_logger("TraceMLAggregatorLifecycle")
 
-    session_root = Path(str(normalized.logs_dir)).resolve() / session_id
-    aggregator_dir = session_root / "aggregator"
-    aggregator_dir.mkdir(parents=True, exist_ok=True)
-
-    db_path = (
-        Path(str(normalized.db_path))
-        if normalized.db_path
-        else aggregator_dir / "telemetry"
-    )
-    normalized = replace(normalized, db_path=str(db_path))
-
     event = stop_event or threading.Event()
-    aggregator = _build_aggregator(
-        logger=logger,
-        stop_event=event,
-        settings=normalized,
-    )
+    aggregator = None
     try:
+        session_root = Path(str(normalized.logs_dir)).resolve() / session_id
+        aggregator_dir = session_root / "aggregator"
+        aggregator_dir.mkdir(parents=True, exist_ok=True)
+        db_path = (
+            Path(str(normalized.db_path))
+            if normalized.db_path
+            else aggregator_dir / "telemetry"
+        )
+        normalized = replace(normalized, db_path=str(db_path))
+        aggregator = _build_aggregator(
+            logger=logger,
+            stop_event=event,
+            settings=normalized,
+        )
         aggregator.start()
-    except BaseException:
-        event.set()
+        os.environ["TRACEML_AGGREGATOR_PORT"] = str(aggregator.endpoint.port)
+    except BaseException as exc:
         try:
-            aggregator.stop(timeout_sec=1.0)
+            logger.error(
+                "[TraceML] Aggregator startup failed",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
         except Exception:
             pass
+        event.set()
+        if aggregator is not None:
+            try:
+                aggregator.stop(timeout_sec=1.0)
+            except Exception:
+                pass
         raise
-
-    os.environ["TRACEML_AGGREGATOR_PORT"] = str(aggregator.endpoint.port)
 
     return AggregatorHandle(
         settings=normalized,

--- a/src/traceml_ai/runtime/lifecycle.py
+++ b/src/traceml_ai/runtime/lifecycle.py
@@ -196,7 +196,7 @@ def start_aggregator(
     _apply_settings_env(normalized)
 
     if logger is None:
-        setup_error_logger(is_aggregator=True)
+        setup_error_logger(role="aggregator")
         logger = get_error_logger("TraceMLAggregatorLifecycle")
 
     session_root = Path(str(normalized.logs_dir)).resolve() / session_id

--- a/src/traceml_ai/runtime/runtime.py
+++ b/src/traceml_ai/runtime/runtime.py
@@ -55,7 +55,7 @@ class TraceMLRuntime:
         self.mode = self._settings.mode
         self.profile = getattr(self._settings, "profile", "run")
 
-        setup_error_logger()
+        setup_error_logger(role="rank")
         self._logger = get_error_logger("TraceMLRuntime")
 
         # Runtime identity separates local device rank from globally unique

--- a/src/traceml_ai/runtime/sender.py
+++ b/src/traceml_ai/runtime/sender.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional
 
-from traceml_ai.loggers.error_log import get_error_logger
+from traceml_ai.loggers.error_log import (
+    get_error_logger,
+    log_internal_exception,
+)
 
 
 @dataclass(frozen=True)
@@ -153,15 +156,8 @@ class TelemetryPublisher:
             self._log_exception("TCPClient.close failed", exc)
 
     def _log_exception(self, label: str, exc: Exception) -> None:
-        """Log an exception without raising."""
-        log = getattr(self._logger, "exception", None)
-        if callable(log):
-            log("[TraceML] %s: %s", label, exc)
-            return
-
-        fallback = getattr(self._logger, "error", None)
-        if callable(fallback):
-            fallback(f"[TraceML] {label}: {exc}")
+        """Log a publisher failure without inheriting user context."""
+        log_internal_exception(self._logger, f"[TraceML] {label}", exc)
 
     @staticmethod
     def _sampler_name(sampler: Any) -> str:

--- a/tests/aggregator/test_finalization.py
+++ b/tests/aggregator/test_finalization.py
@@ -2,6 +2,7 @@ import json
 import threading
 import time
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -11,7 +12,7 @@ from traceml_ai.aggregator.trace_aggregator import (
     TraceMLAggregator,
     TraceMLFinalizationError,
 )
-from traceml_ai.runtime.settings import TraceMLSettings
+from traceml_ai.runtime.settings import AggregatorEndpoint, TraceMLSettings
 from traceml_ai.sdk.protocol import get_final_summary_json_path
 from traceml_ai.telemetry.control import build_rank_finished_payload
 
@@ -467,6 +468,55 @@ def test_stop_rejects_stale_summary_when_refresh_fails(
         )
     )
     assert current_payload == stale_payload
+
+
+def test_fatal_summary_failure_is_logged_once_at_process_boundary(
+    monkeypatch,
+    tmp_path,
+):
+    aggregator = _make_aggregator(
+        tmp_path,
+        writer=_Writer(_ok_result()),
+        tcp=_TCP(),
+    )
+    logger = Mock()
+    aggregator._logger = logger
+    monkeypatch.setattr(
+        trace_aggregator,
+        "generate_summary",
+        Mock(side_effect=RuntimeError("generation failed")),
+    )
+    monkeypatch.setattr(
+        aggregator_main,
+        "_install_signal_handlers",
+        lambda _event: None,
+    )
+
+    handle = Mock()
+    handle.endpoint = AggregatorEndpoint("127.0.0.1", 1234, "run")
+    handle.stop.side_effect = aggregator.stop
+
+    def _start(_settings, *, logger, stop_event):
+        stop_event.set()
+        return handle
+
+    monkeypatch.setattr(aggregator_main, "start_aggregator", _start)
+
+    rc = aggregator_main.run_aggregator(
+        TraceMLSettings(
+            mode="summary",
+            logs_dir=str(tmp_path),
+            session_id="run",
+            finalize_timeout_sec=0.0,
+        ),
+        logger=logger,
+    )
+
+    assert rc == 1
+    logger.error.assert_called_once()
+    assert logger.error.call_args.args[0] == (
+        "[TraceML] Aggregator exiting due to error"
+    )
 
 
 def test_stop_generates_summary_through_real_writer(tmp_path):

--- a/tests/aggregator/test_finalization.py
+++ b/tests/aggregator/test_finalization.py
@@ -514,6 +514,7 @@ def test_fatal_summary_failure_is_logged_once_at_process_boundary(
 
     assert rc == 1
     logger.error.assert_called_once()
+    assert logger.error.call_count + logger.exception.call_count == 1
     assert logger.error.call_args.args[0] == (
         "[TraceML] Aggregator exiting due to error"
     )

--- a/tests/integrations/test_ray.py
+++ b/tests/integrations/test_ray.py
@@ -1,5 +1,8 @@
 import importlib
 import sys
+from unittest.mock import Mock
+
+import pytest
 
 from traceml_ai.integrations.ray import (
     TraceMLRayConfig,
@@ -88,6 +91,57 @@ def test_worker_settings_connect_to_actor_endpoint():
     assert settings.sampler_interval_sec == 2.0
     assert settings.aggregator.connect_host == "10.0.0.9"
     assert settings.aggregator.port == 34567
+
+
+def test_ray_actor_logs_finalization_failure_once(monkeypatch):
+    import traceml_ai.integrations.ray as ray_integration
+
+    failure = RuntimeError("summary generation failed")
+    handle = Mock()
+    handle.stop.side_effect = failure
+    logger = Mock()
+    fake_ray = Mock()
+    fake_ray.util.get_node_ip_address.return_value = "10.0.0.9"
+    start_aggregator = Mock(return_value=handle)
+    get_error_logger = Mock(return_value=logger)
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    monkeypatch.setattr(ray_integration, "start_aggregator", start_aggregator)
+    monkeypatch.setattr(ray_integration, "get_error_logger", get_error_logger)
+
+    actor = ray_integration._TraceMLAggregatorActor(
+        TraceMLRayConfig(session_id="ray-run", stop_timeout_sec=7.5)
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        actor.stop()
+
+    assert raised.value is failure
+    start_aggregator.assert_called_once()
+    get_error_logger.assert_called_once_with("TraceMLRayAggregator")
+    handle.stop.assert_called_once_with(timeout_sec=7.5)
+    logger.error.assert_called_once()
+    log_message = logger.error.call_args.args[0]
+    assert "[TraceML] Ray aggregator finalization failed" in log_message
+    assert "RuntimeError: summary generation failed" in log_message
+
+    # A failed stop is still terminal; cleanup must not log or stop twice.
+    actor.stop()
+    handle.stop.assert_called_once()
+    logger.error.assert_called_once()
+
+
+def test_ray_actor_stop_remains_best_effort_at_driver_boundary():
+    import traceml_ai.integrations.ray as ray_integration
+
+    actor = Mock()
+    actor.stop.remote.return_value = "stop-ref"
+    ray = Mock()
+    ray.get.side_effect = RuntimeError("remote finalization failed")
+
+    ray_integration._stop_actor_best_effort(ray, actor)
+
+    ray.get.assert_called_once_with("stop-ref")
+    ray.kill.assert_called_once_with(actor, no_restart=True)
 
 
 def test_ray_disabled_delegates_to_native_torch_trainer(monkeypatch):

--- a/tests/loggers/test_error_log.py
+++ b/tests/loggers/test_error_log.py
@@ -11,6 +11,7 @@ handler lived on ``"traceml"`` while every call site logged under
 ``"traceml_ai.*"``, leaving every ``traceml_errors.log`` empty.
 """
 
+import io
 import logging
 from unittest.mock import Mock
 
@@ -103,7 +104,7 @@ def test_setup_failure_disables_internal_file_logging(
     monkeypatch.setenv("TRACEML_SESSION_ID", "session_test")
     monkeypatch.setattr(
         error_log,
-        "RotatingFileHandler",
+        "_SilentRotatingFileHandler",
         Mock(side_effect=OSError("read-only filesystem")),
     )
 
@@ -112,3 +113,26 @@ def test_setup_failure_disables_internal_file_logging(
 
     assert len(logger.handlers) == 1
     assert isinstance(logger.handlers[0], logging.NullHandler)
+
+
+def test_write_failure_does_not_reach_stderr(
+    tmp_path, monkeypatch, capsys, clean_error_logger
+):
+    monkeypatch.setenv("TRACEML_LOGS_DIR", str(tmp_path))
+    monkeypatch.setenv("TRACEML_SESSION_ID", "session_test")
+
+    logger = setup_error_logger(role="aggregator")
+    handler = logger.handlers[0]
+    original_stream = handler.stream
+
+    class _BrokenStream(io.StringIO):
+        def write(self, value):
+            raise OSError("disk full")
+
+    try:
+        handler.stream = _BrokenStream()
+        get_error_logger("Probe").error("must remain isolated")
+    finally:
+        handler.stream = original_stream
+
+    assert capsys.readouterr().err == ""

--- a/tests/loggers/test_error_log.py
+++ b/tests/loggers/test_error_log.py
@@ -12,9 +12,11 @@ handler lived on ``"traceml"`` while every call site logged under
 """
 
 import logging
+from unittest.mock import Mock
 
 import pytest
 
+import traceml_ai.loggers.error_log as error_log
 from traceml_ai.loggers.error_log import get_error_logger, setup_error_logger
 
 
@@ -40,13 +42,16 @@ def test_error_from_call_site_lands_in_file(
     monkeypatch.setenv("TRACEML_LOGS_DIR", str(tmp_path))
     monkeypatch.setenv("TRACEML_SESSION_ID", "session_test")
 
-    setup_error_logger(is_aggregator=True)
-    get_error_logger("Probe").error("[TraceML] probe-error-message")
+    setup_error_logger(role="aggregator")
+    probe = get_error_logger("Probe")
+    probe.warning("[TraceML] warning-is-not-persisted")
+    probe.error("[TraceML] probe-error-message")
 
     log_file = tmp_path / "session_test" / "aggregator" / "traceml_errors.log"
     assert log_file.is_file()
     content = log_file.read_text(encoding="utf-8")
     assert "probe-error-message" in content
+    assert "warning-is-not-persisted" not in content
     assert "traceml_ai.Probe" in content
 
 
@@ -58,7 +63,7 @@ def test_rank_process_writes_its_own_error_file(
     monkeypatch.setenv("TRACEML_SESSION_ID", "session_test")
     monkeypatch.setenv("RANK", "3")
 
-    setup_error_logger(is_aggregator=False)
+    setup_error_logger(role="rank")
     get_error_logger("Sampler").error("[TraceML] rank-scoped-error")
 
     log_file = tmp_path / "session_test" / "rank_3" / "traceml_errors.log"
@@ -66,12 +71,44 @@ def test_rank_process_writes_its_own_error_file(
     assert "rank-scoped-error" in log_file.read_text(encoding="utf-8")
 
 
+def test_launcher_writes_its_node_owned_error_file(
+    tmp_path, clean_error_logger
+):
+    session_root = tmp_path / "session_test"
+
+    setup_error_logger(role="launcher", session_root=session_root, node_rank=2)
+    get_error_logger("Launcher").error("[TraceML] launcher-error")
+
+    log_file = session_root / "nodes" / "node_2" / "launcher_errors.log"
+    assert log_file.is_file()
+    assert "launcher-error" in log_file.read_text(encoding="utf-8")
+
+
 def test_setup_is_idempotent(tmp_path, monkeypatch, clean_error_logger):
     monkeypatch.setenv("TRACEML_LOGS_DIR", str(tmp_path))
     monkeypatch.setenv("TRACEML_SESSION_ID", "session_test")
 
-    first = setup_error_logger(is_aggregator=True)
-    second = setup_error_logger(is_aggregator=True)
+    first = setup_error_logger(role="aggregator")
+    second = setup_error_logger(role="aggregator")
 
     assert first is second
     assert len(first.handlers) == 1
+    assert first.propagate is False
+
+
+def test_setup_failure_disables_internal_file_logging(
+    tmp_path, monkeypatch, clean_error_logger
+):
+    monkeypatch.setenv("TRACEML_LOGS_DIR", str(tmp_path))
+    monkeypatch.setenv("TRACEML_SESSION_ID", "session_test")
+    monkeypatch.setattr(
+        error_log,
+        "RotatingFileHandler",
+        Mock(side_effect=OSError("read-only filesystem")),
+    )
+
+    logger = setup_error_logger(role="aggregator")
+    get_error_logger("Probe").error("must not raise")
+
+    assert len(logger.handlers) == 1
+    assert isinstance(logger.handlers[0], logging.NullHandler)

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import types
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -40,7 +41,6 @@ from traceml_ai.runtime.executor import (  # noqa: E402
     extract_script_args,
     read_traceml_env,
     run_user_script,
-    write_user_error_log,
 )
 from traceml_ai.runtime.settings import (
     DEFAULT_FINALIZE_TIMEOUT_SEC,
@@ -196,17 +196,34 @@ def test_build_runtime_settings_carries_trace_max_steps():
     assert settings.expected_world_size == 1
 
 
-def test_write_user_error_log_records_error(tmp_path):
-    cfg = {"logs_dir": str(tmp_path), "session_id": "session-a"}
-    error = RuntimeError("boom")
+def test_runtime_start_and_stop_failures_use_internal_log(monkeypatch):
+    failures = []
+    startup_error = RuntimeError("startup failed")
+    shutdown_error = RuntimeError("shutdown failed")
+    runtime = Mock()
+    runtime.stop.side_effect = shutdown_error
 
-    write_user_error_log(cfg, "User script failed", error)
-
-    log_text = (tmp_path / "session-a" / "torchrun_error.log").read_text(
-        encoding="utf-8"
+    monkeypatch.setattr(
+        executor, "build_runtime_settings", lambda _cfg: object()
     )
-    assert "User script failed" in log_text
-    assert "RuntimeError: boom" in log_text
+    monkeypatch.setattr(
+        executor,
+        "start_runtime_handle",
+        Mock(side_effect=startup_error),
+    )
+    monkeypatch.setattr(
+        executor,
+        "_log_runtime_exception",
+        lambda message, error: failures.append((message, error)),
+    )
+
+    assert isinstance(executor.start_runtime({}), executor.NoOpRuntime)
+    executor.stop_runtime(runtime)
+
+    assert failures == [
+        ("Failed to start TraceMLRuntime", startup_error),
+        ("Error during TraceML runtime shutdown", shutdown_error),
+    ]
 
 
 @pytest.mark.parametrize(
@@ -228,11 +245,6 @@ def test_execute_with_runtime_preserves_base_exceptions_without_user_log(
         raise user_exit
 
     monkeypatch.setattr(executor, "run_user_script", exit_user_script)
-    monkeypatch.setattr(
-        executor,
-        "write_user_error_log",
-        lambda *_args, **_kwargs: events.append("logged"),
-    )
     monkeypatch.setattr(
         executor,
         "stop_runtime",
@@ -268,7 +280,7 @@ def test_torchelastic_record_wraps_entrypoint_when_configured(monkeypatch):
     assert calls == ["record", "entrypoint"]
 
 
-def test_executor_subprocess_preserves_native_traceback_and_compatibility_log(
+def test_executor_user_failure_stays_native_and_out_of_internal_logs(
     tmp_path,
 ):
     script_path = tmp_path / "raise_error.py"
@@ -299,10 +311,7 @@ def test_executor_subprocess_preserves_native_traceback_and_compatibility_log(
     assert result.returncode == 1
     assert "Traceback (most recent call last)" in result.stderr
     assert "RuntimeError: subprocess boom" in result.stderr
-    compatibility_log = (
-        tmp_path / "logs" / "executor-test" / "torchrun_error.log"
-    )
-    assert compatibility_log.is_file()
-    assert "RuntimeError: subprocess boom" in compatibility_log.read_text(
-        encoding="utf-8"
-    )
+    run_root = tmp_path / "logs" / "executor-test"
+    assert not (run_root / "torchrun_error.log").exists()
+    assert not (run_root / "runtime_error.log").exists()
+    assert not list(run_root.rglob("traceml_errors.log"))

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -1,4 +1,6 @@
+import io
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -224,6 +226,27 @@ def test_runtime_start_and_stop_failures_use_internal_log(monkeypatch):
         ("Failed to start TraceMLRuntime", startup_error),
         ("Error during TraceML runtime shutdown", shutdown_error),
     ]
+
+
+def test_shutdown_log_excludes_active_user_exception(monkeypatch):
+    stream = io.StringIO()
+    logger = logging.Logger("test-runtime-error")
+    logger.addHandler(logging.StreamHandler(stream))
+    monkeypatch.setattr(executor, "setup_error_logger", lambda *, role: None)
+    monkeypatch.setattr(executor, "get_error_logger", lambda _name: logger)
+
+    with pytest.raises(ValueError, match="private user failure"):
+        try:
+            raise ValueError("private user failure")
+        finally:
+            try:
+                raise RuntimeError("TraceML shutdown failed")
+            except RuntimeError as error:
+                executor._log_runtime_exception("shutdown failed", error)
+
+    content = stream.getvalue()
+    assert "TraceML shutdown failed" in content
+    assert "private user failure" not in content
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -249,6 +249,32 @@ def test_shutdown_log_excludes_active_user_exception(monkeypatch):
     assert "private user failure" not in content
 
 
+def test_shutdown_log_keeps_explicit_cause_without_user_context(monkeypatch):
+    stream = io.StringIO()
+    logger = logging.Logger("test-runtime-error-with-cause")
+    logger.addHandler(logging.StreamHandler(stream))
+    monkeypatch.setattr(executor, "setup_error_logger", lambda *, role: None)
+    monkeypatch.setattr(executor, "get_error_logger", lambda _name: logger)
+
+    with pytest.raises(ValueError, match="private user failure"):
+        try:
+            raise ValueError("private user failure")
+        finally:
+            try:
+                try:
+                    raise OSError("TraceML socket failure")
+                except OSError as cause:
+                    raise RuntimeError("TraceML shutdown failed") from cause
+            except RuntimeError as error:
+                executor._log_runtime_exception("shutdown failed", error)
+
+    content = stream.getvalue()
+    assert "TraceML socket failure" in content
+    assert "TraceML shutdown failed" in content
+    assert "The above exception was the direct cause" in content
+    assert "private user failure" not in content
+
+
 @pytest.mark.parametrize(
     "user_exit",
     [SystemExit(7), KeyboardInterrupt()],
@@ -303,8 +329,10 @@ def test_torchelastic_record_wraps_entrypoint_when_configured(monkeypatch):
     assert calls == ["record", "entrypoint"]
 
 
+@pytest.mark.parametrize("traceml_disabled", [True, False])
 def test_executor_user_failure_stays_native_and_out_of_internal_logs(
     tmp_path,
+    traceml_disabled,
 ):
     script_path = tmp_path / "raise_error.py"
     script_path.write_text(
@@ -318,7 +346,7 @@ def test_executor_user_failure_stays_native_and_out_of_internal_logs(
         {
             "PYTHONPATH": str(SRC),
             "TRACEML_SCRIPT_PATH": str(script_path),
-            "TRACEML_DISABLED": "1",
+            "TRACEML_DISABLED": "1" if traceml_disabled else "0",
             "TRACEML_LOGS_DIR": str(tmp_path / "logs"),
             "TRACEML_SESSION_ID": "executor-test",
         }
@@ -337,4 +365,11 @@ def test_executor_user_failure_stays_native_and_out_of_internal_logs(
     run_root = tmp_path / "logs" / "executor-test"
     assert not (run_root / "torchrun_error.log").exists()
     assert not (run_root / "runtime_error.log").exists()
-    assert not list(run_root.rglob("traceml_errors.log"))
+    internal_logs = list(run_root.rglob("traceml_errors.log"))
+    if traceml_disabled:
+        assert not internal_logs
+    else:
+        assert len(internal_logs) == 1
+        assert "subprocess boom" not in internal_logs[0].read_text(
+            encoding="utf-8"
+        )

--- a/tests/runtime/test_exporter.py
+++ b/tests/runtime/test_exporter.py
@@ -142,7 +142,10 @@ def test_aggregator_unavailable_does_not_block_or_crash() -> None:
         # The exporter thread keeps attempting sends and swallows failures.
         assert _wait_until(lambda: client.call_count >= 5)
         assert exporter.dropped_count == 0
-        assert len(logger.exceptions) >= 5
+        assert len(logger.errors) >= 5
+        assert all(
+            "RuntimeError: send failed" in item for item in logger.errors
+        )
     finally:
         exporter.stop()
 

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -366,7 +366,7 @@ def test_dashboard_dep_check_passes_without_plotly(monkeypatch) -> None:
 
 
 def test_serve_configures_logging_without_preset_env(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path, capsys
 ) -> None:
     import logging
 
@@ -383,8 +383,10 @@ def test_serve_configures_logging_without_preset_env(
     os.environ.pop("TRACEML_LOGS_DIR", None)
     os.environ.pop("TRACEML_SESSION_ID", None)
 
-    traceml_logger = logging.getLogger("traceml")
+    traceml_logger = logging.getLogger("traceml_ai")
     saved_handlers = traceml_logger.handlers[:]
+    saved_level = traceml_logger.level
+    saved_propagate = traceml_logger.propagate
     traceml_logger.handlers.clear()
 
     # Do not clobber the process signal handlers, and stop before the blocking
@@ -412,6 +414,17 @@ def test_serve_configures_logging_without_preset_env(
         assert rc == 1
         assert os.environ["TRACEML_LOGS_DIR"] == str(tmp_path)
         assert os.environ["TRACEML_SESSION_ID"] == "serve-test"
+        structured_log = (
+            tmp_path / "serve-test" / "aggregator" / "traceml_errors.log"
+        )
+        raw_log = tmp_path / "serve-test" / "aggregator" / "process.stderr.log"
+        content = structured_log.read_text(encoding="utf-8")
+        assert content.count("Aggregator exiting due to error") == 1
+        assert "RuntimeError: stop before blocking" in content
+        assert not (tmp_path / "serve-test" / "aggregator_error.log").exists()
+        stderr = capsys.readouterr().err
+        assert str(structured_log) in stderr
+        assert str(raw_log) in stderr
     finally:
         for handler in traceml_logger.handlers[:]:
             traceml_logger.removeHandler(handler)
@@ -421,6 +434,8 @@ def test_serve_configures_logging_without_preset_env(
                 pass
         for handler in saved_handlers:
             traceml_logger.addHandler(handler)
+        traceml_logger.setLevel(saved_level)
+        traceml_logger.propagate = saved_propagate
         for key, value in saved_env.items():
             if value is None:
                 os.environ.pop(key, None)
@@ -1162,6 +1177,10 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
         return training
 
     monkeypatch.chdir(tmp_path)
+    setup_error_logger = Mock()
+    monkeypatch.setattr(
+        launcher_commands, "setup_error_logger", setup_error_logger
+    )
     install_shutdown_handlers = Mock()
     monkeypatch.setattr(
         launcher_commands,
@@ -1208,6 +1227,11 @@ def test_launcher_scopes_telemetry_health_to_aggregator_owner(
         launch_process(str(script), args)
 
     assert exc.value.code == 0
+    setup_error_logger.assert_called_once_with(
+        role="launcher",
+        session_root=(tmp_path / "logs" / "warn-run").resolve(),
+        node_rank=node_rank,
+    )
     launcher_commands._start_training_output.assert_called_once_with(
         training,
         stdout_path=(

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -371,6 +371,7 @@ def test_serve_configures_logging_without_preset_env(
     import logging
 
     import traceml_ai.aggregator.aggregator_main as agg_main
+    import traceml_ai.runtime.lifecycle as lifecycle
     from traceml_ai.runtime.settings import (
         AggregatorTransportSettings,
         TraceMLSettings,
@@ -393,10 +394,18 @@ def test_serve_configures_logging_without_preset_env(
     # wait by making aggregator startup raise a controlled error.
     monkeypatch.setattr(agg_main, "_install_signal_handlers", lambda ev: None)
 
-    def _boom(*args, **kwargs):
-        raise RuntimeError("stop before blocking")
+    class _FailingAggregator:
+        def start(self):
+            raise RuntimeError("stop before blocking")
 
-    monkeypatch.setattr(agg_main, "start_aggregator", _boom)
+        def stop(self, timeout_sec):
+            return None
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_build_aggregator",
+        lambda **kwargs: _FailingAggregator(),
+    )
 
     settings = TraceMLSettings(
         mode="summary",
@@ -419,7 +428,8 @@ def test_serve_configures_logging_without_preset_env(
         )
         raw_log = tmp_path / "serve-test" / "aggregator" / "process.stderr.log"
         content = structured_log.read_text(encoding="utf-8")
-        assert content.count("Aggregator exiting due to error") == 1
+        assert content.count("Aggregator startup failed") == 1
+        assert "Aggregator exiting due to error" not in content
         assert "RuntimeError: stop before blocking" in content
         assert not (tmp_path / "serve-test" / "aggregator_error.log").exists()
         stderr = capsys.readouterr().err

--- a/tests/runtime/test_lifecycle.py
+++ b/tests/runtime/test_lifecycle.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from typing import Any
 from unittest.mock import Mock
 
+import pytest
+
 from traceml_ai.runtime import lifecycle
 from traceml_ai.runtime.runtime import TraceMLRuntime
 from traceml_ai.runtime.settings import AggregatorEndpoint, TraceMLSettings
@@ -70,6 +72,37 @@ def test_start_aggregator_returns_idempotent_handle(
     handle.stop()
 
     assert handle.stop_event.is_set()
+    assert created[0].stops == 1
+
+
+def test_start_aggregator_logs_endpoint_failure_once(monkeypatch, tmp_path):
+    class _EndpointFailureAggregator(_FakeAggregator):
+        @property
+        def endpoint(self):
+            raise RuntimeError("endpoint unavailable")
+
+    created = []
+
+    def _factory(*, logger, stop_event, settings):
+        aggregator = _EndpointFailureAggregator(
+            logger=logger,
+            stop_event=stop_event,
+            settings=settings,
+        )
+        created.append(aggregator)
+        return aggregator
+
+    logger = Mock()
+    monkeypatch.setattr(lifecycle, "_build_aggregator", _factory)
+
+    with pytest.raises(RuntimeError, match="endpoint unavailable"):
+        lifecycle.start_aggregator(
+            TraceMLSettings(logs_dir=str(tmp_path), session_id="run"),
+            logger=logger,
+        )
+
+    logger.error.assert_called_once()
+    assert created[0].stop_event.is_set()
     assert created[0].stops == 1
 
 

--- a/tests/runtime/test_runtime_identity_wiring.py
+++ b/tests/runtime/test_runtime_identity_wiring.py
@@ -4,6 +4,8 @@
 # you may not use this file except in compliance with the License.
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import Mock
+
 from traceml_ai.runtime.runtime import TraceMLRuntime
 from traceml_ai.runtime.sender import SenderIdentity
 from traceml_ai.runtime.settings import TraceMLSettings
@@ -61,6 +63,7 @@ def test_runtime_uses_local_rank_for_samplers_and_global_rank_for_publisher(
         return []
 
     _FakePublisher.instances.clear()
+    setup_error_logger = Mock()
     monkeypatch.setenv("RANK", "5")
     monkeypatch.setenv("LOCAL_RANK", "1")
     monkeypatch.setenv("WORLD_SIZE", "8")
@@ -68,7 +71,7 @@ def test_runtime_uses_local_rank_for_samplers_and_global_rank_for_publisher(
     monkeypatch.setenv("GROUP_RANK", "1")
     monkeypatch.setattr(
         "traceml_ai.runtime.runtime.setup_error_logger",
-        lambda: None,
+        setup_error_logger,
     )
     monkeypatch.setattr(
         "traceml_ai.runtime.runtime.get_error_logger",
@@ -86,6 +89,7 @@ def test_runtime_uses_local_rank_for_samplers_and_global_rank_for_publisher(
 
     runtime = TraceMLRuntime(settings=TraceMLSettings(mode="summary"))
 
+    setup_error_logger.assert_called_once_with(role="rank")
     assert runtime.global_rank == 5
     assert runtime.local_rank == 1
     assert runtime.world_size == 8

--- a/tests/runtime/test_telemetry_publisher.py
+++ b/tests/runtime/test_telemetry_publisher.py
@@ -4,6 +4,11 @@
 # you may not use this file except in compliance with the License.
 # SPDX-License-Identifier: Apache-2.0
 
+import io
+import logging
+
+import pytest
+
 from traceml_ai.runtime.sender import SenderIdentity, TelemetryPublisher
 
 
@@ -155,8 +160,9 @@ def test_publisher_logs_sender_attach_failures_and_continues() -> None:
 
     assert good_sender.sender is tcp_client
     assert good_sender.rank is None
-    assert len(logger.exceptions) == 1
-    assert "sender attach failed" in logger.exceptions[0][0]
+    assert len(logger.errors) == 1
+    assert "sender attach failed" in logger.errors[0]
+    assert "RuntimeError: attach failed" in logger.errors[0]
 
 
 def test_publisher_flushes_collects_and_sends_one_batch() -> None:
@@ -242,7 +248,7 @@ def test_publisher_logs_failures_and_continues() -> None:
 
     publisher.publish([good_sampler, bad_flush_sampler, bad_collect_sampler])
 
-    messages = [entry[0] for entry in logger.exceptions]
+    messages = logger.errors
     assert len(messages) == 3
     assert any("writer.flush failed" in message for message in messages)
     assert any("collect_payload failed" in message for message in messages)
@@ -273,11 +279,12 @@ def test_publisher_close_failure_is_logged_not_raised() -> None:
 
     publisher.close()
 
-    assert len(logger.exceptions) == 1
-    assert "TCPClient.close failed" in logger.exceptions[0][0]
+    assert len(logger.errors) == 1
+    assert "TCPClient.close failed" in logger.errors[0]
+    assert "RuntimeError: close failed" in logger.errors[0]
 
 
-def test_publisher_uses_error_logger_fallback_when_exception_missing() -> None:
+def test_publisher_supports_an_error_only_logger() -> None:
     class _ErrorOnlyLogger:
         def __init__(self) -> None:
             self.errors: list[str] = []
@@ -296,3 +303,30 @@ def test_publisher_uses_error_logger_fallback_when_exception_missing() -> None:
 
     assert len(logger.errors) == 1
     assert "TCPClient.send_batch failed" in logger.errors[0]
+
+
+def test_cleanup_log_excludes_an_active_user_exception() -> None:
+    stream = io.StringIO()
+    logger = logging.Logger("test-publisher-cleanup")
+    logger.setLevel(logging.ERROR)
+    logger.addHandler(logging.StreamHandler(stream))
+    publisher = TelemetryPublisher(
+        tcp_client=_FakeTCPClient(),
+        identity=SenderIdentity(global_rank=0, local_rank=0),
+        logger=logger,
+    )
+    sampler = _FakeSampler(
+        "BrokenSampler",
+        writer=_FakeWriter(fail_flush=True),
+    )
+
+    with pytest.raises(ValueError, match="private user failure"):
+        try:
+            raise ValueError("private user failure")
+        finally:
+            publisher.flush_writers([sampler])
+
+    content = stream.getvalue()
+    assert "BrokenSampler.writer.flush failed" in content
+    assert "RuntimeError: flush failed" in content
+    assert "private user failure" not in content


### PR DESCRIPTION
## Summary

This PR consolidates TraceML-owned errors into one structured log per process owner.

## What changed

- Added explicit logger roles with collision-free paths:
  - `rank_<global_rank>/traceml_errors.log`
  - `aggregator/traceml_errors.log`
  - `nodes/node_<node_rank>/launcher_errors.log`
- Routed runtime, aggregator, and launcher implementation failures to their respective owners.
- Removed production of:
  - `torchrun_error.log`
  - `runtime_error.log`
  - `aggregator_error.log`
- Kept user exceptions in native Python/torchrun stderr rather than TraceML internal logs.
- Made logger setup idempotent and prevented propagation into user root loggers.
- Ensured logger initialization, write, and rotation failures remain fail-open without polluting workload stderr.
- Ensured aggregator startup and fatal finalization failures are logged exactly once.
- Preserved aggregator raw stderr separately at `aggregator/process.stderr.log`.

## Scope

This PR owns structured TraceML implementation diagnostics only. 

## Out of scope

- JSON logging or a new logging framework
- Cloud upload, log collection, or search
- Rotation-policy changes
- Per-rank raw workload-output capture
- Removal of legacy readers for historical artifacts

## Validation

- `1680 passed, 2 skipped`
- `mkdocs build --strict`
- `git diff --check`
- Verified that combined user and TraceML shutdown failures do not copy the user exception into internal logs
- Verified that logger write failures do not affect execution or terminal output
- Verified exact-once aggregator failure logging
