### PR TITLE
Centralize timing event types and queue ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ which carry the full historical notes for versions predating this file.
 
 ## [Unreleased]
 
+- Timing event types and queue access now live in
+  `instrumentation/step_events.py`. Producers and the timing sampler share an
+  explicit handoff; measurement boundaries, CUDA FIFO processing, and stored
+  output are unchanged.
 - **Breaking:** TraceML implementation errors now have one structured owner:
   `rank_<global_rank>/traceml_errors.log`,
   `aggregator/traceml_errors.log`, or

--- a/docs/developer_guide/step-time-pipeline-contract.md
+++ b/docs/developer_guide/step-time-pipeline-contract.md
@@ -10,7 +10,35 @@ For the public final-summary shape, see
 For user-facing timing definitions, see the
 [Step Time glossary](../user_guide/reading-output.md#step-time-glossary).
 
-## Current flow
+## Training-to-sampler handoff
+
+`instrumentation/step_events.py` owns `TimeEvent`, `StepTimeBatch`, and the
+private timing queue. `utils/timing.py` measures regions and buffers events
+until the existing step boundary assigns their step number and publishes one
+batch through `publish_step_time_batch()`.
+
+```text
+timed regions / optimizer hooks
+  -> utils/timing.py: pending events and step flush
+  -> instrumentation/step_events.py: timing batch queue
+  -> StepTimeSampler: pending FIFO, CUDA resolution, aggregation, storage
+```
+
+The sampler calls `drain_step_time_batches()` to take available batches without
+blocking. Publication and reading transfer references, not copies of events.
+After publication, the producer must not change a batch's membership or step
+identity. Only the sampler resolves its CUDA events.
+
+The queue holds up to 2,048 batches and retains the existing drop-on-full
+behavior. The sampler keeps its existing pending FIFO: an unresolved earlier
+CUDA batch holds back later batches. Reading continues after recording stops
+so already-published measurements can drain. No GPU synchronization is added.
+
+This first cleanup changes the timing handoff only. Memory still uses its
+existing queue, and step completion, failure handling, and input-fetch
+boundaries are unchanged. Global timing is currently not persisted.
+
+## Analysis and presentation flow
 
 ```mermaid
 flowchart LR

--- a/src/dev/repro/hf_accelerate_h2d_window.py
+++ b/src/dev/repro/hf_accelerate_h2d_window.py
@@ -56,8 +56,8 @@ def _positive_control_ms(num_bytes_mb: int = 64) -> float | None:
     """Move a tensor INSIDE trace_step; TraceML should capture this one."""
     import torch
 
+    from traceml_ai.instrumentation.step_events import drain_step_time_batches
     from traceml_ai.sdk.instrumentation import trace_step
-    from traceml_ai.utils.timing import get_step_time_queue
 
     model = torch.nn.Linear(4, 4).cuda()
     host = torch.empty(num_bytes_mb * 1024 * 1024 // 4, dtype=torch.float32)
@@ -66,9 +66,7 @@ def _positive_control_ms(num_bytes_mb: int = 64) -> float | None:
         torch.cuda.synchronize()
 
     captured = None
-    queue = get_step_time_queue()
-    while not queue.empty():
-        batch = queue.get_nowait()
+    for batch in drain_step_time_batches():
         for evt in getattr(batch, "events", []):
             if evt.name == "_traceml_internal:h2d_time":
                 captured = float(getattr(evt, "gpu_ms", 0.0) or 0.0)
@@ -87,8 +85,8 @@ def _traceml_reported_h2d(grad_accum: int = 2) -> float | None:
         TrainingArguments,
     )
 
+    from traceml_ai.instrumentation.step_events import drain_step_time_batches
     from traceml_ai.integrations.huggingface import TraceMLTrainerCallback
-    from traceml_ai.utils.timing import get_step_time_queue
 
     class _DS(torch.utils.data.Dataset):
         def __len__(self):
@@ -128,9 +126,7 @@ def _traceml_reported_h2d(grad_accum: int = 2) -> float | None:
         trainer.train()
 
     reported = None
-    queue = get_step_time_queue()
-    while not queue.empty():
-        batch = queue.get_nowait()
+    for batch in drain_step_time_batches():
         vals = [
             float(getattr(evt, "gpu_ms", 0.0) or 0.0)
             for evt in getattr(batch, "events", [])

--- a/src/traceml_ai/instrumentation/__init__.py
+++ b/src/traceml_ai/instrumentation/__init__.py
@@ -1,6 +1,7 @@
 """Canonical TraceML instrumentation internals.
 
-This package owns the hook installers and monkey patches used by the SDK.
+This package owns the SDK's hook installers and monkey patches, along with
+event types and queues used to transfer measurements to samplers.
 Public user APIs stay in :mod:`traceml` and :mod:`traceml.sdk`; code outside
 TraceML should not need to import from this package directly.
 """

--- a/src/traceml_ai/instrumentation/hooks/optimizer_hooks.py
+++ b/src/traceml_ai/instrumentation/hooks/optimizer_hooks.py
@@ -6,8 +6,9 @@ from torch.optim.optimizer import (
     register_optimizer_step_pre_hook,
 )
 
+from traceml_ai.instrumentation.step_events import TimeEvent, TimeScope
 from traceml_ai.utils.cuda_event_pool import get_cuda_event
-from traceml_ai.utils.timing import TimeEvent, TimeScope, record_event
+from traceml_ai.utils.timing import record_event
 
 # Per-optimizer in-flight timing state
 _OPT_INFLIGHT = {}

--- a/src/traceml_ai/instrumentation/patches/h2d_auto_timer_patch.py
+++ b/src/traceml_ai/instrumentation/patches/h2d_auto_timer_patch.py
@@ -22,7 +22,8 @@ GPU timing
 CUDA events are recorded on the current stream around the ``.to()`` call.
 ``start.record()`` enqueues a timestamp marker before the DMA op;
 ``end.record()`` enqueues one after.  Once ``end`` fires (resolved later via
-``event.query()`` in the sampler — see ``utils/timing.py::TimeEvent.try_resolve``),
+``event.query()`` in the sampler — see
+``instrumentation/step_events.py::TimeEvent.try_resolve``),
 ``start.elapsed_time(end)`` returns the GPU-side wall-clock duration between
 the two markers — including the asynchronous DMA itself.  Accuracy is the
 same for ``non_blocking=True`` and ``non_blocking=False``.

--- a/src/traceml_ai/instrumentation/step_events.py
+++ b/src/traceml_ai/instrumentation/step_events.py
@@ -1,0 +1,112 @@
+# Copyright 2026 OptAI UG (haftungsbeschraenkt)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Timing event contracts and the training-to-sampler handoff.
+
+Producers publish already-grouped step batches. The sampler drains them in
+insertion order and owns CUDA resolution; publishing and draining never wait
+for the GPU. Measurement and pending-step buffering remain in ``utils.timing``.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from queue import Empty, Full, Queue
+
+import torch
+
+from traceml_ai.utils.cuda_event_pool import return_cuda_event
+
+
+class TimeScope(str, Enum):
+    """Whether a timing region belongs to a training step or global work."""
+
+    STEP = "step"
+    GLOBAL = "global"
+
+
+@dataclass
+class TimeEvent:
+    """One timing measurement, possibly holding unresolved CUDA events."""
+
+    name: str
+    device: str
+    cpu_start: float
+    cpu_end: float
+
+    gpu_start: torch.cuda.Event | None = None
+    gpu_end: torch.cuda.Event | None = None
+    gpu_time_ms: float | None = None
+
+    resolved: bool = False
+    step: int = -1
+    scope: TimeScope = TimeScope.STEP
+
+    def try_resolve(self) -> bool:
+        """Resolve on the sampler side without blocking; return readiness."""
+        if self.resolved:
+            return True
+
+        if self.gpu_start and self.gpu_end:
+            if self.gpu_end.query():
+                self.gpu_time_ms = self.gpu_start.elapsed_time(self.gpu_end)
+
+                return_cuda_event(self.gpu_start)
+                return_cuda_event(self.gpu_end)
+
+                self.gpu_start = None
+                self.gpu_end = None
+                self.resolved = True
+        else:
+            self.resolved = True
+
+        return self.resolved
+
+
+@dataclass
+class StepTimeBatch:
+    """Timing events grouped by the producer's existing step boundary.
+
+    Flush assigns both ``step`` and each event's step number. Publication
+    transfers the batch to the sampler without copying its events. Producers
+    must not append to it or change its step identity after publication.
+    """
+
+    step: int
+    events: list[TimeEvent] = field(default_factory=list)
+
+
+_STEP_TIME_QUEUE: Queue[StepTimeBatch] = Queue(maxsize=2048)
+
+
+def publish_step_time_batch(batch: StepTimeBatch) -> None:
+    """Enqueue without blocking; retain the existing drop-on-full policy."""
+    try:
+        _STEP_TIME_QUEUE.put_nowait(batch)
+    except Full:
+        print(
+            f"[TraceML:Timing] Step queue full, dropping step batch {batch.step}",
+            file=sys.stderr,
+        )
+
+
+def drain_step_time_batches() -> list[StepTimeBatch]:
+    """Take available batches in FIFO order, including after recording stops.
+
+    This only transfers references. CUDA readiness and the pending FIFO remain
+    the timing sampler's responsibility.
+    """
+    batches: list[StepTimeBatch] = []
+    while True:
+        try:
+            batch = _STEP_TIME_QUEUE.get_nowait()
+        except Empty:
+            break
+        except Exception:  # noqa: BLE001 - preserve best-effort queue draining
+            break
+
+        if batch is not None:
+            batches.append(batch)
+    return batches

--- a/src/traceml_ai/instrumentation/step_events.py
+++ b/src/traceml_ai/instrumentation/step_events.py
@@ -14,6 +14,7 @@ import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from queue import Empty, Full, Queue
+from typing import Optional
 
 import torch
 
@@ -36,9 +37,9 @@ class TimeEvent:
     cpu_start: float
     cpu_end: float
 
-    gpu_start: torch.cuda.Event | None = None
-    gpu_end: torch.cuda.Event | None = None
-    gpu_time_ms: float | None = None
+    gpu_start: Optional[torch.cuda.Event] = None
+    gpu_end: Optional[torch.cuda.Event] = None
+    gpu_time_ms: Optional[float] = None
 
     resolved: bool = False
     step: int = -1

--- a/src/traceml_ai/integrations/lightning.py
+++ b/src/traceml_ai/integrations/lightning.py
@@ -7,18 +7,14 @@ from typing import TYPE_CHECKING, Any
 from traceml_ai.instrumentation.patches.h2d_auto_timer_patch import (
     h2d_auto_timer,
 )
+from traceml_ai.instrumentation.step_events import TimeEvent, TimeScope
 from traceml_ai.runtime.state import (
     get_trace_session_state,
     mark_trace_step_flushed,
 )
 from traceml_ai.utils.flush_buffers import flush_step_events
 from traceml_ai.utils.step_memory import StepMemoryTracker
-from traceml_ai.utils.timing import (
-    TimeEvent,
-    TimeScope,
-    record_event,
-    timed_region,
-)
+from traceml_ai.utils.timing import record_event, timed_region
 
 if TYPE_CHECKING:
     from lightning.pytorch.callbacks import Callback as _CallbackBase

--- a/src/traceml_ai/samplers/step_time_sampler.py
+++ b/src/traceml_ai/samplers/step_time_sampler.py
@@ -5,7 +5,7 @@ Step-level timing sampler for TraceML.
 
 Reads StepTimeBatch objects from the STEP timing queue, resolves GPU timings
 asynchronously (without blocking training), aggregates repeated regions within
-the same optimizer step, and persists one record per step.
+each batch, and persists one record per flushed batch.
 """
 
 from __future__ import annotations

--- a/src/traceml_ai/samplers/step_time_sampler.py
+++ b/src/traceml_ai/samplers/step_time_sampler.py
@@ -13,14 +13,13 @@ from __future__ import annotations
 from collections import defaultdict, deque
 from typing import Any, Deque, Dict, Tuple
 
-from traceml_ai.samplers.base_sampler import BaseSampler
-from traceml_ai.samplers.schema.step_time_schema import StepTimeEventSample
-from traceml_ai.samplers.utils import append_queue_nowait_to_deque
-from traceml_ai.utils.timing import (
+from traceml_ai.instrumentation.step_events import (
     StepTimeBatch,
     TimeEvent,
-    get_step_time_queue,
+    drain_step_time_batches,
 )
+from traceml_ai.samplers.base_sampler import BaseSampler
+from traceml_ai.samplers.schema.step_time_schema import StepTimeEventSample
 
 _CPU_DURATION_EVENT_NAMES = frozenset(
     {
@@ -48,10 +47,7 @@ class StepTimeSampler(BaseSampler):
         """
         Drain shared STEP queue and append all batches into local FIFO buffer.
         """
-        append_queue_nowait_to_deque(
-            get_step_time_queue(),
-            self._pending,
-        )
+        self._pending.extend(drain_step_time_batches())
 
     @staticmethod
     def _cpu_duration_ms(evt: TimeEvent) -> float:

--- a/src/traceml_ai/samplers/utils.py
+++ b/src/traceml_ai/samplers/utils.py
@@ -13,7 +13,6 @@ contain sampler-specific aggregation logic.
 
 from __future__ import annotations
 
-from collections import deque
 from pathlib import Path
 from queue import Empty
 from typing import Any
@@ -47,19 +46,6 @@ def drain_queue_nowait(queue_obj: Any, *, skip_none: bool = True) -> list[Any]:
         items.append(item)
 
     return items
-
-
-def append_queue_nowait_to_deque(
-    queue_obj: Any,
-    target: deque[Any],
-    *,
-    skip_none: bool = True,
-) -> None:
-    """
-    Drain a queue and append its current items into a target deque.
-    """
-    for item in drain_queue_nowait(queue_obj, skip_none=skip_none):
-        target.append(item)
 
 
 def ensure_session_dir(

--- a/src/traceml_ai/sdk/wrappers.py
+++ b/src/traceml_ai/sdk/wrappers.py
@@ -10,7 +10,8 @@ import torch.nn as nn
 from torch.utils.data import DataLoader
 
 from traceml_ai.instrumentation.h2d import should_time_h2d
-from traceml_ai.utils.timing import TimeScope, timed_region
+from traceml_ai.instrumentation.step_events import TimeScope
+from traceml_ai.utils.timing import timed_region
 
 
 def _raise_duplicate_instrumentation(feature: str, reason: str) -> None:

--- a/src/traceml_ai/utils/timing.py
+++ b/src/traceml_ai/utils/timing.py
@@ -71,7 +71,7 @@ def flush_step_time_buffer(step: int) -> None:
     """
     Flush buffered STEP events as a single StepTimeBatch.
 
-    Called once per optimizer step.
+    Called at the caller-defined step boundary with its assigned step number.
     """
     if _traceml_disabled() or not should_record_trace_events():
         return

--- a/src/traceml_ai/utils/timing.py
+++ b/src/traceml_ai/utils/timing.py
@@ -1,14 +1,8 @@
-"""
-TraceML Timing Core
+"""Timing measurement and pending-step buffering.
 
-This module defines the unified timing pipeline used by TraceML.
-It supports both step-scoped and global timing while preserving
-a single ordered event stream per rank.
-
-Updated:
-- Separate STEP and GLOBAL queues
-- STEP queue receives a StepTimeBatch (one per optimizer step)
-- GLOBAL queue receives TimeEvent directly (immediate enqueue)
+Flush publishes one batch through ``instrumentation.step_events``. That module
+owns the timing event contract and queue; the sampler owns CUDA resolution and
+aggregation. Global timing is currently not persisted.
 """
 
 import os
@@ -16,100 +10,26 @@ import sys
 import time
 from collections import deque
 from contextlib import contextmanager
-from dataclasses import dataclass, field
-from enum import Enum
 from queue import Full, Queue
-from typing import Deque, List, Optional
+from typing import Deque, List
 
 import torch
 
+from traceml_ai.instrumentation.step_events import (
+    StepTimeBatch,
+    TimeEvent,
+    TimeScope,
+    publish_step_time_batch,
+)
 from traceml_ai.runtime.state import should_record_trace_events
-from traceml_ai.utils.cuda_event_pool import get_cuda_event, return_cuda_event
+from traceml_ai.utils.cuda_event_pool import get_cuda_event
 
 
 def _traceml_disabled() -> bool:
     return os.environ.get("TRACEML_DISABLED") == "1"
 
 
-class TimeScope(str, Enum):
-    """
-    Semantic scope of a timing event.
-
-    STEP belongs to a specific training step
-    GLOBAL occurs outside the step loop (init, checkpoint, etc.)
-    """
-
-    STEP = "step"
-    GLOBAL = "global"
-
-
-@dataclass
-class TimeEvent:
-    """
-    Represents a single timing measurement.
-
-    GPU timing uses CUDA events and is resolved asynchronously
-    by the sampler to avoid synchronization.
-    """
-
-    name: str
-    device: str
-    cpu_start: float
-    cpu_end: float
-
-    gpu_start: Optional[torch.cuda.Event] = None
-    gpu_end: Optional[torch.cuda.Event] = None
-    gpu_time_ms: Optional[float] = None
-
-    resolved: bool = False
-    step: int = -1
-    scope: TimeScope = TimeScope.STEP
-
-    def try_resolve(self) -> bool:
-        """
-        Attempt to resolve GPU timing without blocking.
-
-        Returns
-        -------
-        bool
-            True if the event is fully resolved.
-        """
-        if self.resolved:
-            return True
-
-        if self.gpu_start and self.gpu_end:
-            if self.gpu_end.query():
-                self.gpu_time_ms = self.gpu_start.elapsed_time(self.gpu_end)
-
-                return_cuda_event(self.gpu_start)
-                return_cuda_event(self.gpu_end)
-
-                self.gpu_start = None
-                self.gpu_end = None
-                self.resolved = True
-        else:
-            self.resolved = True
-
-        return self.resolved
-
-
-@dataclass
-class StepTimeBatch:
-    """
-    One optimizer-step worth of timing events.
-
-    Notes
-    -----
-    - `events` may contain unresolved GPU events; sampler resolves them.
-    - `events[i].step` is set during flush for convenience / compatibility.
-    """
-
-    step: int
-    events: List[TimeEvent] = field(default_factory=list)
-
-
 _GLOBAL_TIME_QUEUE: Queue = Queue(maxsize=2048)
-_STEP_TIME_QUEUE: Queue = Queue(maxsize=2048)
 
 _STEP_BUFFER: Deque[TimeEvent] = deque()
 
@@ -117,11 +37,6 @@ _STEP_BUFFER: Deque[TimeEvent] = deque()
 def get_global_time_queue() -> Queue:
     """Return the shared GLOBAL timing queue."""
     return _GLOBAL_TIME_QUEUE
-
-
-def get_step_time_queue() -> Queue:
-    """Return the shared STEP timing queue (batches)."""
-    return _STEP_TIME_QUEUE
 
 
 def _enqueue_global(evt: TimeEvent) -> None:
@@ -137,23 +52,12 @@ def _enqueue_global(evt: TimeEvent) -> None:
         )
 
 
-def _enqueue_step_batch(batch: StepTimeBatch) -> None:
-    """Best-effort enqueue STEP batch without blocking."""
-    try:
-        _STEP_TIME_QUEUE.put_nowait(batch)
-    except Full:
-        print(
-            f"[TraceML:Timing] Step queue full, dropping step batch {batch.step}",
-            file=sys.stderr,
-        )
-
-
 def record_event(evt: TimeEvent) -> None:
     """
     Record a timing event.
 
     STEP events are buffered until flush.
-    GLOBAL events are enqueued immediately.
+    GLOBAL timing is currently not persisted.
     """
     if _traceml_disabled() or not should_record_trace_events():
         return
@@ -180,7 +84,7 @@ def flush_step_time_buffer(step: int) -> None:
         evt.step = step  # keep compatibility / make debugging easier
         events.append(evt)
 
-    _enqueue_step_batch(StepTimeBatch(step=step, events=events))
+    publish_step_time_batch(StepTimeBatch(step=step, events=events))
 
 
 @contextmanager

--- a/tests/integrations/test_accelerate.py
+++ b/tests/integrations/test_accelerate.py
@@ -57,13 +57,9 @@ class _FakeAccelerator:
 
 def _drain_step_time_queue() -> list:
     """Drain all StepTimeBatch entries from the shared queue."""
-    from traceml_ai.utils.timing import get_step_time_queue
+    from traceml_ai.instrumentation.step_events import drain_step_time_batches
 
-    queue = get_step_time_queue()
-    batches = []
-    while not queue.empty():
-        batches.append(queue.get_nowait())
-    return batches
+    return drain_step_time_batches()
 
 
 def _reset_traceml_state() -> None:

--- a/tests/integrations/test_deepspeed.py
+++ b/tests/integrations/test_deepspeed.py
@@ -63,13 +63,9 @@ class _FakeDeepSpeedEngine(nn.Module):
 
 def _drain_step_time_queue() -> list:
     """Drain all StepTimeBatch entries from the shared queue."""
-    from traceml_ai.utils.timing import get_step_time_queue
+    from traceml_ai.instrumentation.step_events import drain_step_time_batches
 
-    queue = get_step_time_queue()
-    batches = []
-    while not queue.empty():
-        batches.append(queue.get_nowait())
-    return batches
+    return drain_step_time_batches()
 
 
 def _reset_traceml_state() -> None:

--- a/tests/integrations/test_hf_trainer.py
+++ b/tests/integrations/test_hf_trainer.py
@@ -115,13 +115,9 @@ def _drain_step_memory_queue(model_id: int) -> list:
 
 def _drain_step_time_queue() -> list:
     """Drain all StepTimeBatch entries from the shared queue."""
-    from traceml_ai.utils.timing import get_step_time_queue
+    from traceml_ai.instrumentation.step_events import drain_step_time_batches
 
-    queue = get_step_time_queue()
-    batches = []
-    while not queue.empty():
-        batches.append(queue.get_nowait())
-    return batches
+    return drain_step_time_batches()
 
 
 def _reset_traceml_state() -> None:

--- a/tests/integrations/test_lightning.py
+++ b/tests/integrations/test_lightning.py
@@ -3,8 +3,8 @@ from types import SimpleNamespace
 
 import torch.nn as nn
 
+from traceml_ai.instrumentation.step_events import TimeScope
 from traceml_ai.integrations import lightning as lightning_integration
-from traceml_ai.utils.timing import TimeScope
 
 
 def _enable_callback_without_lightning(monkeypatch):

--- a/tests/integrations/test_telemetry_conformance.py
+++ b/tests/integrations/test_telemetry_conformance.py
@@ -28,11 +28,11 @@ from pathlib import Path
 
 import pytest
 
-from traceml_ai.samplers.utils import drain_queue_nowait
-from traceml_ai.utils.timing import _STEP_BUFFER, get_step_time_queue
+from traceml_ai.instrumentation.step_events import drain_step_time_batches
+from traceml_ai.utils.timing import _STEP_BUFFER
 
 # --- StreamContract registry -------------------------------------------------
-# Logical stream name -> wire name (utils/timing TimeEvent.name).
+# Logical stream name -> wire name (TimeEvent.name).
 STEP_TIME_WIRE = {
     "step_time": "_traceml_internal:step_time",
     "forward": "_traceml_internal:forward_time",
@@ -68,7 +68,7 @@ def _have(*mods: str) -> bool:
 
 def _drain_step_time_names() -> set[str]:
     names: set[str] = set()
-    for batch in drain_queue_nowait(get_step_time_queue()):
+    for batch in drain_step_time_batches():
         for evt in getattr(batch, "events", []):
             names.add(evt.name)
     return names
@@ -108,7 +108,7 @@ def _run_huggingface() -> set[str]:
     # Canonical documented path (#135); == traceml_ai.init(mode="auto"),
     # idempotent if already initialized with the same effective config.
     hf_init()
-    drain_queue_nowait(get_step_time_queue())
+    drain_step_time_batches()
     _STEP_BUFFER.clear()
 
     with tempfile.TemporaryDirectory() as tmp:

--- a/tests/runtime/test_step_time_sampler.py
+++ b/tests/runtime/test_step_time_sampler.py
@@ -1,7 +1,23 @@
+from collections import deque
+from queue import Queue
+
 import pytest
 
+from traceml_ai.instrumentation import step_events
+from traceml_ai.instrumentation.step_events import StepTimeBatch, TimeEvent
+from traceml_ai.runtime.state import configure_trace_recording
 from traceml_ai.samplers.step_time_sampler import StepTimeSampler
-from traceml_ai.utils.timing import StepTimeBatch, TimeEvent
+from traceml_ai.utils import timing
+
+
+@pytest.fixture
+def isolated_timing_queue(monkeypatch):
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+    monkeypatch.setattr(step_events, "_STEP_TIME_QUEUE", Queue(maxsize=2048))
+    monkeypatch.setattr(timing, "_STEP_BUFFER", deque())
+    configure_trace_recording()
+    yield
+    configure_trace_recording()
 
 
 def _payload_for(*events: TimeEvent):
@@ -125,3 +141,101 @@ def test_step_time_sampler_aggregates_repeated_event_clocks() -> None:
     assert stats["cpu_ms"] == pytest.approx(5.0)
     assert stats["gpu_ms"] == pytest.approx(12.0)
     assert stats["n_calls"] == 2
+
+
+def test_flush_preserves_batches_until_sampler_drains(
+    isolated_timing_queue, monkeypatch
+):
+    first = TimeEvent("forward", "cpu", 1.0, 1.002)
+    repeated = TimeEvent("forward", "cpu", 2.0, 2.003)
+    second = TimeEvent("forward", "cpu", 3.0, 3.004)
+    timing.record_event(first)
+    timing.record_event(repeated)
+    timing.flush_step_time_buffer(10)
+    timing.record_event(second)
+    timing.flush_step_time_buffer(11)
+    assert not timing._STEP_BUFFER
+
+    # Recording may stop before the next sampler tick; queued work still drains.
+    configure_trace_recording(max_steps=11).mark_step_flushed(11)
+    monkeypatch.setenv("TRACEML_DISABLED", "1")
+    sampler = StepTimeSampler()
+    rows = []
+    monkeypatch.setattr(sampler, "_add_record", rows.append)
+    sampler.sample()
+
+    assert [row["step"] for row in rows] == [10, 11]
+    assert [first.step, repeated.step, second.step] == [10, 10, 11]
+    assert rows[0]["events"]["forward"]["cpu"]["cpu_ms"] == pytest.approx(5.0)
+    assert rows[0]["events"]["forward"]["cpu"]["n_calls"] == 2
+    assert rows[1]["events"]["forward"]["cpu"]["cpu_ms"] == pytest.approx(4.0)
+    assert [row["timestamp"] for row in rows] == [2.003, 3.004]
+    assert step_events.drain_step_time_batches() == []
+    sampler.sample()
+    assert len(rows) == 2
+
+
+def test_unresolved_cuda_batch_holds_back_later_batches(
+    isolated_timing_queue, monkeypatch
+):
+    class CUDAEvent:
+        ready = False
+        queries = 0
+
+        def query(self):
+            self.queries += 1
+            return self.ready
+
+        def elapsed_time(self, end):
+            assert end.ready
+            return 7.0
+
+        def synchronize(self):
+            pytest.fail("Timing handoff must not synchronize CUDA")
+
+    start, end = CUDAEvent(), CUDAEvent()
+    event = TimeEvent("gpu", "cuda:0", 1.0, 1.002, start, end, step=10)
+    first = StepTimeBatch(10, [event])
+    second = StepTimeBatch(11, [TimeEvent("cpu", "cpu", 2.0, 2.001, step=11)])
+    returned = []
+    monkeypatch.setattr(step_events, "return_cuda_event", returned.append)
+    step_events.publish_step_time_batch(first)
+    step_events.publish_step_time_batch(second)
+    assert end.queries == 0
+
+    sampler = StepTimeSampler()
+    rows = []
+    monkeypatch.setattr(sampler, "_add_record", rows.append)
+    sampler.sample()
+    assert rows == []
+    assert sampler._pending[0] is first
+    assert sampler._pending[1] is second
+    assert sampler.has_pending_recording_data()
+    assert returned == []
+
+    end.ready = True
+    sampler.sample()
+    assert [row["step"] for row in rows] == [10, 11]
+    assert rows[0]["events"]["gpu"]["cuda:0"]["gpu_ms"] == 7.0
+    assert returned == [start, end]
+    assert event.gpu_start is event.gpu_end is None
+    assert not sampler.has_pending_recording_data()
+    sampler.sample()
+    assert len(rows) == 2
+    assert returned == [start, end]
+
+
+def test_full_timing_queue_drops_only_new_batch(isolated_timing_queue, capsys):
+    # Exercise the unchanged production capacity and real nonblocking queue.
+    batches = [StepTimeBatch(step) for step in range(2048)]
+    for batch in batches:
+        step_events.publish_step_time_batch(batch)
+    step_events.publish_step_time_batch(StepTimeBatch(2048))
+
+    drained = step_events.drain_step_time_batches()
+    assert len(drained) == 2048
+    assert all(
+        actual is expected for actual, expected in zip(drained, batches)
+    )
+    assert "dropping step batch 2048" in capsys.readouterr().err
+    assert step_events.drain_step_time_batches() == []

--- a/tests/sdk/test_init_runtime.py
+++ b/tests/sdk/test_init_runtime.py
@@ -112,23 +112,23 @@ def test_direct_runtime_settings_default_to_summary(
 def test_disabled_env_dynamically_silences_low_level_utilities(monkeypatch):
     import torch.nn as nn
 
+    from traceml_ai.instrumentation.step_events import (
+        TimeEvent,
+        TimeScope,
+        drain_step_time_batches,
+    )
     from traceml_ai.utils.step_memory import (
         StepMemoryTracker,
         flush_step_memory_buffer,
         step_memory_queue,
     )
     from traceml_ai.utils.timing import (
-        TimeEvent,
-        TimeScope,
         flush_step_time_buffer,
-        get_step_time_queue,
         record_event,
         timed_region,
     )
 
-    step_time_queue = get_step_time_queue()
-    while not step_time_queue.empty():
-        step_time_queue.get_nowait()
+    drain_step_time_batches()
     while not step_memory_queue.empty():
         step_memory_queue.get_nowait()
 
@@ -155,7 +155,7 @@ def test_disabled_env_dynamically_silences_low_level_utilities(monkeypatch):
         pass
     flush_step_time_buffer(2)
 
-    assert step_time_queue.empty()
+    assert drain_step_time_batches() == []
     assert step_memory_queue.empty()
 
 


### PR DESCRIPTION
 ## Goal

Make the training-to-sampler boundary explicit as part 1 of the step-event
cleanup RFC targeting version_0.3.7.

Previously, utils/timing.py owned measurement, pending events, event types,
and the queue. The sampler accessed that queue through a getter and a
generic drain helper.

This change gives the event types and queue one owner while preserving
the existing measurement and sampling behavior.

## Current flow

Timed regions and optimizer hooks
  -> utils/timing.py: measure and buffer events
  -> existing step boundary: assign the step number and flush
  -> instrumentation/step_events.py: publish the timing batch
  -> StepTimeSampler: drain, resolve CUDA events, aggregate, and persist

## In scope

- Move TimeScope, TimeEvent, StepTimeBatch, and the timing queue into
  instrumentation/step_events.py.
- Replace direct queue access with publish_step_time_batch() and
  drain_step_time_batches().
- Update affected producers, sampler imports, tests, and development scripts.
- Remove the unused append-to-deque queue helper.
- Document the ownership boundary and add a changelog entry.
- Add three focused regression tests for batch delivery, CUDA FIFO
  processing, and queue overflow.

## Behavior preserved

- Measurement boundaries, event names, clocks, and step numbering.
- Grouping performed by the existing caller's flush boundary.
- Repeated-event aggregation and persisted output.
- Queue capacity of 2,048 batches and dropping the incoming batch when full.
- FIFO processing: an unresolved earlier CUDA batch holds back later batches.
- Nonblocking CUDA readiness checks and existing event-pool reuse.
- Draining already-published batches after recording stops.
- Batch transfer by reference, without copying event objects.
- Existing lazy imports for operation without PyTorch.

After publication, producers must not modify batch membership or step
identity. The sampler resolves the batch's CUDA events.

These are internal interfaces; the documented user APIs do not change.

## Out of scope

- Moving memory events or removing model_id: part 2.
- Introducing StepCapture and completion/abort handling: part 3.
- Fixing existing failed-step attribution or session-buffer lifecycle.
- Changing HF/Accelerate input-fetch or H2D measurement boundaries.
- Changing integration-specific gradient-accumulation or step semantics.
- Synchronizing timing and memory samplers through a combined queue or barrier.
- Changing overflow, shutdown, or CUDA error-handling policies.
- Implementing persistence for global timing events.

This PR preserves existing caller-defined step boundaries. It does not
establish one universal optimizer-step definition across integrations.

## Validation

- Fresh-checkout focused suite: 191 passed, 2 skipped, 1 watch smoke test excluded.
- Existing SDK, integration, sampler, recording-state, and torch-free
  import checks included.
- Additional probes covered empty flushes, exception propagation, import
  order, and concurrent publication/draining of 500 batches.
- Executable-code comparison confirmed unchanged measurement, CUDA
  resolution, publication, and sampler calculation logic.
- Strict documentation build and formatting passed.
- CPU overhead probe showed approximately 0.4% difference, within observed
  run variation.

CUDA FIFO behavior was verified with controlled event doubles. Real-GPU
timing accuracy and distributed training were not validated in this review.
