### PR TITLE
Simplify memory ownership and move its handoff into step_events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ which carry the full historical notes for versions predating this file.
 
 ## [Unreleased]
 
+- Memory events and wire records no longer include `model_id`. Pending
+  memory is one snapshot per process, published through the shared step-event
+  handoff. Device metadata, peak-counter boundaries, timestamps, byte units,
+  and the SQLite schema are unchanged.
 - Timing event types and queue access now live in
   `instrumentation/step_events.py`. Producers and the timing sampler share an
   explicit handoff; measurement boundaries, CUDA FIFO processing, and stored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ which carry the full historical notes for versions predating this file.
 
 ## [Unreleased]
 
-- Memory events and wire records no longer include `model_id`. Pending
-  memory is one snapshot per process, published through the shared step-event
-  handoff. Device metadata, peak-counter boundaries, timestamps, byte units,
-  and the SQLite schema are unchanged.
+- Memory events and wire records no longer include `model_id`. The previous
+  per-model pending keying is replaced by one process-local memory snapshot,
+  published through the shared step-event handoff. Device metadata,
+  peak-counter boundaries, timestamps, byte units, and the SQLite schema are
+  unchanged.
 - Timing event types and queue access now live in
   `instrumentation/step_events.py`. Producers and the timing sampler share an
   explicit handoff; measurement boundaries, CUDA FIFO processing, and stored

--- a/docs/developer_guide/step-time-pipeline-contract.md
+++ b/docs/developer_guide/step-time-pipeline-contract.md
@@ -12,16 +12,21 @@ For user-facing timing definitions, see the
 
 ## Training-to-sampler handoff
 
-`instrumentation/step_events.py` owns `TimeEvent`, `StepTimeBatch`, and the
-private timing queue. `utils/timing.py` measures regions and buffers events
-until the existing step boundary assigns their step number and publishes one
-batch through `publish_step_time_batch()`.
+`instrumentation/step_events.py` owns `TimeEvent`, `StepTimeBatch`,
+`StepMemoryEvent`, and two private queues. `utils/timing.py` measures regions
+and buffers events until the existing step boundary assigns their step number
+and publishes one batch through `publish_step_time_batch()`.
 
 ```text
 timed regions / optimizer hooks
   -> utils/timing.py: pending events and step flush
   -> instrumentation/step_events.py: timing batch queue
   -> StepTimeSampler: pending FIFO, CUDA resolution, aggregation, storage
+
+memory tracker
+  -> utils/step_memory.py: one pending snapshot and step flush
+  -> instrumentation/step_events.py: memory event queue
+  -> StepMemorySampler: conversion and storage
 ```
 
 The sampler calls `drain_step_time_batches()` to take available batches without
@@ -29,14 +34,31 @@ blocking. Publication and reading transfer references, not copies of events.
 After publication, the producer must not change a batch's membership or step
 identity. Only the sampler resolves its CUDA events.
 
-The queue holds up to 2,048 batches and retains the existing drop-on-full
-behavior. The sampler keeps its existing pending FIFO: an unresolved earlier
-CUDA batch holds back later batches. Reading continues after recording stops
-so already-published measurements can drain. No GPU synchronization is added.
+Each queue retains its existing capacity of 2,048 items and drops incoming
+items when full: timing items are batches; memory items are device snapshots.
+The timing sampler keeps its existing pending FIFO: an unresolved earlier
+CUDA batch holds back later batches. Both readers continue after recording
+stops so already-published measurements can drain. No GPU synchronization is
+added.
 
-This first cleanup changes the timing handoff only. Memory still uses its
-existing queue, and step completion, failure handling, and input-fetch
-boundaries are unchanged. Global timing is currently not persisted.
+Memory uses `publish_step_memory_event()` and `drain_step_memory_events()`.
+Its peak values describe the process's PyTorch allocator on a tracked device;
+the model selects that device but is not the owner of the measured memory.
+Memory events and wire records therefore do not include `model_id`. The SQLite
+projection already stores device and rank identity without that field.
+
+The current recording path keeps one pending memory snapshot per process for
+one active step on one tracked device. `record()` replaces that snapshot.
+Flush clears the pending slot, assigns the step number, and publishes the
+event. The queue retains all published steps until the sampler drains them.
+There is no model or device key; `device` stays as snapshot metadata. Device
+selection and labels, reset/read boundaries, measurement timestamps, byte
+units, and `None` values for non-CUDA devices are unchanged.
+
+Timing and memory drain independently and may reach different steps on the
+same sampler tick. Step completion, failure handling, and input-fetch
+boundaries remain unchanged. The shared pending-step lifecycle is follow-up
+work; global timing is currently not persisted.
 
 ## Analysis and presentation flow
 

