### PR TITLE
Dev/abhinav/issue451-a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ which carry the full historical notes for versions predating this file.
 
 ## [Unreleased]
 
+- **Removed:** `traceml_ai.integrations.huggingface.TraceMLTrainer` and its
+  `traceml_enabled` argument. The wrapper only installed the callback. Call
+  `traceml_ai.integrations.huggingface.init()` and register
+  `TraceMLTrainerCallback()` with standard `transformers.Trainer` instead.
+  For optional tracing, register the callback conditionally. See the
+  [HF migration instructions](docs/user_guide/integrations/huggingface.md#migration)
+  for the replacement setup.
 - PyTorch Lightning: `TraceMLCallback` now opens the traced step when
   Lightning moves the batch to the device, so the H2D transfer is inside
   Traced Step Time and Step Time on GPU runs; fetches of validation,

--- a/docs/developer_guide/architecture.md
+++ b/docs/developer_guide/architecture.md
@@ -42,7 +42,7 @@ Samplers maintain an incremental append counter per rank per table. The sender s
 The `src/traceml/` package is a deprecated compatibility alias for older import
 paths. New implementation work should go under `src/traceml_ai/`.
 
-For the user-facing API surface (`trace_step`, `TraceMLTrainer`, `TraceMLCallback`, CLI usage), see the [Public API](../user_guide/public-api.md). The source tree above is the canonical reference for internals — start from the entry points and follow the imports.
+For the user-facing API surface (`trace_step`, `TraceMLTrainerCallback`, `TraceMLCallback`, CLI usage), see the [Public API](../user_guide/public-api.md). The source tree above is the canonical reference for internals — start from the entry points and follow the imports.
 
 Contributors changing Step Time should begin with the
 [Step Time pipeline contract](step-time-pipeline-contract.md), which maps its

--- a/docs/developer_guide/step-time-pipeline-contract.md
+++ b/docs/developer_guide/step-time-pipeline-contract.md
@@ -237,6 +237,68 @@ SQLite normalization. `_traceml_internal:step_time` is intentionally stable
 raw telemetry and storage vocabulary below that normalization boundary; it is
 not a public metric name or presentation label.
 
+## Hugging Face steps
+
+For normally completed HF training, one TraceML step contains the microbatches
+used for one optimizer update attempt. The callback opens `trace_step` at
+`on_step_begin` and closes it at `on_step_end`. Accumulating microbatches emit
+`on_substep_end`, which does not advance TraceML's counter.
+
+For example, ten microbatches with `gradient_accumulation_steps=4` produce
+three steps containing four, four, and two microbatches. TraceML IDs are local
+to the process; their increments match HF's for recorded, completed groups,
+but their absolute values can differ after checkpoint resume.
+
+### Timing and memory
+
+All timing events for a group are flushed together as one `StepTimeBatch`.
+`StepTimeSampler` sums repeated forward and backward events within that batch,
+keeping CPU and GPU durations separate. It does not merge separate batches
+that happen to have the same step number.
+
+`StepMemoryTracker` resets the tracked CUDA device's PyTorch peak counters
+once at the start of the group and reads peak allocated/reserved memory once
+at the end. The peak covers all microbatches and optimizer work in that window.
+`StepMemorySampler` stores the result without further aggregation. CPU runs
+report memory as unavailable. Temporary allocation peaks before the callback
+window are not captured, although inputs still resident at its start count
+toward the peak.
+
+The callback window includes gradient clipping, ordinary scheduler work, and
+gradient zeroing. These contribute to Traced Step Time but are outside the
+separately timed forward, backward, and optimizer calls. HF's subsequent
+logging, saving, and evaluation are outside this window. Other callbacks'
+work is included only when it runs inside the measured window.
+
+### Skipped optimizer updates
+
+HF still completes a step when AMP overflow prevents a parameter update.
+TraceML follows that completion event. If the scaler skips the optimizer call,
+no timing event is emitted. A fused optimizer can execute its call but skip updating
+parameters internally; that call still contributes measured optimizer time.
+Neither the step count nor an optimizer timing event proves parameters changed.
+
+### Current limitations
+
+HF requests prepared inputs before `on_step_begin`, so the current callback
+can miss input H2D transfers. Evaluation loader events can also reach the next
+training step. The existing raw input event names are
+`_traceml_internal:dataloader_next` and `_traceml_internal:h2d_time`.
+These gaps can omit transfers from Step Time or assign loader work to the
+wrong training step.
+
+If training is interrupted, callback cleanup can record an unfinished group
+as completed. This requires the separate lifecycle fix. See the
+[HF integration guide](../user_guide/integrations/huggingface.md#limitations)
+for user-facing limitations.
+
+The boundary follows HF's
+[training loop](https://github.com/huggingface/transformers/blob/6622f6f781c9c0b1f2f5541a257943bee95ad586/src/transformers/trainer.py#L1791-L1892)
+and Accelerate's
+[optimizer wrapper](https://github.com/huggingface/accelerate/blob/9e5d1de5d2248a5f3ee8f2d9272ce88a686dc42d/src/accelerate/optimizer.py#L152-L203).
+`tests/integrations/test_hf_trainer.py` checks accumulation, partial groups, and
+scaler overflow. These CPU checks do not establish CUDA timing accuracy.
+
 ## Surface responsibilities
 
 | Surface | Loads | Diagnoses | Presents |

--- a/docs/user_guide/integrations/huggingface.md
+++ b/docs/user_guide/integrations/huggingface.md
@@ -2,11 +2,10 @@
 
 Use TraceML with Hugging Face `Trainer` without rewriting your training loop.
 
-The preferred integration is two steps: call
+The integration is two steps: call
 `traceml_ai.integrations.huggingface.init()` once, then pass
 `TraceMLTrainerCallback` (a standard `transformers.TrainerCallback`) to your
-existing `Trainer`. The legacy `TraceMLTrainer` subclass is still supported. It
-is now a thin wrapper that installs the same callback under the hood.
+existing `Trainer`.
 
 ## 1. Install
 
@@ -51,29 +50,6 @@ trainer.train()
 `traceml_hf.init()` enables automatic timing. The callback groups timing and
 memory measurements into training steps. Use both; you do not need to add
 `traceml.trace_step(...)` to your training code.
-
-### Legacy `TraceMLTrainer`
-
-The `TraceMLTrainer(Trainer)` subclass remains supported for users who already
-adopted it. It is now a thin wrapper that auto-installs
-`TraceMLTrainerCallback` on construction and accepts `traceml_enabled` to turn
-step-level instrumentation on or off:
-
-```python
-from traceml_ai.integrations import huggingface as traceml_hf
-
-traceml_hf.init()
-
-trainer = traceml_hf.TraceMLTrainer(
-    model=model,
-    args=training_args,
-    train_dataset=train_dataset,
-    traceml_enabled=True,
-)
-trainer.train()
-```
-
-New code should prefer the direct callback registration shown above.
 
 ## 3. Launch The Run
 
@@ -133,8 +109,7 @@ for the exact timing boundaries and optimizer behavior.
   a step are outside its memory measurement.
 - **Interrupted training.** If training raises, tracing can remain active
   until a later cleanup call, which may record the unfinished group as a
-  completed step. The legacy wrapper uses the same callback and has the same
-  limitation.
+  completed step.
 - **Callback registration.** Register the callback before `trainer.train()`
   so it receives the training events from the start.
 
@@ -356,10 +331,34 @@ and returns the effective `TraceMLInitConfig`.
 `TraceMLTrainerCallback()` takes no TraceML-specific arguments and records
 standard step-level timing and memory.
 
-`TraceMLTrainer` (legacy thin wrapper) accepts:
+## Migration
 
-- everything that normal `transformers.Trainer` accepts
-- `traceml_enabled=True|False`
+`TraceMLTrainer` was intentionally removed because it only installed
+`TraceMLTrainerCallback`. Replace it with `transformers.Trainer`, call
+`traceml_hf.init()` once, and add `traceml_hf.TraceMLTrainerCallback()` to the
+Trainer's callbacks, as shown above. Keep the rest of your Trainer arguments.
+
+The `traceml_enabled` argument was removed with the wrapper. For optional
+tracing, control initialization and callback registration in your code:
+
+```python
+enable_tracing = True
+callbacks = []  # Add any other Trainer callbacks here.
+if enable_tracing:
+    traceml_hf.init()
+    callbacks.append(traceml_hf.TraceMLTrainerCallback())
+
+trainer = Trainer(
+    model=model,
+    args=training_args,
+    train_dataset=train_dataset,
+    callbacks=callbacks,
+)
+trainer.train()
+```
+
+To disable TraceML for an entire launched run, use `--disable-traceml` as
+shown in Troubleshooting.
 
 ## Next Steps
 

--- a/docs/user_guide/integrations/huggingface.md
+++ b/docs/user_guide/integrations/huggingface.md
@@ -48,17 +48,9 @@ trainer = Trainer(
 trainer.train()
 ```
 
-`traceml_hf.init()` installs TraceML's process-wide instrumentation:
-`DataLoader` fetch timing, the H2D `Tensor.to` patch, and the
-forward/backward/optimizer auto-timers. The callback is a per-step bracket and
-cannot install these on its own, so calling `init()` first is what lets TraceML
-attribute `DataLoader` fetch time and host-to-device copies. It is idempotent
-and safe to call once at startup.
-
-You do not need to add `traceml.trace_step(...)` manually. The callback opens
-and closes `trace_step` around each optimizer step, and the auto-timers `init()`
-installed capture forward, backward, h2d, and optimizer phases inside that
-bracket.
+`traceml_hf.init()` enables automatic timing. The callback groups timing and
+memory measurements into training steps. Use both; you do not need to add
+`traceml.trace_step(...)` to your training code.
 
 ### Legacy `TraceMLTrainer`
 
@@ -114,37 +106,37 @@ to read:
 TraceML can still run alongside W&B, MLflow, and TensorBoard. For tracker
 logging patterns, see [W&B / MLflow](wandb-mlflow.md).
 
+## What one step includes
+
+One TraceML step covers the microbatches used for one HF optimizer update
+attempt. With `gradient_accumulation_steps=4`, four microbatches share one step
+number. A final group can contain fewer microbatches.
+
+Forward and backward times are added across the group. CUDA memory reports
+the peak PyTorch allocated/reserved memory on the tracked device during that
+group, rather than adding memory values. CPU runs report this memory metric
+as unavailable.
+
+TraceML follows HF's completed-step count even when mixed-precision overflow
+skips a parameter update. Step numbers are local to the process, so they may
+differ from HF's `global_step` after checkpoint resume. See the
+[developer guide](../../developer_guide/step-time-pipeline-contract.md#hugging-face-steps)
+for the exact timing boundaries and optimizer behavior.
+
 ## Limitations
 
-The callback path is the right default for most users, but it has structural
-trade-offs vs. the legacy subclass that are worth knowing:
-
-- **Step granularity.** One TraceML step equals one optimizer step. With
-  `gradient_accumulation_steps=N`, forward and backward times from all `N`
-  accumulated micro-batches fold into a single TraceML step. The pre-refactor
-  `TraceMLTrainer.training_step` override counted each micro-batch as its own
-  TraceML step. If you need per-micro-batch attribution under gradient
-  accumulation, open an issue.
-- **Optimizer timing.** Captured by TraceML's global optimizer hooks, which
-  are installed automatically only when running under the default
-  `traceml.init(mode="auto")` path. Under `manual` or `selective` modes
-  optimizer events are not emitted, but this
-  applies consistently to every step, so dashboard step alignment still holds.
-- **Exception safety.** If `training_step` raises, Hugging Face does not call
-  `on_step_end`. The callback defensively closes the trace_step context on
-  the next `on_step_begin`, on `on_train_begin` (so a reused callback instance
-  whose previous run crashed mid-step does not bleed a leaked auto-timer flag
-  into an `eval_on_start=True` evaluation), and on `on_train_end`. Even so, the
-  step where the exception occurred may be reported with incomplete timing or
-  memory. The
-  legacy subclass's `with trace_step(model): super().training_step(...)`
-  pattern ran the `finally` cleanup deterministically. If you need precise
-  attribution on failing steps, the legacy `TraceMLTrainer` path is stricter.
-- **Callback registration timing.** Pass `TraceMLTrainerCallback()` at
-  `Trainer(...)` construction. Callbacks added via `trainer.add_callback(...)`
-  *after* `trainer.train()` has started will not receive `on_train_begin`,
-  which means the first step may be outside TraceML's callback-managed
-  `trace_step` bracket.
+- **Input timing.** Accelerate can transfer batches to the GPU before the
+  callback starts a step. Those H2D copies are currently missed, so Step Time
+  can omit pre-step transfers. Evaluation loader fetches can also be attributed
+  to the next training step.
+- **Memory window.** Temporary allocation peaks before the callback starts
+  a step are outside its memory measurement.
+- **Interrupted training.** If training raises, tracing can remain active
+  until a later cleanup call, which may record the unfinished group as a
+  completed step. The legacy wrapper uses the same callback and has the same
+  limitation.
+- **Callback registration.** Register the callback before `trainer.train()`
+  so it receives the training events from the start.
 
 ## Troubleshooting
 

--- a/docs/user_guide/public-api.md
+++ b/docs/user_guide/public-api.md
@@ -249,8 +249,9 @@ matching integration guide for installation and runtime requirements.
 
 ### Hugging Face
 
-Preferred path: call the integration `init()` once and register
-`TraceMLTrainerCallback` with your existing `transformers.Trainer`.
+Call the integration `init()` once and register `TraceMLTrainerCallback` with
+your existing `transformers.Trainer`. See the
+[Hugging Face guide](integrations/huggingface.md) for setup and limitations.
 
 ::: traceml_ai.integrations.huggingface.init
     options:
@@ -258,17 +259,6 @@ Preferred path: call the integration `init()` once and register
       show_source: false
 
 ::: traceml_ai.integrations.huggingface.TraceMLTrainerCallback
-    options:
-      show_root_heading: true
-      show_source: false
-
-#### Legacy compatibility: `TraceMLTrainer`
-
-`TraceMLTrainer` remains supported for existing users. New code should prefer
-`TraceMLTrainerCallback`; see the [Hugging Face guide](integrations/huggingface.md)
-for its trade-offs.
-
-::: traceml_ai.integrations.huggingface.TraceMLTrainer
     options:
       show_root_heading: true
       show_source: false

--- a/examples/advanced/huggingface_vision_vit.py
+++ b/examples/advanced/huggingface_vision_vit.py
@@ -12,14 +12,16 @@ from transformers import (
     AutoImageProcessor,
     AutoModelForImageClassification,
     DefaultDataCollator,
+    Trainer,
     TrainingArguments,
 )
 
-from traceml_ai.integrations.huggingface import TraceMLTrainer
+from traceml_ai.integrations import huggingface as traceml_hf
 
 
 def main():
-    print("=== TraceMLTrainer Vision Example (ViT) ===")
+    print("=== Hugging Face ViT training with TraceML ===")
+    traceml_hf.init()
 
     # Configuration
     model_name = "google/vit-base-patch16-224-in21k"
@@ -82,14 +84,14 @@ def main():
         remove_unused_columns=False,  # Required for vision datasets sometimes
     )
 
-    # Initialize TraceMLTrainer
-    print("Initializing TraceMLTrainer...")
-    trainer = TraceMLTrainer(
+    # Register TraceML on the standard Hugging Face Trainer.
+    print("Initializing Trainer...")
+    trainer = Trainer(
         model=model,
         args=training_args,
         train_dataset=dataset,
         data_collator=DefaultDataCollator(),
-        traceml_enabled=True,
+        callbacks=[traceml_hf.TraceMLTrainerCallback()],
     )
 
     # Train

--- a/examples/integrations/huggingface_trainer_minimal.py
+++ b/examples/integrations/huggingface_trainer_minimal.py
@@ -5,11 +5,6 @@ from transformers import Trainer, TrainingArguments
 
 from traceml_ai.integrations import huggingface as traceml_hf
 
-# Legacy path still works:
-#   trainer = traceml_hf.TraceMLTrainer(...)
-# TraceMLTrainer is now a thin wrapper that auto-installs
-# TraceMLTrainerCallback under the hood.
-
 SEED = 42
 INPUT_DIM = 128
 HIDDEN_DIM = 256

--- a/src/traceml_ai/integrations/huggingface.py
+++ b/src/traceml_ai/integrations/huggingface.py
@@ -1,3 +1,9 @@
+"""TraceML callbacks for the standard Hugging Face Trainer.
+
+The TraceMLTrainer wrapper was intentionally removed. Use init() and register
+TraceMLTrainerCallback with transformers.Trainer.
+"""
+
 import os
 import sys
 
@@ -15,12 +21,11 @@ def _traceml_disabled() -> bool:
 
 
 try:
-    from transformers import Trainer, TrainerCallback
+    from transformers import TrainerCallback
 
     HAS_TRANSFORMERS = True
 except ImportError:
     HAS_TRANSFORMERS = False
-    Trainer = object  # Fallback for type hinting
     TrainerCallback = object  # Fallback for type hinting
 
 
@@ -70,7 +75,7 @@ def _log_hf_error(message: str, exc: Exception) -> None:
 
 class TraceMLTrainerCallback(TrainerCallback if HAS_TRANSFORMERS else object):
     """
-    Preferred Hugging Face integration for TraceML.
+    Hugging Face Trainer integration for TraceML.
 
     Register with ``Trainer(..., callbacks=[TraceMLTrainerCallback()])``.
 
@@ -118,13 +123,8 @@ class TraceMLTrainerCallback(TrainerCallback if HAS_TRANSFORMERS else object):
         if _traceml_disabled():
             return
 
-        # Fail-loud capability check (#88-class): warn, never raise,
-        # when the current init config leaves telemetry streams this
-        # integration owes dark. on_train_begin runs once per train()
-        # call, after user setup, so it reflects post-init() state and
-        # stays off the per-step hot path. Covers both the direct
-        # callback path and the TraceMLTrainer wrapper (which installs
-        # this callback).
+        # Check instrumentation once per train() call, after user setup.
+        # Missing streams should warn without interrupting training.
         try:
             from traceml_ai.integrations._capability import (
                 warn_if_missing_streams,
@@ -178,41 +178,4 @@ class TraceMLTrainerCallback(TrainerCallback if HAS_TRANSFORMERS else object):
         self._close_step_cm_safely()
 
 
-class TraceMLTrainer(Trainer if HAS_TRANSFORMERS else object):
-    """
-    Thin wrapper around ``transformers.Trainer`` that auto-installs
-    ``TraceMLTrainerCallback``.
-
-    Kept for backward compatibility with users on the original TraceML HF
-    integration API. New code should prefer
-    ``Trainer(..., callbacks=[TraceMLTrainerCallback()])`` directly.
-    """
-
-    def __init__(
-        self,
-        *args,
-        traceml_enabled: bool = True,
-        **kwargs,
-    ):
-        if not HAS_TRANSFORMERS:
-            raise ImportError(
-                "TraceMLTrainer requires the Hugging Face integration. "
-                "Install it with `pip install 'traceml-ai[hf]'`."
-            )
-
-        super().__init__(*args, **kwargs)
-        self.traceml_enabled = traceml_enabled
-
-        if not traceml_enabled or _traceml_disabled():
-            return
-
-        # Dedup guard: a user passing callbacks=[TraceMLTrainerCallback()] to
-        # TraceMLTrainer would otherwise double-instrument every step.
-        existing = getattr(self.callback_handler, "callbacks", [])
-        if any(isinstance(cb, TraceMLTrainerCallback) for cb in existing):
-            return
-
-        self.add_callback(TraceMLTrainerCallback())
-
-
-__all__ = ["TraceMLTrainerCallback", "TraceMLTrainer", "init"]
+__all__ = ["TraceMLTrainerCallback", "init"]

--- a/src/traceml_ai/integrations/huggingface.py
+++ b/src/traceml_ai/integrations/huggingface.py
@@ -80,10 +80,17 @@ class TraceMLTrainerCallback(TrainerCallback if HAS_TRANSFORMERS else object):
     counter advance, the auto-timers for forward/backward/h2d, and the
     per-step capture lifecycle. Nothing is duplicated here.
 
-    One TraceML step equals one optimizer step. With
-    ``gradient_accumulation_steps > 1``, forward and backward events from all
-    accumulated micro-batches fold into a single TraceML step. See the HF
-    integration docs for the full list of limitations vs. ``TraceMLTrainer``.
+    One completed TraceML step corresponds to one HF accumulation/update
+    boundary (``on_step_end``), including when AMP skips the parameter update.
+    ``on_substep_end`` does not advance the counter: forward and backward
+    events from the actual micro-batches in the group fold into one step,
+    including a shorter final group. Optimizer events describe calls that
+    actually run; their count does not drive TraceML's step counter.
+
+    TraceML step IDs remain process-local, so their increments match HF's
+    ``global_step`` increments during recorded, completed groups; their
+    absolute values need not match after checkpoint resume. See the HF
+    integration docs for the input-timing and interrupted-step limitations.
     """
 
     def __init__(self) -> None:

--- a/src/traceml_ai/runtime/state.py
+++ b/src/traceml_ai/runtime/state.py
@@ -28,10 +28,11 @@ class TraceSessionState:
     """
     Process-local state shared by TraceML instrumentation paths.
 
-    The first state carried here is the semantic training-step counter. It is
-    intentionally independent from framework-specific counters such as
-    Lightning's global step because TraceML also treats gradient-accumulation
-    micro-batches as distinct traceable steps.
+    The first state carried here is the semantic training-step counter. Each
+    integration defines the boundary of a completed trace_step: Hugging Face
+    uses an accumulation/update group, while Lightning uses a training batch.
+    This process-local counter is independent of framework counters and is
+    not automatically restored from a framework checkpoint.
     """
 
     initial_step: int = 0

--- a/tests/integrations/test_hf_trainer.py
+++ b/tests/integrations/test_hf_trainer.py
@@ -2,6 +2,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 
 torch = pytest.importorskip("torch")
 pytest.importorskip("transformers")
@@ -11,6 +12,7 @@ from transformers import (  # noqa: E402
     BertConfig,
     BertForSequenceClassification,
     Trainer,
+    TrainerCallback,
     TrainingArguments,
 )
 
@@ -77,6 +79,7 @@ def _build_training_args(
     max_steps: int,
     gradient_accumulation_steps: int = 1,
     batch_size: int = 4,
+    use_cpu: bool | None = None,
 ) -> "TrainingArguments":
     return TrainingArguments(
         output_dir=output_dir,
@@ -84,7 +87,7 @@ def _build_training_args(
         gradient_accumulation_steps=gradient_accumulation_steps,
         max_steps=max_steps,
         logging_steps=1,
-        use_cpu=not torch.cuda.is_available(),
+        use_cpu=not torch.cuda.is_available() if use_cpu is None else use_cpu,
         save_strategy="no",
         report_to="none",
         disable_tqdm=True,
@@ -183,44 +186,62 @@ def test_hf_trainer_callback_integration():
         assert TraceState.step >= max_steps
 
 
-def test_hf_trainer_callback_grad_accum_folds_microbatches():
-    """
-    With gradient_accumulation_steps=2 and max_steps=3, the callback should
-    advance the TraceML step counter exactly 3 times (one TraceML step per
-    optimizer step). Each StepTimeBatch should contain ~grad_accum forward
-    events, validating that sub-phase auto-timers stay armed across the
-    accumulated micro-batches within a single trace_step bracket.
-    """
+@pytest.mark.parametrize(
+    ("grad_accum", "num_rows", "microbatches_per_step"),
+    [
+        pytest.param(1, 40, [1, 1, 1], id="no-accumulation"),
+        pytest.param(2, 40, [2, 2, 2], id="accumulation"),
+        pytest.param(4, 40, [4, 4, 2], id="partial-final-group"),
+        pytest.param(4, 8, [2], id="epoch-shorter-than-group"),
+    ],
+)
+def test_hf_trainer_callback_grad_accum_folds_microbatches(
+    grad_accum, num_rows, microbatches_per_step
+):
+    """Real HF callback boundaries own counting, including partial groups."""
     _reset_traceml_state()
 
     # Auto-timers trace_step arms are no-ops until init() installs the patches.
     init()
-    max_steps = 3
-    grad_accum = 2
+    max_steps = len(microbatches_per_step)
+
+    from traceml_ai.runtime.state import get_trace_session_state
+
+    # HF starts at zero; TraceML may already have recorded other work.
+    trace_state = get_trace_session_state()
+    step_before = trace_state.set_step(7)
+    boundaries = []
+
+    class BoundaryObserver(TrainerCallback):
+        def on_step_begin(self, args, state, control, **kwargs):
+            boundaries.append(("begin", state.global_step, trace_state.step))
+
+        def on_substep_end(self, args, state, control, **kwargs):
+            boundaries.append(("micro", state.global_step, trace_state.step))
+
+        def on_step_end(self, args, state, control, **kwargs):
+            boundaries.append(("end", state.global_step, trace_state.step))
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         output_dir = Path(tmp_dir) / "results"
         model = _build_tiny_model()
-        train_dataset = _TinyTokenizedDataset(num_rows=40)
+        train_dataset = _TinyTokenizedDataset(num_rows=num_rows)
         training_args = _build_training_args(
             str(output_dir),
             max_steps=max_steps,
             gradient_accumulation_steps=grad_accum,
         )
 
-        from traceml_ai.runtime.state import get_trace_session_state
-
-        step_before = get_trace_session_state().step
-
         trainer = Trainer(
             model=model,
             args=training_args,
             train_dataset=train_dataset,
-            callbacks=[TraceMLTrainerCallback()],
+            callbacks=[TraceMLTrainerCallback(), BoundaryObserver()],
         )
         trainer.train()
 
         step_after = get_trace_session_state().step
+        assert trainer.state.global_step == max_steps
         assert step_after - step_before == max_steps, (
             f"Callback should advance step counter by max_steps ({max_steps}), "
             f"not by max_steps * grad_accum. Got delta="
@@ -229,9 +250,22 @@ def test_hf_trainer_callback_grad_accum_folds_microbatches():
 
         batches = _drain_step_time_queue()
         assert len(batches) == max_steps, (
-            f"Expected {max_steps} StepTimeBatches (one per optimizer step), "
+            f"Expected {max_steps} StepTimeBatches (one per update boundary), "
             f"got {len(batches)}."
         )
+        assert [batch.step for batch in batches] == list(
+            range(step_before + 1, step_before + max_steps + 1)
+        )
+        expected_boundaries = []
+        for step, microbatches in enumerate(microbatches_per_step):
+            expected_boundaries.append(("begin", step, step_before + step))
+            expected_boundaries.extend(
+                [("micro", step, step_before + step)] * (microbatches - 1)
+            )
+            expected_boundaries.append(
+                ("end", step + 1, step_before + step + 1)
+            )
+        assert boundaries == expected_boundaries
 
         def _counts(event_name: str) -> list:
             return [
@@ -243,28 +277,102 @@ def test_hf_trainer_callback_grad_accum_folds_microbatches():
         backward_counts = _counts("_traceml_internal:backward_time")
         optimizer_counts = _counts("_traceml_internal:optimizer_step")
 
-        # Each optimizer step calls model.forward() grad_accum times. Each call
-        # produces one outermost-forward event. Allow a small tolerance for
-        # warmup / HF internals but the dominant count must match.
-        assert all(count == grad_accum for count in forward_counts), (
-            f"Expected {grad_accum} forward events per TraceML step "
-            f"(one per micro-batch in the grad-accum group), got "
-            f"{forward_counts}."
-        )
-        # Backward fires once per micro-batch too, so it folds the same way.
-        # Gates against backward auto-timer flags being lost across the
-        # accumulated micro-batches.
-        assert all(count == grad_accum for count in backward_counts), (
-            f"Expected {grad_accum} backward events per TraceML step "
-            f"(one per micro-batch in the grad-accum group), got "
-            f"{backward_counts}."
-        )
+        # Count actual microbatches, not the configured accumulation maximum.
+        assert forward_counts == microbatches_per_step
+        assert backward_counts == microbatches_per_step
         # The optimizer steps exactly once per grad-accum group. Gates against
         # a missing/dummy optimizer event slipping past the forward check.
         assert all(count == 1 for count in optimizer_counts), (
             f"Expected exactly one optimizer event per TraceML step "
             f"(one per optimizer step), got {optimizer_counts}."
         )
+
+
+@pytest.mark.parametrize(
+    ("optimizer_name", "optimizer_counts"),
+    [
+        pytest.param("adamw_torch", [0, 1], id="scaler-skips-call"),
+        pytest.param(
+            "adamw_torch_fused",
+            [1, 1],
+            id="fused-call-skips-update",
+            marks=pytest.mark.skipif(
+                Version(torch.__version__.split("+")[0]) < Version("2.8"),
+                reason="Exercise CPU fused AdamW on PyTorch >= 2.8",
+            ),
+        ),
+    ],
+)
+def test_hf_trainer_callback_counts_update_boundary_when_scaler_skips(
+    tmp_path, optimizer_name, optimizer_counts
+):
+    """Overflow changes optimizer work, not the completed HF step count."""
+    _reset_traceml_state()
+    init()
+
+    from traceml_ai.runtime.state import get_trace_session_state
+
+    class CPUScaledTrainer(Trainer):
+        def create_accelerator_and_postprocess(self):
+            super().create_accelerator_and_postprocess()
+            # Exercise Accelerate's real scaler/optimizer path without CUDA.
+            self.accelerator.scaler = torch.amp.GradScaler("cpu")
+
+        def compute_loss(self, *args, **kwargs):
+            loss = super().compute_loss(*args, **kwargs)
+            # Overflow all microbatches of the first accumulation group only.
+            if self.state.global_step == 0:
+                loss = loss * float("inf")
+            return loss
+
+    model = _build_tiny_model()
+    initial_parameters = [p.detach().clone() for p in model.parameters()]
+    observations = []
+    scales = []
+
+    class UpdateObserver(TrainerCallback):
+        def on_step_end(self, args, state, control, **kwargs):
+            parameters_unchanged = all(
+                torch.equal(initial, current)
+                for initial, current in zip(
+                    initial_parameters, model.parameters()
+                )
+            )
+            observations.append(
+                (
+                    state.global_step,
+                    get_trace_session_state().step,
+                    parameters_unchanged,
+                )
+            )
+            scales.append(trainer.accelerator.scaler.get_scale())
+
+    args = _build_training_args(
+        str(tmp_path), max_steps=2, gradient_accumulation_steps=2, use_cpu=True
+    )
+    args.max_grad_norm = 0.0
+    args.optim = optimizer_name
+    trainer = CPUScaledTrainer(
+        model=model,
+        args=args,
+        train_dataset=_TinyTokenizedDataset(),
+        callbacks=[TraceMLTrainerCallback(), UpdateObserver()],
+    )
+    initial_scale = trainer.accelerator.scaler.get_scale()
+    trainer.train()
+
+    assert observations == [(1, 1, True), (2, 2, False)]
+    assert scales == [initial_scale / 2, initial_scale / 2]
+    batches = _drain_step_time_queue()
+    assert [batch.step for batch in batches] == [1, 2]
+    for name, expected in (
+        ("_traceml_internal:forward_time", [2, 2]),
+        ("_traceml_internal:backward_time", [2, 2]),
+        ("_traceml_internal:optimizer_step", optimizer_counts),
+    ):
+        assert [
+            sum(evt.name == name for evt in batch.events) for batch in batches
+        ] == expected
 
 
 def test_hf_trainer_wrapper_equivalent_to_direct_callback():

--- a/tests/integrations/test_hf_trainer.py
+++ b/tests/integrations/test_hf_trainer.py
@@ -1,5 +1,6 @@
 import tempfile
 from pathlib import Path
+from typing import Optional
 
 import pytest
 from packaging.version import Version
@@ -17,7 +18,6 @@ from transformers import (  # noqa: E402
 )
 
 from traceml_ai.integrations.huggingface import (  # noqa: E402
-    TraceMLTrainer,
     TraceMLTrainerCallback,
     init,
 )
@@ -79,7 +79,7 @@ def _build_training_args(
     max_steps: int,
     gradient_accumulation_steps: int = 1,
     batch_size: int = 4,
-    use_cpu: bool | None = None,
+    use_cpu: Optional[bool] = None,
 ) -> "TrainingArguments":
     return TrainingArguments(
         output_dir=output_dir,
@@ -123,31 +123,6 @@ def _reset_traceml_state() -> None:
     _drain_step_memory_queue()
 
 
-def test_hf_trainer_integration():
-    """
-    Test that TraceMLTrainer (legacy thin-wrapper path) runs a few steps with
-    a real model and TraceML instrumentation enabled.
-    """
-    _reset_traceml_state()
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        output_dir = Path(tmp_dir) / "results"
-        model = _build_tiny_model()
-        train_dataset = _TinyTokenizedDataset()
-        training_args = _build_training_args(str(output_dir), max_steps=5)
-
-        trainer = TraceMLTrainer(
-            model=model,
-            args=training_args,
-            train_dataset=train_dataset,
-            traceml_enabled=True,
-        )
-        trainer.train()
-
-        from traceml_ai.sdk.instrumentation import TraceState
-
-        assert TraceState.step >= 5, "TraceState.step should have incremented"
-
-
 def test_hf_trainer_callback_integration():
     """
     Vanilla transformers.Trainer with TraceMLTrainerCallback should emit
@@ -156,6 +131,7 @@ def test_hf_trainer_callback_integration():
     StepMemoryTracker in the callback.
     """
     _reset_traceml_state()
+    init()
     max_steps = 5
 
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -183,7 +159,7 @@ def test_hf_trainer_callback_integration():
 
         from traceml_ai.sdk.instrumentation import TraceState
 
-        assert TraceState.step >= max_steps
+        assert TraceState.step == max_steps
 
 
 @pytest.mark.parametrize(
@@ -375,102 +351,58 @@ def test_hf_trainer_callback_counts_update_boundary_when_scaler_skips(
         ] == expected
 
 
-def test_hf_trainer_wrapper_equivalent_to_direct_callback():
-    """
-    TraceMLTrainer is now a thin wrapper that auto-installs
-    TraceMLTrainerCallback. Running the same tiny setup through both paths
-    should produce identical step counts and identical numbers of step-memory
-    events. This is the regression gate against the wrapper drifting away
-    from direct callback semantics.
-    """
+def test_hf_trainer_optional_callback_preserves_training():
+    """Conditional callback registration preserves losses and parameters."""
     max_steps = 4
 
-    def _run_with(make_trainer) -> tuple:
+    def _run_with(enable_tracing: bool) -> tuple:
         _reset_traceml_state()
+        torch.manual_seed(42)
+        callbacks = []
+        if enable_tracing:
+            init()
+            callbacks.append(TraceMLTrainerCallback())
+
         with tempfile.TemporaryDirectory() as tmp_dir:
             output_dir = Path(tmp_dir) / "results"
             model = _build_tiny_model()
             train_dataset = _TinyTokenizedDataset()
             training_args = _build_training_args(
-                str(output_dir), max_steps=max_steps
+                str(output_dir), max_steps=max_steps, use_cpu=True
             )
 
-            trainer = make_trainer(model, training_args, train_dataset)
-            trainer.train()
+            trainer = Trainer(
+                model=model,
+                args=training_args,
+                train_dataset=train_dataset,
+                callbacks=callbacks,
+            )
+            result = trainer.train()
+            assert trainer.state.global_step == max_steps
 
             from traceml_ai.runtime.state import get_trace_session_state
 
             step = get_trace_session_state().step
             drained = _drain_step_memory_queue()
-            return step, len(drained)
+            batches = _drain_step_time_queue()
+            parameters = {
+                name: value.detach().clone()
+                for name, value in model.state_dict().items()
+            }
+            return (
+                result.training_loss,
+                parameters,
+                step,
+                len(drained),
+                len(batches),
+            )
 
-    callback_steps, callback_samples = _run_with(
-        lambda m, a, d: Trainer(
-            model=m,
-            args=a,
-            train_dataset=d,
-            callbacks=[TraceMLTrainerCallback()],
-        )
-    )
-
-    wrapper_steps, wrapper_samples = _run_with(
-        lambda m, a, d: TraceMLTrainer(
-            model=m,
-            args=a,
-            train_dataset=d,
-            traceml_enabled=True,
-        )
-    )
-
-    assert callback_steps == max_steps
-    assert wrapper_steps == max_steps
-    assert callback_samples == max_steps
-    assert wrapper_samples == max_steps
-
-
-def test_hf_trainer_wrapper_dedups_user_supplied_callback():
-    """
-    If a user passes their own TraceMLTrainerCallback in callbacks=[...] and
-    also uses TraceMLTrainer, the wrapper must NOT add a second instance.
-    Otherwise every step would be double-bracketed and the step counter would
-    advance twice per optimizer step.
-    """
-    _reset_traceml_state()
-    max_steps = 3
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        output_dir = Path(tmp_dir) / "results"
-        model = _build_tiny_model()
-        train_dataset = _TinyTokenizedDataset()
-        training_args = _build_training_args(
-            str(output_dir), max_steps=max_steps
-        )
-
-        trainer = TraceMLTrainer(
-            model=model,
-            args=training_args,
-            train_dataset=train_dataset,
-            callbacks=[TraceMLTrainerCallback()],
-            traceml_enabled=True,
-        )
-
-        installed = [
-            cb
-            for cb in trainer.callback_handler.callbacks
-            if isinstance(cb, TraceMLTrainerCallback)
-        ]
-        assert len(installed) == 1, (
-            f"Expected exactly one TraceMLTrainerCallback after dedup, "
-            f"found {len(installed)}."
-        )
-
-        trainer.train()
-
-        drained = _drain_step_memory_queue()
-        assert len(drained) == max_steps, (
-            f"Expected one StepMemoryEvent per optimizer step "
-            f"({max_steps}), got {len(drained)}; dedup guard failed."
-        )
+    untraced = _run_with(False)
+    traced = _run_with(True)
+    assert untraced[2:] == (0, 0, 0)
+    assert traced[2:] == (max_steps, max_steps, max_steps)
+    assert traced[0] == pytest.approx(untraced[0])
+    torch.testing.assert_close(traced[1], untraced[1])
 
 
 def test_hf_trainer_callback_noop_when_disabled(monkeypatch):

--- a/tests/integrations/test_telemetry_conformance.py
+++ b/tests/integrations/test_telemetry_conformance.py
@@ -83,13 +83,14 @@ def _run_huggingface() -> set[str]:
     from transformers import (
         BertConfig,
         BertForSequenceClassification,
+        Trainer,
         TrainingArguments,
     )
 
     from traceml_ai.integrations.huggingface import (
-        TraceMLTrainer,
+        TraceMLTrainerCallback,
+        init as hf_init,
     )
-    from traceml_ai.integrations.huggingface import init as hf_init
 
     class _TinyDS(torch.utils.data.Dataset):
         def __init__(self, n=20, seq=16, vocab=128, labels=4):
@@ -134,11 +135,11 @@ def _run_huggingface() -> set[str]:
             use_cpu=not torch.cuda.is_available(),
             save_strategy="no",
         )
-        TraceMLTrainer(
+        Trainer(
             model=model,
             args=args,
             train_dataset=_TinyDS(),
-            traceml_enabled=True,
+            callbacks=[TraceMLTrainerCallback()],
         ).train()
 
     return _drain_step_time_names()


### PR DESCRIPTION
## Goal

Make the Hugging Face integration callback-only:

1. Call `traceml_ai.integrations.huggingface.init()`.
2. Use the standard `transformers.Trainer`.
3. Register `TraceMLTrainerCallback`.

`TraceMLTrainer` only installed the callback, so maintaining both APIs added unnecessary complexity.

Part of #451.

## Changes

- Removed `TraceMLTrainer` and its export.
- Migrated maintained examples and tests to standard `Trainer`.
- Added migration guidance for `TraceMLTrainer` and `traceml_enabled`.
- Clarified that one TraceML step represents one HF accumulation/update boundary.
- Added focused tests for accumulation, partial final groups, skipped optimizer updates and optional callback registration.
- Updated affected documentation and the changelog.
- Updated tests for the StepCapture APIs in `version_0.3.7`.

## Migration

Replace:

```python
trainer = TraceMLTrainer(...)
```

with:

```python
traceml_hf.init()

trainer = Trainer(
    ...,
    callbacks=[traceml_hf.TraceMLTrainerCallback()],
)
```

## Within scope

- Callback-only HF API.
- Wrapper migration.
- Current HF step-boundary documentation.
- Affected examples and tests.

## Outside scope

- Pre-callback input and H2D measurement.
- HF failure and retry cleanup.
- Evaluation and prediction input isolation.
- Timing and reporting changes.
- StepCapture, sampler or queue redesign.
- Changes to standalone Accelerate, Lightning or Ray.

These remaining HF improvements will follow separately under #451.

## Validation

- All GitHub CI checks passed.
- `1,344 passed, 1 skipped` in the integration suite.
- Strict documentation build passed.