--- a/src/traceml_ai/instrumentation/step_events.py
+++ b/src/traceml_ai/instrumentation/step_events.py
@@ -1,11 +1,12 @@
 # Copyright 2026 OptAI UG (haftungsbeschraenkt)
 # SPDX-License-Identifier: Apache-2.0
 
-"""Timing event contracts and the training-to-sampler handoff.
+"""Step event contracts and the training-to-sampler handoff.
 
-Producers publish already-grouped step batches. The sampler drains them in
-insertion order and owns CUDA resolution; publishing and draining never wait
-for the GPU. Measurement and pending-step buffering remain in ``utils.timing``.
+Producers publish timing batches and device memory snapshots through separate
+queues. Samplers drain published records in insertion order; only the timing
+sampler resolves CUDA events. Measurement and pending-step buffering remain
+in ``utils.timing`` and ``utils.step_memory``.
 """
 
 from __future__ import annotations
@@ -14,7 +15,7 @@ import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from queue import Empty, Full, Queue
-from typing import Optional
+from typing import Optional, TypeVar
 
 import torch
 
@@ -79,7 +80,41 @@ class StepTimeBatch:
     events: list[TimeEvent] = field(default_factory=list)
 
 
+@dataclass
+class StepMemoryEvent:
+    """Process allocator peak on a device, measured at the step boundary.
+
+    Peaks are bytes, or ``None`` when CUDA memory is not applicable. Flush
+    assigns ``step`` before publication; producers must not modify the event
+    afterward. ``timestamp`` is the measurement time, not the drain time.
+    """
+
+    step: int
+    device: str
+    timestamp: float
+    peak_allocated: Optional[float]
+    peak_reserved: Optional[float]
+
+
 _STEP_TIME_QUEUE: Queue[StepTimeBatch] = Queue(maxsize=2048)
+_STEP_MEMORY_QUEUE: Queue[StepMemoryEvent] = Queue(maxsize=2048)
+_T = TypeVar("_T")
+
+
+def _drain_queue(queue: Queue[_T]) -> list[_T]:
+    """Transfer available records without waiting or resolving CUDA events."""
+    items: list[_T] = []
+    while True:
+        try:
+            item = queue.get_nowait()
+        except Empty:
+            break
+        except Exception:  # noqa: BLE001 - preserve best-effort queue draining
+            break
+
+        if item is not None:
+            items.append(item)
+    return items
 
 
 def publish_step_time_batch(batch: StepTimeBatch) -> None:
@@ -99,15 +134,21 @@ def drain_step_time_batches() -> list[StepTimeBatch]:
     This only transfers references. CUDA readiness and the pending FIFO remain
     the timing sampler's responsibility.
     """
-    batches: list[StepTimeBatch] = []
-    while True:
-        try:
-            batch = _STEP_TIME_QUEUE.get_nowait()
-        except Empty:
-            break
-        except Exception:  # noqa: BLE001 - preserve best-effort queue draining
-            break
+    return _drain_queue(_STEP_TIME_QUEUE)
 
-        if batch is not None:
-            batches.append(batch)
-    return batches
+
+def publish_step_memory_event(event: StepMemoryEvent) -> None:
+    """Enqueue without blocking; retain the existing drop-on-full policy."""
+    try:
+        _STEP_MEMORY_QUEUE.put_nowait(event)
+    except Full:
+        print(
+            f"[TraceML:StepMemory] Queue full, dropping event for step "
+            f"{event.step} on {event.device}",
+            file=sys.stderr,
+        )
+
+
+def drain_step_memory_events() -> list[StepMemoryEvent]:
+    """Take available memory snapshots, including after recording stops."""
+    return _drain_queue(_STEP_MEMORY_QUEUE)

--- a/src/traceml_ai/integrations/lightning.py
+++ b/src/traceml_ai/integrations/lightning.py
@@ -408,7 +408,7 @@ class TraceMLCallback(_CallbackBase):
         trace_state = get_trace_session_state()
         trace_state.advance_step()
         try:
-            flush_step_events(pl_module, trace_state.step)
+            flush_step_events(trace_state.step)
         except Exception as e:
             _log_lightning_error("flush failed", e)
 

--- a/src/traceml_ai/samplers/schema/step_memory.py
+++ b/src/traceml_ai/samplers/schema/step_memory.py
@@ -22,7 +22,7 @@ class StepMemorySample:
     """
     Step-level peak memory snapshot.
 
-    A single record corresponds to one training step for a given model/device.
+    A record contains process allocator peaks for a step on a tracked device.
 
     Units
     -----
@@ -32,7 +32,6 @@ class StepMemorySample:
 
     sample_idx: int
     timestamp: float
-    model_id: Optional[int]
     device: Optional[str]
     step: Optional[int]
     peak_allocated: Optional[float]
@@ -50,7 +49,6 @@ class StepMemorySample:
         return {
             "seq": self.sample_idx,
             "ts": self.timestamp,
-            "model_id": self.model_id,
             "device": self.device,
             "step": self.step,
             "peak_alloc": self.peak_allocated,
@@ -75,7 +73,6 @@ class StepMemorySample:
         return StepMemorySample(
             sample_idx=data["seq"],
             timestamp=float(data["ts"]),
-            model_id=data.get("model_id"),
             device=data.get("device"),
             step=data.get("step"),
             peak_allocated=data.get("peak_alloc"),

--- a/src/traceml_ai/samplers/step_memory_sampler.py
+++ b/src/traceml_ai/samplers/step_memory_sampler.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from traceml_ai.instrumentation.step_events import (
+    StepMemoryEvent,
+    drain_step_memory_events,
+)
 from traceml_ai.samplers.base_sampler import BaseSampler
 from traceml_ai.samplers.schema.step_memory import StepMemorySample
-from traceml_ai.samplers.utils import drain_queue_nowait
-from traceml_ai.utils.step_memory import StepMemoryEvent, step_memory_queue
 
 
 class StepMemorySampler(BaseSampler):
@@ -22,7 +24,7 @@ class StepMemorySampler(BaseSampler):
         """
         Drain entire step memory queue.
         """
-        for event in drain_queue_nowait(step_memory_queue):
+        for event in drain_step_memory_events():
             sample = self._event_to_sample(event)
             self._add_record(sample.to_wire())
 
@@ -33,7 +35,6 @@ class StepMemorySampler(BaseSampler):
         return StepMemorySample(
             sample_idx=self.sample_idx,
             timestamp=float(event.timestamp),
-            model_id=event.model_id,
             device=event.device,
             step=event.step,
             peak_allocated=event.peak_allocated,

--- a/src/traceml_ai/samplers/utils.py
+++ b/src/traceml_ai/samplers/utils.py
@@ -14,38 +14,8 @@ contain sampler-specific aggregation logic.
 from __future__ import annotations
 
 from pathlib import Path
-from queue import Empty
-from typing import Any
 
 from traceml_ai.runtime.session import rank_dir_name
-
-
-def drain_queue_nowait(queue_obj: Any, *, skip_none: bool = True) -> list[Any]:
-    """
-    Drain a queue without blocking and return all currently available items.
-
-    Notes
-    -----
-    - Uses `get_nowait()` instead of `queue.empty()` to avoid relying on the
-      weaker `empty()` concurrency semantics.
-    - Best-effort by design: unexpected queue exceptions stop draining.
-    """
-    items: list[Any] = []
-
-    while True:
-        try:
-            item = queue_obj.get_nowait()
-        except Empty:
-            break
-        except Exception:
-            break
-
-        if skip_none and item is None:
-            continue
-
-        items.append(item)
-
-    return items
 
 
 def ensure_session_dir(

--- a/src/traceml_ai/sdk/instrumentation.py
+++ b/src/traceml_ai/sdk/instrumentation.py
@@ -196,7 +196,7 @@ def trace_step(model: nn.Module):
             _log_instrumentation_error("record failed", exc)
 
         try:
-            flush_step_events(model, trace_state.step)
+            flush_step_events(trace_state.step)
         except Exception as exc:
             _log_instrumentation_error("flush failed", exc)
 

--- a/src/traceml_ai/utils/flush_buffers.py
+++ b/src/traceml_ai/utils/flush_buffers.py
@@ -1,7 +1,5 @@
 import os
 
-import torch.nn as nn
-
 from traceml_ai.runtime.state import should_record_trace_events
 
 from .step_memory import flush_step_memory_buffer
@@ -12,9 +10,10 @@ def _traceml_disabled() -> bool:
     return os.environ.get("TRACEML_DISABLED") == "1"
 
 
-def flush_step_events(model: nn.Module, step: int) -> None:
+def flush_step_events(step: int) -> None:
+    """Flush pending memory and timing at the caller's existing step boundary."""
     if _traceml_disabled() or not should_record_trace_events():
         return
 
-    flush_step_memory_buffer(model, step)
+    flush_step_memory_buffer(step)
     flush_step_time_buffer(step)

--- a/src/traceml_ai/utils/step_memory.py
+++ b/src/traceml_ai/utils/step_memory.py
@@ -2,6 +2,8 @@
 
 Keep one final allocator snapshot until the existing step boundary flushes it
 through ``instrumentation.step_events``. Device identity stays in the event.
+This path assumes one sequential training-step producer and one tracked device
+per process.
 """
 
 import os

--- a/src/traceml_ai/utils/step_memory.py
+++ b/src/traceml_ai/utils/step_memory.py
@@ -1,49 +1,39 @@
+"""Memory measurement and the process-local pending snapshot.
+
+Keep one final allocator snapshot until the existing step boundary flushes it
+through ``instrumentation.step_events``. Device identity stays in the event.
+"""
+
 import os
-import sys
 import time
-from dataclasses import dataclass
-from queue import Full, Queue
-from typing import Dict, Optional
+from typing import Optional
 
 import torch
 import torch.nn as nn
 
+from traceml_ai.instrumentation.step_events import (
+    StepMemoryEvent,
+    publish_step_memory_event,
+)
 from traceml_ai.runtime.state import should_record_trace_events
 
-step_memory_queue: Queue = Queue(maxsize=2048)
-
-_temp_step_memory_buffer: Dict = {}
+_PENDING_MEMORY: Optional[StepMemoryEvent] = None
 
 
 def _traceml_disabled() -> bool:
     return os.environ.get("TRACEML_DISABLED") == "1"
 
 
-@dataclass
-class StepMemoryEvent:
-    """
-    Peak GPU memory during a TraceML step.
-    """
-
-    step: int
-    model_id: int
-    device: str
-    timestamp: float
-    peak_allocated: Optional[float]
-    peak_reserved: Optional[float]
-
-
 class StepMemoryTracker:
-    """
-    Tracks peak CUDA memory across a train step.
+    """Track process allocator peaks on the model's device across a step.
+
+    The model selects the device; these counters do not measure memory owned
+    by an individual model.
     """
 
     def __init__(self, model: nn.Module):
         if _traceml_disabled() or not should_record_trace_events():
             return  # BYPASS: Do not attach any trackers
-
-        self.model = model
-        self.model_id = id(model)
 
         try:
             self.device = next(model.parameters()).device
@@ -72,6 +62,8 @@ class StepMemoryTracker:
           treat step memory as not applicable instead of a real zero-valued
           measurement
         """
+        global _PENDING_MEMORY
+
         if _traceml_disabled() or not should_record_trace_events():
             return
 
@@ -82,8 +74,7 @@ class StepMemoryTracker:
             peak_allocated = None
             peak_reserved = None
 
-        evt = StepMemoryEvent(
-            model_id=self.model_id,
+        _PENDING_MEMORY = StepMemoryEvent(
             device=str(self.device),
             peak_allocated=(
                 float(peak_allocated) if peak_allocated is not None else None
@@ -95,24 +86,18 @@ class StepMemoryTracker:
             # Capture occurrence time here; queue draining can happen later.
             timestamp=time.time(),
         )
-        _temp_step_memory_buffer[self.model_id] = evt
 
 
-def flush_step_memory_buffer(model: nn.Module, step: int) -> None:
+def flush_step_memory_buffer(step: int) -> None:
+    """Publish the pending snapshot once at the caller's step boundary."""
+    global _PENDING_MEMORY
+
     if _traceml_disabled() or not should_record_trace_events():
         return
-
-    model_id = id(model)
-
-    evt = _temp_step_memory_buffer.pop(model_id, None)
-    if evt is None:
+    # Detach the pending event; subsequent records cannot change queued steps.
+    event, _PENDING_MEMORY = _PENDING_MEMORY, None
+    if event is None:
         return
 
-    evt.step = step
-    try:
-        step_memory_queue.put_nowait(evt)
-    except Full:
-        print(
-            f"[TraceML:StepMemory] Queue full, dropping event for model {evt.model_id}",
-            file=sys.stderr,
-        )
+    event.step = step
+    publish_step_memory_event(event)

--- a/tests/integrations/test_hf_trainer.py
+++ b/tests/integrations/test_hf_trainer.py
@@ -91,26 +91,11 @@ def _build_training_args(
     )
 
 
-def _drain_step_memory_queue(model_id: int) -> list:
-    """Drain only this test's StepMemoryEvents from the shared queue."""
-    from traceml_ai.utils.step_memory import step_memory_queue
+def _drain_step_memory_queue() -> list:
+    """Drain snapshots from this test's recording session."""
+    from traceml_ai.instrumentation.step_events import drain_step_memory_events
 
-    drained = []
-    leftover = []
-    while not step_memory_queue.empty():
-        evt = step_memory_queue.get_nowait()
-        if getattr(evt, "model_id", None) == model_id:
-            drained.append(evt)
-        else:
-            leftover.append(evt)
-
-    # Put back unrelated events so we do not interfere with other tests.
-    for evt in leftover:
-        try:
-            step_memory_queue.put_nowait(evt)
-        except Exception:
-            pass
-    return drained
+    return drain_step_memory_events()
 
 
 def _drain_step_time_queue() -> list:
@@ -123,22 +108,14 @@ def _drain_step_time_queue() -> list:
 def _reset_traceml_state() -> None:
     """Reset TraceML's process-local step counter and drain shared queues."""
     from traceml_ai.runtime.state import reset_trace_session_state
-    from traceml_ai.utils import timing
+    from traceml_ai.utils import step_memory, timing
 
     reset_trace_session_state()
     # Unflushed step events from a previous test would land in our first batch.
     timing._STEP_BUFFER.clear()
+    step_memory._PENDING_MEMORY = None
     _drain_step_time_queue()
-    # Drain any leftover step-memory events. We don't filter by model_id here
-    # because we want a clean slate; older tests' events would otherwise leak
-    # into this test's drained count.
-    from traceml_ai.utils.step_memory import step_memory_queue
-
-    while not step_memory_queue.empty():
-        try:
-            step_memory_queue.get_nowait()
-        except Exception:
-            break
+    _drain_step_memory_queue()
 
 
 def test_hf_trainer_integration():
@@ -192,7 +169,7 @@ def test_hf_trainer_callback_integration():
         )
         trainer.train()
 
-        drained = _drain_step_memory_queue(id(model))
+        drained = _drain_step_memory_queue()
         assert len(drained) == max_steps, (
             f"Expected exactly one StepMemoryEvent per optimizer step "
             f"({max_steps}), got {len(drained)}. A count higher than "
@@ -314,7 +291,7 @@ def test_hf_trainer_wrapper_equivalent_to_direct_callback():
             from traceml_ai.runtime.state import get_trace_session_state
 
             step = get_trace_session_state().step
-            drained = _drain_step_memory_queue(id(model))
+            drained = _drain_step_memory_queue()
             return step, len(drained)
 
     callback_steps, callback_samples = _run_with(
@@ -379,7 +356,7 @@ def test_hf_trainer_wrapper_dedups_user_supplied_callback():
 
         trainer.train()
 
-        drained = _drain_step_memory_queue(id(model))
+        drained = _drain_step_memory_queue()
         assert len(drained) == max_steps, (
             f"Expected one StepMemoryEvent per optimizer step "
             f"({max_steps}), got {len(drained)}; dedup guard failed."
@@ -423,7 +400,7 @@ def test_hf_trainer_callback_noop_when_disabled(monkeypatch):
             f"advanced by {step_after - step_before}."
         )
 
-        drained = _drain_step_memory_queue(id(model))
+        drained = _drain_step_memory_queue()
         assert (
             drained == []
         ), f"Expected no StepMemoryEvents when disabled, got {len(drained)}."

--- a/tests/sdk/test_init_and_wrappers.py
+++ b/tests/sdk/test_init_and_wrappers.py
@@ -296,7 +296,7 @@ def _run_trace_step_once(*, mode, monkeypatch):
     monkeypatch.setattr(
         instrumentation,
         "flush_step_events",
-        lambda model, step: None,
+        lambda step: None,
     )
     monkeypatch.setattr(
         instrumentation,
@@ -359,7 +359,7 @@ def test_trace_step_publishes_runtime_environment_once(monkeypatch):
     monkeypatch.setattr(
         instrumentation,
         "flush_step_events",
-        lambda model, step: None,
+        lambda step: None,
     )
     monkeypatch.setattr(
         instrumentation,
@@ -426,7 +426,7 @@ def test_trace_step_without_init_does_not_auto_install_optimizer_timing(
     monkeypatch.setattr(
         instrumentation,
         "flush_step_events",
-        lambda model, step: None,
+        lambda step: None,
     )
     monkeypatch.setattr(
         instrumentation,
@@ -478,7 +478,7 @@ def test_trace_step_records_gpu_events_for_step_envelope(monkeypatch):
     monkeypatch.setattr(
         instrumentation,
         "flush_step_events",
-        lambda model, step: None,
+        lambda step: None,
     )
     monkeypatch.setattr(
         instrumentation,
@@ -534,7 +534,7 @@ def test_trace_step_marks_recording_draining_after_configured_step(
     monkeypatch.setattr(
         instrumentation,
         "flush_step_events",
-        lambda model, step: None,
+        lambda step: None,
     )
     monkeypatch.setattr(
         instrumentation,

--- a/tests/sdk/test_init_runtime.py
+++ b/tests/sdk/test_init_runtime.py
@@ -115,12 +115,12 @@ def test_disabled_env_dynamically_silences_low_level_utilities(monkeypatch):
     from traceml_ai.instrumentation.step_events import (
         TimeEvent,
         TimeScope,
+        drain_step_memory_events,
         drain_step_time_batches,
     )
     from traceml_ai.utils.step_memory import (
         StepMemoryTracker,
         flush_step_memory_buffer,
-        step_memory_queue,
     )
     from traceml_ai.utils.timing import (
         flush_step_time_buffer,
@@ -129,8 +129,7 @@ def test_disabled_env_dynamically_silences_low_level_utilities(monkeypatch):
     )
 
     drain_step_time_batches()
-    while not step_memory_queue.empty():
-        step_memory_queue.get_nowait()
+    drain_step_memory_events()
 
     monkeypatch.setenv("TRACEML_DISABLED", "1")
 
@@ -149,14 +148,14 @@ def test_disabled_env_dynamically_silences_low_level_utilities(monkeypatch):
     tracker = StepMemoryTracker(model)
     tracker.reset()
     tracker.record()
-    flush_step_memory_buffer(model, 1)
+    flush_step_memory_buffer(1)
 
     with timed_region("disabled_region"):
         pass
     flush_step_time_buffer(2)
 
     assert drain_step_time_batches() == []
-    assert step_memory_queue.empty()
+    assert drain_step_memory_events() == []
 
 
 def test_init_starts_runtime_when_aggregator_reachable(

--- a/tests/sdk/test_step_memory_timestamp.py
+++ b/tests/sdk/test_step_memory_timestamp.py
@@ -3,36 +3,48 @@
 
 from __future__ import annotations
 
+from queue import Queue
+
 import pytest
 import torch
 
 import traceml_ai.utils.step_memory as step_memory_module
+from traceml_ai.instrumentation import step_events
+from traceml_ai.instrumentation.step_events import StepMemoryEvent
+from traceml_ai.runtime.state import configure_trace_recording
 from traceml_ai.samplers.schema.step_memory import StepMemorySample
 from traceml_ai.samplers.step_memory_sampler import StepMemorySampler
-from traceml_ai.utils.step_memory import StepMemoryEvent, StepMemoryTracker
+from traceml_ai.utils.step_memory import (
+    StepMemoryTracker,
+    flush_step_memory_buffer,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_memory_recording(monkeypatch):
+    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
+    monkeypatch.setattr(step_events, "_STEP_MEMORY_QUEUE", Queue(maxsize=2048))
+    monkeypatch.setattr(step_memory_module, "_PENDING_MEMORY", None)
+    configure_trace_recording()
+    yield
+    configure_trace_recording()
 
 
 def test_tracker_captures_timestamp_when_memory_is_measured(
     monkeypatch,
 ) -> None:
-    monkeypatch.delenv("TRACEML_DISABLED", raising=False)
-    monkeypatch.setattr(
-        step_memory_module,
-        "should_record_trace_events",
-        lambda: True,
-    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
     monkeypatch.setattr(step_memory_module.time, "time", lambda: 12.25)
 
-    tracker = StepMemoryTracker.__new__(StepMemoryTracker)
-    tracker.model_id = 7
-    tracker.device = torch.device("cpu")
-
-    try:
-        tracker.record()
-        event = step_memory_module._temp_step_memory_buffer.pop(7)
-        assert event.timestamp == 12.25
-    finally:
-        step_memory_module._temp_step_memory_buffer.pop(7, None)
+    tracker = StepMemoryTracker(torch.nn.Identity())
+    tracker.reset()
+    tracker.record()
+    flush_step_memory_buffer(7)
+    monkeypatch.setattr(step_memory_module.time, "time", lambda: 99.0)
+    (event,) = step_events.drain_step_memory_events()
+    assert event.timestamp == 12.25
+    assert event.device == "cpu"
+    assert event.peak_allocated is event.peak_reserved is None
 
 
 def test_sampler_preserves_event_timestamp_through_wire_schema() -> None:
@@ -40,7 +52,6 @@ def test_sampler_preserves_event_timestamp_through_wire_schema() -> None:
     sampler.sample_idx = 3
     event = StepMemoryEvent(
         step=7,
-        model_id=1,
         device="cuda:0",
         timestamp=12.25,
         peak_allocated=100.0,
@@ -50,9 +61,112 @@ def test_sampler_preserves_event_timestamp_through_wire_schema() -> None:
     sample = sampler._event_to_sample(event)
 
     assert sample.timestamp == 12.25
+    assert sample.to_wire() == {
+        "seq": 3,
+        "ts": 12.25,
+        "device": "cuda:0",
+        "step": 7,
+        "peak_alloc": 100.0,
+        "peak_resv": 200.0,
+    }
     assert StepMemorySample.from_wire(sample.to_wire()) == sample
 
 
 def test_wire_schema_requires_measurement_timestamp() -> None:
     with pytest.raises(KeyError):
         StepMemorySample.from_wire({"seq": 1})
+
+
+def test_pending_snapshot_is_cleared_between_steps(
+    monkeypatch,
+) -> None:
+    tracker = StepMemoryTracker(torch.nn.Linear(1, 1))
+    # Exercise allocator calls without requiring a CUDA-equipped test machine.
+    tracker.device = torch.device("cuda:0")
+    calls = []
+    allocated = iter([100, 150, 30])
+    reserved = iter([200, 250, 60])
+
+    def read_peak(name, values, device):
+        calls.append((name, str(device)))
+        return next(values)
+
+    monkeypatch.setattr(
+        torch.cuda,
+        "reset_peak_memory_stats",
+        lambda device: calls.append(("reset", str(device))),
+    )
+    monkeypatch.setattr(
+        torch.cuda,
+        "max_memory_allocated",
+        lambda device: read_peak("allocated", allocated, device),
+    )
+    monkeypatch.setattr(
+        torch.cuda,
+        "max_memory_reserved",
+        lambda device: read_peak("reserved", reserved, device),
+    )
+    timestamps = iter([10.0, 11.0, 12.0])
+    monkeypatch.setattr(
+        step_memory_module.time, "time", lambda: next(timestamps)
+    )
+
+    tracker.reset()
+    tracker.record()
+    tracker.record()  # Only the final snapshot belongs to this flush.
+    flush_step_memory_buffer(10)
+    # An empty flush must not duplicate the event.
+    flush_step_memory_buffer(10)
+    tracker.reset()
+    tracker.record()
+    flush_step_memory_buffer(11)
+    assert step_memory_module._PENDING_MEMORY is None
+    assert calls == [
+        (name, "cuda:0")
+        for name in (
+            "reset",
+            "allocated",
+            "reserved",
+            "allocated",
+            "reserved",
+            "reset",
+            "allocated",
+            "reserved",
+        )
+    ]
+
+    # Both steps wait in the queue, including after recording is disabled.
+    configure_trace_recording(max_steps=11).mark_step_flushed(11)
+    monkeypatch.setenv("TRACEML_DISABLED", "1")
+    monkeypatch.setattr(step_memory_module.time, "time", lambda: 99.0)
+    sampler = StepMemorySampler()
+    rows = []
+    monkeypatch.setattr(sampler, "_add_record", rows.append)
+    sampler.sample()
+    assert [
+        (r["step"], r["peak_alloc"], r["peak_resv"], r["ts"]) for r in rows
+    ] == [
+        (10, 150.0, 250.0, 11.0),
+        (11, 30.0, 60.0, 12.0),
+    ]
+    assert all(r["device"] == "cuda:0" for r in rows)
+    sampler.sample()
+    assert len(rows) == 2
+
+
+def test_full_memory_queue_drops_only_incoming_event(capsys) -> None:
+    events = [
+        StepMemoryEvent(step, "cpu", float(step), None, None)
+        for step in range(2048)
+    ]
+    for event in events:
+        step_events.publish_step_memory_event(event)
+    step_events.publish_step_memory_event(
+        StepMemoryEvent(2048, "cpu", 2048.0, None, None)
+    )
+
+    drained = step_events.drain_step_memory_events()
+    assert len(drained) == 2048
+    assert all(actual is expected for actual, expected in zip(drained, events))
+    assert "dropping event for step 2048 on cpu" in capsys.readouterr().err
+    assert step_events.drain_step_memory_events() == []


### PR DESCRIPTION
## Goal

Implement part 2 of #453, building on the timing handoff from part 1.
Target: version_0.3.7.

Move memory event definitions and queue ownership into the shared step-events
module. Remove unnecessary model identity while preserving measurement,
sampling, and storage behavior for the current one-device-per-process path.

## What changes

Previously, step_memory.py owned the event definition, memory queue, and
a pending dictionary keyed by model_id.

Now:

- instrumentation/step_events.py owns StepMemoryEvent and the private memory
  queue, with typed publication and drain functions.
- step_memory.py measures memory and keeps one pending snapshot per process.
- record() replaces the pending snapshot.
- flush(step) clears the pending slot, assigns the step number, and publishes
  the event.
- The queue retains previously published snapshots until the sampler drains
  them. Replacing the pending snapshot does not overwrite queued steps.
- device remains snapshot metadata. There is no model or device grouping key.

## Data flow

StepMemoryTracker.record()
  -> one process-local pending snapshot
  -> existing flush boundary: detach, assign step, publish
  -> private memory queue in step_events.py
  -> StepMemorySampler: conversion and persistence

Timing continues through its separate queue and existing CUDA FIFO.

## In scope

- Move memory event and queue ownership to the shared handoff.
- Remove model_id from memory events and wire records.
- Replace the model-keyed pending dictionary with one optional event.
- Remove the unused model argument from internal flush functions and update
  SDK and Lightning callers.
- Share queue-draining code between timing and memory.
- Remove the obsolete sampler queue helper and model-filtering test helpers.
- Update existing tests, developer documentation, and the changelog.

No new files, capture classes, or transport layers are introduced.

## Sampler and measurement behavior

StepMemorySampler.sample() is unchanged. Sampler edits are limited to imports,
the queue reader, and removing model_id from event-to-sample conversion.

The following remain unchanged:

- Device selection and device labels.
- Peak-counter reset/read boundaries.
- Measurement timestamps, byte units, and non-CUDA None values.
- Existing step definitions and gradient-accumulation behavior.
- Queue capacity of 2,048 events and drop-on-full behavior.
- Draining published events after recording stops.
- Timing aggregation, CUDA FIFO processing, and event-pool handling.
- SQLite schema and downstream memory calculations.

Removing model_id is an intentional telemetry metadata change.
The SQLite projection already omitted it, so no database migration is needed.

## Out of scope

- StepCapture and shared completion/abort handling: part 3.
- Fixing existing failed-step attribution or session-buffer lifecycle.
- HF/Accelerate input-fetch and H2D measurement changes.
- Concurrent independent training loops or multiple pending device snapshots
  within one process.
- Changing integration-specific step boundaries.
- Combining timing and memory queues or synchronizing their samplers.
- New aggregation, backpressure, shutdown, or CUDA error-handling policies.

The single pending event can move into StepCapture later without changing
the published event or sampler interface.

## Validation

- Focused suite: 235 passed, 2 skipped, 1 watch smoke test excluded.
- Only two added memory regression tests:
  - Consecutive steps queued before draining, final-snapshot replacement,
    empty flushes, timestamps, and draining after recording stops.
  - Queue capacity, overflow, and retained-event ordering.
- Existing timestamp, wire-schema, CPU, SDK, integration, timing, and
  downstream memory tests retained and adapted.
- Code comparison confirmed unchanged device selection, memory reset logic,
  and sampler sample() behavior.
- Strict documentation build and formatting passed; no new lint findings.
- CPU collection overhead remained comparable to version_0.3.7.

Real CUDA hardware was unavailable; CUDA behavior was checked using
controlled test doubles.